### PR TITLE
Fix native fallback and PGS zero timestamps

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -65,6 +65,10 @@ def has_native_mvc_splitter() -> bool:
     return os.access(config.EDGE264_TEST_PATH, os.X_OK)
 
 
+def can_use_native_mvc_splitter(disc_info: DiscInfo) -> bool:
+    return disc_info.color_depth == 8 and has_native_mvc_splitter()
+
+
 def ensure_legacy_frim_available() -> None:
     wineboot_path = config.HOMEBREW_PREFIX_BIN / "wineboot"
     missing_paths = [path for path in [config.WINE_PATH, wineboot_path, config.FRIMDECODE_PATH] if not path.exists()]
@@ -223,7 +227,7 @@ def split_mvc_to_stereo(
 ):
     ffmpeg_left_log = left_output_path.with_suffix(".log")
     ffmpeg_right_log = right_output_path.with_suffix(".log")
-    if has_native_mvc_splitter():
+    if can_use_native_mvc_splitter(disc_info):
         result = split_mvc_to_stereo_native(
             video_input_path,
             left_output_path,

--- a/bd_to_avp/vendor/pgsrip/utils.py
+++ b/bd_to_avp/vendor/pgsrip/utils.py
@@ -15,7 +15,7 @@ def safe_get(b: bytes, i: int, default_value=0):
 
 
 def to_time(value: typing.Optional[int]):
-    return SubRipTime.from_ordinal(value) if value else None
+    return SubRipTime.from_ordinal(value) if value is not None else None
 
 
 T = typing.TypeVar('T')

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -141,7 +141,7 @@ class DependencyVerificationTests(unittest.TestCase):
                 self.assertFalse(install.needs_legacy_frim_stack())
                 self.assertEqual(install.get_required_casks(), ["makemkv"])
 
-    def test_mts_sources_do_not_require_legacy_wine_stack_when_native_helper_is_ready(self) -> None:
+    def test_mts_sources_do_not_need_runtime_legacy_stack_when_native_helper_is_ready(self) -> None:
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o755)

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -111,6 +111,39 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertEqual(result, (Path("left.mov"), Path("right.mov")))
         native_split.assert_called_once_with(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
 
+    def test_split_uses_frim_fallback_for_10_bit_sources(self) -> None:
+        disc_info = DiscInfo(name="Sample", color_depth=10)
+        process = Mock()
+        process.wait.return_value = 0
+
+        with tempfile.NamedTemporaryFile() as helper_file:
+            helper_path = Path(helper_file.name)
+            helper_path.chmod(0o755)
+
+            with (
+                patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
+                patch.object(video.config, "source_path", Path("source.mkv")),
+                patch.object(video.config, "keep_files", True),
+                patch.object(video.config, "swap_eyes", False),
+                patch.object(video.config, "WINE_PATH", Path("wine")),
+                patch.object(video.config, "FRIMDECODE_PATH", Path("FRIMDecode64.exe")),
+                patch.object(video.config, "HOMEBREW_PREFIX_BIN", Path("/opt/homebrew/bin")),
+                patch.object(video.config, "left_right_bitrate", 12),
+                patch.object(video.config, "software_encoder", False),
+                patch.object(video.config, "frame_rate", ""),
+                patch.object(video.config, "resolution", ""),
+                patch("bd_to_avp.modules.video.split_mvc_to_stereo_native") as native_split,
+                patch("bd_to_avp.modules.video.ensure_legacy_frim_available"),
+                patch("bd_to_avp.modules.video.temporary_fifo", return_value=_FakeFifos()),
+                patch("bd_to_avp.modules.video.run_ffmpeg_async", return_value=process),
+                patch("bd_to_avp.modules.video.run_command") as run_command,
+                patch("bd_to_avp.modules.video.atexit.register"),
+            ):
+                video.split_mvc_to_stereo(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
+
+        native_split.assert_not_called()
+        self.assertEqual(run_command.call_args.args[1], "FRIM to split MVC to stereo.")
+
     def test_split_keeps_frim_fallback_for_mts_sources_when_native_helper_is_missing(self) -> None:
         disc_info = DiscInfo(name="Sample")
         process = Mock()

--- a/tests/test_vendor_pgsrip_edge_cases.py
+++ b/tests/test_vendor_pgsrip_edge_cases.py
@@ -7,6 +7,7 @@ from bd_to_avp.vendor.pgsrip.media import PgsSubtitleItem
 from bd_to_avp.vendor.pgsrip.mkv import Mkv, MkvTrack
 from bd_to_avp.vendor.pgsrip.options import Options
 from bd_to_avp.vendor.pgsrip.ripper import PgsToSrtRipper
+from bd_to_avp.vendor.pgsrip.utils import to_time
 
 
 class MkvTrackOrderingTests(unittest.TestCase):
@@ -40,6 +41,12 @@ class MkvTrackOrderingTests(unittest.TestCase):
 
 
 class PgsSubtitleItemTimestampTests(unittest.TestCase):
+    def test_zero_valued_timestamp_converts_to_subrip_zero(self) -> None:
+        timestamp = to_time(0)
+
+        self.assertIsNotNone(timestamp)
+        self.assertEqual(str(timestamp), "00:00:00,000")
+
     def test_zero_valued_next_start_is_available_for_end_repair(self) -> None:
         item = _subtitle_item(start=-5000, end=-5000)
         next_item = _subtitle_item(start=0, end=12000)


### PR DESCRIPTION
## Summary
- keep 10-bit MVC sources out of the native splitter path so they fall back to FRIM while FRIM remains supported
- preserve zero-valued PGS timestamps instead of converting them to missing timestamps
- add regression coverage for 10-bit MVC fallback and zero PGS timestamp conversion

## Notes
This intentionally does not remove Wine/FRIM yet. That should be a separate cleanup PR after testing, because it changes the supported fallback contract.

## Verification
- `git diff --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp tests`
- `uv run python -m unittest discover -s tests -t .`
