### PR TITLE
Reject abbreviated manual release SHAs

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -49,7 +49,7 @@ jobs:
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
             echo "Manual releases must use a branch or tag ref, not a raw SHA. Tag the commit first or package a branch." >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- reject 7-40 character hex-only `source_ref` values for manual Briefcase releases
- keep branch/tag refs accepted so manual packaging does not run detached on commit SHAs

## Validation
- local regex smoke for branch, tag, abbreviated SHA, full SHA, and branch-with-hex-name cases
- `git diff --check`
- `actionlint .github/workflows/briefcase.yml`

Refs #65