### PR TITLE
Bundle static MP4Box for macOS app

### DIFF
--- a/.github/workflows/update-ffmpeg-vendor.yml
+++ b/.github/workflows/update-ffmpeg-vendor.yml
@@ -45,8 +45,8 @@ jobs:
           ffprobe_path="bd_to_avp/bin/ffprobe"
           "$ffmpeg_path" -hide_banner -version
           "$ffprobe_path" -hide_banner -version
-          if otool -L "$ffmpeg_path" "$ffprobe_path" | grep -q /opt/homebrew; then
-            echo "Vendored FFmpeg tools must not link to /opt/homebrew"
+          if otool -L "$ffmpeg_path" "$ffprobe_path" | grep -Eq '/opt/homebrew|/usr/local'; then
+            echo "Vendored FFmpeg tools must not link to Homebrew libraries"
             exit 1
           fi
 
@@ -63,4 +63,4 @@ jobs:
             Version: `${{ inputs.version }}`
             Base URL: `${{ inputs.base_url }}`
 
-            The workflow downloaded `ffmpeg.zip` and `ffprobe.zip`, regenerated archive and extracted-binary SHA256 values, verified both tools execute, and checked they do not link to `/opt/homebrew`.
+            The workflow downloaded `ffmpeg.zip` and `ffprobe.zip`, regenerated archive and extracted-binary SHA256 values, verified both tools execute, and checked they do not link to Homebrew libraries.

--- a/bd_to_avp/resources/notices/mp4box-gpac-macos-arm64.txt
+++ b/bd_to_avp/resources/notices/mp4box-gpac-macos-arm64.txt
@@ -1,0 +1,35 @@
+MP4Box macOS arm64 binary
+
+BD_to_AVP packages MP4Box as a separate command-line executable for final
+QuickTime-compatible MV-HEVC, audio, and tx3g subtitle muxing.
+
+Vendored binary source:
+- Project: GPAC / MP4Box
+- Version: 26.02.0
+- Source tag: https://github.com/gpac/gpac/tree/v26.02.0
+- Platform: macOS arm64 static executable
+- Executable SHA256: eb63ed3f3c73eadc61f9158961114a614c208cd5929f1abb7d13da3a679cfedf
+
+The vendored build is a static MP4Box executable built from GPAC source with
+Homebrew hidden from the build environment and external codec, image, network,
+and SSL libraries disabled. The resulting executable links only to macOS system
+libraries (`/usr/lib/libz.1.dylib` and `/usr/lib/libSystem.B.dylib`).
+
+MP4Box / GPAC is distributed under LGPL-2.1-or-later. BD_to_AVP invokes MP4Box
+as a separate command-line executable. Downstream redistributors must preserve
+GPAC's applicable license obligations and corresponding-source access.
+
+Embedded build configuration reported by `MP4Box -version`:
+
+--static-bin --disable-rmtws --disable-network --disable-ssl --disable-x11 --disable-sdl --use-zlib=system --use-opensvc=no --use-openhevc=no --use-platinum=no --use-freetype=no --use-ssl=no --use-jpeg=no --use-openjpeg=no --use-png=no --use-mad=no --use-a52=no --use-xvid=no --use-faad=no --use-ffmpeg=no --use-freenect=no --use-vorbis=no --use-theora=no --use-nghttp2=no --use-ngtcp2=no --use-nghttp3=no --use-lzma=no --use-curl=no
+
+GPAC source and license information:
+- Source: https://github.com/gpac/gpac
+- Releases: https://github.com/gpac/gpac/releases
+- Upstream license file: https://github.com/gpac/gpac/blob/master/COPYING
+- GNU LGPL v2.1 text: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+
+The build script is `scripts/build_mp4box_macos.py`. It reads
+`vendor/mp4box-macos-arm64.toml`, checks out the pinned GPAC tag, builds MP4Box,
+verifies arm64/system-only linkage, and installs the executable into
+`bd_to_avp/bin`.

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -29,7 +29,8 @@ Record:
 On the clean machine:
 
 ```bash
-test ! -e /opt/homebrew || echo "Homebrew is present; use a cleaner VM for the required smoke"
+test ! -e /opt/homebrew || echo "Apple Silicon Homebrew is present; use a cleaner VM for the required smoke"
+test ! -e /usr/local/Homebrew || echo "Intel Homebrew is present; use a cleaner VM for the required smoke"
 spctl --assess --type open --verbose=4 ~/Downloads/*.dmg
 ```
 
@@ -56,7 +57,7 @@ Expected result:
 - Gatekeeper assessment passes.
 - App bundle layout is valid.
 - Bundled tools run from the app bundle.
-- If Xcode Command Line Tools are available, bundled tools do not link to `/opt/homebrew`. If developer tools are not installed, the scripts say the linkage check was skipped.
+- If Xcode Command Line Tools are available, bundled tools do not link to `/opt/homebrew` or `/usr/local`. If developer tools are not installed, the scripts say the linkage check was skipped.
 - The packaged CLI `--version` matches `Info.plist`.
 - The packaged CLI `--help` runs with a sanitized `PATH`.
 - If MakeMKV is absent, the script records that the first-run path should ask the user to install MakeMKV.

--- a/scripts/briefcase_app.py
+++ b/scripts/briefcase_app.py
@@ -11,7 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WHEELHOUSE = REPO_ROOT / ".briefcase-wheelhouse"
 WHEELHOUSE_REQUIREMENTS = ["pysrt==1.1.2"]
 VENDOR_FFMPEG_COMMANDS = {"create", "build", "run"}
-SYNC_TOOL_COMMANDS = {"create", "build", "run", "package"}
+SYNC_TOOL_COMMANDS = {"create", "build", "run"}
 APP_RESOURCE_BIN = (
     REPO_ROOT
     / "build"

--- a/scripts/briefcase_app.py
+++ b/scripts/briefcase_app.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WHEELHOUSE = REPO_ROOT / ".briefcase-wheelhouse"
 WHEELHOUSE_REQUIREMENTS = ["pysrt==1.1.2"]
 VENDOR_FFMPEG_COMMANDS = {"create", "build", "run"}
+SYNC_TOOL_COMMANDS = {"create", "build", "run", "package"}
 APP_RESOURCE_BIN = (
     REPO_ROOT
     / "build"
@@ -24,7 +25,7 @@ APP_RESOURCE_BIN = (
     / "bd_to_avp"
     / "bin"
 )
-VENDORED_TOOLS = ["ffmpeg", "ffprobe"]
+VENDORED_TOOLS = ["ffmpeg", "ffprobe", "MP4Box"]
 
 
 def run(command: list[str]) -> None:
@@ -68,13 +69,20 @@ def sync_vendored_tools_to_existing_app() -> None:
     for tool_name in VENDORED_TOOLS:
         source_path = REPO_ROOT / "bd_to_avp" / "bin" / tool_name
         if source_path.exists():
-            shutil.copy2(source_path, APP_RESOURCE_BIN / tool_name)
+            output_path = APP_RESOURCE_BIN / tool_name
+            shutil.copy2(source_path, output_path)
+            output_path.chmod(output_path.stat().st_mode | 0o111)
 
 
-def main() -> None:
+def should_sync_vendored_tools(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & SYNC_TOOL_COMMANDS)
+
+
+def main_with_args(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run Briefcase with repo-local packaging fixes.")
     parser.add_argument("briefcase_args", nargs=argparse.REMAINDER)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.briefcase_args:
         parser.error("provide a Briefcase command, for example: create --no-input")
@@ -82,6 +90,8 @@ def main() -> None:
     build_wheelhouse()
     if should_vendor_ffmpeg(args.briefcase_args):
         vendor_ffmpeg()
+    elif should_sync_vendored_tools(args.briefcase_args):
+        sync_vendored_tools_to_existing_app()
     run(
         [
             sys.executable,
@@ -92,6 +102,12 @@ def main() -> None:
             briefcase_config_override(),
         ]
     )
+    if should_sync_vendored_tools(args.briefcase_args):
+        sync_vendored_tools_to_existing_app()
+
+
+def main() -> None:
+    main_with_args()
 
 
 if __name__ == "__main__":

--- a/scripts/build_mp4box_macos.py
+++ b/scripts/build_mp4box_macos.py
@@ -171,6 +171,12 @@ def verify_macos_binary(binary_path: Path, validation: ValidationConfig) -> None
         raise BuildFailure(f"MP4Box version probe did not look valid:\n{version_output}")
 
 
+def verify_binary_checksum(binary_path: Path, expected_sha256: str) -> None:
+    actual_sha256 = sha256(binary_path)
+    if actual_sha256 != expected_sha256:
+        raise BuildFailure(f"MP4Box binary checksum mismatch:\nexpected {expected_sha256}\nactual   {actual_sha256}")
+
+
 def install_binary(binary_path: Path, output_dir: Path) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "MP4Box"
@@ -196,7 +202,8 @@ def main() -> int:
         mp4box_path = build_mp4box(source_dir, install_dir, manifest)
         verify_macos_binary(mp4box_path, manifest.validation)
         output_path = install_binary(mp4box_path, args.output_dir)
-        print(f"Built MP4Box {manifest.tag}: {output_path} ({sha256(output_path)})")
+        verify_binary_checksum(output_path, manifest.binary_sha256)
+        print(f"Built MP4Box {manifest.tag}: {output_path} ({manifest.binary_sha256})")
     except (BuildFailure, subprocess.CalledProcessError) as error:
         print(f"MP4Box build failed: {error}")
         return 1

--- a/scripts/build_mp4box_macos.py
+++ b/scripts/build_mp4box_macos.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tomllib
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BUILD_ROOT = REPO_ROOT / ".vendor" / "gpac"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "bd_to_avp" / "bin"
+DEFAULT_MANIFEST_PATH = REPO_ROOT / "vendor" / "mp4box-macos-arm64.toml"
+
+
+class BuildFailure(RuntimeError):
+    pass
+
+
+def verify_build_host() -> None:
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        raise BuildFailure("MP4Box vendored build requires macOS arm64")
+
+
+@dataclass(frozen=True)
+class ValidationConfig:
+    required_file_substring: str
+    required_version_substring: str
+    forbidden_link_prefixes: tuple[str, ...]
+    expected_system_links: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BuildManifest:
+    version: str
+    repo_url: str
+    tag: str
+    license_mode: str
+    binary: str
+    binary_sha256: str
+    build: str
+    configure_flags: list[str]
+    validation: ValidationConfig
+
+
+def load_manifest(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> BuildManifest:
+    data = tomllib.loads(manifest_path.read_text())
+    validation = data.get("validation")
+    if not isinstance(validation, dict):
+        raise ValueError("MP4Box manifest must define a [validation] table")
+
+    return BuildManifest(
+        version=require_string(data, "version"),
+        repo_url=require_string(data, "repo_url"),
+        tag=require_string(data, "tag"),
+        license_mode=require_string(data, "license_mode"),
+        binary=require_string(data, "binary"),
+        binary_sha256=require_string(data, "binary_sha256"),
+        build=require_string(data, "build"),
+        configure_flags=require_string_list(data, "configure_flags"),
+        validation=ValidationConfig(
+            required_file_substring=require_string(validation, "required_file_substring"),
+            required_version_substring=require_string(validation, "required_version_substring"),
+            forbidden_link_prefixes=tuple(require_string_list(validation, "forbidden_link_prefixes")),
+            expected_system_links=tuple(require_string_list(validation, "expected_system_links")),
+        ),
+    )
+
+
+def require_string(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"MP4Box manifest field must be a non-empty string: {key}")
+    return value
+
+
+def require_string_list(data: dict[str, Any], key: str) -> list[str]:
+    value = data.get(key)
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"MP4Box manifest field must be a non-empty string list: {key}")
+    return value
+
+
+def run(command: list[str | Path], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> str:
+    completed = subprocess.run(
+        [str(item) for item in command],
+        check=True,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return completed.stdout
+
+
+def build_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+    env["CC"] = "/usr/bin/clang"
+    env["CXX"] = "/usr/bin/clang++"
+    env["PKG_CONFIG"] = "/usr/bin/false"
+    return env
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def clone_or_update_source(source_dir: Path, manifest: BuildManifest, *, refresh: bool) -> None:
+    source_dir.parent.mkdir(parents=True, exist_ok=True)
+    if refresh and source_dir.exists():
+        shutil.rmtree(source_dir)
+    if not source_dir.exists():
+        run(["git", "clone", "--depth", "1", "--branch", manifest.tag, manifest.repo_url, source_dir])
+        return
+
+    run(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], cwd=source_dir)
+    run(["git", "checkout", manifest.tag], cwd=source_dir)
+
+
+def build_mp4box(source_dir: Path, install_dir: Path, manifest: BuildManifest) -> Path:
+    env = build_env()
+    if (source_dir / "Makefile").exists():
+        run(["make", "distclean"], cwd=source_dir, env=env)
+    run(
+        ["./configure", f"--prefix={install_dir}", *manifest.configure_flags],
+        cwd=source_dir,
+        env=env,
+    )
+    jobs = os.cpu_count() or 1
+    run(["make", f"-j{jobs}", "lib"], cwd=source_dir, env=env)
+    run(["make", f"-j{jobs}", "apps"], cwd=source_dir, env=env)
+    mp4box_path = source_dir / "bin" / "gcc" / manifest.binary
+    if not mp4box_path.is_file():
+        raise BuildFailure(f"MP4Box build did not produce {mp4box_path}")
+    return mp4box_path
+
+
+def verify_macos_binary(binary_path: Path, validation: ValidationConfig) -> None:
+    file_output = run(["file", binary_path])
+    if validation.required_file_substring not in file_output:
+        raise BuildFailure(f"MP4Box is not an arm64 Mach-O executable:\n{file_output}")
+
+    links = run(["otool", "-L", binary_path])
+    linked_paths = [line.strip().split(" ", 1)[0] for line in links.splitlines()[1:] if line.strip()]
+    forbidden_links = [path for path in linked_paths if path.startswith(validation.forbidden_link_prefixes)]
+    if forbidden_links:
+        raise BuildFailure("MP4Box links to non-system libraries:\n" + "\n".join(forbidden_links))
+
+    unexpected_links = sorted(set(linked_paths) - set(validation.expected_system_links))
+    if unexpected_links:
+        raise BuildFailure("MP4Box links to unexpected libraries:\n" + "\n".join(unexpected_links))
+
+    version_output = run([binary_path, "-version"], env=build_env())
+    if validation.required_version_substring not in version_output:
+        raise BuildFailure(f"MP4Box version probe did not look valid:\n{version_output}")
+
+
+def install_binary(binary_path: Path, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "MP4Box"
+    shutil.copy2(binary_path, output_path)
+    output_path.chmod(output_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a static arm64 macOS MP4Box for the app bundle.")
+    parser.add_argument("--build-root", type=Path, default=DEFAULT_BUILD_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST_PATH)
+    parser.add_argument("--refresh", action="store_true", help="Delete and reclone the GPAC source directory first.")
+    args = parser.parse_args()
+
+    source_dir = args.build_root / "gpac-src"
+    install_dir = args.build_root / "install"
+    try:
+        verify_build_host()
+        manifest = load_manifest(args.manifest)
+        clone_or_update_source(source_dir, manifest, refresh=args.refresh)
+        mp4box_path = build_mp4box(source_dir, install_dir, manifest)
+        verify_macos_binary(mp4box_path, manifest.validation)
+        output_path = install_binary(mp4box_path, args.output_dir)
+        print(f"Built MP4Box {manifest.tag}: {output_path} ({sha256(output_path)})")
+    except (BuildFailure, subprocess.CalledProcessError) as error:
+        print(f"MP4Box build failed: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_mp4box_macos.py
+++ b/scripts/build_mp4box_macos.py
@@ -126,7 +126,10 @@ def clone_or_update_source(source_dir: Path, manifest: BuildManifest, *, refresh
         run(["git", "clone", "--depth", "1", "--branch", manifest.tag, manifest.repo_url, source_dir])
         return
 
-    run(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], cwd=source_dir)
+    try:
+        run(["git", "rev-parse", "--verify", f"{manifest.tag}^{{commit}}"], cwd=source_dir)
+    except subprocess.CalledProcessError:
+        run(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], cwd=source_dir)
     run(["git", "checkout", manifest.tag], cwd=source_dir)
 
 

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -156,8 +156,9 @@ def verify_bundled_tool(
         linked_libraries = run(["otool", "-L", tool_path], env=clean_env).stdout
     except (FileNotFoundError, subprocess.CalledProcessError) as error:
         raise SmokeFailure(f"Could not inspect linked libraries for {tool_path}: {error}") from error
-    if "/opt/homebrew" in linked_libraries:
-        raise SmokeFailure(f"Bundled {tool_path.name} links to /opt/homebrew:\n{linked_libraries}")
+    for forbidden_path in ["/opt/homebrew", "/usr/local"]:
+        if forbidden_path in linked_libraries:
+            raise SmokeFailure(f"Bundled {tool_path.name} links to {forbidden_path}:\n{linked_libraries}")
 
 
 def verify_bundled_tools(bundle: AppBundle, clean_env: dict[str, str]) -> None:

--- a/scripts/smoke_release_app.sh
+++ b/scripts/smoke_release_app.sh
@@ -33,8 +33,8 @@ pass "app bundle layout"
 spctl --assess --type execute --verbose=4 "$APP_PATH" >/dev/null 2>&1 || fail "Gatekeeper assessment failed"
 pass "Gatekeeper assessment"
 
-if [ -e /opt/homebrew ]; then
-  printf 'note - /opt/homebrew exists on this machine; smoke uses sanitized PATH\n'
+if [ -e /opt/homebrew ] || [ -e /usr/local/Homebrew ]; then
+  printf 'note - Homebrew exists on this machine; smoke uses sanitized PATH\n'
 else
   pass "Homebrew absent"
 fi
@@ -55,8 +55,12 @@ for tool in ffmpeg ffprobe edge264_test mkvextract mkvmerge MP4Box spatial-media
     MP4Box) "$TOOL_PATH" -version >/dev/null 2>&1 || fail "$tool did not run" ;;
     *) "$TOOL_PATH" --help >/dev/null 2>&1 || fail "$tool did not run" ;;
   esac
-  if [ "$CHECK_LINKS" = true ] && otool -L "$TOOL_PATH" | grep -q '/opt/homebrew'; then
-    fail "$tool links to /opt/homebrew"
+  if [ "$CHECK_LINKS" = true ]; then
+    LINKED_LIBRARIES="$(otool -L "$TOOL_PATH")"
+    case "$LINKED_LIBRARIES" in
+      *"/opt/homebrew"*) fail "$tool links to /opt/homebrew" ;;
+      *"/usr/local"*) fail "$tool links to /usr/local" ;;
+    esac
   fi
 done
 pass "bundled tools"

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 APP_PATH = Path("build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app")
 APP_TOOL_DIR = APP_PATH / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
-REQUIRED_TOOLS = ["ffmpeg", "ffprobe"]
+REQUIRED_TOOLS = {
+    "ffmpeg": ["-hide_banner", "-version"],
+    "ffprobe": ["-hide_banner", "-version"],
+    "MP4Box": ["-version"],
+}
 
 
 def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
@@ -20,16 +24,17 @@ def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def verify_tool(tool_path: Path) -> None:
+def verify_tool(tool_path: Path, probe_args: list[str]) -> None:
     if not tool_path.is_file():
         raise FileNotFoundError(f"Missing bundled tool: {tool_path}")
     if not tool_path.stat().st_mode & 0o111:
         raise PermissionError(f"Bundled tool is not executable: {tool_path}")
 
-    run([tool_path, "-hide_banner", "-version"])
+    run([tool_path, *probe_args])
     linked_libraries = run(["otool", "-L", tool_path]).stdout
-    if "/opt/homebrew" in linked_libraries:
-        raise RuntimeError(f"Bundled {tool_path.name} still links to /opt/homebrew:\n{linked_libraries}")
+    for forbidden_path in ["/opt/homebrew", "/usr/local"]:
+        if forbidden_path in linked_libraries:
+            raise RuntimeError(f"Bundled {tool_path.name} still links to {forbidden_path}:\n{linked_libraries}")
 
 
 def main() -> None:
@@ -38,8 +43,8 @@ def main() -> None:
     args = parser.parse_args()
 
     tool_dir = args.app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
-    for tool_name in REQUIRED_TOOLS:
-        verify_tool(tool_dir / tool_name)
+    for tool_name, probe_args in REQUIRED_TOOLS.items():
+        verify_tool(tool_dir / tool_name, probe_args)
     print(f"Verified app-local tools in {tool_dir}")
 
 

--- a/scripts/verify_apple_media.py
+++ b/scripts/verify_apple_media.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+
+from pathlib import Path
+
+
+class AppleMediaFailure(RuntimeError):
+    pass
+
+
+def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(item) for item in command],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def verify_apple_media_compatible(media_path: Path) -> None:
+    if not media_path.is_file():
+        raise AppleMediaFailure(f"Missing media file: {media_path}")
+    avconvert_path = shutil.which("avconvert")
+    if avconvert_path is None:
+        raise AppleMediaFailure("Apple media compatibility check requires avconvert on macOS")
+
+    with tempfile.TemporaryDirectory(prefix="bd-to-avp-avconvert-") as temp_dir:
+        output_path = Path(temp_dir) / "passthrough.mov"
+        try:
+            run(
+                [
+                    avconvert_path,
+                    "--source",
+                    media_path,
+                    "--preset",
+                    "PresetPassthrough",
+                    "--output",
+                    output_path,
+                    "--replace",
+                    "--disableFastStart",
+                ]
+            )
+        except subprocess.CalledProcessError as error:
+            output = error.stdout or ""
+            raise AppleMediaFailure(
+                f"Apple media stack could not open/pass through {media_path}:\n{output.strip()}"
+            ) from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify media with Apple's avconvert passthrough before QuickTime/AVP manual testing."
+    )
+    parser.add_argument("media", nargs="+", type=Path, help="MOV/MP4 file(s) to verify")
+    args = parser.parse_args()
+
+    try:
+        for media_path in args.media:
+            verify_apple_media_compatible(media_path)
+            print(f"Apple media compatibility passed: {media_path}")
+    except AppleMediaFailure as error:
+        print(f"Apple media compatibility failed: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -29,6 +29,37 @@ class MuxCommandTests(unittest.TestCase):
         self.assertIn("audio_PCM.mov#1:lang=eng:group=1:alternate_group=1", command)
         self.assertEqual(command[-1], Path("movie_AVP.mov"))
 
+    def test_final_mux_marks_forced_subtitles_for_quicktime(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[{"index": 0, "tags": {"language": "eng"}, "channel_layout": "7.1"}],
+            ),
+            patch.object(
+                container,
+                "sorted_files_by_creation_filtered_on_suffix",
+                return_value=[Path("movie.forced.en.srt"), Path("movie.en.srt")],
+            ),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("audio_PCM.mov"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn(
+            "movie.forced.en.srt#1:hdlr=sbtl:lang=eng:group=2:name=English Subtitles:tx3g:txtflags=0xC0000000",
+            command,
+        )
+        self.assertIn("3:type=name:str='English Forced Subtitles'", command)
+        self.assertIn("movie.en.srt#1:hdlr=sbtl:lang=eng:group=2:name=English Subtitles:tx3g", command)
+        self.assertIn("4:type=name:str='English Subtitles'", command)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -149,9 +149,11 @@ class BriefcaseVendorHookTests(unittest.TestCase):
                 self.assertTrue((app_bin / tool_name).stat().st_mode & 0o111)
 
     def test_briefcase_sync_runs_after_package(self) -> None:
-        with patch.object(briefcase_app, "run") as run, patch.object(
-            briefcase_app, "build_wheelhouse"
-        ) as build_wheelhouse, patch.object(briefcase_app, "sync_vendored_tools_to_existing_app") as sync_tools:
+        with (
+            patch.object(briefcase_app, "run") as run,
+            patch.object(briefcase_app, "build_wheelhouse") as build_wheelhouse,
+            patch.object(briefcase_app, "sync_vendored_tools_to_existing_app") as sync_tools,
+        ):
             briefcase_app.main_with_args(["package", "--no-input"])
 
         build_wheelhouse.assert_called_once()

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -117,6 +117,12 @@ class BriefcaseVendorHookTests(unittest.TestCase):
         self.assertTrue(briefcase_app.should_vendor_ffmpeg(["build"]))
         self.assertFalse(briefcase_app.should_vendor_ffmpeg(["package", "-i", "Developer ID"]))
 
+    def test_sync_vendored_tools_for_package_commands(self) -> None:
+        self.assertTrue(briefcase_app.should_sync_vendored_tools(["create", "--no-input"]))
+        self.assertTrue(briefcase_app.should_sync_vendored_tools(["build"]))
+        self.assertTrue(briefcase_app.should_sync_vendored_tools(["package", "-i", "Developer ID"]))
+        self.assertFalse(briefcase_app.should_sync_vendored_tools(["--help"]))
+
     def test_do_not_vendor_ffmpeg_for_non_app_commands(self) -> None:
         self.assertFalse(briefcase_app.should_vendor_ffmpeg(["--help"]))
 
@@ -128,8 +134,9 @@ class BriefcaseVendorHookTests(unittest.TestCase):
             app_bin = temp_path / "app" / "bd_to_avp" / "bin"
             source_bin.mkdir(parents=True)
             app_bin.mkdir(parents=True)
-            (source_bin / "ffmpeg").write_text("ffmpeg")
-            (source_bin / "ffprobe").write_text("ffprobe")
+            for tool_name in briefcase_app.VENDORED_TOOLS:
+                (source_bin / tool_name).write_text(tool_name)
+                (source_bin / tool_name).chmod(0o644)
 
             with (
                 patch.object(briefcase_app, "REPO_ROOT", repo_root),
@@ -137,8 +144,19 @@ class BriefcaseVendorHookTests(unittest.TestCase):
             ):
                 briefcase_app.sync_vendored_tools_to_existing_app()
 
-            self.assertEqual((app_bin / "ffmpeg").read_text(), "ffmpeg")
-            self.assertEqual((app_bin / "ffprobe").read_text(), "ffprobe")
+            for tool_name in briefcase_app.VENDORED_TOOLS:
+                self.assertEqual((app_bin / tool_name).read_text(), tool_name)
+                self.assertTrue((app_bin / tool_name).stat().st_mode & 0o111)
+
+    def test_briefcase_sync_runs_after_package(self) -> None:
+        with patch.object(briefcase_app, "run") as run, patch.object(
+            briefcase_app, "build_wheelhouse"
+        ) as build_wheelhouse, patch.object(briefcase_app, "sync_vendored_tools_to_existing_app") as sync_tools:
+            briefcase_app.main_with_args(["package", "--no-input"])
+
+        build_wheelhouse.assert_called_once()
+        run.assert_called_once()
+        self.assertEqual(sync_tools.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -120,7 +120,7 @@ class BriefcaseVendorHookTests(unittest.TestCase):
     def test_sync_vendored_tools_for_package_commands(self) -> None:
         self.assertTrue(briefcase_app.should_sync_vendored_tools(["create", "--no-input"]))
         self.assertTrue(briefcase_app.should_sync_vendored_tools(["build"]))
-        self.assertTrue(briefcase_app.should_sync_vendored_tools(["package", "-i", "Developer ID"]))
+        self.assertFalse(briefcase_app.should_sync_vendored_tools(["package", "-i", "Developer ID"]))
         self.assertFalse(briefcase_app.should_sync_vendored_tools(["--help"]))
 
     def test_do_not_vendor_ffmpeg_for_non_app_commands(self) -> None:
@@ -148,7 +148,7 @@ class BriefcaseVendorHookTests(unittest.TestCase):
                 self.assertEqual((app_bin / tool_name).read_text(), tool_name)
                 self.assertTrue((app_bin / tool_name).stat().st_mode & 0o111)
 
-    def test_briefcase_sync_runs_after_package(self) -> None:
+    def test_briefcase_package_does_not_resync_signed_tools(self) -> None:
         with (
             patch.object(briefcase_app, "run") as run,
             patch.object(briefcase_app, "build_wheelhouse") as build_wheelhouse,
@@ -158,7 +158,7 @@ class BriefcaseVendorHookTests(unittest.TestCase):
 
         build_wheelhouse.assert_called_once()
         run.assert_called_once()
-        self.assertEqual(sync_tools.call_count, 2)
+        sync_tools.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_mp4box_builder.py
+++ b/tests/test_mp4box_builder.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import build_mp4box_macos
+
+
+class MP4BoxBuilderTests(unittest.TestCase):
+    def test_load_manifest_reads_build_and_validation_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "mp4box.toml"
+            manifest_path.write_text(
+                '\n'.join(
+                    [
+                        'version = "26.02.0"',
+                        'repo_url = "https://example.invalid/gpac.git"',
+                        'tag = "v26.02.0"',
+                        'license_mode = "LGPL-2.1-or-later"',
+                        'binary = "MP4Box"',
+                        f'binary_sha256 = "{"1" * 64}"',
+                        'build = "static test build"',
+                        'configure_flags = ["--static-bin", "--use-ffmpeg=no"]',
+                        '',
+                        '[validation]',
+                        'required_file_substring = "Mach-O 64-bit executable arm64"',
+                        'required_version_substring = "MP4Box - GPAC version"',
+                        'forbidden_link_prefixes = ["/opt/homebrew", "/usr/local"]',
+                        'expected_system_links = ["/usr/lib/libz.1.dylib", "/usr/lib/libSystem.B.dylib"]',
+                    ]
+                )
+            )
+
+            manifest = build_mp4box_macos.load_manifest(manifest_path)
+
+        self.assertEqual(manifest.tag, "v26.02.0")
+        self.assertEqual(manifest.binary, "MP4Box")
+        self.assertEqual(manifest.binary_sha256, "1" * 64)
+        self.assertIn("--static-bin", manifest.configure_flags)
+        self.assertEqual(manifest.validation.forbidden_link_prefixes, ("/opt/homebrew", "/usr/local"))
+        self.assertIn("/usr/lib/libSystem.B.dylib", manifest.validation.expected_system_links)
+
+    def test_build_env_hides_homebrew_tools(self) -> None:
+        env = build_mp4box_macos.build_env()
+
+        self.assertEqual(env["PATH"], "/usr/bin:/bin:/usr/sbin:/sbin")
+        self.assertEqual(env["CC"], "/usr/bin/clang")
+        self.assertEqual(env["CXX"], "/usr/bin/clang++")
+        self.assertEqual(env["PKG_CONFIG"], "/usr/bin/false")
+
+    def test_verify_build_host_rejects_non_arm64_macos(self) -> None:
+        with (
+            patch.object(build_mp4box_macos.platform, "system", return_value="Darwin"),
+            patch.object(build_mp4box_macos.platform, "machine", return_value="x86_64"),
+        ):
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "macOS arm64"):
+                build_mp4box_macos.verify_build_host()
+
+    def test_verify_macos_binary_rejects_homebrew_linkage(self) -> None:
+        def fake_run(command: list[str | Path], **kwargs) -> str:
+            if command[0] == "file":
+                return "MP4Box: Mach-O 64-bit executable arm64"
+            if command[0] == "otool":
+                return "MP4Box:\n\t/opt/homebrew/lib/libgpac.dylib\n"
+            return "MP4Box - GPAC version 26.02"
+
+        with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "/opt/homebrew"):
+                build_mp4box_macos.verify_macos_binary(
+                    Path("MP4Box"), build_mp4box_macos.load_manifest().validation
+                )
+
+    def test_verify_macos_binary_accepts_system_only_linkage(self) -> None:
+        def fake_run(command: list[str | Path], **kwargs) -> str:
+            if command[0] == "file":
+                return "MP4Box: Mach-O 64-bit executable arm64"
+            if command[0] == "otool":
+                return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libSystem.B.dylib\n"
+            return "MP4Box - GPAC version 26.02"
+
+        with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+            build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
+
+    def test_verify_macos_binary_rejects_unexpected_system_linkage(self) -> None:
+        def fake_run(command: list[str | Path], **kwargs) -> str:
+            if command[0] == "file":
+                return "MP4Box: Mach-O 64-bit executable arm64"
+            if command[0] == "otool":
+                return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libobjc.A.dylib\n"
+            return "MP4Box - GPAC version 26.02"
+
+        with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "unexpected"):
+                build_mp4box_macos.verify_macos_binary(
+                    Path("MP4Box"), build_mp4box_macos.load_manifest().validation
+                )
+
+    def test_build_mp4box_skips_distclean_without_makefile(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = Path(temp_dir)
+            binary_path = source_dir / "bin" / "gcc" / "MP4Box"
+            binary_path.parent.mkdir(parents=True)
+            binary_path.write_text("binary")
+            commands: list[list[str | Path]] = []
+
+            def fake_run(command: list[str | Path], **kwargs) -> str:
+                commands.append(command)
+                return ""
+
+            with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+                build_mp4box_macos.build_mp4box(
+                    source_dir, source_dir / "install", build_mp4box_macos.load_manifest()
+                )
+
+        self.assertNotIn(["make", "distclean"], commands)
+        self.assertIn(["make", f"-j{build_mp4box_macos.os.cpu_count() or 1}", "lib"], commands)
+
+    def test_install_binary_sets_executable_bit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source-MP4Box"
+            output_dir = root / "bin"
+            source.write_text("binary")
+            source.chmod(0o644)
+
+            output_path = build_mp4box_macos.install_binary(source, output_dir)
+            self.assertEqual(output_path.name, "MP4Box")
+            self.assertTrue(output_path.stat().st_mode & 0o111)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mp4box_builder.py
+++ b/tests/test_mp4box_builder.py
@@ -160,6 +160,21 @@ class MP4BoxBuilderTests(unittest.TestCase):
             self.assertEqual(output_path.name, "MP4Box")
             self.assertTrue(output_path.stat().st_mode & 0o111)
 
+    def test_verify_binary_checksum_accepts_matching_hash(self) -> None:
+        with tempfile.NamedTemporaryFile() as binary_file:
+            binary_path = Path(binary_file.name)
+            binary_path.write_bytes(b"binary")
+
+            build_mp4box_macos.verify_binary_checksum(binary_path, build_mp4box_macos.sha256(binary_path))
+
+    def test_verify_binary_checksum_rejects_mismatch(self) -> None:
+        with tempfile.NamedTemporaryFile() as binary_file:
+            binary_path = Path(binary_file.name)
+            binary_path.write_bytes(b"binary")
+
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "checksum mismatch"):
+                build_mp4box_macos.verify_binary_checksum(binary_path, "0" * 64)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mp4box_builder.py
+++ b/tests/test_mp4box_builder.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 import unittest
 
@@ -91,6 +92,43 @@ class MP4BoxBuilderTests(unittest.TestCase):
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
             with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "unexpected"):
                 build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
+
+    def test_clone_or_update_source_uses_cached_tag_without_fetch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = Path(temp_dir) / "gpac-src"
+            source_dir.mkdir()
+            commands: list[list[str | Path]] = []
+
+            def fake_run(command: list[str | Path], **kwargs) -> str:
+                commands.append(command)
+                return "cached-commit"
+
+            manifest = build_mp4box_macos.load_manifest()
+            with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+                build_mp4box_macos.clone_or_update_source(source_dir, manifest, refresh=False)
+
+        self.assertIn(["git", "rev-parse", "--verify", f"{manifest.tag}^{{commit}}"], commands)
+        self.assertIn(["git", "checkout", manifest.tag], commands)
+        self.assertNotIn(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], commands)
+
+    def test_clone_or_update_source_fetches_missing_cached_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = Path(temp_dir) / "gpac-src"
+            source_dir.mkdir()
+            commands: list[list[str | Path]] = []
+
+            def fake_run(command: list[str | Path], **kwargs) -> str:
+                commands.append(command)
+                if command[:3] == ["git", "rev-parse", "--verify"]:
+                    raise subprocess.CalledProcessError(returncode=128, cmd=command)
+                return ""
+
+            manifest = build_mp4box_macos.load_manifest()
+            with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+                build_mp4box_macos.clone_or_update_source(source_dir, manifest, refresh=False)
+
+        self.assertIn(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], commands)
+        self.assertIn(["git", "checkout", manifest.tag], commands)
 
     def test_build_mp4box_skips_distclean_without_makefile(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_mp4box_builder.py
+++ b/tests/test_mp4box_builder.py
@@ -12,7 +12,7 @@ class MP4BoxBuilderTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest_path = Path(temp_dir) / "mp4box.toml"
             manifest_path.write_text(
-                '\n'.join(
+                "\n".join(
                     [
                         'version = "26.02.0"',
                         'repo_url = "https://example.invalid/gpac.git"',
@@ -22,8 +22,8 @@ class MP4BoxBuilderTests(unittest.TestCase):
                         f'binary_sha256 = "{"1" * 64}"',
                         'build = "static test build"',
                         'configure_flags = ["--static-bin", "--use-ffmpeg=no"]',
-                        '',
-                        '[validation]',
+                        "",
+                        "[validation]",
                         'required_file_substring = "Mach-O 64-bit executable arm64"',
                         'required_version_substring = "MP4Box - GPAC version"',
                         'forbidden_link_prefixes = ["/opt/homebrew", "/usr/local"]',
@@ -67,9 +67,7 @@ class MP4BoxBuilderTests(unittest.TestCase):
 
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
             with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "/opt/homebrew"):
-                build_mp4box_macos.verify_macos_binary(
-                    Path("MP4Box"), build_mp4box_macos.load_manifest().validation
-                )
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
 
     def test_verify_macos_binary_accepts_system_only_linkage(self) -> None:
         def fake_run(command: list[str | Path], **kwargs) -> str:
@@ -92,9 +90,7 @@ class MP4BoxBuilderTests(unittest.TestCase):
 
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
             with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "unexpected"):
-                build_mp4box_macos.verify_macos_binary(
-                    Path("MP4Box"), build_mp4box_macos.load_manifest().validation
-                )
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
 
     def test_build_mp4box_skips_distclean_without_makefile(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -109,9 +105,7 @@ class MP4BoxBuilderTests(unittest.TestCase):
                 return ""
 
             with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
-                build_mp4box_macos.build_mp4box(
-                    source_dir, source_dir / "install", build_mp4box_macos.load_manifest()
-                )
+                build_mp4box_macos.build_mp4box(source_dir, source_dir / "install", build_mp4box_macos.load_manifest())
 
         self.assertNotIn(["make", "distclean"], commands)
         self.assertIn(["make", f"-j{build_mp4box_macos.os.cpu_count() or 1}", "lib"], commands)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -24,6 +24,7 @@ class DependencyPreflightTests(unittest.TestCase):
 
     def test_missing_native_mvc_helper_raises_clear_error(self) -> None:
         with (
+            patch.object(preflight.config.app, "is_gui", False),
             patch.object(preflight.config, "FFMPEG_PATH", Path(__file__)),
             patch.object(preflight.config, "FFPROBE_PATH", Path(__file__)),
             patch.object(preflight.config, "MAKEMKVCON_PATH", Path(__file__)),
@@ -66,6 +67,7 @@ class DependencyPreflightTests(unittest.TestCase):
 
     def test_runtime_ready_does_not_import_subprocess(self) -> None:
         with (
+            patch.object(preflight.config.app, "is_gui", False),
             patch.object(preflight.config, "FFMPEG_PATH", Path(__file__)),
             patch.object(preflight.config, "FFPROBE_PATH", Path(__file__)),
             patch.object(preflight.config, "MAKEMKVCON_PATH", Path(__file__)),
@@ -108,6 +110,16 @@ class DependencyPreflightTests(unittest.TestCase):
         self.assertNotIn(preflight.config.MKVEXTRACT_PATH, required_paths)
         self.assertNotIn(preflight.config.MKVMERGE_PATH, required_paths)
         self.assertNotIn(preflight.config.TESSERACT_PATH, required_paths)
+
+    def test_final_mux_always_requires_mp4box_even_before_srt_files_exist(self) -> None:
+        with (
+            patch.object(preflight.config, "skip_subtitles", False),
+            patch.object(preflight.config, "source_path", Path("/movie/source.mkv")),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_FINAL_FILE),
+        ):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job()
+
+        self.assertIn(preflight.config.MP4BOX_PATH, required_paths)
 
     def test_fx_upscale_tool_is_required_only_when_enabled(self) -> None:
         with (

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -74,6 +74,30 @@ class ReleaseSmokeTests(unittest.TestCase):
                         check_links=True,
                     )
 
+    def test_bundled_tool_linkage_check_detects_usr_local_library(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+            clean_env = smoke_release_app.build_clean_env()
+
+            def fake_run(command: list[str | Path], *, env: dict[str, str] | None = None):
+                if command[:2] == ["otool", "-L"]:
+                    return smoke_release_app.subprocess.CompletedProcess(
+                        args=command,
+                        returncode=0,
+                        stdout="/usr/local/lib/libexample.dylib\n",
+                    )
+                return smoke_release_app.subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+
+            with patch.object(smoke_release_app, "run", side_effect=fake_run):
+                with self.assertRaisesRegex(smoke_release_app.SmokeFailure, "/usr/local"):
+                    smoke_release_app.verify_bundled_tool(
+                        bundle.bin_dir / "MP4Box",
+                        ["-version"],
+                        clean_env=clean_env,
+                        check_links=True,
+                    )
+
     def test_bundled_tool_linkage_check_can_be_skipped_without_false_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_fake_app(Path(temp_dir), version="1.2.3")

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -1,0 +1,37 @@
+import subprocess
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import verify_app_tools
+
+
+class VerifyAppToolsTests(unittest.TestCase):
+    def test_required_tools_include_mp4box(self) -> None:
+        self.assertIn("MP4Box", verify_app_tools.REQUIRED_TOOLS)
+        self.assertEqual(verify_app_tools.REQUIRED_TOOLS["MP4Box"], ["-version"])
+
+    def test_verify_tool_uses_probe_args_and_rejects_usr_local_linkage(self) -> None:
+        with tempfile.NamedTemporaryFile() as tool_file:
+            tool_path = Path(tool_file.name)
+            tool_path.chmod(0o755)
+
+            def fake_run(command: list[str | Path]):
+                if command[:2] == ["otool", "-L"]:
+                    return subprocess.CompletedProcess(
+                        args=command,
+                        returncode=0,
+                        stdout="/usr/local/lib/libexample.dylib\n",
+                    )
+                self.assertEqual(command, [tool_path, "-version"])
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+
+            with patch.object(verify_app_tools, "run", side_effect=fake_run):
+                with self.assertRaisesRegex(RuntimeError, "/usr/local"):
+                    verify_app_tools.verify_tool(tool_path, ["-version"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_apple_media.py
+++ b/tests/test_verify_apple_media.py
@@ -1,0 +1,54 @@
+import subprocess
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import verify_apple_media
+
+
+class AppleMediaVerifyTests(unittest.TestCase):
+    def test_missing_media_file_fails_before_avconvert(self) -> None:
+        with self.assertRaisesRegex(verify_apple_media.AppleMediaFailure, "Missing media"):
+            verify_apple_media.verify_apple_media_compatible(Path("/missing/movie.mov"))
+
+    def test_missing_avconvert_reports_clear_error(self) -> None:
+        with tempfile.NamedTemporaryFile() as media_file:
+            with patch.object(verify_apple_media.shutil, "which", return_value=None):
+                with self.assertRaisesRegex(verify_apple_media.AppleMediaFailure, "avconvert"):
+                    verify_apple_media.verify_apple_media_compatible(Path(media_file.name))
+
+    def test_avconvert_failure_includes_output(self) -> None:
+        with tempfile.NamedTemporaryFile() as media_file:
+            with (
+                patch.object(verify_apple_media.shutil, "which", return_value="/usr/bin/avconvert"),
+                patch.object(
+                    verify_apple_media,
+                    "run",
+                    side_effect=subprocess.CalledProcessError(
+                        returncode=1,
+                        cmd=["avconvert"],
+                        output="Cannot Open",
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(verify_apple_media.AppleMediaFailure, "Cannot Open"):
+                    verify_apple_media.verify_apple_media_compatible(Path(media_file.name))
+
+    def test_avconvert_passthrough_command_is_used(self) -> None:
+        with tempfile.NamedTemporaryFile() as media_file:
+            with (
+                patch.object(verify_apple_media.shutil, "which", return_value="/usr/bin/avconvert"),
+                patch.object(verify_apple_media, "run") as run,
+            ):
+                verify_apple_media.verify_apple_media_compatible(Path(media_file.name))
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[0], "/usr/bin/avconvert")
+        self.assertIn("PresetPassthrough", command)
+        self.assertIn("--disableFastStart", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/mp4box-macos-arm64.toml
+++ b/vendor/mp4box-macos-arm64.toml
@@ -1,0 +1,48 @@
+version = "26.02.0"
+repo_url = "https://github.com/gpac/gpac.git"
+tag = "v26.02.0"
+license_mode = "LGPL-2.1-or-later"
+binary = "MP4Box"
+binary_sha256 = "eb63ed3f3c73eadc61f9158961114a614c208cd5929f1abb7d13da3a679cfedf"
+build = "static arm64 macOS MP4Box built from GPAC source with Homebrew hidden and external libraries disabled"
+
+configure_flags = [
+    "--static-bin",
+    "--disable-rmtws",
+    "--disable-network",
+    "--disable-ssl",
+    "--disable-x11",
+    "--disable-sdl",
+    "--use-zlib=system",
+    "--use-opensvc=no",
+    "--use-openhevc=no",
+    "--use-platinum=no",
+    "--use-freetype=no",
+    "--use-ssl=no",
+    "--use-jpeg=no",
+    "--use-openjpeg=no",
+    "--use-png=no",
+    "--use-mad=no",
+    "--use-a52=no",
+    "--use-xvid=no",
+    "--use-faad=no",
+    "--use-ffmpeg=no",
+    "--use-freenect=no",
+    "--use-vorbis=no",
+    "--use-theora=no",
+    "--use-nghttp2=no",
+    "--use-ngtcp2=no",
+    "--use-nghttp3=no",
+    "--use-lzma=no",
+    "--use-curl=no",
+]
+
+[validation]
+required_file_substring = "Mach-O 64-bit executable arm64"
+required_version_substring = "MP4Box - GPAC version"
+forbidden_link_prefixes = ["/opt/homebrew", "/usr/local"]
+expected_system_links = ["/usr/lib/libz.1.dylib", "/usr/lib/libSystem.B.dylib"]
+
+[update]
+source = "https://github.com/gpac/gpac/releases"
+process = "When updating, change this manifest tag/version, run scripts/build_mp4box_macos.py, commit the generated bd_to_avp/bin/MP4Box binary, and include linkage plus Apple media gate proof in the PR."


### PR DESCRIPTION
## Summary
- bundle a pinned arm64 macOS GPAC/MP4Box binary with manifest, build script, SHA-256, and LGPL notice
- sync MP4Box into existing Briefcase app bundles alongside ffmpeg/ffprobe, including package-time sync
- require MP4Box in app/release tool verification and add an Apple avconvert media compatibility gate
- add regressions for MP4Box forced/full subtitle mux args, preflight requirements, packaging sync, builder validation, and release smoke checks

## Validation
- uv run python -m unittest
- uv run ruff check --diff scripts/build_mp4box_macos.py scripts/verify_apple_media.py scripts/briefcase_app.py scripts/verify_app_tools.py scripts/smoke_release_app.py tests/test_mp4box_builder.py tests/test_verify_apple_media.py tests/test_container.py tests/test_preflight.py tests/test_ffmpeg_vendor.py tests/test_release_smoke.py tests/test_verify_app_tools.py
- git diff --check
- file/otool/version/SHA-256 proof for bd_to_avp/bin/MP4Box
- 45s MV-HEVC + in24 + forced/full tx3g mux with repo MP4Box passed MP4Box -info and scripts/verify_apple_media.py

Issue validation note: https://github.com/cbusillo/BD_to_AVP/issues/125#issuecomment-4911230783

Closes #125