### PR TITLE
Fix Briefcase notarization credentials

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -94,7 +94,6 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
       - name: Store Notarization Credentials
         run: |
-          echo "${{ secrets.KEYCHAIN_PASSWORD }}" | xcrun altool --store-password-in-keychain-item "${{ secrets.KEYCHAIN_NAME }}" -u "${{ secrets.APPLE_ID }}" -p -
           xcrun notarytool store-credentials "${{ secrets.KEYCHAIN_NAME }}" --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.KEYCHAIN_PASSWORD }}" --team-id "${{ secrets.TEAM_ID }}"
       - name: Extract version
         id: extract_version


### PR DESCRIPTION
## Summary
- remove obsolete `altool --store-password-in-keychain-item` usage
- rely on `notarytool store-credentials` for the modern macOS runner

## Validation
- `git diff --check`
- `actionlint .github/workflows/briefcase.yml`

Refs #65