### PR TITLE
Document GUI distribution policy

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -206,7 +206,7 @@ jobs:
             
             ** The GUI app no longer installs Homebrew or command-line dependencies on first launch. Install MakeMKV separately before converting Blu-ray discs. Power users who use the terminal/PyPI version should follow the manual dependency instructions in the README. **
             
-            You can use the terminal version with "/Applications/Blu-ray to AVP.app/Contents/MacOS/Blu-ray to AVP". If you run the binary with any arguments, it will work like the previous terminal app.  No arguments will open the GUI.
+            You can use the terminal version with "/Applications/3D Blu-ray to Vision Pro.app/Contents/MacOS/3D Blu-ray to Vision Pro". If you run the binary with any arguments, it will work like the previous terminal app. No arguments will open the GUI.
           draft: false
           prerelease: ${{ steps.release_metadata.outputs.prerelease }}
           make_latest: ${{ steps.release_metadata.outputs.make_latest }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The GUI app does not install Homebrew or modify your shell setup. Runtime tools 
 MakeMKV remains an external requirement for reading Blu-ray discs; install the current macOS version from the
 [MakeMKV] website before converting discs.
 
+See [Distribution Policy](docs/distribution-policy.md) for the current GUI
+release artifact and dependency policy.
+
 ## Terminal install or update (power users)
 
 The terminal/PyPI version is for power users who manage their own command-line dependencies. Install the tools listed

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -1,0 +1,91 @@
+# Distribution Policy
+
+BD_to_AVP currently ships the GUI as a notarized macOS DMG from
+GitHub Releases. The DMG is the primary artifact for normal users; the
+terminal/PyPI path remains available for power users who manage their own
+command-line tools.
+
+This policy keeps the app predictable on clean Macs and makes distribution
+decisions explicit instead of hiding dependency installation behind first launch.
+
+## Current GUI Channel
+
+- Primary artifact: notarized DMG attached to GitHub Releases.
+- Install flow: user downloads the DMG, drags the app to `/Applications`, and
+  approves the normal Gatekeeper launch prompt if macOS asks.
+- The GUI app must not install Homebrew, edit shell startup files, request
+  administrator privileges for setup, or run broad package-manager upgrades.
+- Runtime tools should be bundled into the app when their licenses and Apple
+  notarization behavior make that practical.
+- MakeMKV remains an external app dependency for Blu-ray disc and title
+  extraction. The GUI should detect `/Applications/MakeMKV.app` and give a
+  plain recovery message when it is missing.
+- The release DMG must pass the clean-machine smoke checklist in
+  [release-smoke.md](release-smoke.md) before wider promotion.
+
+## Bundled Runtime Tools
+
+The release workflow signs and verifies the GUI runtime tools before packaging.
+`scripts/verify_app_tools.py --profile release` is the release gate for
+app-local tools.
+
+Required app-local tools today:
+
+- `ffmpeg`
+- `ffprobe`
+- `MP4Box`
+- `edge264_test`
+- `spatial-media-kit-tool`
+
+The release gate should fail if a required bundled executable is missing, not
+executable, or linked to Homebrew paths such as `/opt/homebrew` or `/usr/local`.
+
+Apple Vision OCR is the GUI subtitle OCR path. The clean-machine smoke should
+verify that the packaged app runtime can import and run the Apple Vision OCR
+smoke without requiring MKVToolNix or Tesseract.
+
+## External Dependencies
+
+External dependencies must be visible to the user and recoverable without
+reinstalling BD_to_AVP.
+
+- MakeMKV is currently external and expected at `/Applications/MakeMKV.app`.
+- A missing external dependency should produce a message that names the external
+  app/tool and explains the next step.
+- A missing bundled dependency should be treated as a release blocker or linked
+  to a focused follow-up issue. Do not tell users to reinstall the current app
+  unless the current release artifact actually contains the missing dependency.
+
+## Terminal And PyPI Channel
+
+The terminal/PyPI channel is for users who intentionally manage dependencies
+themselves. README terminal instructions may continue to use Homebrew because
+that channel is explicitly command-line oriented.
+
+Terminal dependency changes should not weaken the GUI policy. If a tool is
+required by the GUI, the release workflow should either bundle and verify it or
+document it as an external dependency with preflight behavior.
+
+## Deferred Tracks
+
+- PKG artifact policy is tracked in #118. Until that issue decides otherwise,
+  PKG output is not the normal-user release path.
+- Homebrew distribution for CLI users is tracked in #119.
+- Sparkle-style auto-updates for direct DMG builds are tracked in #120.
+- App Store feasibility and sandbox constraints are tracked in #121.
+- MakeMKV replacement/removal is tracked in #103.
+- Native MVC splitter stability and upstream edge264 follow-through are tracked
+  in #135 and #140.
+
+## Promotion Checklist
+
+Before promoting a GUI release beyond tester/RC use:
+
+1. Release workflow completes successfully for the intended tag or branch.
+2. The release gate verifies app-local runtime tools with the `release` profile.
+3. The DMG passes Gatekeeper assessment on a clean Apple Silicon macOS machine.
+4. The app launches without Homebrew, Python, virtualenv, or repo checkout state.
+5. Missing MakeMKV produces the expected external-dependency recovery path.
+6. Installed MakeMKV clears the preflight blocker.
+7. A tester or maintainer records at least one media-path smoke result for the
+   release candidate when test media is available.

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -1,6 +1,11 @@
 # Clean-Machine Release Smoke
 
-Use this checklist before a wider GUI release. The goal is to prove the app bundle works on a Mac that does not have the developer machine's Homebrew, Python, virtualenv, or cached build state.
+Use this checklist before a wider GUI release. The goal is to prove the app
+bundle works on a Mac that does not have the developer machine's Homebrew,
+Python, virtualenv, or cached build state.
+
+See [distribution-policy.md](distribution-policy.md) for the current GUI artifact
+and dependency policy.
 
 ## Test Machine
 
@@ -11,11 +16,15 @@ Use this checklist before a wider GUI release. The goal is to prove the app bund
 - No Python setup beyond the tools already present on macOS.
 - Network access for GitHub release download and the app update check.
 
-Snapshots are useful: take a clean snapshot before installing BD_to_AVP, and another after installing MakeMKV if you need to repeat both missing-MakeMKV and installed-MakeMKV paths.
+Snapshots are useful: take a clean snapshot before installing BD_to_AVP, and
+another after installing MakeMKV if you need to repeat both missing-MakeMKV and
+installed-MakeMKV paths.
 
 ## Artifacts
 
-Use the release DMG from GitHub Releases. The DMG is the primary GUI artifact. PKG artifacts are not part of the normal-user smoke unless a later issue keeps them for a specific deployment use case.
+Use the release DMG from GitHub Releases. The DMG is the primary GUI artifact.
+PKG artifacts are not part of the normal-user smoke unless a later issue keeps
+them for a specific deployment use case.
 
 Record:
 
@@ -29,27 +38,37 @@ Record:
 On the clean machine:
 
 ```bash
-test ! -e /opt/homebrew || echo "Apple Silicon Homebrew is present; use a cleaner VM for the required smoke"
-test ! -e /usr/local/Homebrew || echo "Intel Homebrew is present; use a cleaner VM for the required smoke"
+test ! -e /opt/homebrew || \
+  echo "Apple Silicon Homebrew is present; use a cleaner VM"
+test ! -e /usr/local/Homebrew || \
+  echo "Intel Homebrew is present; use a cleaner VM"
 spctl --assess --type open --verbose=4 ~/Downloads/*.dmg
 ```
 
-The DMG check uses `--type open` because it assesses the downloaded disk image. The app smoke uses `--type execute` because it assesses the installed app bundle.
+The DMG check uses `--type open` because it assesses the downloaded disk image.
+The app smoke uses `--type execute` because it assesses the installed app
+bundle.
 
-Mount the DMG, drag the app to `/Applications`, eject the DMG, then open the app once from Finder. Approve the normal Gatekeeper prompt if macOS shows one. After that first user-approved launch, quit the app and run the automated smoke.
+Mount the DMG, drag the app to `/Applications`, eject the DMG, then open the app
+once from Finder. Approve the normal Gatekeeper prompt if macOS shows one. After
+that first user-approved launch, quit the app and run the automated smoke.
 
 ## Automated App Smoke
 
-Run the shell smoke script from a checkout, copied script, or downloaded source archive. It uses macOS system tools and the packaged app, so it is the preferred VM command:
+Run the shell smoke script from a checkout, copied script, or downloaded source
+archive. It uses macOS system tools and the packaged app, so it is the preferred
+VM command:
 
 ```bash
 sh scripts/smoke_release_app.sh "/Applications/3D Blu-ray to Vision Pro.app"
 ```
 
-For an in-repo Python harness with the same core checks, use a machine that already has Python available:
+For an in-repo Python harness with the same core checks, use a machine that
+already has Python available:
 
 ```bash
-python3 scripts/smoke_release_app.py --app-path "/Applications/3D Blu-ray to Vision Pro.app"
+python3 scripts/smoke_release_app.py \
+  --app-path "/Applications/3D Blu-ray to Vision Pro.app"
 ```
 
 Expected result:
@@ -57,12 +76,17 @@ Expected result:
 - Gatekeeper assessment passes.
 - App bundle layout is valid.
 - Bundled tools run from the app bundle.
-- If Xcode Command Line Tools are available, bundled tools do not link to `/opt/homebrew` or `/usr/local`. If developer tools are not installed, the scripts say the linkage check was skipped.
+- If Xcode Command Line Tools are available, bundled tools do not link to
+  `/opt/homebrew` or `/usr/local`. If developer tools are not installed, the
+  scripts say the linkage check was skipped.
 - The packaged CLI `--version` matches `Info.plist`.
 - The packaged CLI `--help` runs with a sanitized `PATH`.
-- If MakeMKV is absent, the script records that the first-run path should ask the user to install MakeMKV.
+- The packaged Apple Vision OCR smoke runs with a sanitized `PATH`.
+- If MakeMKV is absent, the script records that the first-run path should ask
+  the user to install MakeMKV.
 
-For unsigned local development builds only, use the Python harness and add `--skip-spctl`.
+For unsigned local development builds only, use the Python harness and add
+`--skip-spctl`.
 
 ## Manual GUI Smoke
 
@@ -70,7 +94,8 @@ With MakeMKV absent:
 
 1. Open the app from `/Applications`.
 2. Confirm Gatekeeper does not block launch.
-3. Confirm the app does not ask to install Homebrew, run terminal commands, or request admin privileges.
+3. Confirm the app does not ask to install Homebrew, run terminal commands, or
+   request admin privileges.
 4. Start a disc-oriented conversion far enough to trigger preflight.
 5. Confirm the message asks for MakeMKV in plain user-facing language.
 
@@ -79,7 +104,8 @@ With MakeMKV installed:
 1. Install the current macOS MakeMKV app from the official MakeMKV website.
 2. Reopen BD_to_AVP.
 3. Confirm the MakeMKV preflight no longer blocks disc-oriented work.
-4. If test media is available, run a short conversion smoke and record the first failing stage, logs, runtime, and whether output files are created.
+4. If test media is available, run a short conversion smoke and record the first
+   failing stage, logs, runtime, and whether output files are created.
 
 ## Pass Criteria
 
@@ -87,11 +113,10 @@ With MakeMKV installed:
 - The app's bundled tools are used where expected.
 - Missing MakeMKV produces a clear recovery path.
 - Installing MakeMKV clears the MakeMKV preflight blocker.
-- Any remaining missing bundled tool is recorded as a release blocker or linked to a follow-up issue. A reinstall-app message for a tool that is not part of the app bundle is a blocker, because reinstalling the current app will not add it.
-
-## Known Release Blockers
-
-- `v0.2.143rc2` does not bundle the subtitle runtime tools required by that build, so it cannot pass the clean-machine GUI subtitle path. #143 removes MKVToolNix and Tesseract from the subtitle runtime path; do not promote an RC until that replacement has shipped and passed the clean-machine subtitle smoke.
+- Any remaining missing bundled tool is recorded as a release blocker or linked
+  to a follow-up issue. A reinstall-app message for a tool that is not part of
+  the app bundle is a blocker, because reinstalling the current app will not add
+  it.
 
 ## Follow-Up Routing
 

--- a/scripts/smoke_release_app.sh
+++ b/scripts/smoke_release_app.sh
@@ -73,6 +73,12 @@ esac
 PATH="$MINIMAL_PATH" "$APP_EXECUTABLE" --help >/dev/null 2>&1 || fail "CLI help failed"
 pass "CLI help with sanitized PATH"
 
+OCR_OUTPUT="$(PATH="$MINIMAL_PATH" "$APP_EXECUTABLE" --smoke-apple-vision-ocr 2>&1)"
+case "$OCR_OUTPUT" in
+  *"Apple Vision OCR import smoke passed"*) pass "Apple Vision OCR smoke" ;;
+  *) fail "Apple Vision OCR smoke output was unexpected: $OCR_OUTPUT" ;;
+esac
+
 if [ -x /Applications/MakeMKV.app/Contents/MacOS/makemkvcon ]; then
   pass "MakeMKV installed"
 else


### PR DESCRIPTION
## Summary

- Add a canonical GUI distribution policy covering DMG-first releases, external MakeMKV, bundled runtime tools, and deferred PKG/Sparkle/App Store tracks.
- Link the policy from the README and clean-machine release smoke docs.
- Make the shell release smoke verify the packaged Apple Vision OCR path.
- Update the release-note terminal path to the current app bundle/executable name.

## Validation

- `sh -n scripts/smoke_release_app.sh`
- `shellcheck scripts/smoke_release_app.sh`
- `npx --yes markdownlint-cli2 docs/distribution-policy.md docs/release-smoke.md`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/briefcase.yml`
- `git diff --check`

Refs #88
