### PR TITLE
Clean final pgsrip CodeQL note

### DIFF
--- a/bd_to_avp/vendor/pgsrip/cli.py
+++ b/bd_to_avp/vendor/pgsrip/cli.py
@@ -67,6 +67,7 @@ class LanguageParamType(click.ParamType):
             return Language.fromietf(value)
         except (BabelfishError, ValueError):
             self.fail(f"{click.style(f'{value}', bold=True)} is not a valid language")
+            return None
 
 
 class AgeParamType(click.ParamType):


### PR DESCRIPTION
## Summary
- make the vendored pgsrip language conversion failure path explicit for CodeQL

## Validation
- `uv run python -m unittest discover -s tests -t .`
- `uv run python -c 'import bd_to_avp.vendor.pgsrip.cli'`
- `uv run bd-to-avp --help`
- `uv run mypy bd_to_avp`

Refs #113.
