### PR TITLE
Clean vendored pgsrip CodeQL notes

### DIFF
--- a/bd_to_avp/vendor/pgsrip/cli.py
+++ b/bd_to_avp/vendor/pgsrip/cli.py
@@ -30,9 +30,12 @@ class DebugProgressBar(typing.Generic[T]):
 
     def __iter__(self):
         if not self.debug:
-            return self.progressbar.__iter__()
+            with self.progressbar as progressbar:
+                yield from progressbar
+            return None
 
         yield from self.iterable
+        return None
 
     def __enter__(self):
         if not self.debug:
@@ -47,9 +50,13 @@ class DebugProgressBar(typing.Generic[T]):
         if not self.debug:
             return self.progressbar.__exit__(exc_type, exc, traceback)
 
+        return None
+
     def update(self, n_steps: int, current_item: typing.Optional[T] = None) -> None:
         if not self.debug:
             return self.progressbar.update(n_steps, current_item)
+
+        return None
 
 
 class LanguageParamType(click.ParamType):

--- a/bd_to_avp/vendor/pgsrip/media.py
+++ b/bd_to_avp/vendor/pgsrip/media.py
@@ -73,6 +73,8 @@ class PgsSubtitleItem:
 
             return PgsImage(img_data, palettes)
 
+        return None
+
     @property
     def language(self):
         return self.media_path.language
@@ -190,7 +192,7 @@ class Pgs:
             f.write(f'{new_line.join([str(ds) for ds in display_sets])}')
         with open(os.path.join(self.temp_folder, 'display-sets.json'), mode='w', encoding='utf8') as f:
             json.dump([ds.to_json() for ds in display_sets], f,
-                      indent=2, ensure_ascii=False, default=lambda x: str(x))
+                      indent=2, ensure_ascii=False, default=str)
 
     def __repr__(self):
         return f'<{self.__class__.__name__} [{self}]>'

--- a/bd_to_avp/vendor/pgsrip/pgs.py
+++ b/bd_to_avp/vendor/pgsrip/pgs.py
@@ -345,15 +345,21 @@ class ObjectDefinitionSegment(BaseSegment):
         if self.sequence_type != ObjectSequenceType.LAST:
             return from_hex(self.data[4:7])
 
+        return None
+
     @property
     def width(self):
         if self.sequence_type != ObjectSequenceType.LAST:
             return from_hex(self.data[7:9])
 
+        return None
+
     @property
     def height(self):
         if self.sequence_type != ObjectSequenceType.LAST:
             return from_hex(self.data[9:11])
+
+        return None
 
     @property
     def img_data(self):


### PR DESCRIPTION
## Summary
- make vendored pgsrip debug progress bar return paths explicit
- make PGS image/object optional returns explicit
- replace the JSON fallback lambda with `str`

## Validation
- `uv run python -m unittest discover -s tests -t .`
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app; import bd_to_avp.vendor.pgsrip.cli; import bd_to_avp.vendor.pgsrip.media; import bd_to_avp.vendor.pgsrip.pgs'`
- `uv run bd-to-avp --help`
- `uv run python - <<'PY' ... DebugProgressBar smoke ... PY`
- `uv run mypy bd_to_avp`

Refs #113.
