### PR TITLE
Automate FFmpeg vendor pin updates

### DIFF
--- a/.github/workflows/update-ffmpeg-vendor.yml
+++ b/.github/workflows/update-ffmpeg-vendor.yml
@@ -1,0 +1,66 @@
+name: Update FFmpeg Vendor Pins
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: FFmpeg version represented by the candidate build, for example 8.1.3
+        required: true
+      base_url:
+        description: Base URL containing ffmpeg.zip and ffprobe.zip
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-ffmpeg-vendor:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Refresh FFmpeg manifest
+        env:
+          FFMPEG_VERSION: ${{ inputs.version }}
+          FFMPEG_BASE_URL: ${{ inputs.base_url }}
+        run: |
+          uv run python -m scripts.update_ffmpeg_manifest \
+            --version "$FFMPEG_VERSION" \
+            --base-url "$FFMPEG_BASE_URL"
+
+      - name: Vendor and verify FFmpeg tools
+        run: |
+          uv run python scripts/vendor_ffmpeg_macos.py --refresh
+          ffmpeg_path="bd_to_avp/bin/ffmpeg"
+          ffprobe_path="bd_to_avp/bin/ffprobe"
+          "$ffmpeg_path" -hide_banner -version
+          "$ffprobe_path" -hide_banner -version
+          if otool -L "$ffmpeg_path" "$ffprobe_path" | grep -q /opt/homebrew; then
+            echo "Vendored FFmpeg tools must not link to /opt/homebrew"
+            exit 1
+          fi
+
+      - name: Create update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          branch: automation/update-ffmpeg-vendor
+          delete-branch: true
+          title: Update app-local FFmpeg vendor pins to ${{ inputs.version }}
+          commit-message: Update app-local FFmpeg vendor pins to ${{ inputs.version }}
+          body: |
+            Updates the app-local macOS arm64 FFmpeg vendor manifest.
+
+            Version: `${{ inputs.version }}`
+            Base URL: `${{ inputs.base_url }}`
+
+            The workflow downloaded `ffmpeg.zip` and `ffprobe.zip`, regenerated archive and extracted-binary SHA256 values, verified both tools execute, and checked they do not link to `/opt/homebrew`.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository helper scripts used by tests and workflows."""

--- a/scripts/update_ffmpeg_manifest.py
+++ b/scripts/update_ffmpeg_manifest.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts import vendor_ffmpeg_macos
+
+
+DEFAULT_MANIFEST_PATH = vendor_ffmpeg_macos.DEFAULT_MANIFEST_PATH
+DEFAULT_ASSET_NAMES = ["ffmpeg", "ffprobe"]
+
+
+@dataclass(frozen=True)
+class UpdatedAsset:
+    name: str
+    zip_sha256: str
+    binary_sha256: str
+
+
+@dataclass(frozen=True)
+class UpdatedManifest:
+    version: str
+    base_url: str
+    license_mode: str
+    build: str
+    assets: list[UpdatedAsset]
+
+
+def build_candidate_manifest(
+    *,
+    version: str,
+    base_url: str,
+    license_mode: str,
+    build: str,
+    asset_names: list[str],
+) -> UpdatedManifest:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        archive_dir = temp_path / "archives"
+        output_dir = temp_path / "bin"
+        archive_dir.mkdir()
+        output_dir.mkdir()
+        assets: list[UpdatedAsset] = []
+
+        for asset_name in asset_names:
+            url = f"{base_url.rstrip('/')}/{asset_name}.zip"
+            archive_path = archive_dir / f"{asset_name}.zip"
+            vendor_ffmpeg_macos.download(url, archive_path)
+            zip_sha256 = vendor_ffmpeg_macos.sha256(archive_path)
+            binary_path = extract_asset_binary(asset_name, archive_path, output_dir)
+            binary_sha256 = vendor_ffmpeg_macos.sha256(binary_path)
+            assets.append(UpdatedAsset(name=asset_name, zip_sha256=zip_sha256, binary_sha256=binary_sha256))
+
+    return UpdatedManifest(
+        version=version,
+        base_url=base_url.rstrip("/"),
+        license_mode=license_mode,
+        build=build,
+        assets=assets,
+    )
+
+
+def extract_asset_binary(asset_name: str, archive_path: Path, output_dir: Path) -> Path:
+    with zipfile.ZipFile(archive_path) as archive:
+        matches = [name for name in archive.namelist() if Path(name).name == asset_name]
+        if len(matches) != 1:
+            raise ValueError(f"Expected one {asset_name} binary in {archive_path.name}, found {matches}")
+        extracted_path = Path(archive.extract(matches[0], output_dir))
+
+    output_path = output_dir / asset_name
+    if extracted_path != output_path:
+        output_path.unlink(missing_ok=True)
+        extracted_path.replace(output_path)
+    return output_path
+
+
+def render_manifest(manifest: UpdatedManifest) -> str:
+    lines = [
+        toml_string("version", manifest.version),
+        toml_string("base_url", manifest.base_url),
+        toml_string("license_mode", manifest.license_mode),
+        toml_string("build", manifest.build),
+        "",
+    ]
+    for asset in manifest.assets:
+        lines.extend(
+            [
+                "[[assets]]",
+                toml_string("name", asset.name),
+                toml_string("zip_sha256", asset.zip_sha256),
+                toml_string("binary_sha256", asset.binary_sha256),
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def toml_string(key: str, value: str) -> str:
+    escaped_value = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{key} = "{escaped_value}"'
+
+
+def write_manifest(manifest_path: Path, manifest: UpdatedManifest) -> None:
+    manifest_path.write_text(render_manifest(manifest))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refresh the app-local macOS arm64 FFmpeg vendor manifest.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST_PATH)
+    parser.add_argument("--version", required=True, help="FFmpeg version represented by the candidate build.")
+    parser.add_argument("--base-url", required=True, help="Base URL containing ffmpeg.zip and ffprobe.zip.")
+    parser.add_argument("--license-mode", default="GPLv3")
+    parser.add_argument(
+        "--build",
+        default="static macOS arm64 build from ffmpeg.martin-riedl.de",
+        help="Human-readable build/source description stored in the manifest.",
+    )
+    parser.add_argument("--asset", dest="asset_names", action="append", choices=DEFAULT_ASSET_NAMES)
+    args = parser.parse_args()
+
+    asset_names = args.asset_names or DEFAULT_ASSET_NAMES
+    old_manifest = vendor_ffmpeg_macos.load_manifest(args.manifest)
+    new_manifest = build_candidate_manifest(
+        version=args.version,
+        base_url=args.base_url,
+        license_mode=args.license_mode,
+        build=args.build,
+        asset_names=asset_names,
+    )
+    write_manifest(args.manifest, new_manifest)
+    print(f"Updated FFmpeg manifest: {old_manifest.version} -> {new_manifest.version}")
+    print(f"Old base URL: {old_manifest.base_url}")
+    print(f"New base URL: {new_manifest.base_url}")
+    for asset in new_manifest.assets:
+        print(f"{asset.name}: zip={asset.zip_sha256} binary={asset.binary_sha256}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vendor_ffmpeg_macos.py
+++ b/scripts/vendor_ffmpeg_macos.py
@@ -4,17 +4,18 @@ import argparse
 import hashlib
 import shutil
 import stat
+import tomllib
 import urllib.request
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CACHE_DIR = REPO_ROOT / ".vendor" / "ffmpeg"
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "bd_to_avp" / "bin"
-DOWNLOAD_BASE_URL = "https://ffmpeg.martin-riedl.de/download/macos/arm64/1783011502_8.1.2"
-FFMPEG_VERSION = "8.1.2"
+DEFAULT_MANIFEST_PATH = REPO_ROOT / "vendor" / "ffmpeg-macos-arm64.toml"
 USER_AGENT = "BD_to_AVP ffmpeg vendor script"
 DOWNLOAD_TIMEOUT_SECONDS = 30
 
@@ -22,30 +23,56 @@ DOWNLOAD_TIMEOUT_SECONDS = 30
 @dataclass(frozen=True)
 class BinaryAsset:
     name: str
+    url: str
     zip_sha256: str
     binary_sha256: str
-
-    @property
-    def url(self) -> str:
-        return f"{DOWNLOAD_BASE_URL}/{self.name}.zip"
 
     @property
     def archive_name(self) -> str:
         return f"{self.name}.zip"
 
 
-ASSETS = [
-    BinaryAsset(
-        name="ffmpeg",
-        zip_sha256="ef1aa60006c7b77ce170c1608c08d8e4ba1c30c5746f2ac986ded932d0ac2c3c",
-        binary_sha256="eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d",
-    ),
-    BinaryAsset(
-        name="ffprobe",
-        zip_sha256="c39787f4af7a3932502d2d48db6f6feaaa836b48a73ef78c32cc3285df61dfaf",
-        binary_sha256="ed9dc5871914b466b96b402c9ec0ba68ce4f836e72faa464b1b4e279835bd4a6",
-    ),
-]
+@dataclass(frozen=True)
+class VendorManifest:
+    version: str
+    base_url: str
+    license_mode: str
+    build: str
+    assets: list[BinaryAsset]
+
+
+def load_manifest(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> VendorManifest:
+    data = tomllib.loads(manifest_path.read_text())
+    return manifest_from_data(data)
+
+
+def manifest_from_data(data: dict[str, Any]) -> VendorManifest:
+    base_url = require_string(data, "base_url").rstrip("/")
+    assets = [
+        BinaryAsset(
+            name=require_string(asset, "name"),
+            url=f"{base_url}/{require_string(asset, 'name')}.zip",
+            zip_sha256=require_string(asset, "zip_sha256"),
+            binary_sha256=require_string(asset, "binary_sha256"),
+        )
+        for asset in data.get("assets", [])
+    ]
+    if not assets:
+        raise ValueError("FFmpeg vendor manifest must define at least one asset")
+    return VendorManifest(
+        version=require_string(data, "version"),
+        base_url=base_url,
+        license_mode=require_string(data, "license_mode"),
+        build=require_string(data, "build"),
+        assets=assets,
+    )
+
+
+def require_string(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"FFmpeg vendor manifest field must be a non-empty string: {key}")
+    return value
 
 
 def sha256(path: Path) -> str:
@@ -57,6 +84,8 @@ def sha256(path: Path) -> str:
 
 
 def download(url: str, destination: Path) -> None:
+    if not url.startswith("https://"):
+        raise ValueError(f"FFmpeg vendor downloads must use HTTPS: {url}")
     destination.parent.mkdir(parents=True, exist_ok=True)
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     with urllib.request.urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response, destination.open("wb") as file:
@@ -115,13 +144,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Vendor static macOS arm64 FFmpeg tools into bd_to_avp/bin.")
     parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST_PATH)
     parser.add_argument("--refresh", action="store_true", help="Download archives even when cached copies exist.")
     args = parser.parse_args()
 
+    manifest = load_manifest(args.manifest)
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    for asset in ASSETS:
+    for asset in manifest.assets:
         output_path = vendor_asset(asset, args.cache_dir, args.output_dir, args.refresh)
-        print(f"Vendored {asset.name} {FFMPEG_VERSION}: {output_path} ({sha256(output_path)})")
+        print(f"Vendored {asset.name} {manifest.version}: {output_path} ({sha256(output_path)})")
 
 
 if __name__ == "__main__":

--- a/tests/test_ffmpeg_manifest_update.py
+++ b/tests/test_ffmpeg_manifest_update.py
@@ -1,0 +1,120 @@
+import hashlib
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import update_ffmpeg_manifest, vendor_ffmpeg_macos
+
+
+class UpdateFfmpegManifestTests(unittest.TestCase):
+    def test_render_manifest_is_deterministic(self) -> None:
+        manifest = update_ffmpeg_manifest.UpdatedManifest(
+            version="8.1.3",
+            base_url="https://example.invalid/8.1.3",
+            license_mode="GPLv3",
+            build="test build",
+            assets=[
+                update_ffmpeg_manifest.UpdatedAsset(
+                    name="ffmpeg",
+                    zip_sha256="0" * 64,
+                    binary_sha256="1" * 64,
+                )
+            ],
+        )
+
+        self.assertEqual(
+            update_ffmpeg_manifest.render_manifest(manifest),
+            "\n".join(
+                [
+                    'version = "8.1.3"',
+                    'base_url = "https://example.invalid/8.1.3"',
+                    'license_mode = "GPLv3"',
+                    'build = "test build"',
+                    "",
+                    "[[assets]]",
+                    'name = "ffmpeg"',
+                    f'zip_sha256 = "{"0" * 64}"',
+                    f'binary_sha256 = "{"1" * 64}"',
+                    "",
+                ]
+            ),
+        )
+
+    def test_build_candidate_manifest_downloads_and_hashes_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            archive_path = source_dir / "ffmpeg.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("nested/ffmpeg", b"binary")
+            expected_zip_sha256 = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+
+            def copy_archive(_url: str, destination: Path) -> None:
+                destination.write_bytes(archive_path.read_bytes())
+
+            with patch("scripts.vendor_ffmpeg_macos.download", side_effect=copy_archive):
+                manifest = update_ffmpeg_manifest.build_candidate_manifest(
+                    version="8.1.3",
+                    base_url="https://example.invalid/build",
+                    license_mode="GPLv3",
+                    build="test build",
+                    asset_names=["ffmpeg"],
+                )
+
+        self.assertEqual(manifest.version, "8.1.3")
+        self.assertEqual(manifest.assets[0].zip_sha256, expected_zip_sha256)
+        self.assertEqual(manifest.assets[0].binary_sha256, hashlib.sha256(b"binary").hexdigest())
+
+    def test_written_manifest_loads_in_vendor_script(self) -> None:
+        manifest = update_ffmpeg_manifest.UpdatedManifest(
+            version="8.1.3",
+            base_url="https://example.invalid/8.1.3",
+            license_mode="GPLv3",
+            build="test build",
+            assets=[
+                update_ffmpeg_manifest.UpdatedAsset(
+                    name="ffmpeg",
+                    zip_sha256="0" * 64,
+                    binary_sha256="1" * 64,
+                )
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "ffmpeg.toml"
+            update_ffmpeg_manifest.write_manifest(manifest_path, manifest)
+            loaded_manifest = vendor_ffmpeg_macos.load_manifest(manifest_path)
+
+        self.assertEqual(loaded_manifest.version, "8.1.3")
+        self.assertEqual(loaded_manifest.assets[0].name, "ffmpeg")
+        self.assertEqual(loaded_manifest.assets[0].binary_sha256, "1" * 64)
+
+    def test_written_manifest_escapes_toml_strings(self) -> None:
+        manifest = update_ffmpeg_manifest.UpdatedManifest(
+            version='8.1.3 "quoted"',
+            base_url="https://example.invalid/build\\path",
+            license_mode="GPLv3",
+            build='build with "quotes" and \\slashes',
+            assets=[
+                update_ffmpeg_manifest.UpdatedAsset(
+                    name="ffmpeg",
+                    zip_sha256="0" * 64,
+                    binary_sha256="1" * 64,
+                )
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "ffmpeg.toml"
+            update_ffmpeg_manifest.write_manifest(manifest_path, manifest)
+            loaded_manifest = vendor_ffmpeg_macos.load_manifest(manifest_path)
+
+        self.assertEqual(loaded_manifest.version, '8.1.3 "quoted"')
+        self.assertEqual(loaded_manifest.base_url, "https://example.invalid/build\\path")
+        self.assertEqual(loaded_manifest.build, 'build with "quotes" and \\slashes')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -25,9 +25,10 @@ class VendorFfmpegTests(unittest.TestCase):
 
             output_path = vendor_ffmpeg_macos.extract_binary(
                 vendor_ffmpeg_macos.BinaryAsset(
-                    "ffmpeg",
-                    vendor_ffmpeg_macos.sha256(archive_path),
-                    FAKE_BINARY_SHA256,
+                    name="ffmpeg",
+                    url="https://example.invalid/ffmpeg.zip",
+                    zip_sha256=vendor_ffmpeg_macos.sha256(archive_path),
+                    binary_sha256=FAKE_BINARY_SHA256,
                 ),
                 archive_path,
                 output_dir,
@@ -48,7 +49,10 @@ class VendorFfmpegTests(unittest.TestCase):
                 archive.writestr("ffprobe", b"binary")
 
             asset = vendor_ffmpeg_macos.BinaryAsset(
-                "ffprobe", vendor_ffmpeg_macos.sha256(archive_path), FAKE_BINARY_SHA256
+                name="ffprobe",
+                url="https://example.invalid/ffprobe.zip",
+                zip_sha256=vendor_ffmpeg_macos.sha256(archive_path),
+                binary_sha256=FAKE_BINARY_SHA256,
             )
 
             with patch("scripts.vendor_ffmpeg_macos.download") as download:
@@ -58,6 +62,31 @@ class VendorFfmpegTests(unittest.TestCase):
             self.assertEqual(output_path, output_dir / "ffprobe")
             self.assertTrue(output_path.exists())
 
+    def test_load_manifest_builds_asset_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "ffmpeg.toml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        'version = "8.1.2"',
+                        'base_url = "https://example.invalid/ffmpeg"',
+                        'license_mode = "GPLv3"',
+                        'build = "test build"',
+                        "",
+                        "[[assets]]",
+                        'name = "ffmpeg"',
+                        f'zip_sha256 = "{"0" * 64}"',
+                        f'binary_sha256 = "{"1" * 64}"',
+                    ]
+                )
+            )
+
+            manifest = vendor_ffmpeg_macos.load_manifest(manifest_path)
+
+        self.assertEqual(manifest.version, "8.1.2")
+        self.assertEqual(manifest.license_mode, "GPLv3")
+        self.assertEqual(manifest.assets[0].url, "https://example.invalid/ffmpeg/ffmpeg.zip")
+
     def test_archive_checksum_mismatch_raises(self) -> None:
         with tempfile.NamedTemporaryFile() as archive_file:
             archive_path = Path(archive_file.name)
@@ -65,6 +94,13 @@ class VendorFfmpegTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "Checksum mismatch"):
                 vendor_ffmpeg_macos.verify_archive(archive_path, "0" * 64)
+
+    def test_download_rejects_non_https_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "ffmpeg.zip"
+
+            with self.assertRaisesRegex(ValueError, "HTTPS"):
+                vendor_ffmpeg_macos.download("http://example.invalid/ffmpeg.zip", destination)
 
     def test_binary_checksum_mismatch_raises(self) -> None:
         with tempfile.NamedTemporaryFile() as binary_file:

--- a/vendor/ffmpeg-macos-arm64.toml
+++ b/vendor/ffmpeg-macos-arm64.toml
@@ -1,0 +1,14 @@
+version = "8.1.2"
+base_url = "https://ffmpeg.martin-riedl.de/download/macos/arm64/1783011502_8.1.2"
+license_mode = "GPLv3"
+build = "static macOS arm64 build from ffmpeg.martin-riedl.de"
+
+[[assets]]
+name = "ffmpeg"
+zip_sha256 = "ef1aa60006c7b77ce170c1608c08d8e4ba1c30c5746f2ac986ded932d0ac2c3c"
+binary_sha256 = "eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d"
+
+[[assets]]
+name = "ffprobe"
+zip_sha256 = "c39787f4af7a3932502d2d48db6f6feaaa836b48a73ef78c32cc3285df61dfaf"
+binary_sha256 = "ed9dc5871914b466b96b402c9ec0ba68ce4f836e72faa464b1b4e279835bd4a6"


### PR DESCRIPTION
## Summary

- Move app-local macOS arm64 FFmpeg/FFprobe pins into `vendor/ffmpeg-macos-arm64.toml`.
- Update `scripts/vendor_ffmpeg_macos.py` to read the manifest instead of hard-coding URLs and hashes.
- Add `scripts/update_ffmpeg_manifest.py` to refresh a trusted candidate build URL, compute archive and extracted-binary SHA256 values, and rewrite the manifest.
- Add a manual GitHub workflow that runs the updater, verifies vendored tools execute and do not link to `/opt/homebrew`, and opens a reviewable PR with `peter-evans/create-pull-request`.
- Keep Dependabot as-is for supported ecosystems; avoid Renovate because checksum regeneration still requires custom code.

Refs #105
Refs #101

## Design Notes

This intentionally uses `workflow_dispatch` rather than a fully scheduled scraper. The FFmpeg binary host does not expose a reliable directory listing, and candidate build selection is a trust decision. The workflow automates the repeatable parts: download, hash, manifest rewrite, tool verification, and PR creation.

Security hardening included in this PR:

- workflow inputs are passed through environment variables before shell use
- write-permission workflow actions are pinned to full commit SHAs
- vendor downloads require HTTPS
- generated TOML strings are escaped and round-tripped through the vendor loader in tests

## Validation

- `uv run python -m unittest discover -s tests -t .` (52 tests)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp tests scripts`
- `uv build`
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'`
- `uv run bd-to-avp --help`
- `uv run bd-to-avp --version`
- `uv run python -m scripts.update_ffmpeg_manifest --help`
- `git diff --check`

## Review Notes

- Initial plan validation used Claude and Antigravity/Gemini-family agents; both recommended the simpler GitHub Action + updater script instead of Renovate.
- Implementation review used GPT, Claude, and Antigravity/Gemini-family agents.
- Review findings fixed before PR: module execution mode, workflow input handling, HTTPS enforcement, stale labels, scheduled no-op removal, TOML escaping, and action SHA pinning.
