### PR TITLE
Fix installer smoke review findings

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -54,7 +54,7 @@
       "default": "uv run mypy bd_to_avp"
     },
     "test": {
-      "unitSmoke": "uv run python -m unittest discover -s tests",
+      "unitSmoke": "uv run python -m unittest discover -s tests -t .",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv run mypy bd_to_avp
 
       - name: Unit smoke tests
-        run: uv run python -m unittest discover -s tests
+        run: uv run python -m unittest discover -s tests -t .
 
       - name: Import smoke
         run: >-

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -213,7 +213,7 @@ def check_is_package_installed(package: str) -> bool:
     if not app_paths:
         return False
 
-    return any(not is_file_quarantined(app_path) for app_path in app_paths)
+    return all(not is_file_quarantined(app_path) for app_path in app_paths)
 
 
 def get_cask_app_paths(package: str) -> list[Path]:

--- a/bd_to_avp/vendor/pgsrip/cli.py
+++ b/bd_to_avp/vendor/pgsrip/cli.py
@@ -88,7 +88,7 @@ AGE = AgeParamType()
 @click.option('-A', '--srt-age', type=AGE, help='Filter videos which srt subtitles are newer than AGE, e.g. 12h, 1w2d.')
 @click.option('-f', '--force', is_flag=True, default=False,
               help='re-rip and overwrite existing srt subtitles, even if they already exist')
-@click.option('-a', '--all', is_flag=True, default=False,
+@click.option('--all', is_flag=True, default=False,
               help='rip all tracks for a given language, even another track for that language was already ripped')
 @click.option('-w', '--max-workers', type=click.IntRange(1, 50), default=None, help='Maximum number of threads to use.')
 @click.option('--keep-temp-files', is_flag=True, help='Do not delete temporary files created, '

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Installer smoke tests."""

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -95,6 +95,24 @@ class CaskDetectionTests(unittest.TestCase):
         ):
             self.assertTrue(install.check_is_package_installed("makemkv"))
 
+    def test_installed_cask_with_any_quarantined_app_bundle_needs_repair(self) -> None:
+        brew_process = subprocess.CompletedProcess(
+            ["/opt/homebrew/bin/brew", "list", "--cask", "--formula", "wine-stable"],
+            0,
+            stdout="wine-stable\n",
+            stderr="",
+        )
+        app_paths = [Mock(spec=Path), Mock(spec=Path)]
+        for app_path in app_paths:
+            app_path.exists.return_value = True
+
+        with (
+            patch("bd_to_avp.install.subprocess.run", return_value=brew_process),
+            patch("bd_to_avp.install.get_cask_app_paths", return_value=app_paths),
+            patch("bd_to_avp.install.is_file_quarantined", side_effect=[False, True]),
+        ):
+            self.assertFalse(install.check_is_package_installed("wine-stable"))
+
 
 class DependencyVerificationTests(unittest.TestCase):
     def test_missing_dependency_binaries_raise_clear_error(self) -> None:

--- a/tests/test_vendor_pgsrip_cli.py
+++ b/tests/test_vendor_pgsrip_cli.py
@@ -1,0 +1,18 @@
+import unittest
+from typing import Any, cast
+
+from bd_to_avp.vendor.pgsrip.cli import pgsrip
+
+
+class PgsripCliTests(unittest.TestCase):
+    def test_age_keeps_short_option_when_all_is_long_only(self) -> None:
+        command = cast(Any, pgsrip)
+        options_by_name = {option.name: option for option in command.params if hasattr(option, "opts")}
+
+        self.assertIn("-a", options_by_name["age"].opts)
+        self.assertIn("--age", options_by_name["age"].opts)
+        self.assertEqual(options_by_name["all"].opts, ["--all"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make unittest discovery importable and run it with an explicit top-level directory
- require all present candidate cask app bundles to be unquarantined before considering a cask ready
- remove the duplicate `-a` short option from the vendored pgsrip `--all` flag so `-a/--age` stays usable
- add regression coverage for cask quarantine detection and vendored pgsrip CLI option wiring

## Auto-review handling

- Accepted: cask readiness false-positive when multiple bundle locations exist
- Accepted: duplicate vendored pgsrip `-a` option
- Clarified: `uv run python -m unittest discover -s tests` passed on PR #87/main CI, but adding `-t .` plus `tests/__init__.py` makes the command robust and explicit

## Validation

- `uv run python -m unittest discover -s tests -t .`
- `actionlint .github/workflows/*.yml`
- `uv run ruff format --check .`
- `uv run ruff check --diff bd_to_avp/install.py bd_to_avp/vendor/pgsrip/cli.py tests`
- `uv run ruff check bd_to_avp/install.py bd_to_avp/vendor/pgsrip/cli.py tests`
- `uv run mypy bd_to_avp tests`
- `uv run python -c "import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app"`
- `git diff --check`
- `uv build`
