### PR TITLE
Reconcile vendored pgsrip 0.1.12 fixes

### DIFF
--- a/bd_to_avp/vendor/pgsrip/__init__.py
+++ b/bd_to_avp/vendor/pgsrip/__init__.py
@@ -1,7 +1,11 @@
-"""Vendored pgsrip runtime used for PGS subtitle OCR."""
+"""Vendored pgsrip runtime used for PGS subtitle OCR.
+
+This is a BD_to_AVP-maintained local fork based on pgsrip 0.1.11 with selected
+upstream 0.1.12 runtime fixes and app-specific tool resolution changes.
+"""
 
 __title__ = "pgsrip"
-__version__ = "0.1.11"
+__version__ = "0.1.12+bd_to_avp"
 __short_version__ = "0.1"
 __author__ = "Rato"
 __license__ = "MIT"

--- a/bd_to_avp/vendor/pgsrip/media.py
+++ b/bd_to_avp/vendor/pgsrip/media.py
@@ -30,8 +30,8 @@ class PgsSubtitleItem:
         self.start = min([ds.pcs.presentation_timestamp for ds in display_sets] or [None])
         self.end = max([ds.pcs.presentation_timestamp for ds in display_sets] or [None])
         self.image = PgsSubtitleItem.generate_image(display_sets)
-        self.x_offset = min([ds.wds.x_offset for ds in display_sets] or [None])
-        self.y_offset = min([ds.wds.y_offset for ds in display_sets] or [None])
+        self.x_offset = min([ds.wds.x_offset for ds in display_sets if ds.wds.num_windows > 0] or [None])
+        self.y_offset = min([ds.wds.y_offset for ds in display_sets if ds.wds.num_windows > 0] or [None])
         self.text: typing.Optional[str] = None
         self.place: typing.Optional[typing.Tuple[int, int, int, int]] = None
 

--- a/bd_to_avp/vendor/pgsrip/pgs.py
+++ b/bd_to_avp/vendor/pgsrip/pgs.py
@@ -271,7 +271,7 @@ class WindowDefinitionSegment(BaseSegment):
 
     @property
     def window_id(self):
-        return self.data[1]
+        return safe_get(self.data, 1, None)
 
     @property
     def x_offset(self):

--- a/bd_to_avp/vendor/pgsrip/utils.py
+++ b/bd_to_avp/vendor/pgsrip/utils.py
@@ -4,7 +4,7 @@ from pysrt import SubRipTime
 
 
 def from_hex(b: bytes):
-    return int(b.hex(), base=16)
+    return int(b.hex(), base=16) if len(b) > 0 else None
 
 
 def safe_get(b: bytes, i: int, default_value=0):

--- a/tests/test_vendor_pgsrip_edge_cases.py
+++ b/tests/test_vendor_pgsrip_edge_cases.py
@@ -6,8 +6,9 @@ from bd_to_avp.vendor.pgsrip.media_path import MediaPath
 from bd_to_avp.vendor.pgsrip.media import PgsSubtitleItem
 from bd_to_avp.vendor.pgsrip.mkv import Mkv, MkvTrack
 from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.vendor.pgsrip.pgs import WindowDefinitionSegment
 from bd_to_avp.vendor.pgsrip.ripper import PgsToSrtRipper
-from bd_to_avp.vendor.pgsrip.utils import to_time
+from bd_to_avp.vendor.pgsrip.utils import from_hex, to_time
 
 
 class MkvTrackOrderingTests(unittest.TestCase):
@@ -56,6 +57,23 @@ class PgsSubtitleItemTimestampTests(unittest.TestCase):
         self.assertEqual(item.end, -1)
 
 
+class PgsSubtitleItemWindowTests(unittest.TestCase):
+    def test_offsets_ignore_display_sets_without_windows(self) -> None:
+        item = PgsSubtitleItem(0, MediaPath("fake.sup"), [_display_set(0, None, None), _display_set(1, 12, 34)])
+
+        self.assertEqual(item.x_offset, 12)
+        self.assertEqual(item.y_offset, 34)
+
+    def test_window_definition_segment_allows_zero_windows(self) -> None:
+        segment = WindowDefinitionSegment(_pgs_segment_bytes(b"\x00"))
+
+        self.assertEqual(segment.num_windows, 0)
+        self.assertIsNone(segment.window_id)
+
+    def test_empty_hex_converts_to_none(self) -> None:
+        self.assertIsNone(from_hex(b""))
+
+
 class PgsRipperEmptyTrackTests(unittest.TestCase):
     def test_empty_subtitle_items_do_not_crash_ripper_initialization(self) -> None:
         pgs = Mock()
@@ -92,6 +110,21 @@ def _subtitle_item(start: int, end: int) -> PgsSubtitleItem:
     item.x_offset = 0
     item.y_offset = 0
     return item
+
+
+def _display_set(num_windows: int, x_offset: int | None, y_offset: int | None) -> Mock:
+    display_set = Mock()
+    display_set.pcs.presentation_timestamp = 0
+    display_set.wds.num_windows = num_windows
+    display_set.wds.x_offset = x_offset
+    display_set.wds.y_offset = y_offset
+    display_set.pcs.is_start.return_value = False
+    return display_set
+
+
+def _pgs_segment_bytes(data: bytes) -> bytes:
+    size = len(data).to_bytes(2, byteorder="big")
+    return b"PG" + b"\x00" * 8 + b"\x17" + size + data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- adapt selected upstream pgsrip 0.1.12 runtime fixes into the vendored local fork
- document the vendored package as a BD_to_AVP-maintained local fork
- add edge-case tests for zero-window PGS data and empty hex parsing

## Upstream 0.1.12 changes reviewed
- `--all` no longer uses short alias `-a` in the pgsrip CLI; already present locally before this PR
- subtitle offsets now ignore display sets with zero PGS windows; adapted here
- `WindowDefinitionSegment.window_id` now tolerates zero-window payloads; adapted here
- `from_hex(b"")` now returns `None`; adapted here
- dependency/workflow/Dockerfile changes were not imported because they do not apply to the vendored runtime

## Validation
- `uv run python -m unittest tests.test_vendor_pgsrip_edge_cases`
- `uv run python -m unittest discover -s tests -t .`
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app; import bd_to_avp.vendor.pgsrip'`
- `uv run bd-to-avp --help`
- `uv run mypy bd_to_avp`
- `uv run ruff check --diff tests/test_vendor_pgsrip_edge_cases.py`
- `uv run ruff check tests/test_vendor_pgsrip_edge_cases.py`

Refs #113.
