### PR TITLE
Use native splitter for MTS/M2TS MVC streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Ensure the following are installed on your Mac *(If not using the Quick Install 
 - **[MP4Box]**: A multimedia packager available for Windows, Mac, and Linux.
 - **[MKVToolNix]**: A set of tools to create, alter, and inspect Matroska files.
 
-Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction. Extracted MVC `.h264` video now uses a
-bundled native Apple Silicon MVC splitter when available, with the legacy Wine/FRIMDecode64.exe path retained for
-compatibility cases such as direct `.mts`/`.m2ts` sources.
+Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction. Extracted MVC `.h264` video, including
+MVC video extracted from direct `.mts`/`.m2ts` sources, now uses a bundled native Apple Silicon MVC splitter when
+available. The legacy Wine/FRIMDecode64.exe path is retained as a fallback when the native helper is unavailable.
 
 ## Manual Installation
 

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -167,9 +167,7 @@ def get_required_casks() -> list[str]:
 
 
 def needs_legacy_frim_stack() -> bool:
-    return not is_native_mvc_splitter_ready() or bool(
-        config.source_path and config.source_path.suffix.lower() in config.MTS_EXTENSIONS
-    )
+    return not is_native_mvc_splitter_ready()
 
 
 def ensure_native_mvc_splitter_executable() -> bool:

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -223,12 +223,7 @@ def split_mvc_to_stereo(
 ):
     ffmpeg_left_log = left_output_path.with_suffix(".log")
     ffmpeg_right_log = right_output_path.with_suffix(".log")
-    is_mts = None
-    if config.source_path and config.source_path.suffix.lower() in config.MTS_EXTENSIONS:
-        is_mts = video_input_path
-        video_input_path = config.source_path
-
-    if not is_mts and has_native_mvc_splitter():
+    if has_native_mvc_splitter():
         result = split_mvc_to_stereo_native(
             video_input_path,
             left_output_path,
@@ -241,6 +236,11 @@ def split_mvc_to_stereo(
             left_output_path.with_suffix(".native_mvc.log").unlink(missing_ok=True)
             video_input_path.unlink(missing_ok=True)
         return result
+
+    is_mts = None
+    if config.source_path and config.source_path.suffix.lower() in config.MTS_EXTENSIONS:
+        is_mts = video_input_path
+        video_input_path = config.source_path
 
     ensure_legacy_frim_available()
 

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -141,7 +141,7 @@ class DependencyVerificationTests(unittest.TestCase):
                 self.assertFalse(install.needs_legacy_frim_stack())
                 self.assertEqual(install.get_required_casks(), ["makemkv"])
 
-    def test_mts_sources_still_require_legacy_wine_stack(self) -> None:
+    def test_mts_sources_do_not_require_legacy_wine_stack_when_native_helper_is_ready(self) -> None:
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o755)
@@ -151,8 +151,13 @@ class DependencyVerificationTests(unittest.TestCase):
                 patch.object(install.config, "source_path", Path("/movie/source.m2ts")),
                 patch.object(install.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             ):
-                self.assertTrue(install.needs_legacy_frim_stack())
-                self.assertEqual(install.get_required_casks(), ["makemkv", "wine-stable"])
+                self.assertFalse(install.needs_legacy_frim_stack())
+                self.assertEqual(install.get_required_casks(), ["makemkv"])
+
+    def test_missing_native_mvc_helper_requires_legacy_wine_stack(self) -> None:
+        with patch.object(install.config, "EDGE264_TEST_PATH", Path("/missing/edge264_test")):
+            self.assertTrue(install.needs_legacy_frim_stack())
+            self.assertEqual(install.get_required_casks(), ["makemkv", "wine-stable"])
 
     def test_native_mvc_helper_repairs_missing_execute_bit(self) -> None:
         with tempfile.NamedTemporaryFile() as helper_file:

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -87,13 +87,37 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertEqual(result, (Path("left.mov"), Path("right.mov")))
         native_split.assert_called_once()
 
-    def test_split_keeps_frim_path_for_mts_sources(self) -> None:
+    def test_split_uses_native_helper_for_mts_sources_when_present(self) -> None:
+        disc_info = DiscInfo(name="Sample")
+
+        with tempfile.NamedTemporaryFile() as helper_file:
+            helper_path = Path(helper_file.name)
+            helper_path.chmod(0o755)
+
+            with (
+                patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
+                patch.object(video.config, "source_path", Path("source.m2ts")),
+                patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                patch.object(video.config, "keep_files", True),
+                patch(
+                    "bd_to_avp.modules.video.split_mvc_to_stereo_native",
+                    return_value=(Path("left.mov"), Path("right.mov")),
+                ) as native_split,
+            ):
+                result = video.split_mvc_to_stereo(
+                    Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, ""
+                )
+
+        self.assertEqual(result, (Path("left.mov"), Path("right.mov")))
+        native_split.assert_called_once_with(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
+
+    def test_split_keeps_frim_fallback_for_mts_sources_when_native_helper_is_missing(self) -> None:
         disc_info = DiscInfo(name="Sample")
         process = Mock()
         process.wait.return_value = 0
 
         with (
-            patch.object(video.config, "EDGE264_TEST_PATH", Mock(exists=Mock(return_value=True))),
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("/missing/edge264_test")),
             patch.object(video.config, "source_path", Path("source.m2ts")),
             patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             patch.object(video.config, "keep_files", True),


### PR DESCRIPTION
## Summary
- use the bundled native Apple Silicon MVC splitter for MVC streams extracted from direct `.mts` / `.m2ts` sources
- keep the legacy Wine/FRIM path only as the fallback when the native helper is unavailable
- stop requiring `wine-stable` for `.mts` / `.m2ts` sources when the native helper is ready
- update tests and release notes to match the native-first behavior

## Verification
- `git diff --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp tests`
- `uv run python -m unittest discover -s tests -t .`
- Controlled smoke with `/tmp/bd_to_avp_mts_probe/sample_with_audio.m2ts` generated from the MVC benchmark sample:
  - existing extraction produced `/tmp/bd_to_avp_mts_probe/app_flow_audio/sample_mvc.h264` and audio MOV
  - extracted MVC stream contained MVC NAL type 20 packets
  - native splitter produced left/right HEVC MOV outputs with 1439 frames at 1920x1080, 24000/1001

Refs #94
