### PR TITLE
Show native MVC split status

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -154,6 +154,7 @@ def split_mvc_to_stereo_native(
     try:
         skip_multithreaded_attempt = False
         if should_probe_native_multithread_splitter():
+            print("Checking native MVC splitter with a short multi-threaded probe.")
             skip_multithreaded_attempt = native_multithread_splitter_probe_crashed(
                 native_input_path,
                 splitter_log_path,
@@ -244,6 +245,8 @@ def run_native_mvc_split_attempt(
     single_threaded: bool,
 ) -> None:
     splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=single_threaded)
+    attempt_name = "single-threaded" if single_threaded else "multi-threaded"
+    print(f"Running native MVC split and encode ({attempt_name}).")
 
     if config.output_commands:
         splitter_command_text = " ".join(str(command) for command in splitter_command)
@@ -254,7 +257,6 @@ def run_native_mvc_split_attempt(
     ffmpeg_process = None
     try:
         with open(ffmpeg_log_path, "a") as ffmpeg_log, open(splitter_log_path, "ab") as splitter_log:
-            attempt_name = "single-threaded" if single_threaded else "multi-threaded"
             ffmpeg_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n")
             splitter_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n".encode())
             splitter_process = subprocess.Popen(splitter_command, stdout=subprocess.PIPE, stderr=splitter_log)

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -49,6 +49,13 @@ class NativeMvcSplitError(RuntimeError):
 
 
 NATIVE_MVC_PROBE_TIMEOUT_SECONDS = 30
+NATIVE_MVC_RETRY_SIGNALS = {
+    signal.SIGABRT,
+    signal.SIGBUS,
+    signal.SIGFPE,
+    signal.SIGILL,
+    signal.SIGSEGV,
+}
 
 
 def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threaded: bool = False) -> list[str | Path]:
@@ -193,7 +200,7 @@ def split_mvc_to_stereo_native(
                 single_threaded=True,
             )
     except subprocess.CalledProcessError as error:
-        if error.cmd and Path(error.cmd[0]).name == config.EDGE264_TEST_PATH.name:
+        if native_splitter_should_report_crash(error):
             raise NativeMvcSplitError(build_native_splitter_failure_message(error, splitter_log_path)) from error
         raise
     finally:
@@ -221,8 +228,8 @@ def native_multithread_splitter_probe_crashed(native_input_path: Path, splitter_
                 try:
                     splitter_process.wait(timeout=2)
                 except subprocess.TimeoutExpired:
-                    # The probe already survived long enough; leave full cleanup to the process group handler.
-                    pass
+                    splitter_process.kill()
+                    splitter_process.wait(timeout=2)
             return False
 
     if splitter_process.returncode == 0:
@@ -293,7 +300,18 @@ def run_native_mvc_split_attempt(
 
 
 def native_splitter_died_by_signal(error: subprocess.CalledProcessError) -> bool:
-    return error.returncode < 0 and bool(error.cmd) and Path(error.cmd[0]).name == config.EDGE264_TEST_PATH.name
+    if error.returncode >= 0 or not error.cmd or Path(error.cmd[0]).name != config.EDGE264_TEST_PATH.name:
+        return False
+    try:
+        return signal.Signals(-error.returncode) in NATIVE_MVC_RETRY_SIGNALS
+    except ValueError:
+        return False
+
+
+def native_splitter_should_report_crash(error: subprocess.CalledProcessError) -> bool:
+    if not error.cmd or Path(error.cmd[0]).name != config.EDGE264_TEST_PATH.name:
+        return False
+    return error.returncode >= 0 or native_splitter_died_by_signal(error)
 
 
 def build_native_splitter_failure_message(error: subprocess.CalledProcessError, splitter_log_path: Path) -> str:

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -219,6 +219,24 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertIn("Native MVC splitter crashed; retrying once in single-threaded mode.", stdout.getvalue())
         self.assertIn("Running native MVC split and encode (single-threaded).", stdout.getvalue())
 
+    def test_native_split_does_not_retry_when_splitter_is_cancelled(self) -> None:
+        splitter_cancelled = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[-15])
+        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_cancelled, ffmpeg_broken_pipe]) as popen,
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                video.split_mvc_to_stereo_native(
+                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+                )
+
+        self.assertEqual(popen.call_count, 2)
+
     def test_native_split_probes_iso_sources_and_skips_doomed_multithread_attempt(self) -> None:
         splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
         ffmpeg_retry = _FakeProcess(returncode=0, stdout=None, stderr=None)
@@ -286,7 +304,7 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertTrue(result)
 
     def test_native_multithread_probe_returns_false_after_timeout(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=None, raises_timeout=True)
+        splitter = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-15, raises_timeout_once=True)
 
         with (
             tempfile.TemporaryDirectory() as temp_dir,
@@ -299,6 +317,28 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         self.assertFalse(result)
         splitter.terminate.assert_called_once()
+        splitter.kill.assert_not_called()
+
+    def test_native_multithread_probe_kills_splitter_when_timeout_cleanup_stalls(self) -> None:
+        splitter = _FakeProcess(
+            returncode=None,
+            stdout=None,
+            returncode_after_wait=-9,
+            raises_timeout_count=2,
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter),
+        ):
+            result = video.native_multithread_splitter_probe_crashed(
+                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+            )
+
+        self.assertFalse(result)
+        splitter.terminate.assert_called_once()
+        splitter.kill.assert_called_once()
 
     def test_native_split_raises_clear_error_when_single_thread_retry_sigaborts(self) -> None:
         splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
@@ -337,17 +377,28 @@ class _FakeProcess:
         returncode_after_wait: int | None = None,
         poll_results: list[int | None] | None = None,
         raises_timeout: bool = False,
+        raises_timeout_once: bool = False,
+        raises_timeout_count: int = 0,
     ) -> None:
         self.returncode = returncode
         self.returncode_after_wait = returncode_after_wait if returncode_after_wait is not None else returncode
         self.poll_results = poll_results or []
         self.raises_timeout = raises_timeout
+        self.raises_timeout_once = raises_timeout_once
+        self.raises_timeout_count = raises_timeout_count
         self.stdout = stdout
         self.stderr = stderr
         self.terminate = Mock()
+        self.kill = Mock()
 
     def wait(self, timeout=None) -> int:
         if self.raises_timeout:
+            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
+        if self.raises_timeout_count > 0:
+            self.raises_timeout_count -= 1
+            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
+        if self.raises_timeout_once:
+            self.raises_timeout_once = False
             raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
         self.returncode = self.returncode_after_wait
         if self.returncode is None:

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -228,7 +228,9 @@ class NativeMvcSelectionTests(unittest.TestCase):
             patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
             patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
             patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_cancelled, ffmpeg_broken_pipe]) as popen,
+            patch(
+                "bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_cancelled, ffmpeg_broken_pipe]
+            ) as popen,
         ):
             with self.assertRaises(subprocess.CalledProcessError):
                 video.split_mvc_to_stereo_native(

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -1,6 +1,8 @@
 import subprocess
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -202,15 +204,20 @@ class NativeMvcSelectionTests(unittest.TestCase):
                 side_effect=[splitter_crash, ffmpeg_broken_pipe, splitter_retry, ffmpeg_retry],
             ),
         ):
-            result = video.split_mvc_to_stereo_native(
-                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-            )
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                result = video.split_mvc_to_stereo_native(
+                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+                )
 
         self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
         self.assertEqual(
             [command_call.kwargs for command_call in splitter_command.call_args_list],
             [{"single_threaded": False}, {"single_threaded": True}],
         )
+        self.assertIn("Running native MVC split and encode (multi-threaded).", stdout.getvalue())
+        self.assertIn("Native MVC splitter crashed; retrying once in single-threaded mode.", stdout.getvalue())
+        self.assertIn("Running native MVC split and encode (single-threaded).", stdout.getvalue())
 
     def test_native_split_probes_iso_sources_and_skips_doomed_multithread_attempt(self) -> None:
         splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
@@ -228,13 +235,18 @@ class NativeMvcSelectionTests(unittest.TestCase):
             patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
             patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_retry, ffmpeg_retry]),
         ):
-            result = video.split_mvc_to_stereo_native(
-                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-            )
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                result = video.split_mvc_to_stereo_native(
+                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+                )
 
         self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
         probe.assert_called_once()
         self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": True}])
+        self.assertIn("Checking native MVC splitter with a short multi-threaded probe.", stdout.getvalue())
+        self.assertIn("Native MVC splitter probe crashed; using slower single-threaded mode.", stdout.getvalue())
+        self.assertIn("Running native MVC split and encode (single-threaded).", stdout.getvalue())
 
     def test_native_split_does_not_probe_mkv_sources(self) -> None:
         splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])


### PR DESCRIPTION
## Summary
- print an explicit native MVC probe status before the short ISO probe
- print the active native MVC split/encode mode for multi-threaded and single-threaded attempts
- assert the probe/retry status messages in native MVC tests

Fixes #136

## Tests
- uv run python -m unittest tests.test_native_mvc_split
- uv run python -m unittest discover -s tests -t .