### PR TITLE
Retire stale master branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: CI
   push:
     branches:
       - main
-      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- remove the stale master branch from CI push triggers
- keep main as the only default development push target

## Why
The repository default branch is main, and the old master branch is stale migration residue. Removing it from active CI prevents treating an unprotected stale branch as part of the live development workflow.

## Validation
- actionlint .github/workflows/ci.yml
- git diff --check