### PR TITLE
Remove unsupported Homebrew no-quarantine flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ brew install ffmpeg gpac mkvtoolnix python@3.12 tesseract
 # Install MakeMKV. Homebrew may still provide a cask, but if Gatekeeper blocks it,
 # install the current macOS build from https://www.makemkv.com/ and make sure
 # makemkvcon is available in your PATH.
-brew install --cask --no-quarantine makemkv
+brew install --cask makemkv
 
 # Install Wine. BD_to_AVP currently uses Wine to run FRIMDecode64.exe for MVC splitting.
 # The Homebrew wine-stable cask is deprecated, so manual Wine installation may be
 # required if this command stops working.
-brew install --cask --no-quarantine wine-stable
+brew install --cask wine-stable
 
 # Ensure Python 3.12 is correctly installed then create a virtual environment
 python3.12 -m pip install --upgrade pip

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -246,9 +246,6 @@ def manage_brew_package(
 
 def build_brew_command(packages: list[str], cask: bool = False, operation: str = "install") -> list[str]:
     brew_command = ["/opt/homebrew/bin/brew", operation, "--force"]
-    if operation == "install":
-        brew_command.append("--no-quarantine")
-
     if cask:
         brew_command.append("--cask")
 

--- a/installer.sh
+++ b/installer.sh
@@ -48,7 +48,7 @@ echo "Installing dependencies..."
 
 if ! command -v makemkvcon &>/dev/null; then
     echo "Installing MakeMKV..."
-    "$BREW_PATH/brew" install --cask --no-quarantine makemkv || handle_error "Failed to install MakeMKV cask"
+    "$BREW_PATH/brew" install --cask makemkv || handle_error "Failed to install MakeMKV cask"
 fi
 
 if ! command -v makemkvcon &>/dev/null; then
@@ -57,7 +57,7 @@ fi
 
 if ! command -v wine &>/dev/null || ! command -v wineboot &>/dev/null; then
     echo "Installing Wine..."
-    "$BREW_PATH/brew" install --cask --no-quarantine wine-stable || handle_error "Failed to install Wine cask"
+    "$BREW_PATH/brew" install --cask wine-stable || handle_error "Failed to install Wine cask"
 fi
 
 if ! command -v wine &>/dev/null || ! command -v wineboot &>/dev/null; then


### PR DESCRIPTION
## Summary
- remove `--no-quarantine` from GUI-managed Homebrew cask installs
- remove `--no-quarantine` from the terminal installer
- update README cask install commands

## Validation
- `build_brew_command(["makemkv"], cask=True)` now produces `brew install --force --cask makemkv`
- real Homebrew dry-run accepts `/opt/homebrew/bin/brew install --force --cask makemkv --dry-run`
- no remaining `--no-quarantine` references
- `git diff --check`
- `zsh -n installer.sh`
- `actionlint .github/workflows/*.yml`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv build`

Refs #65