### PR TITLE
Gate releases on required GUI tools

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -186,7 +186,7 @@ jobs:
           done
           find build/bd-to-avp/macos/app -path "*/bd_to_avp/bin/*" -type f -perm +111 -exec codesign --force --options runtime --timestamp --sign "${{ secrets.DEV_ID }}" {} \;
           find build/bd-to-avp/macos/app -name "*.dylib" -exec codesign --force --sign - {} \;
-          uv run python scripts/verify_app_tools.py
+          uv run python scripts/verify_app_tools.py --profile release
           uv run python scripts/briefcase_app.py package -i "${{ secrets.DEV_ID }}"
       - name: Upload log on failure
         if: failure()

--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -91,12 +91,24 @@ def build_missing_dependency_message(missing_binaries: list[Path]) -> str:
 
 def get_gui_recovery_steps(missing_binaries: list[Path]) -> str:
     missing_makemkv = config.MAKEMKVCON_PATH in missing_binaries
-    missing_bundled_tools = any(path != config.MAKEMKVCON_PATH for path in missing_binaries)
-    if missing_makemkv and missing_bundled_tools:
+    missing_subtitle_tools = any(is_subtitle_tool_path(path) for path in missing_binaries)
+    missing_other_tools = any(
+        path != config.MAKEMKVCON_PATH and not is_subtitle_tool_path(path) for path in missing_binaries
+    )
+    if missing_makemkv and missing_other_tools:
         return "Install MakeMKV for macOS. If other tools are listed, reinstall the app."
     if missing_makemkv:
         return "Install MakeMKV for macOS, then open the app again."
+    if missing_subtitle_tools and not missing_other_tools:
+        return (
+            "Subtitle extraction requires MKVToolNix and Tesseract, which are not bundled in this release. "
+            "Install those tools separately or enable Skip Subtitles before processing."
+        )
     return "Reinstall the app, then open it again."
+
+
+def is_subtitle_tool_path(path: Path) -> bool:
+    return path in {config.MKVEXTRACT_PATH, config.MKVMERGE_PATH, config.TESSERACT_PATH}
 
 
 def get_dependency_name(path: Path) -> str:

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -89,6 +89,10 @@ With MakeMKV installed:
 - Installing MakeMKV clears the MakeMKV preflight blocker.
 - Any remaining missing tool is recorded as a release blocker or linked to a follow-up issue. A reinstall-app message for an unbundled tool such as MP4Box, MKVToolNix, or Tesseract is a blocker, because reinstalling the current app will not add those tools.
 
+## Known Release Blockers
+
+- `v0.2.143rc2` does not bundle `mkvextract`, `mkvmerge`, or `tesseract`, so it cannot pass the clean-machine GUI subtitle path. Do not promote an RC with this gap unless the release contract is explicitly changed to make those tools external dependencies and the GUI recovery message explains that path.
+
 ## Follow-Up Routing
 
 - Missing bundled GUI dependency: file or update the relevant #88 child issue.

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -7,16 +7,19 @@ from pathlib import Path
 
 APP_PATH = Path("build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app")
 APP_TOOL_DIR = APP_PATH / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
-REQUIRED_TOOLS = {
+CORE_TOOLS = {
     "ffmpeg": ["-hide_banner", "-version"],
     "ffprobe": ["-hide_banner", "-version"],
+    "MP4Box": ["-version"],
+}
+GUI_RUNTIME_TOOLS = {
     "edge264_test": ["--help"],
     "mkvextract": ["--version"],
     "mkvmerge": ["--version"],
-    "MP4Box": ["-version"],
     "spatial-media-kit-tool": ["--help"],
     "tesseract": ["--version"],
 }
+REQUIRED_TOOLS = CORE_TOOLS | GUI_RUNTIME_TOOLS
 
 
 def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
@@ -45,10 +48,12 @@ def verify_tool(tool_path: Path, probe_args: list[str]) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Verify app-local command-line tools in the Briefcase app bundle.")
     parser.add_argument("--app-path", type=Path, default=APP_PATH)
+    parser.add_argument("--profile", choices=["core", "release"], default="core")
     args = parser.parse_args()
 
     tool_dir = args.app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
-    for tool_name, probe_args in REQUIRED_TOOLS.items():
+    tools = CORE_TOOLS if args.profile == "core" else REQUIRED_TOOLS
+    for tool_name, probe_args in tools.items():
         verify_tool(tool_dir / tool_name, probe_args)
     print(f"Verified app-local tools in {tool_dir}")
 

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -10,7 +10,12 @@ APP_TOOL_DIR = APP_PATH / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
 REQUIRED_TOOLS = {
     "ffmpeg": ["-hide_banner", "-version"],
     "ffprobe": ["-hide_banner", "-version"],
+    "edge264_test": ["--help"],
+    "mkvextract": ["--version"],
+    "mkvmerge": ["--version"],
     "MP4Box": ["-version"],
+    "spatial-media-kit-tool": ["--help"],
+    "tesseract": ["--version"],
 }
 
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -65,6 +65,27 @@ class DependencyPreflightTests(unittest.TestCase):
         self.assertIn("Reinstall the app", message)
         self.assertNotIn("/missing", message)
 
+    def test_gui_missing_subtitle_tools_message_does_not_recommend_reinstall(self) -> None:
+        with (
+            patch.object(preflight.config.app, "is_gui", True),
+            patch.object(preflight.config, "MKVEXTRACT_PATH", Path("/missing/mkvextract")),
+            patch.object(preflight.config, "MKVMERGE_PATH", Path("/missing/mkvmerge")),
+            patch.object(preflight.config, "TESSERACT_PATH", Path("/missing/tesseract")),
+        ):
+            message = preflight.build_missing_dependency_message(
+                [
+                    Path("/missing/mkvextract"),
+                    Path("/missing/mkvmerge"),
+                    Path("/missing/tesseract"),
+                ]
+            )
+
+        self.assertIn("MKVToolNix", message)
+        self.assertIn("Tesseract", message)
+        self.assertIn("Skip Subtitles", message)
+        self.assertNotIn("Reinstall the app", message)
+        self.assertNotIn("/missing", message)
+
     def test_runtime_ready_does_not_import_subprocess(self) -> None:
         with (
             patch.object(preflight.config.app, "is_gui", False),

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -13,6 +13,21 @@ class VerifyAppToolsTests(unittest.TestCase):
         self.assertIn("MP4Box", verify_app_tools.REQUIRED_TOOLS)
         self.assertEqual(verify_app_tools.REQUIRED_TOOLS["MP4Box"], ["-version"])
 
+    def test_required_tools_cover_gui_runtime_dependencies(self) -> None:
+        self.assertEqual(
+            set(verify_app_tools.REQUIRED_TOOLS),
+            {
+                "ffmpeg",
+                "ffprobe",
+                "edge264_test",
+                "mkvextract",
+                "mkvmerge",
+                "MP4Box",
+                "spatial-media-kit-tool",
+                "tesseract",
+            },
+        )
+
     def test_verify_tool_uses_probe_args_and_rejects_usr_local_linkage(self) -> None:
         with tempfile.NamedTemporaryFile() as tool_file:
             tool_path = Path(tool_file.name)

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -13,6 +13,9 @@ class VerifyAppToolsTests(unittest.TestCase):
         self.assertIn("MP4Box", verify_app_tools.REQUIRED_TOOLS)
         self.assertEqual(verify_app_tools.REQUIRED_TOOLS["MP4Box"], ["-version"])
 
+    def test_core_tools_match_ci_briefcase_smoke_scope(self) -> None:
+        self.assertEqual(set(verify_app_tools.CORE_TOOLS), {"ffmpeg", "ffprobe", "MP4Box"})
+
     def test_required_tools_cover_gui_runtime_dependencies(self) -> None:
         self.assertEqual(
             set(verify_app_tools.REQUIRED_TOOLS),
@@ -27,6 +30,11 @@ class VerifyAppToolsTests(unittest.TestCase):
                 "tesseract",
             },
         )
+
+    def test_release_profile_adds_gui_runtime_dependencies(self) -> None:
+        self.assertLess(set(verify_app_tools.CORE_TOOLS), set(verify_app_tools.REQUIRED_TOOLS))
+        self.assertIn("mkvextract", verify_app_tools.REQUIRED_TOOLS)
+        self.assertNotIn("mkvextract", verify_app_tools.CORE_TOOLS)
 
     def test_verify_tool_uses_probe_args_and_rejects_usr_local_linkage(self) -> None:
         with tempfile.NamedTemporaryFile() as tool_file:


### PR DESCRIPTION
## Summary
- add core vs release profiles to the app-tool verifier
- keep normal CI's Briefcase smoke on currently bundled core tools
- make the signed release workflow use the strict GUI-runtime tool profile so releases fail if mkvextract, mkvmerge, or tesseract are missing
- avoid telling GUI users to reinstall the app when only subtitle tools are missing
- document that v0.2.143rc2 is blocked because it lacks mkvextract, mkvmerge, and tesseract

## RC2 validation finding
- downloaded and mounted v0.2.143rc2 DMG
- SHA256: fc916d66693fe14a2f4495d677a30774fe6f7c7c5861ca72550bebf2eb5eba60
- smoke command failed on missing bundled mkvextract:

```bash
uv run python scripts/smoke_release_app.py --app-path "/Volumes/3D Blu-ray to Vision Pro 0.2.143rc2/3D Blu-ray to Vision Pro.app"
```

```text
Release app smoke failed: Missing bundled tool: /Volumes/3D Blu-ray to Vision Pro 0.2.143rc2/3D Blu-ray to Vision Pro.app/Contents/Resources/app/bd_to_avp/bin/mkvextract
```

## Tests
- uv run ruff format --check scripts/verify_app_tools.py tests/test_verify_app_tools.py bd_to_avp/preflight.py tests/test_preflight.py
- uv run python -m unittest tests.test_preflight tests.test_verify_app_tools tests.test_release_smoke
- uv run python -m unittest discover -s tests -t .

Refs #88
