### PR TITLE
Resolve first-party Python CodeQL findings

### DIFF
--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -50,7 +50,7 @@ class MainWindow(QMainWindow):
         self.setup_window()
         self.create_main_layout()
 
-        self.processing_thread = ProcessingThread(main_window=self)
+        self.processing_thread = ProcessingThread(parent=self)
         self.processing_thread.signals.progress_updated.connect(self.update_processing_output)
         self.processing_thread.error_occurred.connect(self.handle_processing_error)
         self.processing_thread.mkv_creation_error.connect(self.handle_mkv_creation_error)
@@ -449,6 +449,7 @@ class MainWindow(QMainWindow):
             )
             self.save_config()
             self.process_start_time = datetime.now()
+        self.processing_thread.start_stage = config.start_stage
         self.processing_thread.start()
         self.process_button.setText(self.STOP_PROCESSING_TEXT)
 

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -1,5 +1,4 @@
 import sys
-from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QObject, QThread, Signal
 from PySide6.QtWidgets import QWidget
@@ -10,9 +9,6 @@ from ..modules.command import terminate_process, Spinner
 from bd_to_avp.modules.process import start_process
 from ..modules.config import Stage
 from ..modules.sub import SRTCreationError
-
-if TYPE_CHECKING:
-    from .main_window import MainWindow
 
 
 class ProcessingSignals(QObject):
@@ -26,18 +22,17 @@ class ProcessingThread(QThread):
     file_exists_error = Signal(FileExistsError)
     process_completed = Signal()
 
-    def __init__(self, main_window: "MainWindow", parent: QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.signals = ProcessingSignals()
         self.output_handler = OutputHandler(self.signals.progress_updated.emit)
-        self.main_window = main_window
+        self.start_stage = Stage.CREATE_MKV
 
     def run(self) -> None:
         sys.stdout = self.output_handler  # type: ignore
 
         try:
-            selected_stage = int(self.main_window.start_stage_combobox.current_text().split(" - ")[0])
-            start_process(Stage.get_stage(selected_stage))
+            start_process(self.start_stage)
             self.process_completed.emit()
         except MKVCreationError as error:
             self.mkv_creation_error.emit(error)
@@ -50,7 +45,6 @@ class ProcessingThread(QThread):
         finally:
             Spinner.stop_all()
             sys.stdout = sys.__stdout__
-            self.main_window.process_button.setText(self.main_window.START_PROCESSING_TEXT)
 
     def terminate(self) -> None:
         terminate_process()

--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -163,5 +163,6 @@ def kill_processes_by_name(process_names: list[str]) -> None:
 def kill_process_by_name(process_name: str) -> None:
     try:
         subprocess.run(["pkill", "-f", process_name], check=True)
-    except subprocess.CalledProcessError:
-        pass
+    except subprocess.CalledProcessError as error:
+        if error.returncode != 1:
+            raise

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -55,9 +55,6 @@ def create_mvc_and_audio(
             audio_output_path,
         )
 
-    # if not config.keep_files and mkv_output_path and config.source_path != mkv_output_path:
-    #     mkv_output_path.unlink(missing_ok=True)
-
     return audio_output_path, video_output_path
 
 


### PR DESCRIPTION
## Summary
- decouple ProcessingThread from the concrete MainWindow by passing the selected processing stage into the worker
- keep UI state updates owned by MainWindow signal handlers
- make pkill misses explicit while preserving unexpected failure propagation
- remove dead commented-out container cleanup code

## Validation
- uv run ruff check --diff bd_to_avp/gui/processing.py bd_to_avp/gui/main_window.py bd_to_avp/modules/command.py bd_to_avp/modules/container.py
- uv run ruff check bd_to_avp/gui/processing.py bd_to_avp/gui/main_window.py bd_to_avp/modules/command.py bd_to_avp/modules/container.py
- uv run mypy bd_to_avp
- uv run python -m unittest discover -s tests -t .
- uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'
- uv run bd-to-avp --help

Refs #111. Vendored pgsrip findings are intentionally deferred to #113.