### PR TITLE
Remove vulnerable pgsrip dependency path

### DIFF
--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import ffmpeg
 import requests
 from babelfish import Language
-from pgsrip import Mkv, Options, pgsrip
+from bd_to_avp.vendor.pgsrip import Mkv, Options, pgsrip
 
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.command import Spinner

--- a/bd_to_avp/vendor/__init__.py
+++ b/bd_to_avp/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored runtime dependencies."""

--- a/bd_to_avp/vendor/pgsrip/LICENSE
+++ b/bd_to_avp/vendor/pgsrip/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Rato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bd_to_avp/vendor/pgsrip/__init__.py
+++ b/bd_to_avp/vendor/pgsrip/__init__.py
@@ -1,0 +1,14 @@
+"""Vendored pgsrip runtime used for PGS subtitle OCR."""
+
+__title__ = "pgsrip"
+__version__ = "0.1.11"
+__short_version__ = "0.1"
+__author__ = "Rato"
+__license__ = "MIT"
+__url__ = "https://github.com/ratoaq2/pgsrip"
+
+from . import api as pgsrip
+from .media import Media, Pgs
+from .mkv import Mkv
+from .options import Options
+from .sup import Sup

--- a/bd_to_avp/vendor/pgsrip/__main__.py
+++ b/bd_to_avp/vendor/pgsrip/__main__.py
@@ -1,0 +1,4 @@
+from bd_to_avp.vendor.pgsrip.cli import pgsrip
+
+if __name__ == '__main__':
+    pgsrip()

--- a/bd_to_avp/vendor/pgsrip/api.py
+++ b/bd_to_avp/vendor/pgsrip/api.py
@@ -1,0 +1,26 @@
+import logging
+import typing
+
+from bd_to_avp.vendor.pgsrip import core
+from bd_to_avp.vendor.pgsrip.media import Media, Pgs
+from bd_to_avp.vendor.pgsrip.options import Options
+
+
+logger = logging.getLogger(__name__)
+
+
+def scan_path(path: str, options: typing.Optional[Options] = None):
+    collected: typing.List[Media] = []
+    filtered_out: typing.List[str] = []
+    discarded: typing.List[str] = []
+    core.scan_path(path, collected, filtered_out, discarded, options=options or Options())
+
+    return collected, filtered_out, discarded
+
+
+def rip(media: Media, options: typing.Optional[Options] = None):
+    return core.rip(media, options or Options())
+
+
+def rip_pgs(pgs: Pgs, options: typing.Optional[Options] = None):
+    return core.rip_pgs(pgs, options or Options())

--- a/bd_to_avp/vendor/pgsrip/cli.py
+++ b/bd_to_avp/vendor/pgsrip/cli.py
@@ -1,0 +1,198 @@
+import logging
+import os
+import re
+import typing
+from datetime import timedelta
+from types import TracebackType
+
+from babelfish import Error as BabelfishError, Language
+
+import click
+
+import pytesseract as tess
+
+from bd_to_avp.vendor.pgsrip import Pgs, __version__, api
+from bd_to_avp.vendor.pgsrip.media import Media
+from bd_to_avp.vendor.pgsrip.options import Options
+
+logger = logging.getLogger('pgsrip')
+
+
+T = typing.TypeVar('T')
+
+
+class DebugProgressBar(typing.Generic[T]):
+
+    def __init__(self, debug: bool, iterable: typing.Iterable[T], **kwargs):
+        self.debug = debug
+        self.iterable = iterable
+        self.progressbar = click.progressbar(iterable, **kwargs)
+
+    def __iter__(self):
+        if not self.debug:
+            return self.progressbar.__iter__()
+
+        yield from self.iterable
+
+    def __enter__(self):
+        if not self.debug:
+            return self.progressbar.__enter__()
+
+        return self
+
+    def __exit__(self,
+                 exc_type: typing.Optional[typing.Type[BaseException]],
+                 exc: typing.Optional[BaseException],
+                 traceback: typing.Optional[TracebackType]):
+        if not self.debug:
+            return self.progressbar.__exit__(exc_type, exc, traceback)
+
+    def update(self, n_steps: int, current_item: typing.Optional[T] = None) -> None:
+        if not self.debug:
+            return self.progressbar.update(n_steps, current_item)
+
+
+class LanguageParamType(click.ParamType):
+    name = 'language'
+
+    def convert(self, value, param, ctx):
+        try:
+            return Language.fromietf(value)
+        except (BabelfishError, ValueError):
+            self.fail(f"{click.style(f'{value}', bold=True)} is not a valid language")
+
+
+class AgeParamType(click.ParamType):
+    name = 'age'
+
+    def convert(self, value, param, ctx):
+        match = re.match(r'^(?:(?P<weeks>\d+?)w)?(?:(?P<days>\d+?)d)?(?:(?P<hours>\d+?)h)?$', value)
+        if not match:
+            self.fail('%s is not a valid age' % value)
+
+        return timedelta(**{k: int(v) for k, v in match.groupdict('0').items()})
+
+
+LANGUAGE = LanguageParamType()
+AGE = AgeParamType()
+
+
+@click.command()
+@click.option('-c', '--config', type=click.Path(), help='cleanit configuration path to be used')
+@click.option('-l', '--language', type=LANGUAGE, multiple=True, help='Language as IETF code, '
+              'e.g. en, pt-BR (can be used multiple times).')
+@click.option('-t', '--tag', required=False, multiple=True, help='Rule tags to be used, '
+              'e.g. ocr, tidy, no-sdh, no-style, no-lyrics, no-spam (can be used multiple times). ')
+@click.option('-e', '--encoding', help='Save subtitles using the following encoding.')
+@click.option('-a', '--age', type=AGE, help='Filter videos newer than AGE, e.g. 12h, 1w2d.')
+@click.option('-A', '--srt-age', type=AGE, help='Filter videos which srt subtitles are newer than AGE, e.g. 12h, 1w2d.')
+@click.option('-f', '--force', is_flag=True, default=False,
+              help='re-rip and overwrite existing srt subtitles, even if they already exist')
+@click.option('-a', '--all', is_flag=True, default=False,
+              help='rip all tracks for a given language, even another track for that language was already ripped')
+@click.option('-w', '--max-workers', type=click.IntRange(1, 50), default=None, help='Maximum number of threads to use.')
+@click.option('--keep-temp-files', is_flag=True, help='Do not delete temporary files created, '
+                                                      'e.g. extracted sup files, generated png files '
+                                                      'and other useful debug files')
+@click.option('--debug', is_flag=True, help='Print useful information for debugging and for reporting bugs.')
+@click.option('-v', '--verbose', count=True, help='Display debug messages')
+@click.argument('path', type=click.Path(), required=True, nargs=-1)
+@click.version_option(__version__)
+def pgsrip(config: typing.Optional[str],
+           language: typing.Optional[typing.Tuple[Language]],
+           tag: typing.Optional[typing.Tuple[str]],
+           encoding: typing.Optional[str],
+           age: typing.Optional[timedelta],
+           srt_age: typing.Optional[timedelta],
+           force: bool,
+           all: bool,
+           debug: bool,
+           max_workers: typing.Optional[int],
+           keep_temp_files: bool,
+           verbose: int,
+           path: typing.Tuple[str]):
+    if debug:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        logger.info(f'Tesseract version: {tess.get_tesseract_version()}')
+        logger.info(f'Tesseract data: {os.getenv("TESSDATA_PREFIX")}')
+
+    if config and (not os.path.isfile(config) or os.path.isdir(config)):
+        click.echo(f"Invalid configuration is defined: {click.style(config, bold=True)}")
+        return
+
+    options = Options(config_path=config,
+                      languages=set(language or []),
+                      tags=set(tag or []),
+                      encoding=encoding,
+                      overwrite=force,
+                      one_per_lang=not all,
+                      keep_temp_files=keep_temp_files,
+                      max_workers=max_workers,
+                      age=age,
+                      srt_age=srt_age)
+
+    rules = options.config.select_rules(tags=options.tags, languages=options.languages)
+    if not rules:
+        values = tuple(options.tags) + tuple(str(lang) for lang in options.languages)
+        click.echo(f"No rules defined for {click.style(', '.join(values), bold=True)}")
+        return
+
+    collected_medias: typing.List[Media] = []
+    filtered_out_paths: typing.List[str] = []
+    discarded_paths: typing.List[str] = []
+    for p in path:
+        c, f, d = api.scan_path(p, options)
+        collected_medias.extend(c)
+        filtered_out_paths.extend(f)
+        discarded_paths.extend(d)
+
+    if debug or verbose > 1:
+        if verbose > 2:
+            for p in filtered_out_paths:
+                click.echo(f"{click.style(p, fg='yellow', bold=True)} filtered out")
+        for p in discarded_paths:
+            click.echo(f"{click.style(p, fg='red', bold=True)} discarded")
+
+    collected_pgs_medias: typing.List[Pgs] = []
+    medias_progressbar = DebugProgressBar(debug or verbose > 1,
+                                          collected_medias,
+                                          label='Collecting pgs subtitles',
+                                          item_show_func=lambda item: str(item or ''))
+
+    with medias_progressbar as bar:
+        for m in bar:
+            collected_pgs_medias.extend(list(m.get_pgs_medias(options)))
+
+    # report collected medias
+    report = (f"{click.style(str(len(collected_pgs_medias)), bold=True, fg='green')} "
+              f"PGS subtitle{'s' if len(collected_pgs_medias) > 1 else ''} collected "
+              f"from {click.style(str(len(collected_medias)), bold=True, fg='green')} "
+              f"file{'s' if len(collected_medias) > 1 else ''}")
+    if filtered_out_paths:
+        report += (f" / {click.style(str(len(filtered_out_paths)), bold=True, fg='yellow')} "
+                   f"file{'s' if len(filtered_out_paths) > 1 else ''} filtered out")
+    if discarded_paths:
+        report += (f" / {click.style(str(len(discarded_paths)), bold=True, fg='red')} "
+                   f"path{'s' if len(discarded_paths) > 1 else ''} ignored")
+    click.echo(report)
+
+    pgs_progressbar = DebugProgressBar(debug or verbose > 1,
+                                       collected_pgs_medias,
+                                       label='Ripping subtitles',
+                                       update_min_steps=0,
+                                       item_show_func=lambda s: click.style(str(s or ''), bold=True))
+
+    ripped_count = 0
+    with pgs_progressbar as bar:
+        for pgs in bar:
+            bar.update(0, pgs)
+            ripped_count += api.rip_pgs(pgs, options)
+
+    # report ripped subtitles
+    click.echo(f"{click.style(str(ripped_count), bold=True, fg='green')} "
+               f"PGS subtitle{'s' if ripped_count > 1 else ''} ripped from "
+               f"{click.style(str(len(collected_medias)), bold=True, fg='blue')} "
+               f"file{'s' if len(collected_medias) > 1 else ''}")

--- a/bd_to_avp/vendor/pgsrip/core.py
+++ b/bd_to_avp/vendor/pgsrip/core.py
@@ -1,0 +1,77 @@
+import logging
+import os
+import typing
+
+from bd_to_avp.vendor.pgsrip.media import Media, Pgs
+from bd_to_avp.vendor.pgsrip.mkv import Mkv
+from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.vendor.pgsrip.ripper import PgsToSrtRipper
+from bd_to_avp.vendor.pgsrip.sup import Sup
+
+
+logger = logging.getLogger(__name__)
+
+MEDIAS: typing.Dict[str, typing.Union[typing.Type[Sup], typing.Type[Mkv]]] = {
+    '.sup': Sup,
+    '.mkv': Mkv,
+    '.mks': Mkv
+}
+EXTENSIONS = tuple(MEDIAS.keys())
+
+
+def scan_path(path: str,
+              collected: typing.List[Media],
+              filtered_out: typing.List[str],
+              discarded: typing.List[str],
+              options: Options):
+    if not os.path.exists(path):
+        logger.debug('Non existent path %s discarded', path)
+        discarded.append(path)
+
+    elif os.path.isfile(path):
+        if path.lower().endswith(EXTENSIONS):
+            if path.lower().endswith(EXTENSIONS):
+                # noinspection PyBroadException
+                try:
+                    ext = os.path.splitext(path.lower())[1]
+                    media = MEDIAS[ext](path)
+                    if media.matches(options):
+                        collected.append(media)
+                    else:
+                        filtered_out.append(path)
+                except Exception as exc:
+                    logger.debug('Path %s discarded: <%s> %s', path, type(exc).__name__, exc)
+                    discarded.append(path)
+
+    elif os.path.isdir(path):
+        for dir_path, dir_names, file_names in os.walk(path):
+            for filename in file_names:
+                file_path = os.path.join(dir_path, filename)
+                scan_path(file_path, collected, filtered_out, discarded, options)
+
+
+def rip(media: Media, options: Options):
+    counter = 0
+    for pgs in media.get_pgs_medias(options):
+        counter += rip_pgs(pgs, options)
+
+    return counter
+
+
+def rip_pgs(pgs: Pgs, options: Options):
+    # noinspection PyBroadException
+    try:
+        with pgs as p:
+            if not p.matches(options):
+                return False
+
+            rules = options.config.select_rules(tags=options.tags, languages={p.language})
+            srt = PgsToSrtRipper(p, options).rip(lambda t: rules.apply(t, '')[0])
+            srt.save(encoding=options.encoding)
+            return True
+    except Exception as e:
+        logger.warning('Error while trying to rip %s: <%s> [%s]',
+                       pgs.media_path, type(e).__name__, e,
+                       exc_info=logger.isEnabledFor(logging.DEBUG))
+
+    return False

--- a/bd_to_avp/vendor/pgsrip/media.py
+++ b/bd_to_avp/vendor/pgsrip/media.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import typing
+from abc import ABC, abstractmethod
+from datetime import timedelta
+from types import TracebackType
+
+from babelfish import Language
+
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.vendor.pgsrip.pgs import DisplaySet, Palette, PgsImage, PgsReader
+from bd_to_avp.vendor.pgsrip.utils import pairwise
+
+logger = logging.getLogger(__name__)
+
+
+class PgsSubtitleItem:
+
+    def __init__(self,
+                 index: int,
+                 media_path: MediaPath,
+                 display_sets: typing.List[DisplaySet]):
+        self.index = index
+        self.media_path = media_path
+        self.start = min([ds.pcs.presentation_timestamp for ds in display_sets] or [None])
+        self.end = max([ds.pcs.presentation_timestamp for ds in display_sets] or [None])
+        self.image = PgsSubtitleItem.generate_image(display_sets)
+        self.x_offset = min([ds.wds.x_offset for ds in display_sets] or [None])
+        self.y_offset = min([ds.wds.y_offset for ds in display_sets] or [None])
+        self.text: typing.Optional[str] = None
+        self.place: typing.Optional[typing.Tuple[int, int, int, int]] = None
+
+    @staticmethod
+    def create_items(media_path: MediaPath, display_sets: typing.Iterable[DisplaySet]):
+        current_sets: typing.List[DisplaySet] = []
+        index = 0
+        candidates: typing.List[PgsSubtitleItem] = []
+        for ds in display_sets:
+            if current_sets and ds.is_start():
+                candidates.append(PgsSubtitleItem(index, media_path, current_sets))
+                current_sets = []
+                index += 1
+
+            current_sets.append(ds)
+
+        if current_sets:
+            candidates.append(PgsSubtitleItem(index, media_path, current_sets))
+
+        results = []
+        for item, next_item in pairwise(candidates):
+            if item.auto_fix(next_item=next_item):
+                results.append(item)
+
+        return results
+
+    @staticmethod
+    def generate_image(display_sets: typing.Iterable[DisplaySet]):
+        for ds in display_sets:
+            if not ds.pcs.is_start():
+                continue
+
+            palettes: typing.List[Palette] = []
+            for pds in ds.pds_segments:
+                palettes += pds.palettes
+            img_data = b''
+            for ods in ds.ods_segments:
+                img_data += ods.img_data
+
+            return PgsImage(img_data, palettes)
+
+    @property
+    def language(self):
+        return self.media_path.language
+
+    @property
+    def height(self):
+        return self.image.shape[0]
+
+    @property
+    def width(self):
+        return self.image.shape[1]
+
+    @property
+    def h_center(self):
+        shape = self.shape
+        return shape[0] + (shape[2] - shape[0]) // 2
+
+    @property
+    def shape(self):
+        height, width = self.height, self.width
+        y_offset, x_offset = self.y_offset, self.x_offset
+
+        return y_offset, x_offset, y_offset + height, x_offset + width
+
+    def auto_fix(self, next_item: typing.Optional[PgsSubtitleItem]):
+        valid = True
+        if self.image is None:
+            logger.warning('Corrupted %r: No Image', self)
+            valid = False
+        if self.y_offset is None:
+            logger.warning('Corrupted %r: No y_offset', self)
+            valid = False
+        if self.x_offset is None:
+            logger.warning('Corrupted %r: No x_offset', self)
+            valid = False
+        if self.start is None:
+            logger.warning('Corrupted %r: No Start timestamp', self)
+            valid = False
+        elif not self.end or self.end <= self.start:
+            if next_item and next_item.start and self.start + 10000 >= next_item.start:
+                self.end = max(self.start + 1, next_item.start - 1)
+                logger.info('Fix applied for %r: Subtitle end timestamp was fixed', self)
+            else:
+                logger.warning('Corrupted %r: Subtitle with corrupted end timestamp', self)
+                valid = False
+
+        return valid
+
+    def intersect(self, item: PgsSubtitleItem):
+        shape = self.shape
+
+        return shape[0] <= item.h_center <= shape[2]
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self}]>'
+
+    def __str__(self):
+        return f'{self.media_path} [{self.start} --> {self.end or ""}]'
+
+
+class Pgs:
+
+    def __init__(self,
+                 media_path: MediaPath,
+                 options: Options,
+                 data_reader: typing.Callable[[], bytes],
+                 temp_folder: str):
+        self.media_path = media_path
+        self.options = options
+        self.data_reader = data_reader
+        self.temp_folder = temp_folder
+        self._items: typing.Optional[typing.List[PgsSubtitleItem]] = None
+
+    @property
+    def language(self):
+        return self.media_path.language
+
+    @property
+    def srt_path(self):
+        return self.media_path.translate(number=0, extension='srt')
+
+    @property
+    def items(self):
+        if self._items is None:
+            data = self.data_reader()
+            self._items = self.decode(data, self.media_path)
+        return self._items
+
+    def matches(self, options: Options):
+        if not self.srt_path.exists():
+            return True
+
+        if not options.overwrite:
+            logger.debug('Skipping %s since %s already exists', self, self.srt_path)
+            return False
+        if options.srt_age and self.srt_path.m_age < options.srt_age:
+            logger.debug('Skipping since %s is too new', self.srt_path)
+            return False
+
+        return True
+
+    def decode(self, data: bytes, media_path: MediaPath):
+        display_sets = list(PgsReader.decode(data, media_path))
+        logger.info(f'Decoding {media_path}')
+
+        if self.options.keep_temp_files:
+            self.dump_display_sets(display_sets)
+
+        return PgsSubtitleItem.create_items(media_path, display_sets)
+
+    def dump_display_sets(self, display_sets: typing.List[DisplaySet]):
+        new_line = '\n'
+        with open(os.path.join(self.temp_folder, 'display-sets.txt'), mode='w', encoding='utf8') as f:
+            f.write(f'{new_line.join([str(ds) for ds in display_sets])}')
+        with open(os.path.join(self.temp_folder, 'display-sets.json'), mode='w', encoding='utf8') as f:
+            json.dump([ds.to_json() for ds in display_sets], f,
+                      indent=2, ensure_ascii=False, default=lambda x: str(x))
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self}]>'
+
+    def __str__(self):
+        return str(self.media_path)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self,
+                 exc_type: typing.Optional[typing.Type[BaseException]],
+                 exc: typing.Optional[BaseException],
+                 traceback: typing.Optional[TracebackType]):
+        self._items = None
+        if self.options.keep_temp_files:
+            logger.info('Keeping temporary files in %s', self.temp_folder)
+        else:
+            logger.debug('Removing temporary files in %s', self.temp_folder)
+            shutil.rmtree(self.temp_folder)
+
+
+class Media(ABC):
+
+    def __init__(self, media_path: MediaPath, languages: typing.Set[Language]):
+        self.name = str(media_path)
+        self.media_path = media_path
+        self.languages = languages
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self.media_path}]>'
+
+    def __str__(self):
+        return str(self.media_path)
+
+    @property
+    def age(self):
+        if self.media_path.exists():
+            return self.media_path.m_age
+
+        return timedelta()
+
+    def matches(self, options: Options):
+        if options.age and self.age > options.age:
+            return False
+
+        if options.languages and not self.languages.intersection(options.languages):
+            return False
+
+        return True
+
+    @abstractmethod
+    def get_pgs_medias(self, options: Options) -> typing.Iterable[Pgs]:
+        pass

--- a/bd_to_avp/vendor/pgsrip/media_path.py
+++ b/bd_to_avp/vendor/pgsrip/media_path.py
@@ -1,0 +1,61 @@
+import logging
+import os
+import tempfile
+import typing
+from copy import copy
+from datetime import datetime
+
+from babelfish import Language
+
+
+logger = logging.getLogger(__name__)
+
+
+class MediaPath:
+
+    def __init__(self, path: str):
+        file_part, extension = os.path.splitext(path)
+        base_path, code = os.path.splitext(file_part)
+        self.number = 0
+        self.language = Language.fromcleanit(code[1:] if code else 'und')
+        self.extension = extension[1:] if extension else None
+        self.base_path = base_path if self.language else file_part
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{str(self)}]>'
+
+    def __str__(self):
+        return f'{self.base_path}' \
+               f'{f"-{self.number}" if self.number else ""}' \
+               f'{f".{str(self.language)}" if self.language else ""}' \
+               f'{f".{self.extension}" if self.extension else ""}'
+
+    @property
+    def m_age(self):
+        return datetime.utcnow() - datetime.utcfromtimestamp(os.path.getmtime(str(self)))
+
+    def create_temp_folder(self):
+        base_name = os.path.basename(str(self))
+        temp_folder = tempfile.mkdtemp(prefix=base_name, suffix='.pgsrip')
+        logger.debug('%s is using temporary folder %s', self, temp_folder)
+        return temp_folder
+
+    def get_data(self):
+        with open(str(self), 'rb') as f:
+            return f.read()
+
+    def exists(self):
+        return os.path.exists(str(self))
+
+    def translate(self,
+                  language: typing.Optional[Language] = None,
+                  extension: typing.Optional[str] = None,
+                  number: typing.Optional[int] = None):
+        media_path = copy(self)
+        if number is not None:
+            media_path.number = number
+        if language is not None:
+            media_path.language = language
+        if extension is not None:
+            media_path.extension = extension
+        return media_path

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -1,0 +1,110 @@
+import json
+import logging
+import os
+import typing
+from subprocess import check_output
+
+from babelfish import Language
+
+from trakit.api import trakit
+
+from bd_to_avp.vendor.pgsrip.media import Media, Pgs
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.options import Options
+
+logger = logging.getLogger(__name__)
+
+
+class MkvPgs(Pgs):
+
+    @classmethod
+    def read_data(cls, media_path: MediaPath, track_id: int, temp_folder: str):
+        lang_ext = f'.{str(media_path.language)}' if media_path.language else ''
+        sup_file = os.path.join(temp_folder, f'{track_id}{lang_ext}.sup')
+        cmd = ['mkvextract', str(media_path), 'tracks', f'{track_id}:{sup_file}']
+        check_output(cmd)
+        with open(sup_file, mode='rb') as f:
+            return f.read()
+
+    def __init__(self, media_path: MediaPath, track_id: int, language: Language, number: int, options: Options):
+        temp_folder = media_path.create_temp_folder()
+        super().__init__(media_path=media_path.translate(language=language, number=number),
+                         options=options,
+                         data_reader=lambda: self.read_data(
+                             media_path=media_path, track_id=track_id, temp_folder=temp_folder),
+                         temp_folder=temp_folder)
+        self.track_id = track_id
+
+    def __str__(self):
+        return (f'{self.media_path.translate(language=Language("und"), number=0)} '
+                f'[{self.track_id}:{self.media_path.language}]')
+
+
+class MkvTrack:
+
+    def __init__(self, track: dict):
+        self.id = track['id']
+        self.type = track['type']
+        self.codec = track['codec']
+        self.properties = track.get('properties', {})
+
+    @property
+    def enabled(self):
+        return self.properties.get('enabled_track')
+
+    @property
+    def language(self):
+        lang_ietf = self.properties.get('language_ietf')
+        lang_alpha = self.properties.get('language')
+        track_name = self.properties.get('track_name')
+
+        language = Language.fromcleanit(lang_ietf or lang_alpha or 'und')
+        options = {'expected_language': language} if language else {}
+        guess = trakit(track_name, options) if track_name else {}
+
+        return guess.get('language') or language
+
+    @property
+    def forced(self):
+        return self.properties.get('forced_track')
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{str(self)}]>'
+
+    def __str__(self):
+        return f'{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}'
+
+
+class Mkv(Media):
+
+    def __init__(self, path: str):
+        metadata = json.loads(check_output(['mkvmerge', '-i', '-F', 'json', path]))
+        tracks = [MkvTrack(t) for t in metadata.get('tracks', [])]
+        super().__init__(MediaPath(path), languages={t.language for t in tracks})
+        self.tracks = tracks
+
+    def get_pgs_medias(self, options: Options):
+        tracks = [t for t in self.tracks
+                  if t.type == 'subtitles' and t.codec == 'HDMV PGS' and t.enabled]
+        tracks.sort(key=lambda x: x.forced)
+        tracks.sort(key=lambda x: x.id)
+        selected_languages: typing.Dict[Language, int] = {}
+        for t in tracks:
+            language = t.language
+            if options.languages and language not in options.languages:
+                logger.debug('Filtering out track %s:%s in %s', t.id, language, self)
+                continue
+
+            if options.one_per_lang and language in selected_languages:
+                logger.debug('Skipping track %s:%s in %s', t.id, language, self)
+                continue
+
+            if not language:
+                logger.debug('Skipping unknown language track %s in %s', t.id, self)
+                continue
+
+            pgs = MkvPgs(self.media_path, t.id, language, selected_languages.get(language, 0), options=options)
+            if pgs.matches(options):
+                logger.debug('Selecting track %s:%s in %s', t.id, language, self)
+                yield pgs
+                selected_languages[language] = selected_languages.get(language, 0) + 1

--- a/bd_to_avp/vendor/pgsrip/options.py
+++ b/bd_to_avp/vendor/pgsrip/options.py
@@ -1,0 +1,84 @@
+import enum
+import typing
+from datetime import timedelta
+
+from babelfish import Language
+
+from cleanit import Config
+
+
+@enum.unique
+class TesseractEngineMode(enum.Enum):
+    LEGACY = 0
+    NEURAL = 1
+    LEGACY_AND_NEURAL = 2
+    DEFAULT_AVAILABLE = 3
+
+
+@enum.unique
+class TesseractPageSegmentationMode(enum.Enum):
+    OSD_ONLY = 0
+    AUTOMATIC_PAGE_SEGMENTATION_WITH_OSD = 1
+    AUTOMATIC_PAGE_SEGMENTATION_WITHOUT_OSD_OR_OCR = 2
+    FULLY_AUTOMATIC_PAGE_SEGMENTATION_WITHOUT_OSD = 3
+    SINGLE_COLUMN_OF_TEXT_OF_VARIABLE_SIZES = 4
+    SINGLE_UNIFORM_BLOCK_OF_VERTICALLY_ALIGNED_TEXT = 5
+    SINGLE_UNIFORM_BLOCK_OF_TEXT = 6
+    SINGLE_TEXT_LINE = 7
+    SINGLE_WORD = 8
+    SINGLE_WORD_IN_CIRCLE = 9
+    SINGLE_CHARACTER = 10
+    SPARSE_TEXT = 11
+    SPARSE_TEXT_WITH_OSD = 12
+    RAW_LINE = 13
+
+
+class Options:
+
+    def __init__(self,
+                 config_path: typing.Optional[str] = None,
+                 languages: typing.Optional[typing.Set[Language]] = None,
+                 tags: typing.Optional[typing.Set[str]] = None,
+                 encoding: typing.Optional[str] = None,
+                 overwrite=False,
+                 one_per_lang=True,
+                 keep_temp_files=False,
+                 max_workers: typing.Optional[int] = None,
+                 confidence: typing.Optional[int] = None,
+                 tesseract_width: typing.Optional[int] = None,
+                 tesseract_oem: typing.Optional[TesseractEngineMode] = None,
+                 tesseract_psm: typing.Optional[TesseractPageSegmentationMode] = None,
+                 age: typing.Optional[timedelta] = None,
+                 srt_age: typing.Optional[timedelta] = None):
+        self.config = Config.from_path(config_path) if config_path else Config()
+        self.languages = languages or set()
+        self.tags = tags or {'default'}
+        self.encoding = encoding
+        self.overwrite = overwrite
+        self.one_per_lang = one_per_lang
+        self.keep_temp_files = keep_temp_files
+        self.max_workers = max_workers
+        self.confidence = confidence
+        self.tesseract_width = tesseract_width
+        self.tesseract_oem = tesseract_oem
+        self.tesseract_psm = tesseract_psm
+        self.age = age
+        self.srt_age = srt_age
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self}]>'
+
+    def __str__(self):
+        return (f'languages:{self.languages}, '
+                f'tags:{self.tags}, '
+                f'encoding:{self.encoding}, '
+                f'overwrite:{self.overwrite}, '
+                f'one_per_lang:{self.one_per_lang}, '
+                f'keep_temp_files:{self.keep_temp_files}, '
+                f'max_workers:{self.max_workers}, '
+                f'confidence:{self.confidence}, '
+                f'tesseract_width:{self.tesseract_width}, '
+                f'tesseract_oem:{self.tesseract_oem}, '
+                f'tesseract_psm:{self.tesseract_psm}, '
+                f'age:{self.age}, '
+                f'srt_age:{self.srt_age}')

--- a/bd_to_avp/vendor/pgsrip/pgs.py
+++ b/bd_to_avp/vendor/pgsrip/pgs.py
@@ -1,0 +1,454 @@
+import enum
+import logging
+import typing
+
+import cv2
+
+import numpy as np
+from numpy import ndarray
+
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.utils import from_hex, safe_get, to_time
+
+logger = logging.getLogger(__name__)
+
+
+@enum.unique
+class SegmentType(enum.Enum):
+    PDS = int('0x14', 16)
+    ODS = int('0x15', 16)
+    PCS = int('0x16', 16)
+    WDS = int('0x17', 16)
+    END = int('0x80', 16)
+
+
+@enum.unique
+class CompositionState(enum.Enum):
+    NORMAL_CASE = from_hex(b'\x00')
+    ACQUISITION_POINT = from_hex(b'\x40')
+    EPOCH_START = from_hex(b'\x80')
+
+
+@enum.unique
+class ObjectSequenceType(enum.Enum):
+    LAST = from_hex(b'\x40')
+    FIRST = from_hex(b'\x80')
+    FIRST_AND_LAST = from_hex(b'\xc0')
+
+
+class Palette(typing.NamedTuple):
+    y: int
+    cr: int
+    cb: int
+    alpha: int
+
+
+class PgsReader:
+
+    @classmethod
+    def read_segments(cls, data: bytes, media_path: MediaPath):
+        count = 0
+        b = data
+        while b:
+            if b[:2] != b'PG':
+                logger.warning('%s Ignoring invalid PGS segment data: %s', media_path, b)
+                break
+
+            if len(b) < 13:
+                logger.warning('%s Ignoring invalid PGS segment data with less than 13 bytes: %s', media_path, b)
+                break
+
+            segment_type = SEGMENT_TYPE[SegmentType(b[10])]
+            size = 13 + from_hex(b[11:13])
+            yield segment_type(b[:size])
+            count += size
+            b = b[size:]
+
+    @classmethod
+    def decode(cls, data: bytes, media_path: MediaPath):
+        segments: typing.List[BaseSegment] = []
+        index = 0
+        for s in cls.read_segments(data, media_path):
+            segments.append(s)
+            if s.type == SegmentType.END:
+                yield DisplaySet(index, segments)
+                segments = []
+                index += 1
+
+
+class PgsImage:
+
+    def __init__(self, data: bytes, palettes: typing.List[Palette]):
+        self.rle_data = data
+        self.palettes = palettes
+        self._data: typing.Optional[ndarray] = None
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._data = self.decode_rle_image(self.rle_data, self.palettes)
+        return self._data
+
+    @classmethod
+    def decode_rle_image(cls, data: bytes, palettes: typing.List[Palette], binary=True):
+        image_array: typing.List[int] = []
+        alpha_array: typing.List[int] = []
+        dimension = 1 if binary else 3
+        cols = 1
+        i = 0
+        while i < len(data):
+            length, color, count = cls.decode_rle_position(data, i)
+            if not length and cols < 2:
+                cols = len(image_array) // dimension
+            palette = palettes[color]
+            image_color = cls.get_color(palette, binary)
+            image_array.extend(image_color * length)
+            if not binary:
+                alpha_array.extend([palette[3]] * length)
+            i += count
+
+        rows = (len(image_array) // dimension + cols - 1) // cols
+        if cols * rows * dimension != len(image_array):
+            # corrupted image
+            delta = cols * rows * dimension - len(image_array)
+            image_array.extend((cls.get_color(palettes[0], binary) * dimension) * delta)
+
+        img = np.array(image_array, dtype=np.uint8).reshape((rows, cols) if binary else (rows, cols, dimension))
+        if binary:
+            return img
+
+        image = cv2.cvtColor(img, cv2.COLOR_YCR_CB2BGR)
+        a_channel = np.array(alpha_array, dtype=np.uint8).reshape(rows, cols)
+        b_channel, g_channel, r_channel = cv2.split(image)
+        image = cv2.merge((b_channel, g_channel, r_channel, a_channel))
+        return image
+
+    @classmethod
+    def get_color(cls, palette: Palette, binary: bool):
+        return ([0] if palette[0] > 127 else [255]) if binary else palette[:3]
+
+    @classmethod
+    def decode_rle_position(cls, data: bytes, i: int):
+        first = safe_get(data, i)
+        if first:
+            return 1, first, 1
+
+        second = safe_get(data, i + 1)
+        if second < 64:
+            return second, 0, 2
+
+        third = safe_get(data, i + 2)
+        if second < 128:
+            return ((second - 64) << 8) + third, 0, 3
+        elif second < 192:
+            return second - 128, third, 3
+
+        fourth = safe_get(data, i + 3)
+        return ((second - 192) << 8) + third, fourth, 4
+
+    @property
+    def shape(self):
+        return self.data.shape
+
+
+class BaseSegment:
+
+    def __init__(self, b: bytes):
+        self.bytes = b
+
+    @property
+    def presentation_timestamp(self):
+        return to_time(from_hex(self.bytes[2:6]) / 90)
+
+    @property
+    def decoding_timestamp(self):
+        return to_time(from_hex(self.bytes[6:10]) / 90)
+
+    @property
+    def type(self):
+        return SegmentType(self.bytes[10])
+
+    @property
+    def size(self):
+        return from_hex(self.bytes[11:13])
+
+    @property
+    def data(self):
+        return self.bytes[13:]
+
+    def to_json(self):
+        attributes = {
+            'type': 'type',
+            'pts': 'presentation_timestamp',
+            'dts': 'decoding_timestamp',
+            'size': 'size',
+            **self.attributes()
+        }
+
+        def to_value(v: typing.Any):
+            return v.name if isinstance(v, enum.Enum) else v
+
+        return {
+            k: to_value(getattr(self, v)) for k, v in attributes.items() if getattr(self, v) is not None
+        }
+
+    def attributes(self):
+        raise NotImplementedError
+
+    def __len__(self):
+        return self.size
+
+    def __bool__(self):
+        return True
+
+    def __str__(self):
+        strings = []
+        for k, v in self.to_json().items():
+            if v is not None:
+                strings.append(f'{k}={v}')
+
+        return ', '.join(strings)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}: [{self}]>'
+
+
+class PresentationCompositionSegment(BaseSegment):
+
+    @property
+    def width(self):
+        return from_hex(self.data[0:2])
+
+    @property
+    def height(self):
+        return from_hex(self.data[2:4])
+
+    @property
+    def frame_rate(self):
+        return self.data[4]
+
+    @property
+    def composition_number(self):
+        return from_hex(self.data[5:7])
+
+    @property
+    def composition_state(self):
+        return CompositionState(self.data[7])
+
+    @property
+    def palette_update(self):
+        return bool(self.data[8])
+
+    @property
+    def palette_id(self):
+        return self.data[9]
+
+    @property
+    def number_composition_objects(self):
+        return self.data[10]
+
+    def attributes(self):
+        return {
+            'width': 'width',
+            'height': 'height',
+            'frame_rate': 'frame_rate',
+            'number': 'composition_number',
+            'state': 'composition_state',
+            'palette_update': 'palette_update',
+            'palette_id': 'palette_id',
+            'num_objects': 'number_composition_objects'
+        }
+
+    def is_start(self):
+        return self.composition_state in (CompositionState.EPOCH_START, CompositionState.ACQUISITION_POINT)
+
+
+class WindowDefinitionSegment(BaseSegment):
+
+    @property
+    def num_windows(self):
+        return self.data[0]
+
+    @property
+    def window_id(self):
+        return self.data[1]
+
+    @property
+    def x_offset(self):
+        return from_hex(self.data[2:4])
+
+    @property
+    def y_offset(self):
+        return from_hex(self.data[4:6])
+
+    @property
+    def width(self):
+        return from_hex(self.data[6:8])
+
+    @property
+    def height(self):
+        return from_hex(self.data[8:10])
+
+    def attributes(self):
+        return {
+            'num_windows': 'num_windows',
+            'window_id': 'window_id',
+            'x_offset': 'x_offset',
+            'y_offset': 'y_offset',
+            'width': 'width',
+            'height': 'height'
+        }
+
+
+class PaletteDefinitionSegment(BaseSegment):
+
+    def __init__(self, b: bytes):
+        super().__init__(b)
+        self.palettes = [Palette(0, 0, 0, 0)] * 256
+        # Slice from byte 2 til end of segment. Divide by 5 to determine number of palette entries
+        # Iterate entries. Explode the 5 bytes into namedtuple Palette. Must be exploded
+        for entry in range(len(self.data[2:]) // 5):
+            i = 2 + entry * 5
+            self.palettes[self.data[i]] = Palette(*self.data[i + 1:i + 5])
+
+    @property
+    def palette_id(self):
+        return self.data[0]
+
+    @property
+    def version(self):
+        return self.data[1]
+
+    def attributes(self):
+        return {
+            'palette_id': 'palette_id',
+            'version': 'version'
+        }
+
+
+class ObjectDefinitionSegment(BaseSegment):
+
+    @property
+    def id(self):
+        return from_hex(self.data[0:2])
+
+    @property
+    def version(self):
+        return self.data[2]
+
+    @property
+    def sequence_type(self):
+        return ObjectSequenceType(self.data[3])
+
+    @property
+    def data_len(self):
+        if self.sequence_type != ObjectSequenceType.LAST:
+            return from_hex(self.data[4:7])
+
+    @property
+    def width(self):
+        if self.sequence_type != ObjectSequenceType.LAST:
+            return from_hex(self.data[7:9])
+
+    @property
+    def height(self):
+        if self.sequence_type != ObjectSequenceType.LAST:
+            return from_hex(self.data[9:11])
+
+    @property
+    def img_data(self):
+        if self.sequence_type == ObjectSequenceType.LAST:
+            return self.data[4:]
+
+        return self.data[11:]
+
+    def attributes(self):
+        return {
+            'id': 'id',
+            'version': 'version',
+            'sequence_type': 'sequence_type',
+            'data_len': 'data_len',
+            'width': 'width',
+            'height': 'height'
+        }
+
+
+class EndSegment(BaseSegment):
+
+    def attributes(self):
+        return {}
+
+
+SEGMENT_TYPE = {
+    SegmentType.PDS: PaletteDefinitionSegment,
+    SegmentType.ODS: ObjectDefinitionSegment,
+    SegmentType.PCS: PresentationCompositionSegment,
+    SegmentType.WDS: WindowDefinitionSegment,
+    SegmentType.END: EndSegment
+}
+
+
+class DisplaySet:
+
+    def __init__(self, index: int, segments: typing.List[BaseSegment]):
+        self.index = index
+        self.segments = segments
+
+    @property
+    def pcs(self):
+        return [s for s in self.segments if isinstance(s, PresentationCompositionSegment)][0]
+
+    @property
+    def wds(self):
+        return [s for s in self.segments if isinstance(s, WindowDefinitionSegment)][0]
+
+    @property
+    def pds_segments(self):
+        return [s for s in self.segments if isinstance(s, PaletteDefinitionSegment)]
+
+    @property
+    def ods_segments(self):
+        return [s for s in self.segments if isinstance(s, ObjectDefinitionSegment)]
+
+    @property
+    def end(self):
+        return [s for s in self.segments if isinstance(s, EndSegment)][0]
+
+    def is_start(self):
+        return self.pcs.is_start()
+
+    def is_valid(self):
+        valid = True
+        counts: typing.Dict[SegmentType, int] = {}
+        for s in self.segments:
+            counts[s.type] = counts.get(s.type, 0) + 1
+            if (isinstance(s, PresentationCompositionSegment)
+                    and s.composition_state == CompositionState.ACQUISITION_POINT):
+                logger.warning('ACQUISITION_POINT found %s, %r', s, self)
+
+        for t in (SegmentType.PCS, SegmentType.WDS, SegmentType.END):
+            count = counts.get(t)
+            if not count:
+                logger.warning('No %s found for %r', t, self)
+                valid = False
+            elif count > 1:
+                logger.warning('Multiple %s found for %r', t, self)
+                valid = False
+
+        return valid
+
+    def to_json(self):
+        return {
+            'index': self.index,
+            'segments': [s.to_json() for s in self.segments]
+        }
+
+    def __str__(self):
+        strings = [f'DS[{self.index}]']
+        for s in self.segments:
+            strings.append(f'\t{s}')
+
+        return '\n'.join(strings)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}: {self}]>'

--- a/bd_to_avp/vendor/pgsrip/ripper.py
+++ b/bd_to_avp/vendor/pgsrip/ripper.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import typing
+
+import cv2
+
+import numpy as np
+
+from pysrt import SubRipFile, SubRipItem
+
+import pytesseract as tess
+
+from bd_to_avp.vendor.pgsrip.media import Pgs, PgsSubtitleItem
+from bd_to_avp.vendor.pgsrip.options import Options, TesseractEngineMode, TesseractPageSegmentationMode
+from bd_to_avp.vendor.pgsrip.tsv import TsvData
+
+
+logger = logging.getLogger(__name__)
+
+
+class ImageArea:
+
+    def __init__(self, items: typing.List[PgsSubtitleItem], gap: typing.Tuple[int, int]):
+        self.gap = gap
+        self.width = sum([(item.shape[3] - item.shape[1]) for item in items]) + (len(items) - 1) * gap[1]
+        self.shape = (
+            min([item.shape[0] for item in items]), items[0].shape[1],
+            max([item.shape[2] for item in items]), min([item.shape[1] for item in items]) + self.width)
+        self.items = items
+
+    def __str__(self):
+        return str(self.shape)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self}]>'
+
+    @property
+    def height(self):
+        return self.shape[2] - self.shape[0]
+
+    def create_area_image(self, start: typing.Tuple[int, int]):
+        area_image = np.full((self.height, self.width), 255, dtype=np.uint8)
+
+        current_width = 0
+        for item in self.items:
+            h_start, w_start, h_end, w_end = self.get_shape(item, current_width=current_width)
+            item.place = (
+                start[0] + h_start, start[1] + w_start,
+                start[0] + h_end, start[1] + w_end
+            )
+            area_image[h_start:h_end, w_start:w_end] = item.image.data
+            current_width += item.width + self.gap[1]
+
+        return area_image
+
+    def get_shape(self, item: PgsSubtitleItem, current_width=0, full_shape=False):
+        start_y = 0
+        start_x = current_width
+        h_start = start_y + ((item.shape[0] - self.shape[0]) if not full_shape else 0)
+        w_start = start_x
+        h_end = h_start + (item.image.shape[0] if not full_shape else self.height)
+        w_end = w_start + (item.image.shape[1] if not full_shape else self.width)
+
+        return h_start, w_start, h_end, w_end
+
+
+class FullImage:
+
+    def __init__(self, areas: typing.List[ImageArea], gap: typing.Tuple[int, int]):
+        border = 100
+        total_height = sum([area.height for area in areas]) + (len(areas) - 1) * gap[0] + 2 * border
+        total_width = max([area.width for area in areas]) + 2 * border
+        full_image = np.full((total_height, total_width), 255, dtype=np.uint8)
+        h_start = border
+        w_start = border
+        for area in areas:
+            h_end = h_start + area.height
+            w_end = w_start + area.width
+            full_image[h_start:h_end, w_start:w_end] = area.create_area_image((h_start, w_start))
+            h_start = h_end + gap[0]
+
+        self.data = full_image
+
+    @classmethod
+    def from_items(cls, items: typing.List[PgsSubtitleItem], gap: typing.Tuple[int, int], max_width: int):
+        areas: typing.List[ImageArea] = []
+        remaining = list(items)
+        remaining.sort(key=lambda x: x.height)
+        while len(remaining) > 0:
+            first_item = remaining.pop(0)
+            area_items = [first_item] + [item for item in remaining if item.intersect(first_item)]
+            remaining = [item for item in remaining if not item.intersect(first_item)]
+            current_items: typing.List[PgsSubtitleItem] = []
+            current_width = 0
+            for area_item in area_items:
+                current_width += area_item.width + gap[1]
+                if current_width > max_width:
+                    areas.append(ImageArea(current_items, gap))
+                    current_width = area_item.width
+                    current_items = [area_item]
+                else:
+                    current_items.append(area_item)
+
+            if len(current_items) > 0:
+                areas.append(ImageArea(current_items, gap))
+
+        return FullImage(areas, gap)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{self}]>'
+
+    def __str__(self):
+        return f'{self.data.shape}]'
+
+
+class PgsToSrtRipper:
+
+    def __init__(self, pgs: Pgs, options: Options):
+        self.pgs = pgs
+        self.confidence = min(max(options.confidence or 65, 0), 100)
+        self.max_tess_width = min(max(options.tesseract_width or 31 * 1024, 10 * 1024), 31 * 1024)
+        self.omp_thread_limit = options.max_workers
+        self.oem = options.tesseract_oem or TesseractEngineMode.NEURAL
+        self.psm = options.tesseract_psm or TesseractPageSegmentationMode.SINGLE_UNIFORM_BLOCK_OF_TEXT
+        max_height = max([item.height for item in self.pgs.items]) // 2
+        self.gap = (max_height // 2 + 30, max_height // 2 + 100)
+        self.keep_temp_files = options.keep_temp_files
+
+    def process(self,
+                subs: SubRipFile,
+                items: typing.List[PgsSubtitleItem],
+                post_process,
+                confidence: int,
+                max_width: int,
+                oem: TesseractEngineMode,
+                psm: TesseractPageSegmentationMode):
+        full_image = FullImage.from_items(items, self.gap, max_width)
+
+        config = {
+            'output_type': tess.Output.DICT,
+            'config': f'--psm {psm.value} --oem {oem.value}'
+        }
+
+        if self.pgs.language:
+            config.update({'lang': self.pgs.language.alpha3})
+
+        if self.omp_thread_limit:
+            os.environ['OMP_THREAD_LIMIT'] = str(self.omp_thread_limit)
+        if self.keep_temp_files:
+            png_file = os.path.join(self.pgs.temp_folder,
+                                    f'{os.path.basename(subs.path)}-{len(items)}'
+                                    f'-psm{psm.value}-{oem.name}-{confidence}.png')
+            logger.debug('Writing temporary png file %s', png_file)
+            cv2.imwrite(png_file, full_image.data)
+
+        data = TsvData(tess.image_to_data(full_image.data, **config), confidence=confidence)
+
+        if self.keep_temp_files:
+            results_file = os.path.join(self.pgs.temp_folder,
+                                        f'{os.path.basename(subs.path)}-{len(items)}-{confidence}.json')
+            logger.debug('Writing temporary results file %s', results_file)
+            with open(results_file, mode='w', encoding='utf8') as f:
+                json.dump([i.__dict__ for i in data.items], f, indent=2, ensure_ascii=False)
+
+        remaining = []
+        for item in items:
+            text = self.accept(data, item, confidence)
+            if text is None:
+                remaining.append(item)
+                continue
+
+            text = item.text
+            if post_process:
+                text = post_process(text)
+            if text:
+                item = SubRipItem(0, item.start, item.end, text)
+                subs.append(item)
+
+        return remaining
+
+    @classmethod
+    def accept(cls, data: TsvData, item: PgsSubtitleItem, confidence: int):
+        rows = data.select(item.place) if item.place else []
+        lines = []
+        words = []
+        last_row = None
+        for row in rows:
+            if row.conf < confidence:
+                if not data.has_word(row.text):
+                    return None
+
+            if last_row is not None and (last_row.page_num < row.page_num
+                                         or last_row.block_num < row.block_num
+                                         or last_row.par_num < row.par_num
+                                         or last_row.line_num < row.line_num) \
+                    and len(words) > 0:
+                lines.append(' '.join(words))
+                words.clear()
+            words.append(row.text)
+            last_row = row
+
+        if len(words) > 0:
+            lines.append(' '.join(words))
+            words.clear()
+
+        item.text = '\n'.join(lines).strip()
+        return item.text
+
+    def rip(self, post_process: typing.Callable[[str], str]):
+        subs = SubRipFile(path=str(self.pgs.media_path.translate(extension='srt')))
+        oem, psm, confidence, max_width = self.oem, self.psm, self.confidence, self.max_tess_width
+        items = self.pgs.items
+        previous_size = len(items)
+        while previous_size > 0:
+            items = self.process(subs, items, post_process, confidence, max_width, oem, psm)
+            if not items:
+                break
+
+            current_size = len(items)
+            if current_size < 20:
+                max_width = min(sum([item.width + self.gap[1] for item in items]), self.max_tess_width)
+                confidence = 0
+                remaining_items = self.process(subs, items, post_process, confidence, max_width, oem, psm)
+                if remaining_items:
+                    logger.warning('Subtitles were not ripped: %r', remaining_items)
+                break
+            elif current_size > previous_size * 0.8:
+                max_width = min(sum([item.width + self.gap[1] for item in items]), self.max_tess_width) // 2
+                confidence = max(0, confidence - 5)
+            previous_size = current_size
+
+        subs.clean_indexes()
+
+        return subs

--- a/bd_to_avp/vendor/pgsrip/sup.py
+++ b/bd_to_avp/vendor/pgsrip/sup.py
@@ -1,0 +1,21 @@
+import logging
+from typing import Iterable
+
+from bd_to_avp.vendor.pgsrip.media import Media, Pgs
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.options import Options
+
+logger = logging.getLogger(__name__)
+
+
+class Sup(Media):
+
+    def __init__(self, path: str):
+        media_path = MediaPath(path)
+        super().__init__(media_path, languages={media_path.language})
+
+    def get_pgs_medias(self, options: Options) -> Iterable[Pgs]:
+        temp_folder = self.media_path.create_temp_folder()
+        pgs = Pgs(self.media_path, options=options, data_reader=self.media_path.get_data, temp_folder=temp_folder)
+        if pgs.matches(options):
+            yield pgs

--- a/bd_to_avp/vendor/pgsrip/tsv.py
+++ b/bd_to_avp/vendor/pgsrip/tsv.py
@@ -1,0 +1,58 @@
+import typing
+
+
+class TsvDataItem:
+
+    def __init__(self, level, page_num, block_num, par_num, line_num, word_num, left, top, width, height, conf, text):
+        self.level = int(level)
+        self.page_num = int(page_num)
+        self.block_num = int(block_num)
+        self.par_num = int(par_num)
+        self.line_num = int(line_num)
+        self.word_num = int(word_num)
+        self.left = int(left)
+        self.top = int(top)
+        self.width = int(width)
+        self.height = int(height)
+        self.conf = int(float(conf))  # cast to float first to handle strings passed by pytesseract<0.3.10
+        self.text = text
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} [{str(self)}]>'
+
+    def __str__(self):
+        return f'{(self.top, self.left)}{self.text}'
+
+    @property
+    def h_center(self):
+        return self.top + self.height // 2
+
+    @property
+    def w_center(self):
+        return self.left + self.width // 2
+
+    def matches(self, shape: typing.Tuple[int, int, int, int]):
+        h_start, w_start, h_end, w_end = shape
+        return h_start <= self.h_center <= h_end and w_start <= self.w_center <= w_end
+
+
+class TsvData:
+
+    def __init__(self, data: dict, confidence: int):
+        self.confidence = confidence
+        keys = data.keys()
+        items = [TsvDataItem(**{k: values[i] for (i, k) in enumerate(keys)}) for values in (
+            zip(*[data[key] for key in keys]))]
+        items.sort(key=lambda x: x.word_num)
+        items.sort(key=lambda x: x.line_num)
+        items.sort(key=lambda x: x.par_num)
+        items.sort(key=lambda x: x.block_num)
+        items.sort(key=lambda x: x.page_num)
+        self.items = items
+        self.words = {item.text for item in items if item.text and item.conf >= confidence}
+
+    def select(self, shape: typing.Tuple[int, int, int, int]):
+        return [item for item in self.items if item.level == 5 and item.matches(shape)]
+
+    def has_word(self, word: str):
+        return word in self.words

--- a/bd_to_avp/vendor/pgsrip/utils.py
+++ b/bd_to_avp/vendor/pgsrip/utils.py
@@ -1,0 +1,33 @@
+import typing
+
+from pysrt import SubRipTime
+
+
+def from_hex(b: bytes):
+    return int(b.hex(), base=16)
+
+
+def safe_get(b: bytes, i: int, default_value=0):
+    try:
+        return b[i]
+    except IndexError:
+        return default_value
+
+
+def to_time(value: typing.Optional[int]):
+    return SubRipTime.from_ordinal(value) if value else None
+
+
+T = typing.TypeVar('T')
+
+
+def pairwise(iterable: typing.Iterable[T]) -> typing.Iterable[typing.Tuple[T, typing.Optional[T]]]:
+    """s -> (s0, s1), (s1, s2), (s2, s3), (s2, None)"""
+    it = iter(iterable)
+    a = next(it, None)
+    if a is not None:
+        for b in it:
+            yield a, b
+            a = b
+
+        yield a, None

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 files = bd_to_avp
+exclude = ^bd_to_avp/vendor/pgsrip/
 
 [mypy-ffmpeg]
 ignore_missing_imports = True
@@ -7,5 +8,8 @@ ignore_missing_imports = True
 [mypy-babelfish]
 ignore_missing_imports = True
 
-[mypy-pgsrip]
-ignore_missing_imports = True
+[mypy-bd_to_avp.vendor.pgsrip]
+ignore_errors = True
+
+[mypy-bd_to_avp.vendor.pgsrip.*]
+ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,20 @@ authors = [
 keywords = ["Blu-ray", "3D", "Apple Vision Pro", "MV-HEVC", "Conversion", "Vision Pro", "BD3D"]
 dependencies = [
     "babelfish>=0.6.1,<0.7",
+    "cleanit>=0.4.8,<0.5",
+    "click>=8.1.3,<9",
     "ffmpeg-python>=0.2.0,<0.3",
     "humanize>=4.9.0,<5",
+    "numpy>=2,<3",
     "opencv-python==4.10.0.84",
     "packaging>=24.1,<27",
-    "pgsrip==0.1.11",
     "psutil>=5.9.8,<8",
     "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
+    "pysrt>=1.1.2,<2",
+    "pytesseract>=0.3.10,<0.4",
     "requests>=2.32.3,<3",
-    "setuptools>=70.3.0,<71",
+    "trakit>=0.2.2,<0.3",
     "wakepy>=0.9.1,<1.1",
 ]
 
@@ -81,16 +85,20 @@ copyright = "Shiny Computers 2024"
 sources = ["bd_to_avp", "pyproject.toml", "README.md"]
 requires = [
     "babelfish>=0.6.1,<0.7",
+    "cleanit>=0.4.8,<0.5",
+    "click>=8.1.3,<9",
     "ffmpeg-python>=0.2.0,<0.3",
     "humanize>=4.9.0,<5",
+    "numpy>=2,<3",
     "opencv-python==4.10.0.84",
     "packaging>=24.1,<27",
-    "pgsrip==0.1.11",
     "psutil>=5.9.8,<8",
     "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
+    "pysrt>=1.1.2,<2",
+    "pytesseract>=0.3.10,<0.4",
     "requests>=2.32.3,<3",
-    "setuptools>=70.3.0,<71",
+    "trakit>=0.2.2,<0.3",
     "wakepy>=0.9.1,<1.1",
 ]
 
@@ -100,6 +108,7 @@ universal_build = false
 [tool.ruff]
 line-length = 120
 target-version = "py312"
+extend-exclude = ["bd_to_avp/vendor/pgsrip"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "RUF"]

--- a/uv.lock
+++ b/uv.lock
@@ -91,16 +91,20 @@ version = "0.2.141"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },
+    { name = "cleanit" },
+    { name = "click" },
     { name = "ffmpeg-python" },
     { name = "humanize" },
+    { name = "numpy" },
     { name = "opencv-python" },
     { name = "packaging" },
-    { name = "pgsrip" },
     { name = "psutil" },
     { name = "pygithub" },
     { name = "pyside6" },
+    { name = "pysrt" },
+    { name = "pytesseract" },
     { name = "requests" },
-    { name = "setuptools" },
+    { name = "trakit" },
     { name = "wakepy" },
 ]
 
@@ -117,16 +121,20 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "babelfish", specifier = ">=0.6.1,<0.7" },
+    { name = "cleanit", specifier = ">=0.4.8,<0.5" },
+    { name = "click", specifier = ">=8.1.3,<9" },
     { name = "ffmpeg-python", specifier = ">=0.2.0,<0.3" },
     { name = "humanize", specifier = ">=4.9.0,<5" },
+    { name = "numpy", specifier = ">=2,<3" },
     { name = "opencv-python", specifier = "==4.10.0.84" },
     { name = "packaging", specifier = ">=24.1,<27" },
-    { name = "pgsrip", specifier = "==0.1.11" },
     { name = "psutil", specifier = ">=5.9.8,<8" },
     { name = "pygithub", specifier = ">=2.3.0,<3" },
     { name = "pyside6", specifier = ">=6.7.1,<7" },
+    { name = "pysrt", specifier = ">=1.1.2,<2" },
+    { name = "pytesseract", specifier = ">=0.3.10,<0.4" },
     { name = "requests", specifier = ">=2.32.3,<3" },
-    { name = "setuptools", specifier = ">=70.3.0,<71" },
+    { name = "trakit", specifier = ">=0.2.2,<0.3" },
     { name = "wakepy", specifier = ">=0.9.1,<1.1" },
 ]
 
@@ -705,26 +713,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pgsrip"
-version = "0.1.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babelfish" },
-    { name = "cleanit" },
-    { name = "click" },
-    { name = "numpy" },
-    { name = "opencv-python" },
-    { name = "pysrt" },
-    { name = "pytesseract" },
-    { name = "setuptools" },
-    { name = "trakit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/63/0301da494ddb17ed72c093aabab4fc41f6e5dff9af6a40acb1525491f141/pgsrip-0.1.11.tar.gz", hash = "sha256:0029e8e70c225e7fcfeeb190e30fb3452107e486ba80c5c279907ef2ea9d5195", size = 16899, upload-time = "2024-06-23T06:46:06.238Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/0d/1ce5ae5d6efd45ae1a6c1cb7b4387b490b54ae443ebe9117fa061a8c8ce3/pgsrip-0.1.11-py3-none-any.whl", hash = "sha256:807cbbf315ee3698d261af660dd89efe62f992149b68fe86f47caff3bb581e8e", size = 20790, upload-time = "2024-06-23T06:46:05.022Z" },
-]
-
-[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1082,11 +1070,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/d8/10a70e86f6c28ae59f101a9de6d77bf70f147180fbf40c3af0f64080adc3/setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5", size = 2333112, upload-time = "2024-07-09T16:08:06.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/15/88e46eb9387e905704b69849618e699dc2f54407d8953cc4ec4b8b46528d/setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc", size = 931070, upload-time = "2024-07-09T16:07:58.829Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- vendor the small pgsrip 0.1.11 runtime under bd_to_avp/vendor with its MIT license
- switch subtitle extraction to the vendored runtime
- remove the PyPI pgsrip dependency that forced vulnerable setuptools<71
- declare pgsrip's real runtime dependencies directly
- refresh uv.lock so setuptools resolves to patched 83.0.0

## Why
GitHub Dependabot reports high-severity setuptools alerts. A direct setuptools bump is impossible while PyPI pgsrip declares setuptools>=70.1,<71, and upstream still has that constraint. Vendoring removes the vulnerable metadata path while preserving current subtitle behavior.

## Validation
- vendored pgsrip import/API smoke
- confirmed PyPI pgsrip is no longer installed
- confirmed setuptools 83.0.0, black 26.5.1, briefcase 0.4.3
- uv sync --all-groups --python 3.12 --locked
- git diff --check
- actionlint .github/workflows/*.yml
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy bd_to_avp
- uv build