### PR TITLE
Bump version to 0.2.142

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.2.141"
+version = "0.2.142"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -73,7 +73,7 @@ include = [
 project_name = "3D Blu-ray to Vision pro"
 bundle = "com.shinycomputers"
 architectures = ["arm64"]
-version = "0.2.141"
+version = "0.2.142"
 icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.2.141"
+version = "0.2.142"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- bump package and Briefcase app version to 0.2.142
- prepare final release after v0.2.141rc4 tester green

## Validation
- uv run python -m unittest discover -s tests -t .

## Release context
- v0.2.141 was pulled and points at an older build
- v0.2.141rc4 was tester-validated for bundled MP4Box, ISO/no-subtitle handling, and native MVC splitter crash retry
- final release should use a fresh v0.2.142 tag