### PR TITLE
Install FRIM fallback dependencies while supported

### DIFF
--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -105,10 +105,10 @@ def install_deps() -> None:
 
     verify_dependency_binaries()
 
-    if needs_legacy_frim_stack() and not check_rosetta():
+    if installs_legacy_frim_stack() and not check_rosetta():
         install_rosetta()
 
-    if needs_legacy_frim_stack():
+    if installs_legacy_frim_stack():
         wine_boot()
 
     if pw_file_path:
@@ -141,7 +141,7 @@ def install_rosetta() -> None:
 
 def verify_dependency_binaries() -> None:
     missing_binaries = [path for path in [config.MAKEMKVCON_PATH, config.MP4BOX_PATH] if not path.exists()]
-    if needs_legacy_frim_stack():
+    if installs_legacy_frim_stack():
         missing_binaries.append(config.WINE_PATH)
         wineboot_path = config.HOMEBREW_PREFIX_BIN / "wineboot"
         if not wineboot_path.exists():
@@ -161,13 +161,11 @@ def verify_dependency_binaries() -> None:
 
 
 def get_required_casks() -> list[str]:
-    if needs_legacy_frim_stack():
-        return config.BREW_CASKS_TO_INSTALL
-    return [package for package in config.BREW_CASKS_TO_INSTALL if package != "wine-stable"]
+    return config.BREW_CASKS_TO_INSTALL
 
 
-def needs_legacy_frim_stack() -> bool:
-    return not is_native_mvc_splitter_ready()
+def installs_legacy_frim_stack() -> bool:
+    return "wine-stable" in config.BREW_CASKS_TO_INSTALL
 
 
 def ensure_native_mvc_splitter_executable() -> bool:

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -128,36 +128,15 @@ class DependencyVerificationTests(unittest.TestCase):
         ):
             install.verify_dependency_binaries()
 
-    def test_native_mvc_helper_avoids_wine_cask_requirement(self) -> None:
-        with tempfile.NamedTemporaryFile() as helper_file:
-            helper_path = Path(helper_file.name)
-            helper_path.chmod(0o755)
-
-            with (
-                patch.object(install.config, "EDGE264_TEST_PATH", helper_path),
-                patch.object(install.config, "source_path", Path("/movie/source.mkv")),
-                patch.object(install.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-            ):
-                self.assertFalse(install.needs_legacy_frim_stack())
-                self.assertEqual(install.get_required_casks(), ["makemkv"])
-
-    def test_mts_sources_do_not_need_runtime_legacy_stack_when_native_helper_is_ready(self) -> None:
-        with tempfile.NamedTemporaryFile() as helper_file:
-            helper_path = Path(helper_file.name)
-            helper_path.chmod(0o755)
-
-            with (
-                patch.object(install.config, "EDGE264_TEST_PATH", helper_path),
-                patch.object(install.config, "source_path", Path("/movie/source.m2ts")),
-                patch.object(install.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-            ):
-                self.assertFalse(install.needs_legacy_frim_stack())
-                self.assertEqual(install.get_required_casks(), ["makemkv"])
-
-    def test_missing_native_mvc_helper_requires_legacy_wine_stack(self) -> None:
-        with patch.object(install.config, "EDGE264_TEST_PATH", Path("/missing/edge264_test")):
-            self.assertTrue(install.needs_legacy_frim_stack())
+    def test_declared_frim_fallback_keeps_wine_cask_requirement(self) -> None:
+        with patch.object(install.config, "BREW_CASKS_TO_INSTALL", ["makemkv", "wine-stable"]):
+            self.assertTrue(install.installs_legacy_frim_stack())
             self.assertEqual(install.get_required_casks(), ["makemkv", "wine-stable"])
+
+    def test_removed_frim_fallback_avoids_wine_cask_requirement(self) -> None:
+        with patch.object(install.config, "BREW_CASKS_TO_INSTALL", ["makemkv"]):
+            self.assertFalse(install.installs_legacy_frim_stack())
+            self.assertEqual(install.get_required_casks(), ["makemkv"])
 
     def test_native_mvc_helper_repairs_missing_execute_bit(self) -> None:
         with tempfile.NamedTemporaryFile() as helper_file:


### PR DESCRIPTION
## Summary
- install and verify the Wine/FRIM runtime whenever the product still declares the FRIM fallback cask
- separate install-time fallback availability from runtime native-helper selection
- simplify installer smoke tests around the declared fallback contract

## Notes
This keeps the current release line internally consistent while FRIM remains bundled and 10-bit MVC can still fall back to it. The planned Wine/FRIM removal should happen in a separate cleanup PR.

## Verification
- `uv run python -m unittest tests.test_install_smoke tests.test_native_mvc_split`
- `git diff --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp tests`
- `uv run python -m unittest discover -s tests -t .`
- focused review agents: no functional regressions found
