### PR TITLE
Handle ISO subtitle extraction edge cases

### DIFF
--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -332,14 +332,15 @@ class MainWindow(QMainWindow):
         continue_button = message_box.addButton("Continue On Errors", QMessageBox.ButtonRole.NoRole)
 
         result = message_box.exec()
+        clicked_button = message_box.clickedButton()
 
-        if result == QMessageBox.StandardButton.Abort:
+        if result == QMessageBox.StandardButton.Abort or clicked_button is None:
             self.handle_processing_error(error)
             return
 
-        if message_box.clickedButton() == skip_button:
+        if clicked_button == skip_button:
             config.skip_subtitles = True
-        elif message_box.clickedButton() == continue_button:
+        elif clicked_button == continue_button:
             config.continue_on_error = True
 
         config.start_stage = Stage.CREATE_LEFT_RIGHT_FILES

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -46,7 +46,7 @@ class ProcessingThread(QThread):
         except FileExistsError as error:
             self.file_exists_error.emit(error)
             signal_emitted = True
-        except (RuntimeError, ValueError, KeyError) as error:
+        except Exception as error:
             self.error_occurred.emit(error)
             signal_emitted = True
         finally:

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -1,10 +1,11 @@
 import os
 import threading
 from pathlib import Path
+from typing import Any
 
 import ffmpeg
 import requests
-from babelfish import Language
+from babelfish import Error as BabelfishError, Language
 from bd_to_avp.vendor.pgsrip import Mkv, Options, pgsrip
 
 from bd_to_avp.modules.config import config, Stage
@@ -30,14 +31,9 @@ def extract_subtitle_to_srt(mkv_path: Path) -> None:
     tessdata_path = config.app.config_path / "tessdata"
     subtitle_tracks = get_languages_in_mkv(mkv_path)
 
-    if not subtitle_tracks and not config.continue_on_error:
-        raise SRTCreationError("No subtitle tracks found in source.")
-
     if not subtitle_tracks:
+        print("No PGS subtitle tracks found in source; continuing without subtitles.")
         return None
-
-    forced_subtitle_tracks = [track for track in subtitle_tracks if track["forced"] == 1]
-    forced_track_language = forced_subtitle_tracks[0]["language"] if forced_subtitle_tracks else None
 
     needed_languages = [track["language"] for track in subtitle_tracks]
     if needed_languages:
@@ -49,31 +45,68 @@ def extract_subtitle_to_srt(mkv_path: Path) -> None:
     spinner_thread = threading.Thread(target=spinner.start)
     spinner_thread.start()
 
-    for subtitle_path in output_path.glob("*.srt"):
-        subtitle_path.unlink()
+    try:
+        for subtitle_path in output_path.glob("*.srt"):
+            subtitle_path.unlink()
 
-    mkv_file = Mkv(mkv_path.as_posix())
-    os.environ["TESSDATA_PREFIX"] = tessdata_path.as_posix()
+        mkv_file = Mkv(mkv_path.as_posix())
+        os.environ["TESSDATA_PREFIX"] = tessdata_path.as_posix()
 
-    pgsrip.rip(mkv_file, sub_options)
+        pgsrip.rip(mkv_file, sub_options)
 
-    for srt_file in output_path.glob("*.srt"):
-        if srt_file.stat().st_size == 0:
-            srt_file.unlink()
+        for srt_file in output_path.glob("*.srt"):
+            if srt_file.stat().st_size == 0:
+                srt_file.unlink()
 
-    if not any(output_path.glob("*.srt")) and not config.continue_on_error:
-        raise SRTCreationError("No SRT subtitle files with data created.")
+        if not any(output_path.glob("*.srt")) and not config.continue_on_error:
+            raise SRTCreationError("No SRT subtitle files with data created.")
 
-    if forced_track_language:
-        two_alpha_language_code = Language.fromietf(forced_track_language).alpha2
+        mark_forced_srt_files(output_path, subtitle_tracks)
+    finally:
+        spinner.stop()
+        spinner_thread.join()
 
-        forced_srt_file = next(output_path.glob(f"*{two_alpha_language_code}.srt"))
-        if forced_srt_file and forced_srt_file.exists():
-            new_stem = forced_srt_file.stem.replace(f".{two_alpha_language_code}", f".forced.{two_alpha_language_code}")
-            forced_srt_file.rename(forced_srt_file.with_stem(new_stem))
 
-    spinner.stop()
-    spinner_thread.join()
+def mark_forced_srt_files(output_path: Path, subtitle_tracks: list[dict[str, Any]]) -> None:
+    language_counts: dict[str, int] = {}
+    for track in sorted(subtitle_tracks, key=lambda track: (track["forced"] == 1, int(track["index"]))):
+        language_code = subtitle_language_alpha2(track["language"])
+        if not language_code:
+            continue
+
+        track_number_for_language = language_counts.get(language_code, 0)
+        language_counts[language_code] = track_number_for_language + 1
+
+        if track["forced"] != 1:
+            continue
+
+        forced_srt_file = find_srt_for_subtitle_track(output_path, language_code, track_number_for_language)
+        if not forced_srt_file:
+            print(f"Forced subtitle track {track['index']} did not create an SRT file.")
+            continue
+
+        if ".forced." in forced_srt_file.stem:
+            continue
+
+        forced_stem = forced_srt_file.stem.replace(f".{language_code}", f".forced.{language_code}")
+        forced_srt_file.rename(forced_srt_file.with_stem(forced_stem))
+
+
+def find_srt_for_subtitle_track(output_path: Path, language_code: str, track_number_for_language: int) -> Path | None:
+    suffix = f"-{track_number_for_language}.{language_code}" if track_number_for_language else f".{language_code}"
+    candidates = [
+        candidate for candidate in sorted(output_path.glob(f"*{suffix}.srt")) if candidate.stem.endswith(suffix)
+    ]
+    return candidates[0] if candidates else None
+
+
+def subtitle_language_alpha2(language_code: str) -> str | None:
+    if not language_code or language_code == "und":
+        return None
+    try:
+        return Language.fromietf(language_code).alpha2
+    except (BabelfishError, ValueError):
+        return None
 
 
 def get_missing_tessdata_files(languages: list[str], tessdata_path: Path) -> None:
@@ -90,12 +123,16 @@ def get_missing_tessdata_files(languages: list[str], tessdata_path: Path) -> Non
                 f.write(response.content)
 
 
-def get_languages_in_mkv(mkv_path: Path) -> None | list[dict[str, str]]:
+def get_languages_in_mkv(mkv_path: Path) -> None | list[dict[str, Any]]:
     mkv_info = ffmpeg.probe(str(mkv_path), cmd=config.FFPROBE_PATH.as_posix())
     streams = mkv_info["streams"]
-    subtitle_streams = [stream for stream in streams if stream["codec_type"] == "subtitle"]
+    subtitle_streams = [
+        stream
+        for stream in streams
+        if stream["codec_type"] == "subtitle" and stream.get("codec_name") == "hdmv_pgs_subtitle"
+    ]
     if not subtitle_streams:
-        print("No subtitle streams found in MKV.")
+        print("No PGS subtitle streams found in MKV.")
         return None
     subtitle_info = []
     for stream in subtitle_streams:

--- a/tests/test_gui_processing.py
+++ b/tests/test_gui_processing.py
@@ -5,16 +5,33 @@ from bd_to_avp.gui.processing import ProcessingThread
 
 
 class ProcessingThreadTests(unittest.TestCase):
-    def test_unhandled_processing_error_emits_failure_signal(self) -> None:
+    def test_processing_exception_emits_error_signal(self) -> None:
         thread = ProcessingThread()
-        failures = []
+        errors: list[Exception] = []
+        failures: list[bool] = []
+        thread.error_occurred.connect(errors.append)  # type: ignore[arg-type]
         thread.process_failed.connect(lambda: failures.append(True))
 
         with (
-            patch("bd_to_avp.gui.processing.start_process", side_effect=AssertionError("boom")),
+            patch("bd_to_avp.gui.processing.start_process", side_effect=StopIteration("missing subtitle output")),
             patch("bd_to_avp.gui.processing.Spinner.stop_all"),
         ):
-            with self.assertRaises(AssertionError):
+            thread.run()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], StopIteration)
+        self.assertEqual(failures, [])
+
+    def test_non_exception_worker_exit_emits_failure_signal(self) -> None:
+        thread = ProcessingThread()
+        failures: list[bool] = []
+        thread.process_failed.connect(lambda: failures.append(True))
+
+        with (
+            patch("bd_to_avp.gui.processing.start_process", side_effect=SystemExit("boom")),
+            patch("bd_to_avp.gui.processing.Spinner.stop_all"),
+        ):
+            with self.assertRaises(SystemExit):
                 thread.run()
 
         self.assertEqual(failures, [True])

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,0 +1,112 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import sub
+from bd_to_avp.modules.sub import (
+    extract_subtitle_to_srt,
+    get_languages_in_mkv,
+    mark_forced_srt_files,
+    subtitle_language_alpha2,
+)
+
+
+class ForcedSubtitleNamingTests(unittest.TestCase):
+    def test_marks_second_same_language_track_as_forced(self) -> None:
+        tracks = [
+            {"index": 4, "language": "eng", "default": 1, "forced": 0},
+            {"index": 5, "language": "eng", "default": 0, "forced": 1},
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            full_srt = output_path / "movie.en.srt"
+            forced_srt = output_path / "movie-1.en.srt"
+            full_srt.write_text("full", encoding="utf-8")
+            forced_srt.write_text("forced", encoding="utf-8")
+
+            mark_forced_srt_files(output_path, tracks)
+
+            self.assertTrue(full_srt.exists())
+            self.assertFalse(forced_srt.exists())
+            self.assertEqual((output_path / "movie-1.forced.en.srt").read_text(encoding="utf-8"), "forced")
+
+    def test_marks_only_forced_language_track_as_forced(self) -> None:
+        tracks = [{"index": 3, "language": "eng", "default": 0, "forced": 1}]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            forced_srt = output_path / "movie.en.srt"
+            forced_srt.write_text("forced", encoding="utf-8")
+
+            mark_forced_srt_files(output_path, tracks)
+
+            self.assertFalse(forced_srt.exists())
+            self.assertEqual((output_path / "movie.forced.en.srt").read_text(encoding="utf-8"), "forced")
+
+    def test_ignores_unknown_language_for_forced_rename(self) -> None:
+        tracks = [{"index": 3, "language": "und", "default": 0, "forced": 1}]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            subtitle = output_path / "movie.und.srt"
+            subtitle.write_text("forced", encoding="utf-8")
+
+            mark_forced_srt_files(output_path, tracks)
+
+            self.assertTrue(subtitle.exists())
+
+
+class SubtitleLanguageTests(unittest.TestCase):
+    def test_iso_639_2_language_converts_to_alpha2(self) -> None:
+        self.assertEqual(subtitle_language_alpha2("eng"), "en")
+
+    def test_undefined_language_returns_none(self) -> None:
+        self.assertIsNone(subtitle_language_alpha2("und"))
+
+    def test_invalid_language_returns_none(self) -> None:
+        self.assertIsNone(subtitle_language_alpha2("xxx"))
+
+
+class SubtitleStreamDetectionTests(unittest.TestCase):
+    def test_language_detection_uses_only_pgs_streams(self) -> None:
+        probe = {
+            "streams": [
+                {
+                    "index": 2,
+                    "codec_type": "subtitle",
+                    "codec_name": "subrip",
+                    "tags": {"language": "eng"},
+                    "disposition": {"default": 1, "forced": 0},
+                },
+                {
+                    "index": 3,
+                    "codec_type": "subtitle",
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng"},
+                    "disposition": {"default": 0, "forced": 1},
+                },
+            ]
+        }
+
+        with patch.object(sub.ffmpeg, "probe", return_value=probe):
+            tracks = get_languages_in_mkv(Path("movie.mkv"))
+
+        self.assertEqual(tracks, [{"index": 3, "language": "eng", "default": 0, "forced": 1}])
+
+    def test_no_subtitle_tracks_continue_without_pgsrip(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.sub.get_languages_in_mkv", return_value=None),
+            patch("bd_to_avp.modules.sub.pgsrip.rip") as rip,
+            patch.object(sub.config, "skip_subtitles", False),
+            patch.object(sub.config, "continue_on_error", False),
+        ):
+            extract_subtitle_to_srt(Path(temp_dir) / "movie.mkv")
+
+        rip.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- continue without subtitles when the source has no PGS subtitle streams
- make forced subtitle SRT renaming deterministic for mixed full/forced tracks in the same language
- surface unexpected GUI worker exceptions instead of silently resetting the processing button
- treat closing the subtitle recovery dialog as abort instead of resuming with unchanged settings

## Context
Tester report on v0.2.141rc2: multiple ISOs stopped right after SUP/SRT extraction, including sources without subtitles, with no visible error and the Start Processing button returning.

## Validation
- uv run ruff check bd_to_avp/modules/sub.py bd_to_avp/gui/processing.py bd_to_avp/gui/main_window.py tests/test_subtitles.py tests/test_gui_processing.py
- uv run python -m unittest
