### PR TITLE
Probe native splitter before ISO fallback

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -48,6 +48,9 @@ class NativeMvcSplitError(RuntimeError):
     pass
 
 
+NATIVE_MVC_PROBE_TIMEOUT_SECONDS = 30
+
+
 def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threaded: bool = False) -> list[str | Path]:
     options = "-Osk" if single_threaded else "-Omk"
     return [
@@ -55,6 +58,13 @@ def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threa
         video_input_path,
         options,
     ]
+
+
+def should_probe_native_multithread_splitter() -> bool:
+    source_path = config.source_path
+    if not source_path:
+        return False
+    return source_path.suffix.lower() in config.IMAGE_EXTENSIONS
 
 
 def prepare_native_mvc_input(video_input_path: Path) -> Path:
@@ -142,14 +152,31 @@ def split_mvc_to_stereo_native(
     splitter_log_path = left_output_path.with_suffix(".native_mvc.log")
     ffmpeg_log_path = left_output_path.with_suffix(".native_ffmpeg.log")
     try:
-        try:
-            run_native_mvc_split_attempt(
+        skip_multithreaded_attempt = False
+        if should_probe_native_multithread_splitter():
+            skip_multithreaded_attempt = native_multithread_splitter_probe_crashed(
                 native_input_path,
-                ffmpeg_command,
-                ffmpeg_log_path,
                 splitter_log_path,
-                single_threaded=False,
             )
+
+        try:
+            if skip_multithreaded_attempt:
+                print("Native MVC splitter probe crashed; using slower single-threaded mode.")
+                run_native_mvc_split_attempt(
+                    native_input_path,
+                    ffmpeg_command,
+                    ffmpeg_log_path,
+                    splitter_log_path,
+                    single_threaded=True,
+                )
+            else:
+                run_native_mvc_split_attempt(
+                    native_input_path,
+                    ffmpeg_command,
+                    ffmpeg_log_path,
+                    splitter_log_path,
+                    single_threaded=False,
+                )
         except subprocess.CalledProcessError as error:
             if not native_splitter_died_by_signal(error):
                 raise
@@ -173,6 +200,39 @@ def split_mvc_to_stereo_native(
             native_input_path.unlink(missing_ok=True)
 
     return left_output_path, right_output_path
+
+
+def native_multithread_splitter_probe_crashed(native_input_path: Path, splitter_log_path: Path) -> bool:
+    splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=False)
+    splitter_process = None
+    with open(splitter_log_path, "ab") as splitter_log:
+        splitter_log.write(b"\n--- Native MVC split probe: multi-threaded ---\n")
+        try:
+            splitter_process = subprocess.Popen(
+                splitter_command,
+                stdout=subprocess.DEVNULL,
+                stderr=splitter_log,
+            )
+            splitter_process.wait(timeout=NATIVE_MVC_PROBE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            if splitter_process:
+                cleanup_process(splitter_process)
+                try:
+                    splitter_process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    # The probe already survived long enough; leave full cleanup to the process group handler.
+                    pass
+            return False
+
+    if splitter_process.returncode == 0:
+        return False
+    if splitter_process.returncode < 0:
+        return True
+    raise subprocess.CalledProcessError(
+        splitter_process.returncode,
+        splitter_command,
+        output=splitter_log_path.read_text(errors="replace"),
+    )
 
 
 def run_native_mvc_split_attempt(

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -212,6 +212,82 @@ class NativeMvcSelectionTests(unittest.TestCase):
             [{"single_threaded": False}, {"single_threaded": True}],
         )
 
+    def test_native_split_probes_iso_sources_and_skips_doomed_multithread_attempt(self) -> None:
+        splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
+        ffmpeg_retry = _FakeProcess(returncode=0, stdout=None, stderr=None)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "source_path", Path("movie.iso")),
+            patch.object(video.config, "IMAGE_EXTENSIONS", [".iso"]),
+            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed", return_value=True) as probe,
+            patch(
+                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
+                return_value=["edge264_test", "-Osk"],
+            ) as splitter_command,
+            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_retry, ffmpeg_retry]),
+        ):
+            result = video.split_mvc_to_stereo_native(
+                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+            )
+
+        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
+        probe.assert_called_once()
+        self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": True}])
+
+    def test_native_split_does_not_probe_mkv_sources(self) -> None:
+        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
+        ffmpeg_process = _FakeProcess(returncode=0, stdout=None, stderr=None)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "source_path", Path("movie.mkv")),
+            patch.object(video.config, "IMAGE_EXTENSIONS", [".iso"]),
+            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed") as probe,
+            patch(
+                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
+                return_value=["edge264_test", "-Omk"],
+            ) as splitter_command,
+            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter, ffmpeg_process]),
+        ):
+            video.split_mvc_to_stereo_native(
+                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+            )
+
+        probe.assert_not_called()
+        self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": False}])
+
+    def test_native_multithread_probe_returns_true_when_splitter_dies_by_signal(self) -> None:
+        splitter_crash = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-6)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter_crash),
+        ):
+            result = video.native_multithread_splitter_probe_crashed(
+                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+            )
+
+        self.assertTrue(result)
+
+    def test_native_multithread_probe_returns_false_after_timeout(self) -> None:
+        splitter = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=None, raises_timeout=True)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter),
+        ):
+            result = video.native_multithread_splitter_probe_crashed(
+                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+            )
+
+        self.assertFalse(result)
+        splitter.terminate.assert_called_once()
+
     def test_native_split_raises_clear_error_when_single_thread_retry_sigaborts(self) -> None:
         splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
         ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
@@ -248,15 +324,19 @@ class _FakeProcess:
         stderr=None,
         returncode_after_wait: int | None = None,
         poll_results: list[int | None] | None = None,
+        raises_timeout: bool = False,
     ) -> None:
         self.returncode = returncode
         self.returncode_after_wait = returncode_after_wait if returncode_after_wait is not None else returncode
         self.poll_results = poll_results or []
+        self.raises_timeout = raises_timeout
         self.stdout = stdout
         self.stderr = stderr
         self.terminate = Mock()
 
-    def wait(self) -> int:
+    def wait(self, timeout=None) -> int:
+        if self.raises_timeout:
+            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
         self.returncode = self.returncode_after_wait
         if self.returncode is None:
             raise AssertionError("test fake process still running after wait")


### PR DESCRIPTION
## Summary
- add a 30-second multithread native splitter probe for ISO/image sources before launching the expensive left/right encode
- skip directly to slower single-threaded splitting when the probe catches the known edge264 multithread crash
- keep MKV and non-image sources on the existing fast path without probe overhead
- add unit coverage for probe decisions, signal crash detection, and timeout behavior

## Validation
- uv run python -m unittest tests.test_native_mvc_split
- uv run python -m unittest discover -s tests -t .
- local Rainforest real-probe check: 12s could miss the crash; 30s caught the assertion and returned true
- local MKV-derived stream survived bounded -Omk probes

## Related
- Tracks #135
- Ship status-progress note captured separately in #136