### PR TITLE
Clear quarantine after cask installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ brew install ffmpeg gpac mkvtoolnix python@3.12 tesseract
 # install the current macOS build from https://www.makemkv.com/ and make sure
 # makemkvcon is available in your PATH.
 brew install --cask makemkv
+xattr -dr com.apple.quarantine /Applications/MakeMKV.app 2>/dev/null || true
 
 # Install Wine. BD_to_AVP currently uses Wine to run FRIMDecode64.exe for MVC splitting.
 # The Homebrew wine-stable cask is deprecated, so manual Wine installation may be
 # required if this command stops working.
 brew install --cask wine-stable
+xattr -dr com.apple.quarantine "/Applications/Wine Stable.app" 2>/dev/null || true
+xattr -dr com.apple.quarantine /Applications/Wine.app 2>/dev/null || true
 
 # Ensure Python 3.12 is correctly installed then create a virtual environment
 python3.12 -m pip install --upgrade pip

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -12,6 +12,12 @@ from bd_to_avp.modules.config import config
 from bd_to_avp.modules.command import run_command
 
 
+CASK_APP_PATHS = {
+    "makemkv": [Path("/Applications/MakeMKV.app")],
+    "wine-stable": [Path("/Applications/Wine Stable.app"), Path("/Applications/Wine.app")],
+}
+
+
 def prompt_for_password() -> tuple[Path, dict[str, str]]:
     script = """
     with timeout of 3600 seconds
@@ -200,11 +206,18 @@ def check_is_package_installed(package: str) -> bool:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    app_dir_path = next(Path("/Applications").glob(f"{package.replace('-', ' ')}.app"), None)
-    if package in process.stdout and app_dir_path and app_dir_path.exists() and not is_file_quarantined(app_dir_path):
+    if package not in process.stdout:
+        return False
+
+    app_paths = [app_path for app_path in get_cask_app_paths(package) if app_path.exists()]
+    if app_paths and all(not is_file_quarantined(app_path) for app_path in app_paths):
         return True
 
-    return False
+    return not app_paths
+
+
+def get_cask_app_paths(package: str) -> list[Path]:
+    return CASK_APP_PATHS.get(package, [Path("/Applications") / f"{package.replace('-', ' ')}.app"])
 
 
 def is_file_quarantined(file_path: Path) -> bool:
@@ -214,6 +227,32 @@ def is_file_quarantined(file_path: Path) -> bool:
     except subprocess.CalledProcessError as e:
         print(f"Error checking quarantine status: {e}")
         return False
+
+
+def clear_cask_quarantine(packages: list[str], sudo_env: dict[str, str]) -> None:
+    for package in packages:
+        for app_path in get_cask_app_paths(package):
+            if not app_path.exists() or not is_file_quarantined(app_path):
+                continue
+
+            process = subprocess.run(
+                ["xattr", "-dr", "com.apple.quarantine", app_path.as_posix()],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=sudo_env,
+            )
+            if process.returncode != 0:
+                process = subprocess.run(
+                    ["/usr/bin/sudo", "-A", "xattr", "-dr", "com.apple.quarantine", app_path.as_posix()],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=sudo_env,
+                )
+
+            if process.returncode != 0:
+                on_error_process(f"{package} quarantine cleanup", process)
 
 
 def manage_brew_package(
@@ -240,6 +279,9 @@ def manage_brew_package(
 
     if process.returncode != 0:
         on_error_process(packages_str, process)
+
+    if cask and operation == "install":
+        clear_cask_quarantine(packages, sudo_env)
 
     print(f"{packages_str} {operation}ed.")
 

--- a/installer.sh
+++ b/installer.sh
@@ -6,6 +6,18 @@ handle_error() {
     exit 1
 }
 
+clear_quarantine() {
+    app_path="$1"
+    if [ ! -e "$app_path" ]; then
+        return 0
+    fi
+
+    if xattr -p com.apple.quarantine "$app_path" >/dev/null 2>&1; then
+        echo "Clearing Gatekeeper quarantine from $app_path..."
+        xattr -dr com.apple.quarantine "$app_path" 2>/dev/null || sudo xattr -dr com.apple.quarantine "$app_path" || handle_error "Failed to clear quarantine from $app_path"
+    fi
+}
+
 echo "Checking macOS version and architecture..."
 ARCH=$(uname -m)
 MACOS_VERSION=$(sw_vers -productVersion)
@@ -51,6 +63,8 @@ if ! command -v makemkvcon &>/dev/null; then
     "$BREW_PATH/brew" install --cask makemkv || handle_error "Failed to install MakeMKV cask"
 fi
 
+clear_quarantine "/Applications/MakeMKV.app"
+
 if ! command -v makemkvcon &>/dev/null; then
     handle_error "MakeMKV command-line tools were not found after installation. Install MakeMKV from https://www.makemkv.com/ or repair your Homebrew MakeMKV cask before converting discs."
 fi
@@ -59,6 +73,9 @@ if ! command -v wine &>/dev/null || ! command -v wineboot &>/dev/null; then
     echo "Installing Wine..."
     "$BREW_PATH/brew" install --cask wine-stable || handle_error "Failed to install Wine cask"
 fi
+
+clear_quarantine "/Applications/Wine Stable.app"
+clear_quarantine "/Applications/Wine.app"
 
 if ! command -v wine &>/dev/null || ! command -v wineboot &>/dev/null; then
     handle_error "Wine command-line tools were not found after installation. Install or repair Wine before converting MVC 3D Blu-ray video. The Homebrew wine-stable cask is deprecated and may require manual replacement."


### PR DESCRIPTION
## Summary
- clear Gatekeeper quarantine from MakeMKV and Wine app bundles after Homebrew cask installs
- keep current Homebrew cask install syntax without the removed --no-quarantine flag
- document the manual xattr cleanup commands for direct installs

## Validation
- /opt/homebrew/bin/brew install --force --cask makemkv --dry-run
- /opt/homebrew/bin/brew install --force --cask wine-stable --dry-run
- zsh -n installer.sh
- uv run python helper smoke for brew command and cask app paths
- git diff --check
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy bd_to_avp
- uv build