### PR TITLE
Bump version to 0.2.141

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.2.140"
+version = "0.2.141"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -69,7 +69,7 @@ include = [
 project_name = "3D Blu-ray to Vision pro"
 bundle = "com.shinycomputers"
 architectures = ["arm64"]
-version = "0.2.140"
+version = "0.2.141"
 icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.2.140"
+version = "0.2.141"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- bump project and Briefcase versions to 0.2.141
- update uv.lock local package version

## Why
Publishes a patch release after the cask bundle repair fix so users on 0.2.140 can see a newer stable release in the update checker.

## Validation
- git diff --check
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy bd_to_avp
- uv build