### PR TITLE
Avoid retrying native splitter probe on SIGTERM

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -235,7 +235,13 @@ def native_multithread_splitter_probe_crashed(native_input_path: Path, splitter_
     if splitter_process.returncode == 0:
         return False
     if splitter_process.returncode < 0:
-        return True
+        if native_splitter_returncode_is_retry_signal(splitter_process.returncode):
+            return True
+        raise subprocess.CalledProcessError(
+            splitter_process.returncode,
+            splitter_command,
+            output=splitter_log_path.read_text(errors="replace"),
+        )
     raise subprocess.CalledProcessError(
         splitter_process.returncode,
         splitter_command,
@@ -302,8 +308,14 @@ def run_native_mvc_split_attempt(
 def native_splitter_died_by_signal(error: subprocess.CalledProcessError) -> bool:
     if error.returncode >= 0 or not error.cmd or Path(error.cmd[0]).name != config.EDGE264_TEST_PATH.name:
         return False
+    return native_splitter_returncode_is_retry_signal(error.returncode)
+
+
+def native_splitter_returncode_is_retry_signal(returncode: int) -> bool:
+    if returncode >= 0:
+        return False
     try:
-        return signal.Signals(-error.returncode) in NATIVE_MVC_RETRY_SIGNALS
+        return signal.Signals(-returncode) in NATIVE_MVC_RETRY_SIGNALS
     except ValueError:
         return False
 

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -305,6 +305,22 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test_native_multithread_probe_does_not_treat_sigterm_as_crash(self) -> None:
+        splitter_cancelled = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-15)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter_cancelled),
+            self.assertRaises(subprocess.CalledProcessError) as raised,
+        ):
+            video.native_multithread_splitter_probe_crashed(
+                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+            )
+
+        self.assertEqual(raised.exception.returncode, -15)
+
     def test_native_multithread_probe_returns_false_after_timeout(self) -> None:
         splitter = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-15, raises_timeout_once=True)
 


### PR DESCRIPTION
## Summary

- Make the native multi-threaded splitter probe use the same retry-signal whitelist as the full split path.
- Treat SIGTERM and other non-crash signals as ordinary splitter failures instead of probe crashes that silently force single-threaded mode.
- Add regression coverage for SIGTERM during the probe.

## Tests

```bash
uv run python -m unittest tests.test_native_mvc_split
uv run ruff format --check bd_to_avp/modules/video.py tests/test_native_mvc_split.py
uv run ruff check bd_to_avp/modules/video.py tests/test_native_mvc_split.py
uv run mypy bd_to_avp
uv run python -m unittest discover -s tests -t .
```

Local result: all pass, 123 tests.
