### PR TITLE
Fix auto-review regressions

### DIFF
--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -57,6 +57,7 @@ class MainWindow(QMainWindow):
         self.processing_thread.srt_creation_error.connect(self.handle_srt_creation_error)
         self.processing_thread.file_exists_error.connect(self.handle_file_exists_error)
         self.processing_thread.process_completed.connect(self.finished_processing)
+        self.processing_thread.process_failed.connect(self.reset_processing_button)
 
     def setup_window(self) -> None:
         app = QApplication.instance()
@@ -463,6 +464,9 @@ class MainWindow(QMainWindow):
         self.process_button.setText(self.START_PROCESSING_TEXT)
         self.notify_user_with_sound("Glass")
         QMessageBox.information(self, "", message)
+
+    def reset_processing_button(self) -> None:
+        self.process_button.setText(self.START_PROCESSING_TEXT)
 
     def save_config_to_file(self) -> None:
         self.save_config()

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -21,6 +21,7 @@ class ProcessingThread(QThread):
     srt_creation_error = Signal(SRTCreationError)
     file_exists_error = Signal(FileExistsError)
     process_completed = Signal()
+    process_failed = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -30,21 +31,29 @@ class ProcessingThread(QThread):
 
     def run(self) -> None:
         sys.stdout = self.output_handler  # type: ignore
+        signal_emitted = False
 
         try:
             start_process(self.start_stage)
             self.process_completed.emit()
+            signal_emitted = True
         except MKVCreationError as error:
             self.mkv_creation_error.emit(error)
+            signal_emitted = True
         except SRTCreationError as error:
             self.srt_creation_error.emit(error)
+            signal_emitted = True
         except FileExistsError as error:
             self.file_exists_error.emit(error)
+            signal_emitted = True
         except (RuntimeError, ValueError, KeyError) as error:
             self.error_occurred.emit(error)
+            signal_emitted = True
         finally:
             Spinner.stop_all()
             sys.stdout = sys.__stdout__
+            if not signal_emitted:
+                self.process_failed.emit()
 
     def terminate(self) -> None:
         terminate_process()

--- a/scripts/update_ffmpeg_manifest.py
+++ b/scripts/update_ffmpeg_manifest.py
@@ -29,6 +29,14 @@ class UpdatedManifest:
     assets: list[UpdatedAsset]
 
 
+def updated_asset_from_existing(asset: vendor_ffmpeg_macos.BinaryAsset) -> UpdatedAsset:
+    return UpdatedAsset(
+        name=asset.name,
+        zip_sha256=asset.zip_sha256,
+        binary_sha256=asset.binary_sha256,
+    )
+
+
 def build_candidate_manifest(
     *,
     version: str,
@@ -60,6 +68,29 @@ def build_candidate_manifest(
         license_mode=license_mode,
         build=build,
         assets=assets,
+    )
+
+
+def merge_manifest_assets(
+    old_manifest: vendor_ffmpeg_macos.VendorManifest,
+    new_manifest: UpdatedManifest,
+) -> UpdatedManifest:
+    if new_manifest.base_url != old_manifest.base_url and len(new_manifest.assets) < len(old_manifest.assets):
+        raise ValueError("Partial FFmpeg manifest updates must keep the existing base URL")
+
+    updated_assets = {asset.name: asset for asset in new_manifest.assets}
+    merged_assets = [
+        updated_assets.get(asset.name, updated_asset_from_existing(asset)) for asset in old_manifest.assets
+    ]
+    known_asset_names = {asset.name for asset in old_manifest.assets}
+    merged_assets.extend(asset for asset in new_manifest.assets if asset.name not in known_asset_names)
+
+    return UpdatedManifest(
+        version=new_manifest.version,
+        base_url=new_manifest.base_url,
+        license_mode=new_manifest.license_mode,
+        build=new_manifest.build,
+        assets=merged_assets,
     )
 
 
@@ -130,6 +161,7 @@ def main() -> None:
         build=args.build,
         asset_names=asset_names,
     )
+    new_manifest = merge_manifest_assets(old_manifest, new_manifest)
     write_manifest(args.manifest, new_manifest)
     print(f"Updated FFmpeg manifest: {old_manifest.version} -> {new_manifest.version}")
     print(f"Old base URL: {old_manifest.base_url}")

--- a/tests/test_ffmpeg_manifest_update.py
+++ b/tests/test_ffmpeg_manifest_update.py
@@ -115,6 +115,87 @@ class UpdateFfmpegManifestTests(unittest.TestCase):
         self.assertEqual(loaded_manifest.base_url, "https://example.invalid/build\\path")
         self.assertEqual(loaded_manifest.build, 'build with "quotes" and \\slashes')
 
+    def test_partial_manifest_update_preserves_unselected_assets(self) -> None:
+        old_manifest = vendor_ffmpeg_macos.VendorManifest(
+            version="8.1.2",
+            base_url="https://example.invalid/old",
+            license_mode="GPLv3",
+            build="old build",
+            assets=[
+                vendor_ffmpeg_macos.BinaryAsset(
+                    name="ffmpeg",
+                    url="https://example.invalid/old/ffmpeg.zip",
+                    zip_sha256="0" * 64,
+                    binary_sha256="1" * 64,
+                ),
+                vendor_ffmpeg_macos.BinaryAsset(
+                    name="ffprobe",
+                    url="https://example.invalid/old/ffprobe.zip",
+                    zip_sha256="2" * 64,
+                    binary_sha256="3" * 64,
+                ),
+            ],
+        )
+        new_manifest = update_ffmpeg_manifest.UpdatedManifest(
+            version="8.1.3",
+            base_url="https://example.invalid/old",
+            license_mode="GPLv3",
+            build="new build",
+            assets=[
+                update_ffmpeg_manifest.UpdatedAsset(
+                    name="ffmpeg",
+                    zip_sha256="4" * 64,
+                    binary_sha256="5" * 64,
+                )
+            ],
+        )
+
+        merged_manifest = update_ffmpeg_manifest.merge_manifest_assets(old_manifest, new_manifest)
+
+        self.assertEqual([asset.name for asset in merged_manifest.assets], ["ffmpeg", "ffprobe"])
+        self.assertEqual(merged_manifest.assets[0].zip_sha256, "4" * 64)
+        self.assertEqual(merged_manifest.assets[0].binary_sha256, "5" * 64)
+        self.assertEqual(merged_manifest.assets[1].zip_sha256, "2" * 64)
+        self.assertEqual(merged_manifest.assets[1].binary_sha256, "3" * 64)
+
+    def test_partial_manifest_update_rejects_base_url_change(self) -> None:
+        old_manifest = vendor_ffmpeg_macos.VendorManifest(
+            version="8.1.2",
+            base_url="https://example.invalid/old",
+            license_mode="GPLv3",
+            build="old build",
+            assets=[
+                vendor_ffmpeg_macos.BinaryAsset(
+                    name="ffmpeg",
+                    url="https://example.invalid/old/ffmpeg.zip",
+                    zip_sha256="0" * 64,
+                    binary_sha256="1" * 64,
+                ),
+                vendor_ffmpeg_macos.BinaryAsset(
+                    name="ffprobe",
+                    url="https://example.invalid/old/ffprobe.zip",
+                    zip_sha256="2" * 64,
+                    binary_sha256="3" * 64,
+                ),
+            ],
+        )
+        new_manifest = update_ffmpeg_manifest.UpdatedManifest(
+            version="8.1.3",
+            base_url="https://example.invalid/new",
+            license_mode="GPLv3",
+            build="new build",
+            assets=[
+                update_ffmpeg_manifest.UpdatedAsset(
+                    name="ffmpeg",
+                    zip_sha256="4" * 64,
+                    binary_sha256="5" * 64,
+                )
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "Partial FFmpeg manifest updates"):
+            update_ffmpeg_manifest.merge_manifest_assets(old_manifest, new_manifest)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gui_processing.py
+++ b/tests/test_gui_processing.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+
+from bd_to_avp.gui.processing import ProcessingThread
+
+
+class ProcessingThreadTests(unittest.TestCase):
+    def test_unhandled_processing_error_emits_failure_signal(self) -> None:
+        thread = ProcessingThread()
+        failures = []
+        thread.process_failed.connect(lambda: failures.append(True))
+
+        with (
+            patch("bd_to_avp.gui.processing.start_process", side_effect=AssertionError("boom")),
+            patch("bd_to_avp.gui.processing.Spinner.stop_all"),
+        ):
+            with self.assertRaises(AssertionError):
+                thread.run()
+
+        self.assertEqual(failures, [True])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- emit a worker failure signal for unexpected processing-thread exceptions and reset the processing button in `MainWindow`
- preserve unselected FFmpeg manifest assets during partial updates when the base URL is unchanged
- reject partial FFmpeg manifest updates that try to change the global base URL
- add regression tests for both auto-review findings

## Validation
- `uv run python -m unittest tests.test_gui_processing tests.test_ffmpeg_manifest_update`
- `uv run python -m unittest discover -s tests -t .`
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'`
- `uv run bd-to-avp --help`
- `uv run mypy bd_to_avp`
- `uv run ruff check --diff bd_to_avp/gui/processing.py bd_to_avp/gui/main_window.py scripts/update_ffmpeg_manifest.py tests/test_gui_processing.py tests/test_ffmpeg_manifest_update.py`
- `uv run ruff check bd_to_avp/gui/processing.py bd_to_avp/gui/main_window.py scripts/update_ffmpeg_manifest.py tests/test_gui_processing.py tests/test_ffmpeg_manifest_update.py`

Addresses fresh auto-review findings from snapshot `1561f62b`:
- Restore the processing button state on thread failure
- Preserve the other FFmpeg asset when updating one entry
