### PR TITLE
Add installer smoke coverage

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -54,6 +54,7 @@
       "default": "uv run mypy bd_to_avp"
     },
     "test": {
+      "unitSmoke": "uv run python -m unittest discover -s tests",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Type check
         run: uv run mypy bd_to_avp
 
+      - name: Unit smoke tests
+        run: uv run python -m unittest discover -s tests
+
       - name: Import smoke
         run: >-
           uv run python -c

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -1,0 +1,114 @@
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from bd_to_avp import install
+
+
+class BrewCommandTests(unittest.TestCase):
+    def test_cask_install_command_does_not_use_no_quarantine(self) -> None:
+        command = install.build_brew_command(["makemkv"], cask=True)
+
+        self.assertEqual(command, ["/opt/homebrew/bin/brew", "install", "--force", "--cask", "makemkv"])
+        self.assertNotIn("--no-quarantine", command)
+
+    def test_cask_reinstall_command_does_not_use_no_quarantine(self) -> None:
+        command = install.build_brew_command(["wine-stable"], cask=True, operation="reinstall")
+
+        self.assertEqual(command, ["/opt/homebrew/bin/brew", "reinstall", "--force", "--cask", "wine-stable"])
+        self.assertNotIn("--no-quarantine", command)
+
+    def test_formula_install_command_is_not_a_cask_command(self) -> None:
+        command = install.build_brew_command(["ffmpeg", "gpac"])
+
+        self.assertEqual(command, ["/opt/homebrew/bin/brew", "install", "--force", "ffmpeg", "gpac"])
+        self.assertNotIn("--cask", command)
+
+
+class BrewPackageManagementTests(unittest.TestCase):
+    def test_failed_required_cask_install_raises_before_quarantine_cleanup(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["/opt/homebrew/bin/brew", "install", "--force", "--cask", "makemkv"],
+            1,
+            stdout="",
+            stderr="invalid option",
+        )
+
+        with (
+            patch("bd_to_avp.install.subprocess.run", return_value=failed_process),
+            patch("bd_to_avp.install.clear_cask_quarantine") as clear_cask_quarantine,
+            patch("builtins.print"),
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                install.manage_brew_package("makemkv", {}, cask=True)
+
+        clear_cask_quarantine.assert_not_called()
+
+    def test_successful_cask_install_clears_quarantine(self) -> None:
+        succeeded_process = subprocess.CompletedProcess(
+            ["/opt/homebrew/bin/brew", "install", "--force", "--cask", "makemkv"],
+            0,
+            stdout="installed",
+            stderr="",
+        )
+
+        with (
+            patch("bd_to_avp.install.subprocess.run", return_value=succeeded_process),
+            patch("bd_to_avp.install.clear_cask_quarantine") as clear_cask_quarantine,
+            patch("builtins.print"),
+        ):
+            install.manage_brew_package("makemkv", {"SUDO_ASKPASS": "/tmp/askpass"}, cask=True)
+
+        clear_cask_quarantine.assert_called_once_with(["makemkv"], {"SUDO_ASKPASS": "/tmp/askpass"})
+
+
+class CaskDetectionTests(unittest.TestCase):
+    def test_installed_cask_without_expected_app_bundle_needs_repair(self) -> None:
+        brew_process = subprocess.CompletedProcess(
+            ["/opt/homebrew/bin/brew", "list", "--cask", "--formula", "makemkv"],
+            0,
+            stdout="makemkv\n",
+            stderr="",
+        )
+
+        with (
+            patch("bd_to_avp.install.subprocess.run", return_value=brew_process),
+            patch("bd_to_avp.install.get_cask_app_paths", return_value=[Path("/missing/MakeMKV.app")]),
+        ):
+            self.assertFalse(install.check_is_package_installed("makemkv"))
+
+    def test_installed_cask_with_unquarantined_app_bundle_is_ready(self) -> None:
+        brew_process = subprocess.CompletedProcess(
+            ["/opt/homebrew/bin/brew", "list", "--cask", "--formula", "makemkv"],
+            0,
+            stdout="makemkv\n",
+            stderr="",
+        )
+        app_path = Mock(spec=Path)
+        app_path.exists.return_value = True
+
+        with (
+            patch("bd_to_avp.install.subprocess.run", return_value=brew_process),
+            patch("bd_to_avp.install.get_cask_app_paths", return_value=[app_path]),
+            patch("bd_to_avp.install.is_file_quarantined", return_value=False),
+        ):
+            self.assertTrue(install.check_is_package_installed("makemkv"))
+
+
+class DependencyVerificationTests(unittest.TestCase):
+    def test_missing_dependency_binaries_raise_clear_error(self) -> None:
+        fake_homebrew_bin = Path("/missing")
+
+        with (
+            patch.object(install.config, "HOMEBREW_PREFIX_BIN", fake_homebrew_bin),
+            patch.object(install.config, "MAKEMKVCON_PATH", Path("/missing/makemkvcon")),
+            patch.object(install.config, "MP4BOX_PATH", Path("/missing/MP4Box")),
+            patch.object(install.config, "WINE_PATH", Path("/missing/wine")),
+            self.assertRaisesRegex(ValueError, "Required command-line tools are missing"),
+        ):
+            install.verify_dependency_binaries()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add stdlib unittest smoke coverage for Homebrew command construction and installer failure paths
- cover cask install/reinstall command shape, missing cask app bundle repair detection, cask failure fail-fast behavior, quarantine cleanup timing, and missing runtime binary errors
- wire the unittest smoke into CI and `.github/github.json`

Closes #67

## Validation

- `uv run python -m unittest discover -s tests`
- `actionlint .github/workflows/*.yml`
- `uv run ruff format --check .`
- `uv run ruff check --diff tests/test_install_smoke.py`
- `uv run ruff check tests/test_install_smoke.py`
- `uv run mypy bd_to_avp tests`
- `uv run python -c "import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app"`
- `git diff --check`
- `uv build`
