### PR TITLE
Make runtime tool resolution Homebrew-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction.
 MVC video extracted from direct `.mts`/`.m2ts` sources, now uses a bundled native Apple Silicon MVC splitter when
 available. Native MVC splitting supports 8-bit Blu-ray 3D MVC sources only.
 
+Runtime tool lookup prefers explicit `BD_TO_AVP_<TOOL>_PATH` environment overrides, bundled tools in `bd_to_avp/bin`,
+tools already available in `PATH`, and finally the legacy `/opt/homebrew/bin` location. This allows packaged builds to
+move away from Homebrew-managed runtime tools incrementally while keeping existing manual installs working.
+
 ## Manual Installation
 
 To set up your macOS environment for video processing, including creating and handling 3D video content, follow these

--- a/bd_to_avp/__main__.py
+++ b/bd_to_avp/__main__.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 import signal
 
 import psutil
@@ -28,8 +27,7 @@ atexit.register(kill_child_processes)
 
 
 def main() -> None:
-    if config.HOMEBREW_PREFIX_BIN.as_posix() not in os.environ["PATH"]:
-        os.environ["PATH"] = f"{config.HOMEBREW_PREFIX_BIN}:{os.environ['PATH']}"
+    config.configure_tool_environment()
 
     if not config.app.is_gui:
         config.parse_args()

--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -58,7 +58,11 @@ class Spinner:
 
 def add_quotes_to_path_if_space(commands: list[str | Path | bytes]) -> list[str]:
     commands_with_paths_as_strings = [
-        (f'"{command}"' if isinstance(command, Path) and " " in command.as_posix() else str(command))
+        f'"{command}"'
+        if isinstance(command, Path) and " " in command.as_posix()
+        else f'"{command}"'
+        if isinstance(command, str) and " " in command
+        else str(command)
         for command in commands
     ]
     return commands_with_paths_as_strings
@@ -117,7 +121,9 @@ def run_command(commands: list[Any], command_name: str = "", env: dict[str, str]
 def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, **kwargs) -> None:
     kwargs["quiet"] = quiet
     if config.output_commands:
-        output_commands_quoted = add_quotes_to_path_if_space(ffmpeg.compile(stream_spec))
+        output_commands_quoted = add_quotes_to_path_if_space(
+            ffmpeg.compile(stream_spec, cmd=config.FFMPEG_PATH.as_posix())
+        )
         output_commands_str = " ".join(output_commands_quoted)
 
         print(f"Running command:\n{output_commands_str}")
@@ -125,7 +131,7 @@ def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, 
     spinner_thread = threading.Thread(target=spinner.start)
     spinner_thread.start()
     try:
-        ffmpeg.run(stream_spec, **kwargs)
+        ffmpeg.run(stream_spec, cmd=config.FFMPEG_PATH.as_posix(), **kwargs)
     except ffmpeg.Error as e:
         print("FFmpeg Error:")
         print("STDOUT:", e.stdout.decode("utf-8") if e.stdout else "")

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -1,5 +1,8 @@
 import argparse
 import configparser
+import importlib
+import os
+import shutil
 import sys
 
 from enum import Enum, auto
@@ -8,6 +11,40 @@ from pathlib import Path
 from typing import ClassVar
 
 from bd_to_avp.modules.util import get_pyproject_data
+
+
+SCRIPT_PATH = Path(__file__).parent.parent
+SCRIPT_PATH_BIN = SCRIPT_PATH / "bin"
+HOMEBREW_PREFIX = Path("/opt/homebrew")
+HOMEBREW_PREFIX_BIN = HOMEBREW_PREFIX / "bin"
+
+
+def tool_env_var(tool_name: str) -> str:
+    env_tool_name = tool_name.upper().replace("-", "_")
+    return f"BD_TO_AVP_{env_tool_name}_PATH"
+
+
+def resolve_tool_path(
+    tool_name: str,
+    *,
+    env_var: str | None = None,
+    bundled_name: str | None = None,
+    script_bin_path: Path = SCRIPT_PATH_BIN,
+    homebrew_bin_path: Path = HOMEBREW_PREFIX_BIN,
+) -> Path:
+    configured_path = os.environ.get(env_var or tool_env_var(tool_name))
+    if configured_path:
+        return Path(configured_path).expanduser()
+
+    bundled_path = script_bin_path / (bundled_name or tool_name)
+    if bundled_path.exists():
+        return bundled_path
+
+    path_tool = shutil.which(tool_name)
+    if path_tool:
+        return Path(path_tool)
+
+    return homebrew_bin_path / tool_name
 
 
 class Stage(Enum):
@@ -147,16 +184,21 @@ class Config:
         "Program reads data faster than it can write to disk",
     ]
 
-    SCRIPT_PATH = Path(__file__).parent.parent
-    SCRIPT_PATH_BIN = SCRIPT_PATH / "bin"
+    SCRIPT_PATH = SCRIPT_PATH
+    SCRIPT_PATH_BIN = SCRIPT_PATH_BIN
 
-    HOMEBREW_PREFIX = Path("/opt/homebrew")
-    HOMEBREW_PREFIX_BIN = HOMEBREW_PREFIX / "bin"
+    HOMEBREW_PREFIX = HOMEBREW_PREFIX
+    HOMEBREW_PREFIX_BIN = HOMEBREW_PREFIX_BIN
 
-    MAKEMKVCON_PATH = Path(HOMEBREW_PREFIX_BIN / "makemkvcon")
+    FFMPEG_PATH = resolve_tool_path("ffmpeg")
+    FFPROBE_PATH = resolve_tool_path("ffprobe")
+    MAKEMKVCON_PATH = resolve_tool_path("makemkvcon")
+    MKVEXTRACT_PATH = resolve_tool_path("mkvextract")
+    MKVMERGE_PATH = resolve_tool_path("mkvmerge")
+    MP4BOX_PATH = resolve_tool_path("MP4Box")
+    TESSERACT_PATH = resolve_tool_path("tesseract")
     EDGE264_TEST_PATH = SCRIPT_PATH_BIN / "edge264_test"
     SPATIAL_MEDIA_PATH = SCRIPT_PATH_BIN / "spatial-media-kit-tool"
-    MP4BOX_PATH = HOMEBREW_PREFIX_BIN / "MP4Box"
     FX_UPSCALE_PATH = SCRIPT_PATH_BIN / "fx-upscale"
 
     FINAL_FILE_TAG = "_AVP"
@@ -193,6 +235,49 @@ class Config:
         self.language_code = "eng"
         self.remove_extra_languages = False
         self.keep_awake = True
+
+    def configure_tool_environment(self) -> None:
+        configured_dirs = [
+            self.FFMPEG_PATH.parent,
+            self.FFPROBE_PATH.parent,
+            self.MAKEMKVCON_PATH.parent,
+            self.MKVEXTRACT_PATH.parent,
+            self.MKVMERGE_PATH.parent,
+            self.MP4BOX_PATH.parent,
+            self.TESSERACT_PATH.parent,
+        ]
+        existing_path = os.environ.get("PATH", "")
+        existing_dirs = [path for path in existing_path.split(os.pathsep) if path]
+        prepend_dirs: list[str] = []
+
+        for path_dir in configured_dirs:
+            if not path_dir.exists():
+                continue
+            path_dir_str = path_dir.as_posix()
+            if path_dir_str not in prepend_dirs and path_dir_str not in existing_dirs:
+                prepend_dirs.append(path_dir_str)
+
+        script_bin_path = self.SCRIPT_PATH_BIN.as_posix()
+        if (
+            self.SCRIPT_PATH_BIN.exists()
+            and script_bin_path not in prepend_dirs
+            and script_bin_path not in existing_dirs
+        ):
+            prepend_dirs.append(script_bin_path)
+
+        if prepend_dirs:
+            os.environ["PATH"] = os.pathsep.join([*prepend_dirs, *existing_dirs])
+
+        os.environ.setdefault("FFMPEG_BINARY", self.FFMPEG_PATH.as_posix())
+        os.environ.setdefault("FFPROBE_BINARY", self.FFPROBE_PATH.as_posix())
+        self.configure_tesseract_command()
+
+    def configure_tesseract_command(self) -> None:
+        try:
+            pytesseract = importlib.import_module("pytesseract")
+        except ImportError:
+            return
+        pytesseract.pytesseract.tesseract_cmd = self.TESSERACT_PATH.as_posix()
 
     def save_config_to_file(self) -> None:
         config_parser = configparser.ConfigParser()

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -113,7 +113,7 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
 
 
 def get_audio_stream_data(file_path: Path) -> list[dict[str, Any]]:
-    probe = ffmpeg.probe(str(file_path))
+    probe = ffmpeg.probe(str(file_path), cmd=config.FFPROBE_PATH.as_posix())
     if not probe or "streams" not in probe:
         return []
     audio_streams = [stream for stream in probe["streams"] if stream["codec_type"] == "audio"]

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -75,7 +75,7 @@ def get_disc_and_mvc_video_info() -> DiscInfo:
         filename = Path(source).stem
         disc_info = DiscInfo(name=filename)
 
-        ffmpeg_probe_output = ffmpeg.probe(source)["streams"][0]
+        ffmpeg_probe_output = ffmpeg.probe(source, cmd=config.FFPROBE_PATH.as_posix())["streams"][0]
         if all(key in ffmpeg_probe_output for key in ["width", "height"]):
             disc_info.resolution = f"{ffmpeg_probe_output.get('width')}x{ffmpeg_probe_output.get('height')}"
         if "avg_frame_rate" in ffmpeg_probe_output:

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -91,7 +91,7 @@ def get_missing_tessdata_files(languages: list[str], tessdata_path: Path) -> Non
 
 
 def get_languages_in_mkv(mkv_path: Path) -> None | list[dict[str, str]]:
-    mkv_info = ffmpeg.probe(str(mkv_path))
+    mkv_info = ffmpeg.probe(str(mkv_path), cmd=config.FFPROBE_PATH.as_posix())
     streams = mkv_info["streams"]
     subtitle_streams = [stream for stream in streams if stream["codec_type"] == "subtitle"]
     if not subtitle_streams:

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -110,7 +110,11 @@ def generate_native_mvc_ffmpeg_command(
 
     left_output = ffmpeg.output(left_stream, f"file:{left_output_path}", **output_kwargs)
     right_output = ffmpeg.output(right_stream, f"file:{right_output_path}", **output_kwargs)
-    command = ffmpeg.compile(ffmpeg.merge_outputs(left_output, right_output), overwrite_output=True)
+    command = ffmpeg.compile(
+        ffmpeg.merge_outputs(left_output, right_output),
+        cmd=config.FFMPEG_PATH.as_posix(),
+        overwrite_output=True,
+    )
 
     return [arg if arg != "pipe:0" else "-" for arg in command]
 
@@ -260,7 +264,12 @@ def detect_crop_parameters(
     )
 
     try:
-        _, stdout = ffmpeg.run(stream, capture_stdout=True, capture_stderr=True)
+        _, stdout = ffmpeg.run(
+            stream,
+            cmd=config.FFMPEG_PATH.as_posix(),
+            capture_stdout=True,
+            capture_stderr=True,
+        )
         output = stdout.decode("utf-8").split("\n")
     except ffmpeg.Error as e:
         print("FFmpeg Error:")
@@ -324,7 +333,12 @@ def create_left_right_files(
 
 def get_video_color_depth(input_path: Path) -> int:
     try:
-        probe = ffmpeg.probe(str(input_path), select_streams="v:0", show_entries="stream=pix_fmt")
+        probe = ffmpeg.probe(
+            str(input_path),
+            cmd=config.FFPROBE_PATH.as_posix(),
+            select_streams="v:0",
+            show_entries="stream=pix_fmt",
+        )
         streams = probe.get("streams", [])
         if streams:
             pix_fmt = streams[0].get("pix_fmt")

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -11,6 +11,7 @@ from trakit.api import trakit
 from bd_to_avp.vendor.pgsrip.media import Media, Pgs
 from bd_to_avp.vendor.pgsrip.media_path import MediaPath
 from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.modules.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class MkvPgs(Pgs):
     def read_data(cls, media_path: MediaPath, track_id: int, temp_folder: str):
         lang_ext = f'.{media_path.language!s}' if media_path.language else ''
         sup_file = os.path.join(temp_folder, f'{track_id}{lang_ext}.sup')
-        cmd = ['mkvextract', str(media_path), 'tracks', f'{track_id}:{sup_file}']
+        cmd = [config.MKVEXTRACT_PATH, str(media_path), 'tracks', f'{track_id}:{sup_file}']
         check_output(cmd)
         with open(sup_file, mode='rb') as f:
             return f.read()
@@ -78,7 +79,7 @@ class MkvTrack:
 class Mkv(Media):
 
     def __init__(self, path: str):
-        metadata = json.loads(check_output(['mkvmerge', '-i', '-F', 'json', path]))
+        metadata = json.loads(check_output([config.MKVMERGE_PATH, '-i', '-F', 'json', path]))
         tracks = [MkvTrack(t) for t in metadata.get('tracks', [])]
         super().__init__(MediaPath(path), languages={t.language for t in tracks})
         self.tracks = tracks

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -28,6 +28,7 @@ class NativeMvcCommandTests(unittest.TestCase):
         ):
             command = video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
+        self.assertEqual(Path(command[0]).name, Path(video.config.FFMPEG_PATH).name)
         self.assertIn("-f", command)
         self.assertIn("yuv4mpegpipe", command)
         self.assertIn("-filter_complex", command)
@@ -48,6 +49,7 @@ class NativeMvcCommandTests(unittest.TestCase):
         ):
             command = video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
+        self.assertEqual(Path(command[0]).name, Path(video.config.FFMPEG_PATH).name)
         filter_graph = command[command.index("-filter_complex") + 1]
         map_labels = [command[index + 1] for index, value in enumerate(command) if value == "-map"]
         left_label, right_label = map_labels

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -1,0 +1,114 @@
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules.config import config, resolve_tool_path, tool_env_var
+from bd_to_avp.vendor.pgsrip import mkv
+
+
+class ToolResolutionTests(unittest.TestCase):
+    def test_tool_env_var_normalizes_names(self) -> None:
+        self.assertEqual(tool_env_var("MP4Box"), "BD_TO_AVP_MP4BOX_PATH")
+        self.assertEqual(tool_env_var("mkv-extract"), "BD_TO_AVP_MKV_EXTRACT_PATH")
+
+    def test_env_override_wins(self) -> None:
+        with patch.dict(os.environ, {"BD_TO_AVP_FFMPEG_PATH": "/custom/ffmpeg"}, clear=False):
+            self.assertEqual(resolve_tool_path("ffmpeg"), Path("/custom/ffmpeg"))
+
+    def test_app_local_bin_wins_over_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_path = Path(temp_dir)
+            bundled_tool = bin_path / "MP4Box"
+            bundled_tool.touch()
+
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch("bd_to_avp.modules.config.shutil.which", return_value="/usr/bin/MP4Box"),
+            ):
+                self.assertEqual(resolve_tool_path("MP4Box", script_bin_path=bin_path), bundled_tool)
+
+    def test_path_wins_over_homebrew_fallback(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("bd_to_avp.modules.config.shutil.which", return_value="/usr/bin/mkvmerge"),
+        ):
+            self.assertEqual(resolve_tool_path("mkvmerge"), Path("/usr/bin/mkvmerge"))
+
+    def test_homebrew_path_is_last_resort(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), patch("bd_to_avp.modules.config.shutil.which", return_value=None):
+            self.assertEqual(resolve_tool_path("tesseract"), Path("/opt/homebrew/bin/tesseract"))
+
+    def test_configure_tool_environment_orders_configured_paths_before_bundled_bin(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            custom_bin = temp_path / "custom bin"
+            app_bin = temp_path / "app bin"
+            for path in [custom_bin, app_bin]:
+                path.mkdir()
+
+            with (
+                patch.object(config, "SCRIPT_PATH_BIN", app_bin),
+                patch.object(config, "FFMPEG_PATH", custom_bin / "ffmpeg"),
+                patch.object(config, "FFPROBE_PATH", custom_bin / "ffprobe"),
+                patch.object(config, "MAKEMKVCON_PATH", custom_bin / "makemkvcon"),
+                patch.object(config, "MKVEXTRACT_PATH", custom_bin / "mkvextract"),
+                patch.object(config, "MKVMERGE_PATH", custom_bin / "mkvmerge"),
+                patch.object(config, "MP4BOX_PATH", custom_bin / "MP4Box"),
+                patch.object(config, "TESSERACT_PATH", custom_bin / "tesseract"),
+                patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True),
+                patch.object(config, "configure_tesseract_command"),
+            ):
+                config.configure_tool_environment()
+                path_dirs = os.environ["PATH"].split(os.pathsep)
+
+        self.assertEqual(path_dirs[:3], [custom_bin.as_posix(), app_bin.as_posix(), "/usr/bin"])
+
+    def test_configure_tesseract_command_sets_pytesseract_binary(self) -> None:
+        fake_pytesseract = types.SimpleNamespace(pytesseract=types.SimpleNamespace(tesseract_cmd="tesseract"))
+
+        with (
+            patch.object(config, "TESSERACT_PATH", Path("/tools/tesseract")),
+            patch("bd_to_avp.modules.config.importlib.import_module", return_value=fake_pytesseract),
+        ):
+            config.configure_tesseract_command()
+
+        self.assertEqual(fake_pytesseract.pytesseract.tesseract_cmd, "/tools/tesseract")
+
+
+class MkvToolPathTests(unittest.TestCase):
+    def test_mkv_metadata_uses_configured_mkvmerge_path(self) -> None:
+        metadata = b'{"tracks": []}'
+        with (
+            patch.object(mkv.config, "MKVMERGE_PATH", Path("/tools/mkvmerge")),
+            patch("bd_to_avp.vendor.pgsrip.mkv.check_output", return_value=metadata) as check_output,
+        ):
+            mkv.Mkv("movie.mkv")
+
+        check_output.assert_called_once_with([Path("/tools/mkvmerge"), "-i", "-F", "json", "movie.mkv"])
+
+    def test_pgs_extraction_uses_configured_mkvextract_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            sup_path = temp_path / "3.en.sup"
+
+            def write_sup(_command: list[object]) -> bytes:
+                sup_path.write_bytes(b"pgs")
+                return b""
+
+            media_path = mkv.MediaPath("movie.mkv").translate(language=mkv.Language("eng"))
+
+            with (
+                patch.object(mkv.config, "MKVEXTRACT_PATH", Path("/tools/mkvextract")),
+                patch("bd_to_avp.vendor.pgsrip.mkv.check_output", side_effect=write_sup) as check_output,
+            ):
+                data = mkv.MkvPgs.read_data(media_path, 3, temp_dir)
+
+        self.assertEqual(data, b"pgs")
+        check_output.assert_called_once_with([Path("/tools/mkvextract"), str(media_path), "tracks", f"3:{sup_path}"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add centralized runtime tool resolution that prefers `BD_TO_AVP_<TOOL>_PATH`, app-local `bd_to_avp/bin`, PATH, then legacy `/opt/homebrew/bin`.
- Wire resolved paths through FFmpeg/FFprobe, MakeMKV/MP4Box config, and vendored pgsrip MKVToolNix calls.
- Configure runtime PATH/Tesseract behavior so packaged builds can move toward bundled tools without breaking current Homebrew/manual installs.
- Document the new runtime lookup order.

## Proof
- `uv run python -m unittest discover -s tests -t .`
- `uv run ruff format --check bd_to_avp tests`
- `uv run ruff check bd_to_avp tests`
- `uv run mypy bd_to_avp tests`
- `uv build`
- `git diff --check`
- Independent agent review with GPT/Gemini-family agents; actionable findings were fixed and covered by tests.

## Notes
- This is the first Homebrew-free runtime slice. The existing installer/manual setup still uses Homebrew as a compatibility path and remains future cleanup work under issue #101.
