### PR TITLE
Fix pgsrip subtitle edge cases

### DIFF
--- a/bd_to_avp/vendor/pgsrip/media.py
+++ b/bd_to_avp/vendor/pgsrip/media.py
@@ -111,8 +111,8 @@ class PgsSubtitleItem:
         if self.start is None:
             logger.warning('Corrupted %r: No Start timestamp', self)
             valid = False
-        elif not self.end or self.end <= self.start:
-            if next_item and next_item.start and self.start + 10000 >= next_item.start:
+        elif self.end is None or self.end <= self.start:
+            if next_item and next_item.start is not None and self.start + 10000 >= next_item.start:
                 self.end = max(self.start + 1, next_item.start - 1)
                 logger.info('Fix applied for %r: Subtitle end timestamp was fixed', self)
             else:
@@ -130,7 +130,8 @@ class PgsSubtitleItem:
         return f'<{self.__class__.__name__} [{self}]>'
 
     def __str__(self):
-        return f'{self.media_path} [{self.start} --> {self.end or ""}]'
+        end = "" if self.end is None else self.end
+        return f'{self.media_path} [{self.start} --> {end}]'
 
 
 class Pgs:

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -19,7 +19,7 @@ class MkvPgs(Pgs):
 
     @classmethod
     def read_data(cls, media_path: MediaPath, track_id: int, temp_folder: str):
-        lang_ext = f'.{str(media_path.language)}' if media_path.language else ''
+        lang_ext = f'.{media_path.language!s}' if media_path.language else ''
         sup_file = os.path.join(temp_folder, f'{track_id}{lang_ext}.sup')
         cmd = ['mkvextract', str(media_path), 'tracks', f'{track_id}:{sup_file}']
         check_output(cmd)
@@ -66,10 +66,10 @@ class MkvTrack:
 
     @property
     def forced(self):
-        return self.properties.get('forced_track')
+        return bool(self.properties.get('forced_track', False))
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} [{str(self)}]>'
+        return f'<{self.__class__.__name__} [{self!s}]>'
 
     def __str__(self):
         return f'{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}'
@@ -86,8 +86,7 @@ class Mkv(Media):
     def get_pgs_medias(self, options: Options):
         tracks = [t for t in self.tracks
                   if t.type == 'subtitles' and t.codec == 'HDMV PGS' and t.enabled]
-        tracks.sort(key=lambda x: x.forced)
-        tracks.sort(key=lambda x: x.id)
+        tracks.sort(key=lambda x: (x.forced, x.id))
         selected_languages: typing.Dict[Language, int] = {}
         for t in tracks:
             language = t.language

--- a/bd_to_avp/vendor/pgsrip/ripper.py
+++ b/bd_to_avp/vendor/pgsrip/ripper.py
@@ -125,7 +125,7 @@ class PgsToSrtRipper:
         self.omp_thread_limit = options.max_workers
         self.oem = options.tesseract_oem or TesseractEngineMode.NEURAL
         self.psm = options.tesseract_psm or TesseractPageSegmentationMode.SINGLE_UNIFORM_BLOCK_OF_TEXT
-        max_height = max([item.height for item in self.pgs.items]) // 2
+        max_height = max([item.height for item in self.pgs.items], default=0) // 2
         self.gap = (max_height // 2 + 30, max_height // 2 + 100)
         self.keep_temp_files = options.keep_temp_files
 

--- a/tests/test_vendor_pgsrip_edge_cases.py
+++ b/tests/test_vendor_pgsrip_edge_cases.py
@@ -1,0 +1,91 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.media import PgsSubtitleItem
+from bd_to_avp.vendor.pgsrip.mkv import Mkv, MkvTrack
+from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.vendor.pgsrip.ripper import PgsToSrtRipper
+
+
+class MkvTrackOrderingTests(unittest.TestCase):
+    def test_pgs_media_order_treats_missing_forced_flag_as_unforced(self) -> None:
+        track_without_forced = MkvTrack(
+            {
+                "id": 2,
+                "type": "subtitles",
+                "codec": "HDMV PGS",
+                "properties": {"language": "eng", "enabled_track": True},
+            }
+        )
+        forced_track = MkvTrack(
+            {
+                "id": 1,
+                "type": "subtitles",
+                "codec": "HDMV PGS",
+                "properties": {"language": "eng", "enabled_track": True, "forced_track": True},
+            }
+        )
+        mkv = Mkv.__new__(Mkv)
+        mkv.tracks = [forced_track, track_without_forced]
+        mkv.media_path = Mock()
+
+        with patch("bd_to_avp.vendor.pgsrip.mkv.MkvPgs") as mkv_pgs:
+            mkv_pgs.return_value.matches.return_value = True
+            list(mkv.get_pgs_medias(Options(one_per_lang=False)))
+
+        selected_track_ids = [call.args[1] for call in mkv_pgs.call_args_list]
+        self.assertEqual(selected_track_ids, [2, 1])
+
+
+class PgsSubtitleItemTimestampTests(unittest.TestCase):
+    def test_zero_valued_next_start_is_available_for_end_repair(self) -> None:
+        item = _subtitle_item(start=-5000, end=-5000)
+        next_item = _subtitle_item(start=0, end=12000)
+
+        self.assertTrue(item.auto_fix(next_item))
+
+        self.assertEqual(item.end, -1)
+
+
+class PgsRipperEmptyTrackTests(unittest.TestCase):
+    def test_empty_subtitle_items_do_not_crash_ripper_initialization(self) -> None:
+        pgs = Mock()
+        pgs.items = []
+
+        ripper = PgsToSrtRipper(pgs, Options())
+
+        self.assertEqual(ripper.gap, (30, 100))
+
+    def test_empty_subtitle_items_rip_to_empty_srt(self) -> None:
+        pgs = Mock()
+        pgs.items = []
+        pgs.media_path = Mock()
+        pgs.media_path.translate.return_value = Path("empty.srt")
+
+        ripper = PgsToSrtRipper(pgs, Options())
+
+        with patch("bd_to_avp.vendor.pgsrip.ripper.SubRipFile") as subrip_file:
+            subs = Mock()
+            subrip_file.return_value = subs
+
+            self.assertIs(ripper.rip(lambda text: text), subs)
+
+        subs.clean_indexes.assert_called_once()
+        subs.append.assert_not_called()
+
+
+def _subtitle_item(start: int, end: int) -> PgsSubtitleItem:
+    item = PgsSubtitleItem.__new__(PgsSubtitleItem)
+    item.media_path = MediaPath("fake.sup")
+    item.start = start
+    item.end = end
+    item.image = Mock()
+    item.x_offset = 0
+    item.y_offset = 0
+    return item
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- treat missing Matroska `forced_track` metadata as unforced instead of leaving it as `None`
- order PGS subtitle tracks by forced/unforced state and id in one stable key
- preserve zero-valued timestamps during PGS end-time repair
- allow empty decoded subtitle item lists without crashing ripper initialization
- add focused regression tests for all three auto-review findings

## Verification

- `uv run ruff format --check .`
- `uv run ruff check bd_to_avp/vendor/pgsrip/mkv.py bd_to_avp/vendor/pgsrip/media.py bd_to_avp/vendor/pgsrip/ripper.py tests/test_vendor_pgsrip_edge_cases.py`
- `uv run mypy bd_to_avp/vendor/pgsrip/mkv.py bd_to_avp/vendor/pgsrip/media.py bd_to_avp/vendor/pgsrip/ripper.py tests/test_vendor_pgsrip_edge_cases.py`
- `uv run python -m unittest discover -s tests -t .`

Refs auto-review findings:
- guard track ordering against missing forced flags
- preserve zero-valued PGS timestamps
- handle empty subtitle item lists before `max()`
