### PR TITLE
Record branch protection policy

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -5,6 +5,30 @@
     "preferredMergeMethod": "merge",
     "allowedMergeMethods": ["merge"]
   },
+  "branchProtection": {
+    "main": {
+      "system": "classic",
+      "requiresPullRequest": true,
+      "requiredStatusChecks": ["validate"],
+      "requiredApprovals": 0,
+      "enforceAdmins": true,
+      "blocksForcePushes": true,
+      "blocksDeletion": true,
+      "requiresConversationResolution": true
+    },
+    "release": {
+      "system": "ruleset",
+      "rulesetName": "protect-release",
+      "target": "refs/heads/release",
+      "requiresPullRequest": true,
+      "allowedMergeMethods": ["merge"],
+      "requiredStatusChecks": ["validate"],
+      "requiredApprovals": 0,
+      "blocksForcePushes": true,
+      "blocksDeletion": true,
+      "requiresConversationResolution": true
+    }
+  },
   "docs": {
     "overview": "README.md",
     "packageManifest": "pyproject.toml",


### PR DESCRIPTION
## Summary
- document the current main and release branch protection model in repo metadata
- record release as a PR + validate ruleset instead of a blanket update lock

## Validation
- jq empty .github/github.json