### PR TITLE
Use portable keychain search list setup

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -84,7 +84,10 @@ jobs:
         run: |
           KEYCHAIN_PATH="$(pwd)/build.keychain"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          mapfile -t USER_KEYCHAINS < <(security list-keychains -d user | sed 's/[" ]//g')
+          USER_KEYCHAINS=()
+          while IFS= read -r keychain; do
+            USER_KEYCHAINS+=("$keychain")
+          done < <(security list-keychains -d user | sed 's/[" ]//g')
           security list-keychains -d user -s "$KEYCHAIN_PATH" "${USER_KEYCHAINS[@]}"
           security default-keychain -s "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"


### PR DESCRIPTION
## Summary
- replace Bash 4 `mapfile` usage with a Bash 3-compatible loop on the macOS runner
- preserve the temporary keychain search-list fix for notarization polling

## Validation
- `git diff --check`
- `actionlint .github/workflows/briefcase.yml`

Refs #65