### PR TITLE
Prototype direct source reuse

### DIFF
--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -213,6 +213,7 @@ class Config:
         self.remove_extra_languages = False
         self.keep_awake = True
         self.smoke_apple_vision_ocr = False
+        self.direct_pipeline = False
 
     def configure_tool_environment(self) -> None:
         configured_dirs = [
@@ -442,6 +443,11 @@ class Config:
             action="store_false",
             help="Prevent the computer from sleeping during processing.",
         )
+        parser.add_argument(
+            "--direct-pipeline",
+            action="store_true",
+            help=argparse.SUPPRESS,
+        )
 
         args = parser.parse_args()
 
@@ -462,3 +468,11 @@ class Config:
 
 
 config = Config()
+
+
+def is_direct_pipeline_source_reused() -> bool:
+    return bool(
+        config.direct_pipeline
+        and config.source_path
+        and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]
+    )

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import ffmpeg
 
-from bd_to_avp.modules.config import config, Stage
+from bd_to_avp.modules.config import config, is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.file import find_largest_file_with_extensions, sanitize_filename
 from bd_to_avp.modules.command import run_command
 
@@ -163,6 +163,10 @@ def create_custom_makemkv_profile(custom_profile_path: Path, language_code: str)
 
 def create_mkv_file(output_folder: Path, disc_info: DiscInfo, language_code: str) -> Path:
     if config.source_path and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]:
+        if is_direct_pipeline_source_reused():
+            if not config.source_path.is_file():
+                raise FileNotFoundError(f"Direct source file not found: {config.source_path}")
+            return config.source_path
         shutil.copy(config.source_path, output_folder)
         if mkv_file := find_largest_file_with_extensions(output_folder, [".mkv", *config.MTS_EXTENSIONS]):
             return mkv_file

--- a/bd_to_avp/modules/file.py
+++ b/bd_to_avp/modules/file.py
@@ -4,7 +4,7 @@ import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 
-from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.config import Stage, config, is_direct_pipeline_source_reused
 from bd_to_avp.modules.command import run_command
 
 
@@ -44,10 +44,44 @@ def remove_folder_if_exists(folder_path: Path) -> None:
         print(f"Removed existing directory: {folder_path}")
 
 
+def path_is_relative_to(path: Path, parent: Path) -> bool:
+    path_pairs = (
+        (path.absolute(), parent.absolute()),
+        (path.resolve(), parent.resolve()),
+    )
+    for candidate, candidate_parent in path_pairs:
+        try:
+            candidate.relative_to(candidate_parent)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def output_folder_contains_reused_source(output_path: Path) -> bool:
+    return bool(
+        is_direct_pipeline_source_reused()
+        and config.source_path
+        and path_is_relative_to(config.source_path, output_path)
+    )
+
+
+def remove_output_folder_if_safe(output_path: Path, *, raise_if_unsafe: bool = False) -> bool:
+    if output_folder_contains_reused_source(output_path):
+        message = f"Refusing to clear output folder containing direct source media: {config.source_path}"
+        if raise_if_unsafe:
+            raise ValueError(message)
+        print(message)
+        return False
+
+    remove_folder_if_exists(output_path)
+    return True
+
+
 def prepare_output_folder_for_source(disc_name: str) -> Path:
     output_path = config.output_root_path / disc_name
     if config.start_stage == next(iter(Stage)):
-        remove_folder_if_exists(output_path)
+        remove_output_folder_if_safe(output_path, raise_if_unsafe=True)
     output_path.mkdir(parents=True, exist_ok=True)
     return output_path
 
@@ -56,7 +90,7 @@ def move_file_to_output_root_folder(muxed_output_path: Path) -> None:
     final_path = config.output_root_path / muxed_output_path.name
     muxed_output_path.replace(final_path)
     if not config.keep_files:
-        remove_folder_if_exists(muxed_output_path.parent)
+        remove_output_folder_if_safe(muxed_output_path.parent)
 
 
 @contextmanager

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -5,7 +5,7 @@ from wakepy.modes import keep
 
 from bd_to_avp import preflight
 from bd_to_avp.modules.audio import create_transcoded_audio_file
-from bd_to_avp.modules.config import config, Stage
+from bd_to_avp.modules.config import config, is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.container import create_muxed_file, create_mvc_and_audio
 from bd_to_avp.modules.disc import create_mkv_file, get_disc_and_mvc_video_info
 from bd_to_avp.modules.file import (
@@ -69,7 +69,7 @@ def process_each() -> None:
     disc_info.color_depth = get_video_color_depth(mkv_output_path)
     crop_params = detect_crop_parameters(mkv_output_path)
     audio_output_path, video_output_path = create_mvc_and_audio(disc_info.name, mkv_output_path, output_folder)
-    create_srt_from_mkv(mkv_output_path)
+    create_srt_from_mkv(mkv_output_path, output_folder)
     left_output_path, right_output_path = create_left_right_files(
         disc_info, output_folder, video_output_path, crop_params
     )
@@ -88,7 +88,7 @@ def process_each() -> None:
     if not config.keep_files:
         remove_folder_if_exists(tmp_folder)
 
-    if config.remove_original and config.source_path:
+    if config.remove_original and config.source_path and not is_direct_pipeline_source_reused():
         if config.source_path.is_dir():
             remove_folder_if_exists(config.source_path)
         else:

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -1,4 +1,6 @@
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -15,17 +17,17 @@ class SRTCreationError(Exception):
     pass
 
 
-def create_srt_from_mkv(mkv_path: Path) -> None:
+def create_srt_from_mkv(mkv_path: Path, output_path: Path | None = None) -> None:
+    output_path = output_path or mkv_path.parent
     if config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
         if config.skip_subtitles:
-            cleanup_existing_subtitle_files(mkv_path.parent)
+            cleanup_existing_subtitle_files(output_path)
             return None
-        extract_subtitle_to_srt(mkv_path)
+        extract_subtitle_to_srt(mkv_path, output_path)
 
 
-def extract_subtitle_to_srt(mkv_path: Path) -> None:
-    output_path = mkv_path.parent
-
+def extract_subtitle_to_srt(mkv_path: Path, output_path: Path | None = None) -> None:
+    output_path = output_path or mkv_path.parent
     cleanup_existing_subtitle_files(output_path)
 
     if config.skip_subtitles:
@@ -43,22 +45,66 @@ def extract_subtitle_to_srt(mkv_path: Path) -> None:
     spinner_thread.start()
 
     try:
-        mkv_file = Mkv(mkv_path.as_posix())
-        selected_subtitle_tracks = get_selected_subtitle_tracks(mkv_file, sub_options)
+        with subtitle_source_alias(mkv_path, output_path) as subtitle_mkv_path:
+            mkv_file = Mkv(subtitle_mkv_path.as_posix())
+            selected_subtitle_tracks = get_selected_subtitle_tracks(mkv_file, sub_options)
 
-        pgsrip.rip(mkv_file, sub_options)
+            pgsrip.rip(mkv_file, sub_options)
 
-        for srt_file in output_path.glob("*.srt"):
-            if srt_file.stat().st_size == 0:
-                srt_file.unlink()
+            for srt_file in output_path.glob("*.srt"):
+                if srt_file.stat().st_size == 0:
+                    srt_file.unlink()
 
-        if not any(output_path.glob("*.srt")) and not config.continue_on_error:
-            raise SRTCreationError("No SRT subtitle files with data created.")
+            if not any(output_path.glob("*.srt")) and not config.continue_on_error:
+                raise SRTCreationError("No SRT subtitle files with data created.")
 
-        mark_forced_srt_files(selected_subtitle_tracks)
+            mark_forced_srt_files(selected_subtitle_tracks)
     finally:
         spinner.stop()
         spinner_thread.join()
+
+
+@contextmanager
+def subtitle_source_alias(mkv_path: Path, output_path: Path) -> Iterator[Path]:
+    if mkv_path.parent.resolve() == output_path.resolve():
+        yield mkv_path
+        return
+
+    source_path = mkv_path.resolve(strict=True)
+    alias_path = output_path / mkv_path.name
+    if alias_path.is_symlink() and not alias_path.exists():
+        alias_path.unlink()
+
+    if alias_path.exists() or alias_path.is_symlink():
+        try:
+            if alias_path.samefile(source_path):
+                if alias_path.is_symlink():
+                    try:
+                        yield alias_path
+                    finally:
+                        alias_path.unlink(missing_ok=True)
+                else:
+                    yield alias_path
+                return
+        except OSError:
+            pass
+
+        alias_path = unique_subtitle_source_alias_path(mkv_path, output_path)
+
+    alias_path.symlink_to(source_path)
+    try:
+        yield alias_path
+    finally:
+        alias_path.unlink(missing_ok=True)
+
+
+def unique_subtitle_source_alias_path(mkv_path: Path, output_path: Path) -> Path:
+    for index in range(1, 1000):
+        candidate = output_path / f"{mkv_path.stem}.subtitle-source-{index}{mkv_path.suffix}"
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+
+    raise FileExistsError(f"Unable to create a subtitle source alias in {output_path}")
 
 
 def cleanup_existing_subtitle_files(output_path: Path) -> None:

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -77,17 +77,19 @@ def subtitle_source_alias(mkv_path: Path, output_path: Path) -> Iterator[Path]:
 
     if alias_path.exists() or alias_path.is_symlink():
         try:
-            if alias_path.samefile(source_path):
-                if alias_path.is_symlink():
-                    try:
-                        yield alias_path
-                    finally:
-                        alias_path.unlink(missing_ok=True)
-                else:
-                    yield alias_path
-                return
+            alias_matches_source = alias_path.samefile(source_path)
         except OSError:
-            pass
+            alias_matches_source = False
+
+        if alias_matches_source:
+            if alias_path.is_symlink():
+                try:
+                    yield alias_path
+                finally:
+                    alias_path.unlink(missing_ok=True)
+            else:
+                yield alias_path
+            return
 
         alias_path = unique_subtitle_source_alias_path(mkv_path, output_path)
 

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -91,6 +91,23 @@ explicit materialization decision per stage:
 Default mode remains persistent. Direct mode should be opt-in until benchmarks
 prove that it is safe and worth the complexity.
 
+## Internal Source-Reuse Prototype
+
+The first runtime prototype uses an internal direct-pipeline toggle. It is
+intentionally hidden from the supported CLI surface until benchmark evidence
+and the final UX decision are available. Its scope is narrow: direct
+MKV/MTS/M2TS inputs reuse the original source path instead of copying the source
+into the per-title output folder.
+
+This does not create a second processing pipeline and does not stream later
+stage boundaries. Downstream stages continue to consume paths, subtitles remain
+persistent in the output folder, disc/ISO inputs retain their existing MakeMKV
+materialization, and restart/external-upscaler artifacts remain unchanged.
+
+The reused source is user-owned. Cleanup and `--remove-original` do not delete
+it while this prototype is active. The supported CLI surface and boundaries
+remain subject to the benchmark and UX decisions tracked by GitHub issue #126.
+
 ## Likely Safe Boundaries
 
 ### Source Reuse For Existing MKV/MTS/M2TS Inputs

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -1,0 +1,103 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import disc
+from bd_to_avp.modules.config import Stage
+
+
+class DiscStageArtifactTests(unittest.TestCase):
+    def test_mkv_source_copies_to_output_folder_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "output"
+            output_folder.mkdir()
+            source_path.write_bytes(b"source")
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "direct_pipeline", False),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            copied_path = output_folder / source_path.name
+            self.assertEqual(result, copied_path)
+            self.assertEqual(copied_path.read_bytes(), b"source")
+            self.assertTrue(source_path.exists())
+
+    def test_direct_mkv_source_reuses_source_path_without_copying(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "output"
+            output_folder.mkdir()
+            source_path.write_bytes(b"source")
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            self.assertEqual(result, source_path)
+            self.assertFalse((output_folder / source_path.name).exists())
+            self.assertTrue(source_path.exists())
+
+    def test_direct_m2ts_source_reuses_source_path_without_copying(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.m2ts"
+            output_folder = temp_path / "output"
+            output_folder.mkdir()
+            source_path.write_bytes(b"source")
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            self.assertEqual(result, source_path)
+            self.assertFalse((output_folder / source_path.name).exists())
+            self.assertTrue(source_path.exists())
+
+    def test_direct_source_must_exist_before_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "missing.mkv"
+            output_folder = temp_path / "output"
+            output_folder.mkdir()
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                self.assertRaisesRegex(FileNotFoundError, "Direct source file not found"),
+            ):
+                disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+    def test_resume_from_existing_mkv_still_uses_output_folder_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir)
+            existing_mkv = output_folder / "movie.mkv"
+            existing_mkv.write_bytes(b"mkv")
+
+            with (
+                patch.object(disc.config, "source_path", Path("movie.iso")),
+                patch.object(disc.config, "IMAGE_EXTENSIONS", [".iso"]),
+                patch.object(disc.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
+                patch.object(disc, "rip_disc_to_mkv") as rip_disc_to_mkv,
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            self.assertEqual(result, existing_mkv)
+            rip_disc_to_mkv.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 from bd_to_avp import preflight
 from bd_to_avp.modules import process
-from bd_to_avp.modules.config import Stage
+from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
+from bd_to_avp.modules.file import move_file_to_output_root_folder, prepare_output_folder_for_source
 
 
 class ProcessPreflightTests(unittest.TestCase):
@@ -20,6 +21,99 @@ class ProcessPreflightTests(unittest.TestCase):
                 self.assertRaisesRegex(preflight.DependencyPreflightError, "missing tool"),
             ):
                 process.process(Stage.CREATE_MKV)
+
+    def test_direct_pipeline_reused_file_source_is_not_cleanup_owned(self) -> None:
+        with (
+            patch.object(process.config, "direct_pipeline", True),
+            patch.object(process.config, "source_path", Path("movie.mkv")),
+            patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+        ):
+            self.assertTrue(is_direct_pipeline_source_reused())
+
+    def test_default_pipeline_file_source_remains_cleanup_owned(self) -> None:
+        with (
+            patch.object(process.config, "direct_pipeline", False),
+            patch.object(process.config, "source_path", Path("movie.mkv")),
+            patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+        ):
+            self.assertFalse(is_direct_pipeline_source_reused())
+
+    def test_direct_pipeline_iso_source_remains_cleanup_owned(self) -> None:
+        with (
+            patch.object(process.config, "direct_pipeline", True),
+            patch.object(process.config, "source_path", Path("movie.iso")),
+            patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+        ):
+            self.assertFalse(is_direct_pipeline_source_reused())
+
+    def test_create_mkv_start_refuses_to_clear_folder_containing_direct_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            output_folder = output_root / "Movie"
+            output_folder.mkdir()
+            source_path = output_folder / "Movie.mkv"
+            source_path.write_bytes(b"source")
+
+            with (
+                patch.object(process.config, "direct_pipeline", True),
+                patch.object(process.config, "source_path", source_path),
+                patch.object(process.config, "output_root_path", output_root),
+                patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                self.assertRaisesRegex(ValueError, "direct source media"),
+            ):
+                prepare_output_folder_for_source("Movie")
+
+            self.assertTrue(source_path.exists())
+
+    def test_output_move_preserves_folder_containing_direct_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            output_folder = output_root / "Movie"
+            output_folder.mkdir()
+            source_path = output_folder / "Movie.mkv"
+            muxed_path = output_folder / "Movie_AVP.mov"
+            source_path.write_bytes(b"source")
+            muxed_path.write_bytes(b"final")
+
+            with (
+                patch.object(process.config, "direct_pipeline", True),
+                patch.object(process.config, "source_path", source_path),
+                patch.object(process.config, "output_root_path", output_root),
+                patch.object(process.config, "keep_files", False),
+                patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+            ):
+                move_file_to_output_root_folder(muxed_path)
+
+            self.assertTrue(source_path.exists())
+            self.assertTrue(output_folder.exists())
+            self.assertEqual((output_root / "Movie_AVP.mov").read_bytes(), b"final")
+
+    def test_create_mkv_start_preserves_symlink_source_inside_output_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            output_root = temp_path / "output"
+            output_folder = output_root / "Movie"
+            external_folder = temp_path / "source"
+            output_folder.mkdir(parents=True)
+            external_folder.mkdir()
+            external_source = external_folder / "Movie.mkv"
+            source_path = output_folder / "Movie.mkv"
+            external_source.write_bytes(b"source")
+            source_path.symlink_to(external_source)
+
+            with (
+                patch.object(process.config, "direct_pipeline", True),
+                patch.object(process.config, "source_path", source_path),
+                patch.object(process.config, "output_root_path", output_root),
+                patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                self.assertRaisesRegex(ValueError, "direct source media"),
+            ):
+                prepare_output_folder_for_source("Movie")
+
+            self.assertTrue(source_path.is_symlink())
+            self.assertEqual(source_path.resolve(strict=True), external_source.resolve(strict=True))
 
 
 if __name__ == "__main__":

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from contextlib import chdir
 from pathlib import Path
 from unittest.mock import patch
 
@@ -194,6 +195,131 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
 
         self.assertFalse(stale_subtitle.exists())
         extract.assert_not_called()
+
+    def test_skip_subtitles_uses_explicit_output_folder_not_source_folder(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(sub.config, "skip_subtitles", True),
+            patch.object(sub.config, "start_stage", sub.Stage.EXTRACT_SUBTITLES),
+            patch("bd_to_avp.modules.sub.extract_subtitle_to_srt") as extract,
+        ):
+            temp_path = Path(temp_dir)
+            source_folder = temp_path / "source"
+            output_folder = temp_path / "output"
+            source_folder.mkdir()
+            output_folder.mkdir()
+            source_subtitle = source_folder / "movie.en.srt"
+            output_subtitle = output_folder / "movie.en.srt"
+            source_subtitle.write_text("manual", encoding="utf-8")
+            output_subtitle.write_text("stale", encoding="utf-8")
+
+            create_srt_from_mkv(source_folder / "movie.mkv", output_folder)
+
+            source_subtitle_exists = source_subtitle.exists()
+            output_subtitle_exists = output_subtitle.exists()
+
+        self.assertTrue(source_subtitle_exists)
+        self.assertFalse(output_subtitle_exists)
+        extract.assert_not_called()
+
+    def test_subtitle_extraction_aliases_direct_source_into_output_folder(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.sub.get_languages_in_mkv", return_value=[{"index": 3, "language": "eng"}]),
+            patch.object(sub.config, "skip_subtitles", False),
+            patch.object(sub.config, "continue_on_error", False),
+            patch("bd_to_avp.modules.sub.Mkv") as mkv_class,
+            patch("bd_to_avp.modules.sub.get_selected_subtitle_tracks", return_value=[]),
+            patch("bd_to_avp.modules.sub.mark_forced_srt_files") as mark_forced,
+        ):
+            temp_path = Path(temp_dir)
+            source_folder = temp_path / "source"
+            output_folder = temp_path / "output"
+            source_folder.mkdir()
+            output_folder.mkdir()
+            source_mkv = source_folder / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+
+            def write_srt(mkv_file, _options):
+                Path(str(mkv_file.media_path)).with_suffix(".en.srt").write_text("subtitle", encoding="utf-8")
+
+            with patch("bd_to_avp.modules.sub.pgsrip.rip", side_effect=write_srt) as rip:
+                mkv_class.side_effect = lambda path: type("MkvStub", (), {"media_path": Path(path)})()
+
+                extract_subtitle_to_srt(source_mkv, output_folder)
+
+            created_srt = output_folder / "movie.en.srt"
+            self.assertTrue(created_srt.exists())
+            self.assertEqual(created_srt.read_text(encoding="utf-8"), "subtitle")
+            self.assertFalse((source_folder / "movie.en.srt").exists())
+            self.assertFalse((output_folder / "movie.mkv").exists())
+            rip.assert_called_once()
+            mark_forced.assert_called_once_with([])
+
+    def test_subtitle_source_alias_uses_absolute_target_for_relative_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_folder = temp_path / "source"
+            output_folder = temp_path / "output"
+            source_folder.mkdir()
+            output_folder.mkdir()
+            source_mkv = source_folder / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+
+            with chdir(temp_path), sub.subtitle_source_alias(Path("source/movie.mkv"), output_folder) as alias_path:
+                self.assertTrue(alias_path.is_symlink())
+                self.assertEqual(alias_path.resolve(strict=True), source_mkv.resolve(strict=True))
+
+            self.assertFalse(alias_path.is_symlink())
+
+    def test_subtitle_source_alias_reuses_media_already_in_output_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir)
+            source_mkv = output_folder / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+
+            with sub.subtitle_source_alias(source_mkv, output_folder.resolve()) as alias_path:
+                self.assertEqual(alias_path, source_mkv)
+                self.assertFalse(alias_path.is_symlink())
+
+            self.assertTrue(source_mkv.exists())
+
+    def test_subtitle_source_alias_cleans_existing_matching_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_folder = temp_path / "source"
+            output_folder = temp_path / "output"
+            source_folder.mkdir()
+            output_folder.mkdir()
+            source_mkv = source_folder / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+            stale_alias = output_folder / "movie.mkv"
+            stale_alias.symlink_to(source_mkv)
+
+            with sub.subtitle_source_alias(source_mkv, output_folder) as alias_path:
+                self.assertEqual(alias_path, stale_alias)
+                self.assertTrue(alias_path.is_symlink())
+
+            self.assertFalse(stale_alias.is_symlink())
+
+    def test_subtitle_source_alias_avoids_stale_broken_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_folder = temp_path / "source"
+            output_folder = temp_path / "output"
+            source_folder.mkdir()
+            output_folder.mkdir()
+            source_mkv = source_folder / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+            stale_alias = output_folder / "movie.mkv"
+            stale_alias.symlink_to(output_folder / "missing.mkv")
+
+            with sub.subtitle_source_alias(source_mkv, output_folder) as alias_path:
+                self.assertEqual(alias_path, stale_alias)
+                self.assertTrue(alias_path.is_symlink())
+                self.assertEqual(alias_path.resolve(strict=True), source_mkv.resolve(strict=True))
+
+            self.assertFalse(stale_alias.is_symlink())
 
     def test_skip_subtitles_preserves_srt_files_when_subtitle_stage_is_skipped(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- add an internal direct-materialization prototype that reuses existing MKV/MTS/M2TS sources instead of copying them into the output folder
- preserve source ownership through initial and final cleanup, including resumed stages and symlinked source paths
- route subtitle extraction into the owned output folder with temporary alias cleanup while leaving the durable pipeline unchanged
- keep the prototype hidden from public CLI help until benchmark and UX follow-up work is complete

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` (160 tests)
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'`
- `uv build`
- PyCharm changed-files inspection: green, zero findings
- two independent final agent reviews: no blockers or P1 findings

## Follow-up

Benchmarking and the final public CLI/GUI decision remain tracked separately; this PR does not remove other restartable stage artifacts.

Refs #126
Refs #152
