### PR TITLE
Bundle FFmpeg tools during app packaging

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -183,7 +183,9 @@ jobs:
           find . -name QtWebEngineCore.framework -type d | while read -r dir; do
             find "$dir" -type f -execdir codesign --force --verify --verbose --sign "${{ secrets.DEV_ID }}" {} \;
           done
+          find build/bd-to-avp/macos/app -path "*/bd_to_avp/bin/*" -type f -perm +111 -exec codesign --force --options runtime --timestamp --sign "${{ secrets.DEV_ID }}" {} \;
           find build/bd-to-avp/macos/app -name "*.dylib" -exec codesign --force --sign - {} \;
+          uv run python scripts/verify_app_tools.py
           uv run python scripts/briefcase_app.py package -i "${{ secrets.DEV_ID }}"
       - name: Upload log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Briefcase build smoke
         run: uv run python scripts/briefcase_app.py build --no-input
+
+      - name: Verify app-local FFmpeg tools
+        run: uv run python scripts/verify_app_tools.py

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ celerybeat.pid
 .env
 .venv
 .briefcase-wheelhouse/
+.vendor/
+bd_to_avp/bin/ffmpeg
+bd_to_avp/bin/ffprobe
 env/
 venv/
 ENV/

--- a/.idea/BD_to_AVP.iml
+++ b/.idea/BD_to_AVP.iml
@@ -10,7 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/logs" />
       <excludePattern pattern="*.lock" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="uv (BD_to_AVP)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/bd_to_avp/install.py
+++ b/bd_to_avp/install.py
@@ -96,7 +96,9 @@ def install_deps() -> None:
         if not check_is_package_installed(package):
             manage_brew_package(package, sudo_env, True)
 
-    manage_brew_package(config.BREW_PACKAGES_TO_INSTALL, sudo_env)
+    required_formulae = get_required_formulae()
+    if required_formulae:
+        manage_brew_package(required_formulae, sudo_env)
 
     verify_dependency_binaries()
 
@@ -123,6 +125,12 @@ def verify_dependency_binaries() -> None:
 
 def get_required_casks() -> list[str]:
     return config.BREW_CASKS_TO_INSTALL
+
+
+def get_required_formulae() -> list[str]:
+    if config.FFMPEG_PATH.exists() and config.FFPROBE_PATH.exists():
+        return [package for package in config.BREW_PACKAGES_TO_INSTALL if package != "ffmpeg"]
+    return config.BREW_PACKAGES_TO_INSTALL
 
 
 def ensure_native_mvc_splitter_executable() -> bool:

--- a/bd_to_avp/resources/notices/ffmpeg-macos-arm64.txt
+++ b/bd_to_avp/resources/notices/ffmpeg-macos-arm64.txt
@@ -1,0 +1,33 @@
+FFmpeg and FFprobe macOS arm64 binaries
+
+BD_to_AVP packages FFmpeg and FFprobe as separate command-line executables for
+video probing, extraction, filtering, and encoding.
+
+Vendored binary source:
+- Project: FFmpeg
+- Version: 8.1.2
+- Platform: macOS arm64 static executables
+- Download base: https://ffmpeg.martin-riedl.de/download/macos/arm64/1783011502_8.1.2
+- FFmpeg archive SHA256: ef1aa60006c7b77ce170c1608c08d8e4ba1c30c5746f2ac986ded932d0ac2c3c
+- FFprobe archive SHA256: c39787f4af7a3932502d2d48db6f6feaaa836b48a73ef78c32cc3285df61dfaf
+- FFmpeg executable SHA256: eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d
+- FFprobe executable SHA256: ed9dc5871914b466b96b402c9ec0ba68ce4f836e72faa464b1b4e279835bd4a6
+
+The vendored build is GPL-enabled. This is compatible with BD_to_AVP's
+GPL-3.0-or-later license, but downstream redistributors must preserve FFmpeg's
+applicable license obligations and corresponding-source access.
+
+Embedded build configuration reported by `ffmpeg -version` / `ffprobe -version`:
+
+--prefix=/Volumes/ffmpeg_arm64/out --pkg-config-flags=--static --extra-version='https://www.martin-riedl.de' --enable-gray --enable-libxml2 --enable-version3 --enable-gpl --enable-openssl --enable-libfreetype --enable-fontconfig --enable-libharfbuzz --enable-libsnappy --enable-libsrt --enable-libvmaf --enable-libass --enable-libklvanc --enable-libzimg --enable-libzvbi --enable-libaom --enable-libdav1d --enable-libopenh264 --enable-libopenjpeg --enable-librav1e --enable-libsvtav1 --enable-libvpx --enable-libvvenc --enable-libwebp --enable-libx264 --enable-libx265 --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libtheora
+
+FFmpeg source and license information:
+- Source: https://ffmpeg.org/download.html
+- Source tag: https://github.com/FFmpeg/FFmpeg/tree/n8.1.2
+- License overview: https://ffmpeg.org/legal.html
+- Upstream license file: https://github.com/FFmpeg/FFmpeg/blob/master/LICENSE.md
+- GNU GPL v3 text: https://www.gnu.org/licenses/gpl-3.0.txt
+
+The vendoring script is `scripts/vendor_ffmpeg_macos.py`. It downloads the
+pinned archives, verifies the SHA256 checksums above, extracts `ffmpeg` and
+`ffprobe` into `bd_to_avp/bin`, and sets executable bits for packaging.

--- a/scripts/briefcase_app.py
+++ b/scripts/briefcase_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -9,6 +10,21 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WHEELHOUSE = REPO_ROOT / ".briefcase-wheelhouse"
 WHEELHOUSE_REQUIREMENTS = ["pysrt==1.1.2"]
+VENDOR_FFMPEG_COMMANDS = {"create", "build", "run"}
+APP_RESOURCE_BIN = (
+    REPO_ROOT
+    / "build"
+    / "bd-to-avp"
+    / "macos"
+    / "app"
+    / "3D Blu-ray to Vision Pro.app"
+    / "Contents"
+    / "Resources"
+    / "app"
+    / "bd_to_avp"
+    / "bin"
+)
+VENDORED_TOOLS = ["ffmpeg", "ffprobe"]
 
 
 def run(command: list[str]) -> None:
@@ -35,6 +51,26 @@ def briefcase_config_override() -> str:
     return f'requirement_installer_args=["--find-links", "{wheelhouse_path}"]'
 
 
+def should_vendor_ffmpeg(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & VENDOR_FFMPEG_COMMANDS)
+
+
+def vendor_ffmpeg() -> None:
+    run([sys.executable, "scripts/vendor_ffmpeg_macos.py"])
+    sync_vendored_tools_to_existing_app()
+
+
+def sync_vendored_tools_to_existing_app() -> None:
+    if not APP_RESOURCE_BIN.is_dir():
+        return
+
+    for tool_name in VENDORED_TOOLS:
+        source_path = REPO_ROOT / "bd_to_avp" / "bin" / tool_name
+        if source_path.exists():
+            shutil.copy2(source_path, APP_RESOURCE_BIN / tool_name)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run Briefcase with repo-local packaging fixes.")
     parser.add_argument("briefcase_args", nargs=argparse.REMAINDER)
@@ -44,6 +80,8 @@ def main() -> None:
         parser.error("provide a Briefcase command, for example: create --no-input")
 
     build_wheelhouse()
+    if should_vendor_ffmpeg(args.briefcase_args):
+        vendor_ffmpeg()
     run(
         [
             sys.executable,

--- a/scripts/vendor_ffmpeg_macos.py
+++ b/scripts/vendor_ffmpeg_macos.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import stat
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CACHE_DIR = REPO_ROOT / ".vendor" / "ffmpeg"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "bd_to_avp" / "bin"
+DOWNLOAD_BASE_URL = "https://ffmpeg.martin-riedl.de/download/macos/arm64/1783011502_8.1.2"
+FFMPEG_VERSION = "8.1.2"
+USER_AGENT = "BD_to_AVP ffmpeg vendor script"
+DOWNLOAD_TIMEOUT_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class BinaryAsset:
+    name: str
+    zip_sha256: str
+    binary_sha256: str
+
+    @property
+    def url(self) -> str:
+        return f"{DOWNLOAD_BASE_URL}/{self.name}.zip"
+
+    @property
+    def archive_name(self) -> str:
+        return f"{self.name}.zip"
+
+
+ASSETS = [
+    BinaryAsset(
+        name="ffmpeg",
+        zip_sha256="ef1aa60006c7b77ce170c1608c08d8e4ba1c30c5746f2ac986ded932d0ac2c3c",
+        binary_sha256="eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d",
+    ),
+    BinaryAsset(
+        name="ffprobe",
+        zip_sha256="c39787f4af7a3932502d2d48db6f6feaaa836b48a73ef78c32cc3285df61dfaf",
+        binary_sha256="ed9dc5871914b466b96b402c9ec0ba68ce4f836e72faa464b1b4e279835bd4a6",
+    ),
+]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response, destination.open("wb") as file:
+        shutil.copyfileobj(response, file)
+
+
+def verify_archive(path: Path, expected_sha256: str) -> None:
+    actual_sha256 = sha256(path)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(f"Checksum mismatch for {path.name}: expected {expected_sha256}, got {actual_sha256}")
+
+
+def extract_binary(asset: BinaryAsset, archive_path: Path, output_dir: Path) -> Path:
+    with zipfile.ZipFile(archive_path) as archive:
+        names = [name for name in archive.namelist() if Path(name).name == asset.name]
+        if len(names) != 1:
+            raise ValueError(f"Expected one {asset.name} binary in {archive_path.name}, found {names}")
+        extracted_path = Path(archive.extract(names[0], output_dir))
+
+    output_path = output_dir / asset.name
+    if extracted_path != output_path:
+        output_path.unlink(missing_ok=True)
+        extracted_path.replace(output_path)
+        for parent in reversed(extracted_path.parents):
+            if parent == output_dir or not parent.exists():
+                break
+            try:
+                parent.rmdir()
+            except OSError:
+                break
+
+    current_mode = output_path.stat().st_mode
+    output_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return output_path
+
+
+def verify_binary(path: Path, expected_sha256: str) -> None:
+    actual_sha256 = sha256(path)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"Checksum mismatch for extracted {path.name}: expected {expected_sha256}, got {actual_sha256}"
+        )
+
+
+def vendor_asset(asset: BinaryAsset, cache_dir: Path, output_dir: Path, refresh: bool) -> Path:
+    archive_path = cache_dir / asset.archive_name
+    if refresh or not archive_path.exists():
+        download(asset.url, archive_path)
+    verify_archive(archive_path, asset.zip_sha256)
+    output_path = extract_binary(asset, archive_path, output_dir)
+    verify_binary(output_path, asset.binary_sha256)
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Vendor static macOS arm64 FFmpeg tools into bd_to_avp/bin.")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--refresh", action="store_true", help="Download archives even when cached copies exist.")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    for asset in ASSETS:
+        output_path = vendor_asset(asset, args.cache_dir, args.output_dir, args.refresh)
+        print(f"Vendored {asset.name} {FFMPEG_VERSION}: {output_path} ({sha256(output_path)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+APP_PATH = Path("build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app")
+APP_TOOL_DIR = APP_PATH / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
+REQUIRED_TOOLS = ["ffmpeg", "ffprobe"]
+
+
+def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(item) for item in command],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def verify_tool(tool_path: Path) -> None:
+    if not tool_path.is_file():
+        raise FileNotFoundError(f"Missing bundled tool: {tool_path}")
+    if not tool_path.stat().st_mode & 0o111:
+        raise PermissionError(f"Bundled tool is not executable: {tool_path}")
+
+    run([tool_path, "-hide_banner", "-version"])
+    linked_libraries = run(["otool", "-L", tool_path]).stdout
+    if "/opt/homebrew" in linked_libraries:
+        raise RuntimeError(f"Bundled {tool_path.name} still links to /opt/homebrew:\n{linked_libraries}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify app-local command-line tools in the Briefcase app bundle.")
+    parser.add_argument("--app-path", type=Path, default=APP_PATH)
+    args = parser.parse_args()
+
+    tool_dir = args.app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
+    for tool_name in REQUIRED_TOOLS:
+        verify_tool(tool_dir / tool_name)
+    print(f"Verified app-local tools in {tool_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -1,0 +1,109 @@
+import stat
+import tempfile
+import unittest
+import zipfile
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import briefcase_app, vendor_ffmpeg_macos
+
+
+FAKE_BINARY_SHA256 = hashlib.sha256(b"binary").hexdigest()
+
+
+class VendorFfmpegTests(unittest.TestCase):
+    def test_extract_binary_sets_executable_bit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "ffmpeg.zip"
+            output_dir = temp_path / "bin"
+            output_dir.mkdir()
+
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("ffmpeg", b"binary")
+
+            output_path = vendor_ffmpeg_macos.extract_binary(
+                vendor_ffmpeg_macos.BinaryAsset(
+                    "ffmpeg",
+                    vendor_ffmpeg_macos.sha256(archive_path),
+                    FAKE_BINARY_SHA256,
+                ),
+                archive_path,
+                output_dir,
+            )
+
+            self.assertEqual(output_path.name, "ffmpeg")
+            self.assertTrue(output_path.stat().st_mode & stat.S_IXUSR)
+
+    def test_vendor_asset_uses_cached_verified_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            cache_dir = temp_path / "cache"
+            output_dir = temp_path / "bin"
+            cache_dir.mkdir()
+            archive_path = cache_dir / "ffprobe.zip"
+
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("ffprobe", b"binary")
+
+            asset = vendor_ffmpeg_macos.BinaryAsset(
+                "ffprobe", vendor_ffmpeg_macos.sha256(archive_path), FAKE_BINARY_SHA256
+            )
+
+            with patch("scripts.vendor_ffmpeg_macos.download") as download:
+                output_path = vendor_ffmpeg_macos.vendor_asset(asset, cache_dir, output_dir, refresh=False)
+
+            download.assert_not_called()
+            self.assertEqual(output_path, output_dir / "ffprobe")
+            self.assertTrue(output_path.exists())
+
+    def test_archive_checksum_mismatch_raises(self) -> None:
+        with tempfile.NamedTemporaryFile() as archive_file:
+            archive_path = Path(archive_file.name)
+            archive_path.write_bytes(b"unexpected")
+
+            with self.assertRaisesRegex(ValueError, "Checksum mismatch"):
+                vendor_ffmpeg_macos.verify_archive(archive_path, "0" * 64)
+
+    def test_binary_checksum_mismatch_raises(self) -> None:
+        with tempfile.NamedTemporaryFile() as binary_file:
+            binary_path = Path(binary_file.name)
+            binary_path.write_bytes(b"unexpected")
+
+            with self.assertRaisesRegex(ValueError, "extracted"):
+                vendor_ffmpeg_macos.verify_binary(binary_path, "0" * 64)
+
+
+class BriefcaseVendorHookTests(unittest.TestCase):
+    def test_vendor_ffmpeg_for_app_build_commands(self) -> None:
+        self.assertTrue(briefcase_app.should_vendor_ffmpeg(["create", "--no-input"]))
+        self.assertTrue(briefcase_app.should_vendor_ffmpeg(["build"]))
+        self.assertFalse(briefcase_app.should_vendor_ffmpeg(["package", "-i", "Developer ID"]))
+
+    def test_do_not_vendor_ffmpeg_for_non_app_commands(self) -> None:
+        self.assertFalse(briefcase_app.should_vendor_ffmpeg(["--help"]))
+
+    def test_sync_vendored_tools_to_existing_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            repo_root = temp_path / "repo"
+            source_bin = repo_root / "bd_to_avp" / "bin"
+            app_bin = temp_path / "app" / "bd_to_avp" / "bin"
+            source_bin.mkdir(parents=True)
+            app_bin.mkdir(parents=True)
+            (source_bin / "ffmpeg").write_text("ffmpeg")
+            (source_bin / "ffprobe").write_text("ffprobe")
+
+            with (
+                patch.object(briefcase_app, "REPO_ROOT", repo_root),
+                patch.object(briefcase_app, "APP_RESOURCE_BIN", app_bin),
+            ):
+                briefcase_app.sync_vendored_tools_to_existing_app()
+
+            self.assertEqual((app_bin / "ffmpeg").read_text(), "ffmpeg")
+            self.assertEqual((app_bin / "ffprobe").read_text(), "ffprobe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -138,6 +138,20 @@ class DependencyVerificationTests(unittest.TestCase):
     def test_required_casks_only_include_makemkv(self) -> None:
         self.assertEqual(install.get_required_casks(), ["makemkv"])
 
+    def test_required_formulae_skip_ffmpeg_when_bundled_tools_exist(self) -> None:
+        with (
+            patch.object(install.config, "FFMPEG_PATH", Path(__file__)),
+            patch.object(install.config, "FFPROBE_PATH", Path(__file__)),
+        ):
+            self.assertNotIn("ffmpeg", install.get_required_formulae())
+
+    def test_required_formulae_include_ffmpeg_when_bundled_tools_are_missing(self) -> None:
+        with (
+            patch.object(install.config, "FFMPEG_PATH", Path("/missing/ffmpeg")),
+            patch.object(install.config, "FFPROBE_PATH", Path("/missing/ffprobe")),
+        ):
+            self.assertIn("ffmpeg", install.get_required_formulae())
+
     def test_native_mvc_helper_repairs_missing_execute_bit(self) -> None:
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -28,7 +28,7 @@ class NativeMvcCommandTests(unittest.TestCase):
         ):
             command = video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
-        self.assertEqual(Path(command[0]).name, Path(video.config.FFMPEG_PATH).name)
+        self.assertEqual(Path(command[0]), Path(video.config.FFMPEG_PATH))
         self.assertIn("-f", command)
         self.assertIn("yuv4mpegpipe", command)
         self.assertIn("-filter_complex", command)
@@ -49,7 +49,7 @@ class NativeMvcCommandTests(unittest.TestCase):
         ):
             command = video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
-        self.assertEqual(Path(command[0]).name, Path(video.config.FFMPEG_PATH).name)
+        self.assertEqual(Path(command[0]), Path(video.config.FFMPEG_PATH))
         filter_graph = command[command.index("-filter_complex") + 1]
         map_labels = [command[index + 1] for index, value in enumerate(command) if value == "-map"]
         left_label, right_label = map_labels

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -30,6 +30,21 @@ class ToolResolutionTests(unittest.TestCase):
             ):
                 self.assertEqual(resolve_tool_path("MP4Box", script_bin_path=bin_path), bundled_tool)
 
+    def test_app_local_ffmpeg_wins_over_homebrew_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_path = Path(temp_dir)
+            bundled_ffmpeg = bin_path / "ffmpeg"
+            bundled_ffprobe = bin_path / "ffprobe"
+            bundled_ffmpeg.touch()
+            bundled_ffprobe.touch()
+
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch("bd_to_avp.modules.config.shutil.which", side_effect=lambda tool: f"/opt/homebrew/bin/{tool}"),
+            ):
+                self.assertEqual(resolve_tool_path("ffmpeg", script_bin_path=bin_path), bundled_ffmpeg)
+                self.assertEqual(resolve_tool_path("ffprobe", script_bin_path=bin_path), bundled_ffprobe)
+
     def test_path_wins_over_homebrew_fallback(self) -> None:
         with (
             patch.dict(os.environ, {}, clear=True),


### PR DESCRIPTION
## Summary
- Track the repo's PyCharm project SDK as the local uv SDK so `.idea/BD_to_AVP.iml` stops re-dirtying the worktree.
- Add a pinned macOS arm64 FFmpeg/FFprobe vendor script that downloads static 8.1.2 binaries, verifies archive and extracted executable SHA256s, and materializes them into `bd_to_avp/bin` for app packaging.
- Wire Briefcase builds to vendor/sync FFmpeg tools, verify the built app contains executable app-local FFmpeg/FFprobe, and sign the bundled tools during release packaging.
- Skip Homebrew `ffmpeg` formula installation when bundled FFmpeg/FFprobe are present; MakeMKV remains external.
- Add tests for vendoring, resolver precedence, install formula selection, and exact FFmpeg command paths.

## Proof
- `uv run python -m unittest discover -s tests -t .`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp tests`
- `uv build`
- `uv run python scripts/vendor_ffmpeg_macos.py`
- `uv run python scripts/briefcase_app.py build --no-input`
- `uv run python scripts/verify_app_tools.py`
- `git diff --check`
- Review agents: GPT, Claude, and Gemini/Antigravity. Actionable findings were fixed before commit.

## Notes
- The materialized `bd_to_avp/bin/ffmpeg` and `bd_to_avp/bin/ffprobe` binaries are ignored and not committed; CI/release packaging materializes them from pinned checksummed archives.
- The vendored FFmpeg build is GPL-enabled. The notice records the source, hashes, and build configuration; this is compatible with BD_to_AVP's GPL-3.0-or-later license.
- Residual supply-chain risk: this trusts the pinned third-party static binary source plus SHA256. A future improvement could build FFmpeg in our own CI or host a signed internal artifact.

Refs #101
