### PR TITLE
Promote v0.2.141 to release

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -5,6 +5,30 @@
     "preferredMergeMethod": "merge",
     "allowedMergeMethods": ["merge"]
   },
+  "branchProtection": {
+    "main": {
+      "system": "classic",
+      "requiresPullRequest": true,
+      "requiredStatusChecks": ["validate"],
+      "requiredApprovals": 0,
+      "enforceAdmins": true,
+      "blocksForcePushes": true,
+      "blocksDeletion": true,
+      "requiresConversationResolution": true
+    },
+    "release": {
+      "system": "ruleset",
+      "rulesetName": "protect-release",
+      "target": "refs/heads/release",
+      "requiresPullRequest": true,
+      "allowedMergeMethods": ["merge"],
+      "requiredStatusChecks": ["validate"],
+      "requiredApprovals": 0,
+      "blocksForcePushes": true,
+      "blocksDeletion": true,
+      "requiresConversationResolution": true
+    }
+  },
   "docs": {
     "overview": "README.md",
     "packageManifest": "pyproject.toml",

--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -37,7 +37,7 @@ jobs:
       CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: >-
@@ -187,13 +187,13 @@ jobs:
           uv run python scripts/briefcase_app.py package -i "${{ secrets.DEV_ID }}"
       - name: Upload log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: briefcase-log
           path: /Users/runner/work/BD_to_AVP/BD_to_AVP/logs/briefcase.*.build.log
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: |
             ${{ steps.release_metadata.outputs.release_notes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -210,10 +210,10 @@ def check_is_package_installed(package: str) -> bool:
         return False
 
     app_paths = [app_path for app_path in get_cask_app_paths(package) if app_path.exists()]
-    if app_paths and all(not is_file_quarantined(app_path) for app_path in app_paths):
-        return True
+    if not app_paths:
+        return False
 
-    return not app_paths
+    return any(not is_file_quarantined(app_path) for app_path in app_paths)
 
 
 def get_cask_app_paths(package: str) -> list[Path]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.2.140"
+version = "0.2.141"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -69,7 +69,7 @@ include = [
 project_name = "3D Blu-ray to Vision pro"
 bundle = "com.shinycomputers"
 architectures = ["arm64"]
-version = "0.2.140"
+version = "0.2.141"
 icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,14 @@ dependencies = [
     "ffmpeg-python>=0.2.0,<0.3",
     "humanize>=4.9.0,<5",
     "opencv-python==4.10.0.84",
-    "packaging>=24.1,<25",
+    "packaging>=24.1,<27",
     "pgsrip==0.1.11",
-    "psutil>=5.9.8,<6",
+    "psutil>=5.9.8,<8",
     "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
     "requests>=2.32.3,<3",
     "setuptools>=70.3.0,<71",
-    "wakepy>=0.9.1,<0.10",
+    "wakepy>=0.9.1,<1.1",
 ]
 
 [project.urls]
@@ -84,14 +84,14 @@ requires = [
     "ffmpeg-python>=0.2.0,<0.3",
     "humanize>=4.9.0,<5",
     "opencv-python==4.10.0.84",
-    "packaging>=24.1,<25",
+    "packaging>=24.1,<27",
     "pgsrip==0.1.11",
-    "psutil>=5.9.8,<6",
+    "psutil>=5.9.8,<8",
     "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
     "requests>=2.32.3,<3",
     "setuptools>=70.3.0,<71",
-    "wakepy>=0.9.1,<0.10",
+    "wakepy>=0.9.1,<1.1",
 ]
 
 [tool.briefcase.app.bd-to-avp.macOS]

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.2.140"
+version = "0.2.141"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },

--- a/uv.lock
+++ b/uv.lock
@@ -120,14 +120,14 @@ requires-dist = [
     { name = "ffmpeg-python", specifier = ">=0.2.0,<0.3" },
     { name = "humanize", specifier = ">=4.9.0,<5" },
     { name = "opencv-python", specifier = "==4.10.0.84" },
-    { name = "packaging", specifier = ">=24.1,<25" },
+    { name = "packaging", specifier = ">=24.1,<27" },
     { name = "pgsrip", specifier = "==0.1.11" },
-    { name = "psutil", specifier = ">=5.9.8,<6" },
+    { name = "psutil", specifier = ">=5.9.8,<8" },
     { name = "pygithub", specifier = ">=2.3.0,<3" },
     { name = "pyside6", specifier = ">=6.7.1,<7" },
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "setuptools", specifier = ">=70.3.0,<71" },
-    { name = "wakepy", specifier = ">=0.9.1,<0.10" },
+    { name = "wakepy", specifier = ">=0.9.1,<1.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -688,11 +688,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -761,16 +761,18 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "5.9.8"
+version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c", size = 503247, upload-time = "2024-01-19T20:47:09.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81", size = 248702, upload-time = "2024-01-19T20:47:36.303Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/28c5f553667116b2598b9cc55908ec435cb7f77a34f2bff3e3ca765b0f78/psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421", size = 285242, upload-time = "2024-01-19T20:47:39.65Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4", size = 288191, upload-time = "2024-01-19T20:47:43.078Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/2aa3a4acdc1e5940b59d421742356f133185667dd190b166dbcfcf5d7b43/psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0", size = 251252, upload-time = "2024-01-19T20:47:52.88Z" },
-    { url = "https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf", size = 255090, upload-time = "2024-01-19T20:47:56.019Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8", size = 249898, upload-time = "2024-01-19T20:47:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1216,14 +1218,14 @@ wheels = [
 
 [[package]]
 name = "wakepy"
-version = "0.9.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "jeepney", marker = "platform_system == 'DragonFly' or platform_system == 'FreeBSD' or platform_system == 'Minix' or platform_system == 'NetBSD' or platform_system == 'OpenBSD' or platform_system == 'SunOS' or sys_platform == 'aix' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/86/e662f654b3a8c70991a286177f15035a16380f05832a0f3a2e51d12783a7/wakepy-0.9.1.tar.gz", hash = "sha256:4e7e820512e0e69f9aa5fdded2d3225e6f7c9f000814300e8c37d1fa88fe1664", size = 124071, upload-time = "2024-06-04T06:15:37.449Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/13/78e45a3d2cd754f95d2fca5aece046676da559b8e34e294e69bb441f18fd/wakepy-1.0.0.tar.gz", hash = "sha256:a9425e8e77e89bccfe24a70f33ecd8596b474c75ddac79310cd54f2bc92210e3", size = 323693, upload-time = "2026-02-07T21:20:32.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/0c/527fff99ac7a85de27ab43294bc84d402aeeaa0bd68a451af6f19666e4e5/wakepy-0.9.1-py3-none-any.whl", hash = "sha256:fee0722b554a859724f6f47ec28db1d513f15097f235b09ebb1b58f545f90db2", size = 52405, upload-time = "2024-06-04T06:15:34.737Z" },
+    { url = "https://files.pythonhosted.org/packages/52/33/e692c64d00b7a0d203191b1a20c81c32dca93da38345f6f1ad91426e36fc/wakepy-1.0.0-py3-none-any.whl", hash = "sha256:d5497640791517982cf66d894c502e9fa5133dc75c4a45d3b18a3495d1cf8afb", size = 70336, upload-time = "2026-02-07T21:20:31.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- promote the cask bundle repair fix as stable v0.2.141
- includes the 0.2.141 version bump and latest main maintenance updates

## Why
Users on v0.2.140 need a newer stable release for the app's update checker to point at the cask repair behavior.

## Validation
- v0.2.141 GitHub release does not already exist
- PyPI bd-to-avp 0.2.141 does not already exist
- git diff --check
- conflict marker scan
- zsh -n installer.sh
- actionlint .github/workflows/*.yml
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy bd_to_avp
- uv build