### PR TITLE
Repair casks with missing app bundles

### DIFF
--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -210,10 +210,10 @@ def check_is_package_installed(package: str) -> bool:
         return False
 
     app_paths = [app_path for app_path in get_cask_app_paths(package) if app_path.exists()]
-    if app_paths and all(not is_file_quarantined(app_path) for app_path in app_paths):
-        return True
+    if not app_paths:
+        return False
 
-    return not app_paths
+    return any(not is_file_quarantined(app_path) for app_path in app_paths)
 
 
 def get_cask_app_paths(package: str) -> list[Path]:


### PR DESCRIPTION
## Summary
- treat Homebrew casks with missing expected app bundles as needing repair
- preserve successful detection for clean alternate app bundles
- keep quarantined app bundles in the repair path

## Validation
- mocked cask detection smoke: missing bundle false, clean bundle true, quarantined bundle false
- git diff --check
- uv run ruff format --check bd_to_avp/install.py
- uv run ruff check bd_to_avp/install.py
- uv run mypy bd_to_avp/install.py
- uv build