### PR TITLE
Sync GitHub metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -9,7 +9,7 @@
     "main": {
       "system": "classic",
       "requiresPullRequest": true,
-      "requiredStatusChecks": ["validate"],
+      "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
       "requiredApprovals": 0,
       "enforceAdmins": true,
       "blocksForcePushes": true,
@@ -22,7 +22,7 @@
       "target": "refs/heads/release",
       "requiresPullRequest": true,
       "allowedMergeMethods": ["merge"],
-      "requiredStatusChecks": ["validate"],
+      "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
       "requiredApprovals": 0,
       "blocksForcePushes": true,
       "blocksDeletion": true,
@@ -78,9 +78,12 @@
   },
   "importantWorkflows": [
     "CI",
+    "CodeQL",
     "Package with Briefcase and Create Release",
+    "Update FFmpeg Vendor Pins",
     "Publish Python distribution to PyPI"
   ],
+  "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
@@ -94,8 +97,8 @@
       "dependencyGraph": "available",
       "dependabotAlerts": "available",
       "securityAdvisories": "available",
-      "codeScanning": "not_configured",
-      "secretScanning": "not_enabled"
+      "codeScanning": "available",
+      "secretScanning": "available"
     },
     "refreshWhen": [
       "repo visibility changes",


### PR DESCRIPTION
## Summary
- record CodeQL and FFmpeg vendor update workflows in repo metadata
- align main/release required status checks with live branch protection
- mark CodeQL and secret scanning as available based on current GitHub settings

## Validation
- jq empty .github/github.json
- GitHub API: main protection requires validate, Analyze (actions), Analyze (python)
- GitHub API: CodeQL workflow active, 0 open code scanning alerts