### PR TITLE
Retry native MVC split after splitter crash

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -240,7 +240,7 @@ def build_native_splitter_failure_message(error: subprocess.CalledProcessError, 
         try:
             signal_name = signal.Signals(-error.returncode).name
         except ValueError:
-            pass
+            signal_name = f"signal {-error.returncode}"
     return (
         "The native MVC splitter crashed while decoding this MVC video stream "
         f"({signal_name}). This usually means the bundled native decoder hit a Blu-ray MVC bitstream it does not "

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -1,5 +1,6 @@
 import os
 import re
+import signal
 import stat
 import subprocess
 import tempfile
@@ -43,11 +44,16 @@ def explain_native_mvc_unavailable(disc_info: DiscInfo) -> str:
     )
 
 
-def generate_native_mvc_splitter_command(video_input_path: Path) -> list[str | Path]:
+class NativeMvcSplitError(RuntimeError):
+    pass
+
+
+def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threaded: bool = False) -> list[str | Path]:
+    options = "-Osk" if single_threaded else "-Omk"
     return [
         config.EDGE264_TEST_PATH,
         video_input_path,
-        "-Omk",
+        options,
     ]
 
 
@@ -133,20 +139,64 @@ def split_mvc_to_stereo_native(
 ) -> tuple[Path, Path]:
     ffmpeg_command = generate_native_mvc_ffmpeg_command(left_output_path, right_output_path, disc_info, crop_params)
     native_input_path = prepare_native_mvc_input(video_input_path)
-    splitter_command = generate_native_mvc_splitter_command(native_input_path)
+    splitter_log_path = left_output_path.with_suffix(".native_mvc.log")
+    ffmpeg_log_path = left_output_path.with_suffix(".native_ffmpeg.log")
+    try:
+        try:
+            run_native_mvc_split_attempt(
+                native_input_path,
+                ffmpeg_command,
+                ffmpeg_log_path,
+                splitter_log_path,
+                single_threaded=False,
+            )
+        except subprocess.CalledProcessError as error:
+            if not native_splitter_died_by_signal(error):
+                raise
+
+            print("Native MVC splitter crashed; retrying once in single-threaded mode.")
+            left_output_path.unlink(missing_ok=True)
+            right_output_path.unlink(missing_ok=True)
+            run_native_mvc_split_attempt(
+                native_input_path,
+                ffmpeg_command,
+                ffmpeg_log_path,
+                splitter_log_path,
+                single_threaded=True,
+            )
+    except subprocess.CalledProcessError as error:
+        if error.cmd and Path(error.cmd[0]).name == config.EDGE264_TEST_PATH.name:
+            raise NativeMvcSplitError(build_native_splitter_failure_message(error, splitter_log_path)) from error
+        raise
+    finally:
+        if native_input_path != video_input_path:
+            native_input_path.unlink(missing_ok=True)
+
+    return left_output_path, right_output_path
+
+
+def run_native_mvc_split_attempt(
+    native_input_path: Path,
+    ffmpeg_command: list[str],
+    ffmpeg_log_path: Path,
+    splitter_log_path: Path,
+    *,
+    single_threaded: bool,
+) -> None:
+    splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=single_threaded)
 
     if config.output_commands:
         splitter_command_text = " ".join(str(command) for command in splitter_command)
         ffmpeg_command_text = " ".join(ffmpeg_command)
         print(f"Running command:\n{splitter_command_text} | {ffmpeg_command_text}")
 
-    ffmpeg_log_path = left_output_path.with_suffix(".native_ffmpeg.log")
-    splitter_log_path = left_output_path.with_suffix(".native_mvc.log")
-
     splitter_process = None
     ffmpeg_process = None
     try:
-        with open(ffmpeg_log_path, "w") as ffmpeg_log, open(splitter_log_path, "wb") as splitter_log:
+        with open(ffmpeg_log_path, "a") as ffmpeg_log, open(splitter_log_path, "ab") as splitter_log:
+            attempt_name = "single-threaded" if single_threaded else "multi-threaded"
+            ffmpeg_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n")
+            splitter_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n".encode())
             splitter_process = subprocess.Popen(splitter_command, stdout=subprocess.PIPE, stderr=splitter_log)
             ffmpeg_process = subprocess.Popen(
                 ffmpeg_command,
@@ -160,27 +210,43 @@ def split_mvc_to_stereo_native(
                 splitter_process.stdout.close()
 
             ffmpeg_process.wait()
-            if ffmpeg_process.returncode != 0:
+            splitter_failed_before_cleanup = splitter_process.poll() is not None
+            if ffmpeg_process.returncode != 0 and not splitter_failed_before_cleanup:
                 cleanup_process(splitter_process)
             splitter_process.wait()
 
-        if ffmpeg_process.returncode != 0:
-            raise subprocess.CalledProcessError(ffmpeg_process.returncode, ffmpeg_command)
-        if splitter_process.returncode != 0:
+        if splitter_process.returncode != 0 and (ffmpeg_process.returncode == 0 or splitter_failed_before_cleanup):
             raise subprocess.CalledProcessError(
                 splitter_process.returncode,
                 splitter_command,
                 output=splitter_log_path.read_text(errors="replace"),
             )
+        if ffmpeg_process.returncode != 0:
+            raise subprocess.CalledProcessError(ffmpeg_process.returncode, ffmpeg_command)
     finally:
         if splitter_process:
             cleanup_process(splitter_process)
         if ffmpeg_process:
             cleanup_process(ffmpeg_process)
-        if native_input_path != video_input_path:
-            native_input_path.unlink(missing_ok=True)
 
-    return left_output_path, right_output_path
+
+def native_splitter_died_by_signal(error: subprocess.CalledProcessError) -> bool:
+    return error.returncode < 0 and bool(error.cmd) and Path(error.cmd[0]).name == config.EDGE264_TEST_PATH.name
+
+
+def build_native_splitter_failure_message(error: subprocess.CalledProcessError, splitter_log_path: Path) -> str:
+    signal_name = f"signal {-error.returncode}" if error.returncode < 0 else f"exit code {error.returncode}"
+    if error.returncode < 0:
+        try:
+            signal_name = signal.Signals(-error.returncode).name
+        except ValueError:
+            pass
+    return (
+        "The native MVC splitter crashed while decoding this MVC video stream "
+        f"({signal_name}). This usually means the bundled native decoder hit a Blu-ray MVC bitstream it does not "
+        "currently support. The source may need a splitter update or a future fallback path. "
+        f"Details were written to {splitter_log_path}."
+    )
 
 
 def split_mvc_to_stereo(

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -18,6 +18,12 @@ class NativeMvcCommandTests(unittest.TestCase):
 
         self.assertEqual(command, [Path("/tools/edge264_test"), Path("movie_mvc.h264"), "-Omk"])
 
+    def test_native_splitter_command_can_force_single_threaded_decoding(self) -> None:
+        with patch.object(video.config, "EDGE264_TEST_PATH", Path("/tools/edge264_test")):
+            command = video.generate_native_mvc_splitter_command(Path("movie_mvc.h264"), single_threaded=True)
+
+        self.assertEqual(command, [Path("/tools/edge264_test"), Path("movie_mvc.h264"), "-Osk"])
+
     def test_native_ffmpeg_command_splits_side_by_side_stream(self) -> None:
         with (
             patch.object(video.config, "left_right_bitrate", 12),
@@ -159,7 +165,7 @@ class NativeMvcSelectionTests(unittest.TestCase):
             self.assertTrue(helper_path.stat().st_mode & 0o111)
 
     def test_native_split_raises_when_ffmpeg_fails(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15)
+        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[None])
         ffmpeg_process = _FakeProcess(returncode=1, stdout=None, stderr=None)
 
         with (
@@ -175,11 +181,71 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         splitter.terminate.assert_called_once()
 
+    def test_native_split_retries_single_threaded_when_splitter_sigaborts(self) -> None:
+        splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
+        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
+        splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
+        ffmpeg_retry = _FakeProcess(returncode=0, stdout=None, stderr=None)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", side_effect=[
+                ["edge264_test", "-Omk"],
+                ["edge264_test", "-Osk"],
+            ]) as splitter_command,
+            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
+            patch(
+                "bd_to_avp.modules.video.subprocess.Popen",
+                side_effect=[splitter_crash, ffmpeg_broken_pipe, splitter_retry, ffmpeg_retry],
+            ),
+        ):
+            result = video.split_mvc_to_stereo_native(
+                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+            )
+
+        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
+        self.assertEqual(
+            [command_call.kwargs for command_call in splitter_command.call_args_list],
+            [{"single_threaded": False}, {"single_threaded": True}],
+        )
+
+    def test_native_split_raises_clear_error_when_single_thread_retry_sigaborts(self) -> None:
+        splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
+        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
+        splitter_retry_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
+        ffmpeg_retry_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", side_effect=[
+                ["edge264_test", "-Omk"],
+                ["edge264_test", "-Osk"],
+            ]),
+            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
+            patch(
+                "bd_to_avp.modules.video.subprocess.Popen",
+                side_effect=[splitter_crash, ffmpeg_broken_pipe, splitter_retry_crash, ffmpeg_retry_broken_pipe],
+            ),
+        ):
+            with self.assertRaisesRegex(video.NativeMvcSplitError, "SIGABRT"):
+                video.split_mvc_to_stereo_native(
+                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+                )
+
 
 class _FakeProcess:
-    def __init__(self, returncode: int | None, stdout, stderr=None, returncode_after_wait: int | None = None) -> None:
+    def __init__(
+        self,
+        returncode: int | None,
+        stdout,
+        stderr=None,
+        returncode_after_wait: int | None = None,
+        poll_results: list[int | None] | None = None,
+    ) -> None:
         self.returncode = returncode
         self.returncode_after_wait = returncode_after_wait if returncode_after_wait is not None else returncode
+        self.poll_results = poll_results or []
         self.stdout = stdout
         self.stderr = stderr
         self.terminate = Mock()
@@ -191,6 +257,8 @@ class _FakeProcess:
         return self.returncode
 
     def poll(self) -> int | None:
+        if self.poll_results:
+            return self.poll_results.pop(0)
         return self.returncode
 
 

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -189,10 +189,13 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         with (
             tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", side_effect=[
-                ["edge264_test", "-Omk"],
-                ["edge264_test", "-Osk"],
-            ]) as splitter_command,
+            patch(
+                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
+                side_effect=[
+                    ["edge264_test", "-Omk"],
+                    ["edge264_test", "-Osk"],
+                ],
+            ) as splitter_command,
             patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
             patch(
                 "bd_to_avp.modules.video.subprocess.Popen",
@@ -218,10 +221,13 @@ class NativeMvcSelectionTests(unittest.TestCase):
         with (
             tempfile.TemporaryDirectory() as temp_dir,
             patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", side_effect=[
-                ["edge264_test", "-Omk"],
-                ["edge264_test", "-Osk"],
-            ]),
+            patch(
+                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
+                side_effect=[
+                    ["edge264_test", "-Omk"],
+                    ["edge264_test", "-Osk"],
+                ],
+            ),
             patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
             patch(
                 "bd_to_avp.modules.video.subprocess.Popen",


### PR DESCRIPTION
## Summary
- retry native MVC splitting once in edge264 single-threaded mode when the splitter dies by signal
- classify native splitter crashes separately from downstream ffmpeg pipe failures
- preserve/appends native splitter and ffmpeg logs across retry attempts
- return a clearer NativeMvcSplitError if both native attempts fail

## Context
Tester reported v0.2.141rc3 failing on Secrets of the Rainforest (2013) 3D.iso during edge264_test with SIGABRT. The ISO upload was mounted locally as a raw UDF/Blu-ray image, but this machine does not have MakeMKV installed, so the exact decrypted MakeMKV extraction path could not be fully reproduced here.

## Validation
- uv run ruff check bd_to_avp/modules/video.py tests/test_native_mvc_split.py
- uv run python -m unittest
