### PR TITLE
Fix subtitle artifact cleanup and forced-track mapping

### DIFF
--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -7,6 +7,7 @@ import ffmpeg
 import requests
 from babelfish import Error as BabelfishError, Language
 from bd_to_avp.vendor.pgsrip import Mkv, Options, pgsrip
+from bd_to_avp.vendor.pgsrip.mkv import MkvPgs
 
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.command import Spinner
@@ -19,12 +20,15 @@ class SRTCreationError(Exception):
 def create_srt_from_mkv(mkv_path: Path) -> None:
     if config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
         if config.skip_subtitles:
+            cleanup_existing_subtitle_files(mkv_path.parent)
             return None
         extract_subtitle_to_srt(mkv_path)
 
 
 def extract_subtitle_to_srt(mkv_path: Path) -> None:
     output_path = mkv_path.parent
+
+    cleanup_existing_subtitle_files(output_path)
 
     if config.skip_subtitles:
         return None
@@ -46,10 +50,8 @@ def extract_subtitle_to_srt(mkv_path: Path) -> None:
     spinner_thread.start()
 
     try:
-        for subtitle_path in output_path.glob("*.srt"):
-            subtitle_path.unlink()
-
         mkv_file = Mkv(mkv_path.as_posix())
+        selected_subtitle_tracks = get_selected_subtitle_tracks(mkv_file, sub_options)
         os.environ["TESSDATA_PREFIX"] = tessdata_path.as_posix()
 
         pgsrip.rip(mkv_file, sub_options)
@@ -61,43 +63,55 @@ def extract_subtitle_to_srt(mkv_path: Path) -> None:
         if not any(output_path.glob("*.srt")) and not config.continue_on_error:
             raise SRTCreationError("No SRT subtitle files with data created.")
 
-        mark_forced_srt_files(output_path, subtitle_tracks)
+        mark_forced_srt_files(selected_subtitle_tracks)
     finally:
         spinner.stop()
         spinner_thread.join()
 
 
-def mark_forced_srt_files(output_path: Path, subtitle_tracks: list[dict[str, Any]]) -> None:
-    language_counts: dict[str, int] = {}
-    for track in sorted(subtitle_tracks, key=lambda track: (track["forced"] == 1, int(track["index"]))):
-        language_code = subtitle_language_alpha2(track["language"])
-        if not language_code:
-            continue
+def cleanup_existing_subtitle_files(output_path: Path) -> None:
+    for subtitle_path in output_path.glob("*.srt"):
+        subtitle_path.unlink()
 
-        track_number_for_language = language_counts.get(language_code, 0)
-        language_counts[language_code] = track_number_for_language + 1
 
+def get_selected_subtitle_tracks(mkv_file: Mkv, sub_options: Options) -> list[dict[str, Any]]:
+    selected_tracks: list[dict[str, Any]] = []
+    for track, language, number in mkv_file.get_selected_pgs_tracks(sub_options):
+        selected_tracks.append(
+            {
+                "index": track.id,
+                "language": str(track.language),
+                "forced": 1 if track.forced else 0,
+                "srt_path": Path(str(MkvPgs.expected_srt_path(mkv_file.media_path, language, number))),
+            }
+        )
+    return selected_tracks
+
+
+def mark_forced_srt_files(subtitle_tracks: list[dict[str, Any]]) -> None:
+    for track in subtitle_tracks:
         if track["forced"] != 1:
             continue
 
-        forced_srt_file = find_srt_for_subtitle_track(output_path, language_code, track_number_for_language)
-        if not forced_srt_file:
+        forced_srt_file = track["srt_path"]
+        if not forced_srt_file.exists():
             print(f"Forced subtitle track {track['index']} did not create an SRT file.")
             continue
 
         if ".forced." in forced_srt_file.stem:
             continue
 
-        forced_stem = forced_srt_file.stem.replace(f".{language_code}", f".forced.{language_code}")
+        forced_stem = forced_subtitle_stem(forced_srt_file)
         forced_srt_file.rename(forced_srt_file.with_stem(forced_stem))
 
 
-def find_srt_for_subtitle_track(output_path: Path, language_code: str, track_number_for_language: int) -> Path | None:
-    suffix = f"-{track_number_for_language}.{language_code}" if track_number_for_language else f".{language_code}"
-    candidates = [
-        candidate for candidate in sorted(output_path.glob(f"*{suffix}.srt")) if candidate.stem.endswith(suffix)
-    ]
-    return candidates[0] if candidates else None
+def forced_subtitle_stem(subtitle_path: Path) -> str:
+    stem = subtitle_path.stem
+    language_suffix = subtitle_path.with_suffix("").suffix
+    if not language_suffix or not stem.endswith(language_suffix):
+        return f"{stem}.forced"
+
+    return f"{stem[: -len(language_suffix)]}.forced{language_suffix}"
 
 
 def subtitle_language_alpha2(language_code: str) -> str | None:

--- a/bd_to_avp/vendor/pgsrip/media.py
+++ b/bd_to_avp/vendor/pgsrip/media.py
@@ -155,7 +155,7 @@ class Pgs:
 
     @property
     def srt_path(self):
-        return self.media_path.translate(number=0, extension='srt')
+        return self.media_path.translate(extension='srt')
 
     @property
     def items(self):

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 class MkvPgs(Pgs):
 
+    @staticmethod
+    def expected_srt_path(media_path: MediaPath, language: Language, number: int):
+        return media_path.translate(language=language, number=number, extension='srt')
+
     @classmethod
     def read_data(cls, media_path: MediaPath, track_id: int, temp_folder: str):
         lang_ext = f'.{media_path.language!s}' if media_path.language else ''
@@ -84,18 +88,19 @@ class Mkv(Media):
         super().__init__(MediaPath(path), languages={t.language for t in tracks})
         self.tracks = tracks
 
-    def get_pgs_medias(self, options: Options):
+    def get_selected_pgs_tracks(self, options: Options):
         tracks = [t for t in self.tracks
                   if t.type == 'subtitles' and t.codec == 'HDMV PGS' and t.enabled]
         tracks.sort(key=lambda x: (x.forced, x.id))
-        selected_languages: typing.Dict[Language, int] = {}
+        selected_languages: typing.Dict[str, int] = {}
         for t in tracks:
             language = t.language
             if options.languages and language not in options.languages:
                 logger.debug('Filtering out track %s:%s in %s', t.id, language, self)
                 continue
 
-            if options.one_per_lang and language in selected_languages:
+            language_key = str(language)
+            if options.one_per_lang and language_key in selected_languages:
                 logger.debug('Skipping track %s:%s in %s', t.id, language, self)
                 continue
 
@@ -103,8 +108,27 @@ class Mkv(Media):
                 logger.debug('Skipping unknown language track %s in %s', t.id, self)
                 continue
 
-            pgs = MkvPgs(self.media_path, t.id, language, selected_languages.get(language, 0), options=options)
+            number = selected_languages.get(language_key, 0)
+            srt_path = MkvPgs.expected_srt_path(self.media_path, language, number)
+            selected_languages[language_key] = number + 1
+            if srt_path.exists():
+                if not options.overwrite:
+                    logger.debug('Skipping %s:%s in %s since SRT already exists', t.id, language, self)
+                    continue
+
+                if options.srt_age and srt_path.m_age < options.srt_age:
+                    logger.debug('Skipping track %s:%s in %s since SRT is too new', t.id, language, self)
+                    continue
+
+            yield t, language, number
+
+    def get_selected_pgs_medias(self, options: Options):
+        for t, language, number in self.get_selected_pgs_tracks(options):
+            pgs = MkvPgs(self.media_path, t.id, language, number, options=options)
             if pgs.matches(options):
                 logger.debug('Selecting track %s:%s in %s', t.id, language, self)
-                yield pgs
-                selected_languages[language] = selected_languages.get(language, 0) + 1
+                yield t, pgs
+
+    def get_pgs_medias(self, options: Options):
+        for _, pgs in self.get_selected_pgs_medias(options):
+            yield pgs

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -4,8 +4,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from bd_to_avp.modules import sub
+from bd_to_avp.vendor.pgsrip.media_path import MediaPath
+from bd_to_avp.vendor.pgsrip.mkv import MkvTrack
 from bd_to_avp.modules.sub import (
+    create_srt_from_mkv,
     extract_subtitle_to_srt,
+    get_selected_subtitle_tracks,
     get_languages_in_mkv,
     mark_forced_srt_files,
     subtitle_language_alpha2,
@@ -14,48 +18,76 @@ from bd_to_avp.modules.sub import (
 
 class ForcedSubtitleNamingTests(unittest.TestCase):
     def test_marks_second_same_language_track_as_forced(self) -> None:
-        tracks = [
-            {"index": 4, "language": "eng", "default": 1, "forced": 0},
-            {"index": 5, "language": "eng", "default": 0, "forced": 1},
-        ]
-
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir)
             full_srt = output_path / "movie.en.srt"
             forced_srt = output_path / "movie-1.en.srt"
             full_srt.write_text("full", encoding="utf-8")
             forced_srt.write_text("forced", encoding="utf-8")
+            tracks = [
+                {"index": 4, "language": "eng", "default": 1, "forced": 0, "srt_path": full_srt},
+                {"index": 5, "language": "eng", "default": 0, "forced": 1, "srt_path": forced_srt},
+            ]
 
-            mark_forced_srt_files(output_path, tracks)
+            mark_forced_srt_files(tracks)
 
             self.assertTrue(full_srt.exists())
             self.assertFalse(forced_srt.exists())
             self.assertEqual((output_path / "movie-1.forced.en.srt").read_text(encoding="utf-8"), "forced")
 
     def test_marks_only_forced_language_track_as_forced(self) -> None:
-        tracks = [{"index": 3, "language": "eng", "default": 0, "forced": 1}]
-
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir)
             forced_srt = output_path / "movie.en.srt"
             forced_srt.write_text("forced", encoding="utf-8")
+            tracks = [{"index": 3, "language": "eng", "default": 0, "forced": 1, "srt_path": forced_srt}]
 
-            mark_forced_srt_files(output_path, tracks)
+            mark_forced_srt_files(tracks)
 
             self.assertFalse(forced_srt.exists())
             self.assertEqual((output_path / "movie.forced.en.srt").read_text(encoding="utf-8"), "forced")
 
-    def test_ignores_unknown_language_for_forced_rename(self) -> None:
-        tracks = [{"index": 3, "language": "und", "default": 0, "forced": 1}]
-
+    def test_marks_forced_path_without_special_casing_language(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir)
             subtitle = output_path / "movie.und.srt"
             subtitle.write_text("forced", encoding="utf-8")
+            tracks = [{"index": 3, "language": "und", "default": 0, "forced": 1, "srt_path": subtitle}]
 
-            mark_forced_srt_files(output_path, tracks)
+            mark_forced_srt_files(tracks)
 
-            self.assertTrue(subtitle.exists())
+            self.assertFalse(subtitle.exists())
+            self.assertEqual((output_path / "movie.forced.und.srt").read_text(encoding="utf-8"), "forced")
+
+    def test_marks_forced_track_by_selected_srt_path_not_raw_stream_position(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            forced_srt = output_path / "movie.en.srt"
+            shifted_srt = output_path / "movie-1.en.srt"
+            forced_srt.write_text("forced", encoding="utf-8")
+            shifted_srt.write_text("other", encoding="utf-8")
+            tracks = [{"index": 5, "language": "eng", "default": 0, "forced": 1, "srt_path": forced_srt}]
+
+            mark_forced_srt_files(tracks)
+
+            self.assertFalse(forced_srt.exists())
+            self.assertTrue(shifted_srt.exists())
+            self.assertEqual((output_path / "movie.forced.en.srt").read_text(encoding="utf-8"), "forced")
+
+    def test_marks_digit_ended_basename_without_confusing_numbered_sibling(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            forced_srt = output_path / "Movie-2024.en.srt"
+            sibling_srt = output_path / "Movie-2024-1.en.srt"
+            forced_srt.write_text("forced", encoding="utf-8")
+            sibling_srt.write_text("full", encoding="utf-8")
+            tracks = [{"index": 7, "language": "eng", "default": 0, "forced": 1, "srt_path": forced_srt}]
+
+            mark_forced_srt_files(tracks)
+
+            self.assertFalse(forced_srt.exists())
+            self.assertTrue(sibling_srt.exists())
+            self.assertEqual((output_path / "Movie-2024.forced.en.srt").read_text(encoding="utf-8"), "forced")
 
 
 class SubtitleLanguageTests(unittest.TestCase):
@@ -106,6 +138,191 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
             extract_subtitle_to_srt(Path(temp_dir) / "movie.mkv")
 
         rip.assert_not_called()
+
+    def test_no_subtitle_tracks_remove_stale_srt_files(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.sub.get_languages_in_mkv", return_value=None),
+            patch("bd_to_avp.modules.sub.pgsrip.rip") as rip,
+            patch.object(sub.config, "skip_subtitles", False),
+            patch.object(sub.config, "continue_on_error", False),
+        ):
+            output_path = Path(temp_dir)
+            stale_subtitle = output_path / "movie.en.srt"
+            stale_subtitle.write_text("stale", encoding="utf-8")
+
+            extract_subtitle_to_srt(output_path / "movie.mkv")
+
+        self.assertFalse(stale_subtitle.exists())
+        rip.assert_not_called()
+
+    def test_skip_subtitles_remove_stale_srt_files_when_stage_runs(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(sub.config, "skip_subtitles", True),
+            patch.object(sub.config, "start_stage", sub.Stage.EXTRACT_SUBTITLES),
+            patch("bd_to_avp.modules.sub.extract_subtitle_to_srt") as extract,
+        ):
+            output_path = Path(temp_dir)
+            stale_subtitle = output_path / "movie.en.srt"
+            stale_subtitle.write_text("stale", encoding="utf-8")
+
+            create_srt_from_mkv(output_path / "movie.mkv")
+
+        self.assertFalse(stale_subtitle.exists())
+        extract.assert_not_called()
+
+    def test_skip_subtitles_preserves_srt_files_when_subtitle_stage_is_skipped(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(sub.config, "skip_subtitles", True),
+            patch.object(sub.config, "start_stage", sub.Stage.CREATE_FINAL_FILE),
+            patch("bd_to_avp.modules.sub.extract_subtitle_to_srt") as extract,
+        ):
+            output_path = Path(temp_dir)
+            staged_subtitle = output_path / "movie.en.srt"
+            staged_subtitle.write_text("manual", encoding="utf-8")
+
+            create_srt_from_mkv(output_path / "movie.mkv")
+            subtitle_still_exists = staged_subtitle.exists()
+
+        self.assertTrue(subtitle_still_exists)
+        extract.assert_not_called()
+
+
+class SelectedSubtitleTrackTests(unittest.TestCase):
+    def test_selected_tracks_use_pgsrip_output_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            media_path = output_path / "Movie-2024.mkv"
+            media_path.touch()
+            mkv_file = sub.Mkv.__new__(sub.Mkv)
+            mkv_file.media_path = MediaPath(media_path.as_posix())
+            mkv_file.tracks = [
+                make_track(2, enabled=False, forced=False),
+                make_track(3, enabled=True, forced=False),
+                make_track(4, enabled=True, forced=True),
+            ]
+
+            tracks = get_selected_subtitle_tracks(mkv_file, sub.Options(overwrite=True, one_per_lang=False))
+
+        self.assertEqual(
+            tracks,
+            [
+                {
+                    "index": 3,
+                    "language": "en",
+                    "forced": 0,
+                    "srt_path": output_path / "Movie-2024.en.srt",
+                },
+                {
+                    "index": 4,
+                    "language": "en",
+                    "forced": 1,
+                    "srt_path": output_path / "Movie-2024-1.en.srt",
+                },
+            ],
+        )
+
+    def test_selected_track_metadata_does_not_allocate_pgs_temp_folders(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            media_path = output_path / "Movie.mkv"
+            media_path.touch()
+            mkv_file = sub.Mkv.__new__(sub.Mkv)
+            mkv_file.media_path = MediaPath(media_path.as_posix())
+            mkv_file.tracks = [make_track(3, enabled=True, forced=True)]
+
+            with patch.object(MediaPath, "create_temp_folder") as create_temp_folder:
+                tracks = get_selected_subtitle_tracks(mkv_file, sub.Options(overwrite=True, one_per_lang=False))
+
+        self.assertEqual(tracks[0]["srt_path"], output_path / "Movie.en.srt")
+        create_temp_folder.assert_not_called()
+
+    def test_selected_pgs_medias_still_allocate_for_real_rip_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            media_path = output_path / "Movie.mkv"
+            media_path.touch()
+            mkv_file = sub.Mkv.__new__(sub.Mkv)
+            mkv_file.media_path = MediaPath(media_path.as_posix())
+            mkv_file.tracks = [make_track(3, enabled=True, forced=True)]
+
+            with patch.object(MediaPath, "create_temp_folder", return_value=temp_dir) as create_temp_folder:
+                medias = list(mkv_file.get_selected_pgs_medias(sub.Options(overwrite=True, one_per_lang=False)))
+
+        self.assertEqual(len(medias), 1)
+        create_temp_folder.assert_called_once()
+
+    def test_existing_first_srt_does_not_skip_later_numbered_track(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            media_path = output_path / "Movie.mkv"
+            media_path.touch()
+            (output_path / "Movie.en.srt").write_text("existing", encoding="utf-8")
+            mkv_file = sub.Mkv.__new__(sub.Mkv)
+            mkv_file.media_path = MediaPath(media_path.as_posix())
+            mkv_file.tracks = [
+                make_track(3, enabled=True, forced=False),
+                make_track(4, enabled=True, forced=True),
+            ]
+
+            tracks = get_selected_subtitle_tracks(mkv_file, sub.Options(overwrite=False, one_per_lang=False))
+
+        self.assertEqual(
+            tracks,
+            [
+                {
+                    "index": 4,
+                    "language": "en",
+                    "forced": 1,
+                    "srt_path": output_path / "Movie-1.en.srt",
+                }
+            ],
+        )
+
+    def test_existing_numbered_srt_skips_later_track_without_temp_allocation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+            media_path = output_path / "Movie.mkv"
+            media_path.touch()
+            (output_path / "Movie-1.en.srt").write_text("existing", encoding="utf-8")
+            mkv_file = sub.Mkv.__new__(sub.Mkv)
+            mkv_file.media_path = MediaPath(media_path.as_posix())
+            mkv_file.tracks = [
+                make_track(3, enabled=True, forced=False),
+                make_track(4, enabled=True, forced=True),
+            ]
+
+            with patch.object(MediaPath, "create_temp_folder") as create_temp_folder:
+                tracks = get_selected_subtitle_tracks(mkv_file, sub.Options(overwrite=False, one_per_lang=False))
+
+        self.assertEqual(
+            tracks, [{"index": 3, "language": "en", "forced": 0, "srt_path": output_path / "Movie.en.srt"}]
+        )
+        create_temp_folder.assert_not_called()
+
+    def test_pgs_srt_path_preserves_selected_track_number(self) -> None:
+        media_path = MediaPath("Movie.mkv")
+        pgs = sub.MkvPgs.__new__(sub.MkvPgs)
+        pgs.media_path = media_path.translate(language=sub.Language("eng"), number=1)
+
+        self.assertEqual(Path(str(pgs.srt_path)), Path("Movie-1.en.srt"))
+
+
+def make_track(track_id: int, *, enabled: bool, forced: bool, language: str = "eng") -> MkvTrack:
+    return MkvTrack(
+        {
+            "id": track_id,
+            "type": "subtitles",
+            "codec": "HDMV PGS",
+            "properties": {
+                "enabled_track": enabled,
+                "forced_track": forced,
+                "language_ietf": language,
+            },
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_vendor_pgsrip_edge_cases.py
+++ b/tests/test_vendor_pgsrip_edge_cases.py
@@ -33,9 +33,15 @@ class MkvTrackOrderingTests(unittest.TestCase):
         mkv.tracks = [forced_track, track_without_forced]
         mkv.media_path = Mock()
 
-        with patch("bd_to_avp.vendor.pgsrip.mkv.MkvPgs") as mkv_pgs:
+        with (
+            patch(
+                "bd_to_avp.vendor.pgsrip.mkv.MkvPgs.expected_srt_path",
+                return_value=Mock(exists=Mock(return_value=False)),
+            ),
+            patch("bd_to_avp.vendor.pgsrip.mkv.MkvPgs") as mkv_pgs,
+        ):
             mkv_pgs.return_value.matches.return_value = True
-            list(mkv.get_pgs_medias(Options(one_per_lang=False)))
+            list(mkv.get_pgs_medias(Options(one_per_lang=False, overwrite=True)))
 
         selected_track_ids = [call.args[1] for call in mkv_pgs.call_args_list]
         self.assertEqual(selected_track_ids, [2, 1])


### PR DESCRIPTION
## Summary
- clear stale generated SRT files before subtitle early returns when the subtitle stage is active
- map forced subtitle renames from pgsrip-selected track metadata and exact output paths
- preserve numbered same-language SRT paths and avoid selected-track temp-folder leaks

Fixes #138.

## Validation
- `uv run python -m unittest tests.test_subtitles tests.test_container tests.test_vendor_pgsrip_edge_cases tests.test_vendor_pgsrip_cli`
- `uv run python -m unittest discover -s tests -t .`
- `uv run python -m unittest tests.test_subtitles tests.test_vendor_pgsrip_edge_cases`

## Review Notes
- Read-only agent review found and verified fixes for the selected-track temp-folder leak and numbered `Pgs.srt_path` mismatch before this PR was opened.
