### PR TITLE
Fix QuickTime seeking in MP4Box mux

### DIFF
--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -65,7 +65,9 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
         config.MP4BOX_PATH,
         "-new",
         "-add",
-        mv_hevc_path,
+        # QuickTime and AVP seeking depend on a useful sync sample table. MP4Box can
+        # collapse imported MV-HEVC tracks to one sync sample unless this is forced.
+        f"{mv_hevc_path}:forcesync",
     ]
     output_track_index += 1
     for stream in audio_streams:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import container
+
+
+class MuxCommandTests(unittest.TestCase):
+    def test_final_mux_forces_video_sync_samples_for_quicktime_seeking(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[{"index": 0, "tags": {"language": "eng"}, "channel_layout": "7.1"}],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("audio_PCM.mov"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(command[:4], [Path("/tools/MP4Box"), "-new", "-add", "movie_MV-HEVC.mov:forcesync"])
+        self.assertIn("audio_PCM.mov#1:lang=eng:group=1:alternate_group=1", command)
+        self.assertEqual(command[-1], Path("movie_AVP.mov"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- force MP4Box to preserve/mark video sync samples when importing the MV-HEVC intermediate
- add a regression test for the generated final mux command
- connect the fix to the QuickTime/AVP seeking failure signature from #10 and #125

## Evidence

Manual reproduction showed the unpatched final MP4Box mux reported `Only one sync sample` on the video track, while the MV-HEVC intermediate reported normal GOP indexing. QuickTime seeking failed, but VLC could play through it.

Adding `:forcesync` to the MV-HEVC import restored `Average GOP length: 28 samples` in the final file. The patched artifact at `/Volumes/Developer-Artifacts/bd-to-avp-125/manual/movie_AVP_forcesync.mov` passed manual QuickTime seeking.

## Validation

- `uv run python -m unittest tests.test_container tests.test_preflight tests.test_native_mvc_split`
- `uv run python -m unittest discover tests`
- `git diff --check`
- manual MP4Box remux validation: final file reports `Average GOP length: 28 samples`
- manual QuickTime playback/seek test passed

Refs #10
Refs #125
Refs #127
