### PR TITLE
Replace MKVToolNix subtitle extraction with FFmpeg

### DIFF
--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -36,7 +36,7 @@ def get_required_dependency_binaries_for_current_job() -> list[Path]:
     if needs_makemkv():
         required_paths.append(config.MAKEMKVCON_PATH)
     if needs_subtitle_extraction():
-        required_paths.extend([config.MKVEXTRACT_PATH, config.MKVMERGE_PATH, config.TESSERACT_PATH])
+        required_paths.append(config.TESSERACT_PATH)
     if needs_native_mvc_splitter():
         required_paths.append(config.EDGE264_TEST_PATH)
     if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
@@ -100,15 +100,12 @@ def get_gui_recovery_steps(missing_binaries: list[Path]) -> str:
     if missing_makemkv:
         return "Install MakeMKV for macOS, then open the app again."
     if missing_subtitle_tools and not missing_other_tools:
-        return (
-            "Subtitle extraction requires MKVToolNix and Tesseract, which are not bundled in this release. "
-            "Install those tools separately or enable Skip Subtitles before processing."
-        )
+        return "Subtitle extraction requires Tesseract. Reinstall the app or enable Skip Subtitles before processing."
     return "Reinstall the app, then open it again."
 
 
 def is_subtitle_tool_path(path: Path) -> bool:
-    return path in {config.MKVEXTRACT_PATH, config.MKVMERGE_PATH, config.TESSERACT_PATH}
+    return path == config.TESSERACT_PATH
 
 
 def get_dependency_name(path: Path) -> str:

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -1,9 +1,8 @@
-import json
 import logging
-import os
 import typing
-from subprocess import check_output
+import subprocess
 
+import ffmpeg
 from babelfish import Language
 
 from trakit.api import trakit
@@ -17,95 +16,139 @@ logger = logging.getLogger(__name__)
 
 
 class MkvPgs(Pgs):
-
     @staticmethod
     def expected_srt_path(media_path: MediaPath, language: Language, number: int):
-        return media_path.translate(language=language, number=number, extension='srt')
+        return media_path.translate(language=language, number=number, extension="srt")
 
     @classmethod
     def read_data(cls, media_path: MediaPath, track_id: int, temp_folder: str):
-        lang_ext = f'.{media_path.language!s}' if media_path.language else ''
-        sup_file = os.path.join(temp_folder, f'{track_id}{lang_ext}.sup')
-        cmd = [config.MKVEXTRACT_PATH, str(media_path), 'tracks', f'{track_id}:{sup_file}']
-        check_output(cmd)
-        with open(sup_file, mode='rb') as f:
-            return f.read()
+        command = [
+            config.FFMPEG_PATH,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-nostdin",
+            "-i",
+            str(media_path),
+            "-map",
+            f"0:{track_id}",
+            "-c:s",
+            "copy",
+            "-f",
+            "sup",
+            "pipe:1",
+        ]
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        return result.stdout
 
     def __init__(self, media_path: MediaPath, track_id: int, language: Language, number: int, options: Options):
         temp_folder = media_path.create_temp_folder()
-        super().__init__(media_path=media_path.translate(language=language, number=number),
-                         options=options,
-                         data_reader=lambda: self.read_data(
-                             media_path=media_path, track_id=track_id, temp_folder=temp_folder),
-                         temp_folder=temp_folder)
+        super().__init__(
+            media_path=media_path.translate(language=language, number=number),
+            options=options,
+            data_reader=lambda: self.read_data(media_path=media_path, track_id=track_id, temp_folder=temp_folder),
+            temp_folder=temp_folder,
+        )
         self.track_id = track_id
 
     def __str__(self):
-        return (f'{self.media_path.translate(language=Language("und"), number=0)} '
-                f'[{self.track_id}:{self.media_path.language}]')
+        return (
+            f"{self.media_path.translate(language=Language('und'), number=0)} "
+            f"[{self.track_id}:{self.media_path.language}]"
+        )
 
 
 class MkvTrack:
-
     def __init__(self, track: dict):
-        self.id = track['id']
-        self.type = track['type']
-        self.codec = track['codec']
-        self.properties = track.get('properties', {})
+        self.id = track["id"]
+        self.type = track["type"]
+        self.codec = track["codec"]
+        self.properties = track.get("properties", {})
+
+    @classmethod
+    def from_ffprobe_stream(cls, stream: dict):
+        disposition = stream.get("disposition", {})
+        tags = stream.get("tags", {})
+        language = tags.get("language") or tags.get("LANGUAGE") or "und"
+        language_ietf = tags.get("language_ietf") or tags.get("language-ietf") or language
+        stream_type = "subtitles" if stream.get("codec_type") == "subtitle" else stream.get("codec_type", "")
+        return cls(
+            {
+                "id": stream["index"],
+                "type": stream_type,
+                "codec": "HDMV PGS"
+                if stream.get("codec_name") == "hdmv_pgs_subtitle"
+                else stream.get("codec_name", ""),
+                "properties": {
+                    "enabled_track": not bool(disposition.get("disabled", 0)),
+                    "forced_track": bool(disposition.get("forced", 0)),
+                    "default_track": bool(disposition.get("default", 0)),
+                    "language": language,
+                    "language_ietf": language_ietf,
+                    "track_name": tags.get("title") or tags.get("handler_name"),
+                },
+            }
+        )
 
     @property
     def enabled(self):
-        return self.properties.get('enabled_track')
+        return self.properties.get("enabled_track")
 
     @property
     def language(self):
-        lang_ietf = self.properties.get('language_ietf')
-        lang_alpha = self.properties.get('language')
-        track_name = self.properties.get('track_name')
+        lang_ietf = self.properties.get("language_ietf")
+        lang_alpha = self.properties.get("language")
+        track_name = self.properties.get("track_name")
 
-        language = Language.fromcleanit(lang_ietf or lang_alpha or 'und')
-        options = {'expected_language': language} if language else {}
+        language = Language.fromcleanit(lang_ietf or lang_alpha or "und")
+        options = {"expected_language": language} if language else {}
         guess = trakit(track_name, options) if track_name else {}
 
-        return guess.get('language') or language
+        return guess.get("language") or language
 
     @property
     def forced(self):
-        return bool(self.properties.get('forced_track', False))
+        return bool(self.properties.get("forced_track", False))
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} [{self!s}]>'
+        return f"<{self.__class__.__name__} [{self!s}]>"
 
     def __str__(self):
-        return f'{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}'
+        return f"{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}"
 
 
 class Mkv(Media):
-
     def __init__(self, path: str):
-        metadata = json.loads(check_output([config.MKVMERGE_PATH, '-i', '-F', 'json', path]))
-        tracks = [MkvTrack(t) for t in metadata.get('tracks', [])]
-        super().__init__(MediaPath(path), languages={t.language for t in tracks})
+        try:
+            metadata = ffmpeg.probe(path, cmd=config.FFPROBE_PATH.as_posix())
+        except ffmpeg.Error as error:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=[config.FFPROBE_PATH, path],
+                output=error.stdout,
+                stderr=error.stderr,
+            ) from error
+        tracks = [MkvTrack.from_ffprobe_stream(t) for t in metadata.get("streams", [])]
+        super().__init__(MediaPath(path), languages={t.language for t in tracks if t.type == "subtitles"})
         self.tracks = tracks
 
     def get_selected_pgs_tracks(self, options: Options):
-        tracks = [t for t in self.tracks
-                  if t.type == 'subtitles' and t.codec == 'HDMV PGS' and t.enabled]
+        tracks = [t for t in self.tracks if t.type == "subtitles" and t.codec == "HDMV PGS" and t.enabled]
         tracks.sort(key=lambda x: (x.forced, x.id))
         selected_languages: typing.Dict[str, int] = {}
         for t in tracks:
             language = t.language
             if options.languages and language not in options.languages:
-                logger.debug('Filtering out track %s:%s in %s', t.id, language, self)
+                logger.debug("Filtering out track %s:%s in %s", t.id, language, self)
                 continue
 
             language_key = str(language)
             if options.one_per_lang and language_key in selected_languages:
-                logger.debug('Skipping track %s:%s in %s', t.id, language, self)
+                logger.debug("Skipping track %s:%s in %s", t.id, language, self)
                 continue
 
             if not language:
-                logger.debug('Skipping unknown language track %s in %s', t.id, self)
+                logger.debug("Skipping unknown language track %s in %s", t.id, self)
                 continue
 
             number = selected_languages.get(language_key, 0)
@@ -113,11 +156,11 @@ class Mkv(Media):
             selected_languages[language_key] = number + 1
             if srt_path.exists():
                 if not options.overwrite:
-                    logger.debug('Skipping %s:%s in %s since SRT already exists', t.id, language, self)
+                    logger.debug("Skipping %s:%s in %s since SRT already exists", t.id, language, self)
                     continue
 
                 if options.srt_age and srt_path.m_age < options.srt_age:
-                    logger.debug('Skipping track %s:%s in %s since SRT is too new', t.id, language, self)
+                    logger.debug("Skipping track %s:%s in %s since SRT is too new", t.id, language, self)
                     continue
 
             yield t, language, number
@@ -126,7 +169,7 @@ class Mkv(Media):
         for t, language, number in self.get_selected_pgs_tracks(options):
             pgs = MkvPgs(self.media_path, t.id, language, number, options=options)
             if pgs.matches(options):
-                logger.debug('Selecting track %s:%s in %s', t.id, language, self)
+                logger.debug("Selecting track %s:%s in %s", t.id, language, self)
                 yield t, pgs
 
     def get_pgs_medias(self, options: Options):

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -87,11 +87,11 @@ With MakeMKV installed:
 - The app's bundled tools are used where expected.
 - Missing MakeMKV produces a clear recovery path.
 - Installing MakeMKV clears the MakeMKV preflight blocker.
-- Any remaining missing tool is recorded as a release blocker or linked to a follow-up issue. A reinstall-app message for an unbundled tool such as MP4Box, MKVToolNix, or Tesseract is a blocker, because reinstalling the current app will not add those tools.
+- Any remaining missing bundled tool is recorded as a release blocker or linked to a follow-up issue. A reinstall-app message for a tool that is not part of the app bundle is a blocker, because reinstalling the current app will not add it.
 
 ## Known Release Blockers
 
-- `v0.2.143rc2` does not bundle `mkvextract`, `mkvmerge`, or `tesseract`, so it cannot pass the clean-machine GUI subtitle path. Do not promote an RC with this gap unless the release contract is explicitly changed to make those tools external dependencies and the GUI recovery message explains that path.
+- `v0.2.143rc2` does not bundle `mkvextract`, `mkvmerge`, or `tesseract`, so it cannot pass the clean-machine GUI subtitle path. MKVToolNix is being removed from the subtitle path in #143; do not promote an RC while the remaining OCR tool requirement is unresolved.
 
 ## Follow-Up Routing
 

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -23,8 +23,6 @@ REQUIRED_BUNDLED_TOOLS = {
     "ffmpeg": ["-hide_banner", "-version"],
     "ffprobe": ["-hide_banner", "-version"],
     "edge264_test": ["--help"],
-    "mkvextract": ["--version"],
-    "mkvmerge": ["--version"],
     "MP4Box": ["-version"],
     "spatial-media-kit-tool": ["--help"],
     "tesseract": ["--version"],

--- a/scripts/smoke_release_app.sh
+++ b/scripts/smoke_release_app.sh
@@ -46,12 +46,12 @@ else
   printf 'note - developer tools unavailable; skipping otool linkage checks\n'
 fi
 
-for tool in ffmpeg ffprobe edge264_test mkvextract mkvmerge MP4Box spatial-media-kit-tool tesseract; do
+for tool in ffmpeg ffprobe edge264_test MP4Box spatial-media-kit-tool tesseract; do
   TOOL_PATH="$APP_BIN_DIR/$tool"
   [ -x "$TOOL_PATH" ] || fail "missing or non-executable bundled tool: $TOOL_PATH"
   case "$tool" in
     ffmpeg|ffprobe) "$TOOL_PATH" -hide_banner -version >/dev/null 2>&1 || fail "$tool did not run" ;;
-    mkvextract|mkvmerge|tesseract) "$TOOL_PATH" --version >/dev/null 2>&1 || fail "$tool did not run" ;;
+    tesseract) "$TOOL_PATH" --version >/dev/null 2>&1 || fail "$tool did not run" ;;
     MP4Box) "$TOOL_PATH" -version >/dev/null 2>&1 || fail "$tool did not run" ;;
     *) "$TOOL_PATH" --help >/dev/null 2>&1 || fail "$tool did not run" ;;
   esac

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -14,8 +14,6 @@ CORE_TOOLS = {
 }
 GUI_RUNTIME_TOOLS = {
     "edge264_test": ["--help"],
-    "mkvextract": ["--version"],
-    "mkvmerge": ["--version"],
     "spatial-media-kit-tool": ["--help"],
     "tesseract": ["--version"],
 }

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -65,25 +65,16 @@ class DependencyPreflightTests(unittest.TestCase):
         self.assertIn("Reinstall the app", message)
         self.assertNotIn("/missing", message)
 
-    def test_gui_missing_subtitle_tools_message_does_not_recommend_reinstall(self) -> None:
+    def test_gui_missing_tesseract_message_does_not_recommend_reinstall(self) -> None:
         with (
             patch.object(preflight.config.app, "is_gui", True),
-            patch.object(preflight.config, "MKVEXTRACT_PATH", Path("/missing/mkvextract")),
-            patch.object(preflight.config, "MKVMERGE_PATH", Path("/missing/mkvmerge")),
             patch.object(preflight.config, "TESSERACT_PATH", Path("/missing/tesseract")),
         ):
-            message = preflight.build_missing_dependency_message(
-                [
-                    Path("/missing/mkvextract"),
-                    Path("/missing/mkvmerge"),
-                    Path("/missing/tesseract"),
-                ]
-            )
+            message = preflight.build_missing_dependency_message([Path("/missing/tesseract")])
 
-        self.assertIn("MKVToolNix", message)
         self.assertIn("Tesseract", message)
         self.assertIn("Skip Subtitles", message)
-        self.assertNotIn("Reinstall the app", message)
+        self.assertIn("Reinstall the app", message)
         self.assertNotIn("/missing", message)
 
     def test_runtime_ready_does_not_import_subprocess(self) -> None:
@@ -131,6 +122,17 @@ class DependencyPreflightTests(unittest.TestCase):
         self.assertNotIn(preflight.config.MKVEXTRACT_PATH, required_paths)
         self.assertNotIn(preflight.config.MKVMERGE_PATH, required_paths)
         self.assertNotIn(preflight.config.TESSERACT_PATH, required_paths)
+
+    def test_subtitle_extraction_no_longer_requires_mkvtoolnix(self) -> None:
+        with (
+            patch.object(preflight.config, "skip_subtitles", False),
+            patch.object(preflight.config, "start_stage", Stage.EXTRACT_SUBTITLES),
+        ):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job()
+
+        self.assertNotIn(preflight.config.MKVEXTRACT_PATH, required_paths)
+        self.assertNotIn(preflight.config.MKVMERGE_PATH, required_paths)
+        self.assertIn(preflight.config.TESSERACT_PATH, required_paths)
 
     def test_final_mux_always_requires_mp4box_even_before_srt_files_exist(self) -> None:
         with (

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import tempfile
 import types
 import unittest
@@ -107,35 +108,157 @@ class ToolResolutionTests(unittest.TestCase):
 
 
 class MkvToolPathTests(unittest.TestCase):
-    def test_mkv_metadata_uses_configured_mkvmerge_path(self) -> None:
-        metadata = b'{"tracks": []}'
+    def test_mkv_metadata_uses_configured_ffprobe_path(self) -> None:
+        metadata: dict[str, object] = {"streams": []}
         with (
-            patch.object(mkv.config, "MKVMERGE_PATH", Path("/tools/mkvmerge")),
-            patch("bd_to_avp.vendor.pgsrip.mkv.check_output", return_value=metadata) as check_output,
+            patch.object(mkv.config, "FFPROBE_PATH", Path("/tools/ffprobe")),
+            patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata) as probe,
         ):
             mkv.Mkv("movie.mkv")
 
-        check_output.assert_called_once_with([Path("/tools/mkvmerge"), "-i", "-F", "json", "movie.mkv"])
+        probe.assert_called_once_with("movie.mkv", cmd="/tools/ffprobe")
 
-    def test_pgs_extraction_uses_configured_mkvextract_path(self) -> None:
+    def test_mkv_metadata_maps_ffprobe_pgs_streams_to_existing_track_model(self) -> None:
+        metadata = {
+            "streams": [
+                {"index": 0, "codec_type": "video", "codec_name": "h264"},
+                {
+                    "index": 4,
+                    "codec_type": "subtitle",
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng", "title": "English forced"},
+                    "disposition": {"default": 1, "forced": 1},
+                },
+            ]
+        }
+
+        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+            movie = mkv.Mkv("movie.mkv")
+
+        video_track, subtitle_track = movie.tracks
+        self.assertEqual(video_track.type, "video")
+        self.assertEqual(subtitle_track.id, 4)
+        self.assertEqual(subtitle_track.type, "subtitles")
+        self.assertEqual(subtitle_track.codec, "HDMV PGS")
+        self.assertEqual(str(subtitle_track.language), "en")
+        self.assertTrue(subtitle_track.forced)
+        self.assertTrue(subtitle_track.properties["default_track"])
+
+    def test_mkv_metadata_preserves_ffprobe_language_ietf_tag(self) -> None:
+        track = mkv.MkvTrack.from_ffprobe_stream(
+            {
+                "index": 2,
+                "codec_type": "subtitle",
+                "codec_name": "hdmv_pgs_subtitle",
+                "tags": {"language": "por", "language_ietf": "pt-BR"},
+                "disposition": {},
+            }
+        )
+
+        self.assertEqual(track.properties["language"], "por")
+        self.assertEqual(track.properties["language_ietf"], "pt-BR")
+
+    def test_pgs_selection_ignores_disabled_ffprobe_subtitle_streams(self) -> None:
+        metadata = {
+            "streams": [
+                {
+                    "index": 3,
+                    "codec_type": "subtitle",
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng"},
+                    "disposition": {"disabled": 1},
+                },
+                {
+                    "index": 4,
+                    "codec_type": "subtitle",
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng"},
+                    "disposition": {},
+                },
+            ]
+        }
+
+        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+            movie = mkv.Mkv("movie.mkv")
+
+        selected = list(movie.get_selected_pgs_tracks(mkv.Options(overwrite=True, one_per_lang=False)))
+
+        self.assertEqual([track.id for track, _, _ in selected], [4])
+
+    def test_mkv_metadata_wraps_ffprobe_errors_as_called_process_error(self) -> None:
+        error = mkv.ffmpeg.Error("ffprobe", b"out", b"err")
+        with (
+            patch.object(mkv.config, "FFPROBE_PATH", Path("/tools/ffprobe")),
+            patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", side_effect=error),
+            self.assertRaises(subprocess.CalledProcessError) as raised,
+        ):
+            mkv.Mkv("movie.mkv")
+
+        self.assertEqual(raised.exception.cmd, [Path("/tools/ffprobe"), "movie.mkv"])
+        self.assertEqual(raised.exception.stderr, b"err")
+
+    def test_pgs_selection_ignores_non_pgs_subtitle_streams(self) -> None:
+        metadata = {
+            "streams": [
+                {
+                    "index": 2,
+                    "codec_type": "subtitle",
+                    "codec_name": "subrip",
+                    "tags": {"language": "eng"},
+                    "disposition": {"forced": 0},
+                },
+                {
+                    "index": 4,
+                    "codec_type": "subtitle",
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng"},
+                    "disposition": {"forced": 0},
+                },
+            ]
+        }
+
+        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+            movie = mkv.Mkv("movie.mkv")
+
+        selected = list(movie.get_selected_pgs_tracks(mkv.Options(overwrite=True, one_per_lang=False)))
+
+        self.assertEqual([track.id for track, _, _ in selected], [4])
+
+    def test_pgs_extraction_uses_configured_ffmpeg_path_and_stream_index(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            sup_path = temp_path / "3.en.sup"
-
-            def write_sup(_command: list[object]) -> bytes:
-                sup_path.write_bytes(b"pgs")
-                return b""
-
             media_path = mkv.MediaPath("movie.mkv").translate(language=mkv.Language("eng"))
 
             with (
-                patch.object(mkv.config, "MKVEXTRACT_PATH", Path("/tools/mkvextract")),
-                patch("bd_to_avp.vendor.pgsrip.mkv.check_output", side_effect=write_sup) as check_output,
+                patch.object(mkv.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
+                patch(
+                    "bd_to_avp.vendor.pgsrip.mkv.subprocess.run",
+                    return_value=mkv.subprocess.CompletedProcess(args=[], returncode=0, stdout=b"pgs", stderr=b""),
+                ) as run,
             ):
                 data = mkv.MkvPgs.read_data(media_path, 3, temp_dir)
 
         self.assertEqual(data, b"pgs")
-        check_output.assert_called_once_with([Path("/tools/mkvextract"), str(media_path), "tracks", f"3:{sup_path}"])
+        run.assert_called_once_with(
+            [
+                Path("/tools/ffmpeg"),
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-nostdin",
+                "-i",
+                str(media_path),
+                "-map",
+                "0:3",
+                "-c:s",
+                "copy",
+                "-f",
+                "sup",
+                "pipe:1",
+            ],
+            stdout=mkv.subprocess.PIPE,
+            stderr=mkv.subprocess.PIPE,
+            check=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -23,8 +23,6 @@ class VerifyAppToolsTests(unittest.TestCase):
                 "ffmpeg",
                 "ffprobe",
                 "edge264_test",
-                "mkvextract",
-                "mkvmerge",
                 "MP4Box",
                 "spatial-media-kit-tool",
                 "tesseract",
@@ -33,8 +31,8 @@ class VerifyAppToolsTests(unittest.TestCase):
 
     def test_release_profile_adds_gui_runtime_dependencies(self) -> None:
         self.assertLess(set(verify_app_tools.CORE_TOOLS), set(verify_app_tools.REQUIRED_TOOLS))
-        self.assertIn("mkvextract", verify_app_tools.REQUIRED_TOOLS)
-        self.assertNotIn("mkvextract", verify_app_tools.CORE_TOOLS)
+        self.assertIn("tesseract", verify_app_tools.REQUIRED_TOOLS)
+        self.assertNotIn("tesseract", verify_app_tools.CORE_TOOLS)
 
     def test_verify_tool_uses_probe_args_and_rejects_usr_local_linkage(self) -> None:
         with tempfile.NamedTemporaryFile() as tool_file:


### PR DESCRIPTION
## Summary

- Replace vendored pgsrip's MKVToolNix metadata/extraction calls with bundled FFprobe/FFmpeg.
- Keep the existing PGS parser/OCR pipeline unchanged: FFmpeg now supplies raw SUP bytes to pgsrip via stdout.
- Remove `mkvextract`/`mkvmerge` from subtitle preflight, release-smoke, and app-tool verification requirements.
- Preserve forced/full subtitle behavior by mapping FFprobe stream indexes, PGS codec/type names, forced/default dispositions, disabled disposition, and language tags into the existing `MkvTrack` model.

## Tests

```bash
uv run ruff format --check bd_to_avp/vendor/pgsrip/mkv.py bd_to_avp/preflight.py scripts/verify_app_tools.py scripts/smoke_release_app.py tests/test_tool_resolution.py tests/test_preflight.py tests/test_verify_app_tools.py tests/test_release_smoke.py
uv run ruff check bd_to_avp/vendor/pgsrip/mkv.py bd_to_avp/preflight.py scripts/verify_app_tools.py scripts/smoke_release_app.py tests/test_tool_resolution.py tests/test_preflight.py tests/test_verify_app_tools.py tests/test_release_smoke.py
uv run mypy bd_to_avp
uv run python -m unittest discover -s tests -t .
```

Local result: all pass, 128 tests.

## Notes

This PR removes the MKVToolNix runtime dependency for subtitle extraction, but it does not replace Tesseract/OCR. Tesseract remains required by the current release-smoke profile until the OCR path is replaced or intentionally made external.

I do not currently have a local MKV fixture with real PGS subtitle streams; the local Rainforest MKVs have no subtitle streams. The command/model/unit coverage is in place, but real-media PGS extraction proof is still tracked in #143.

Refs #143.
