### PR TITLE
Prototype direct audio transcode

### DIFF
--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -2,14 +2,14 @@ from pathlib import Path
 
 import ffmpeg
 
-from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.config import Stage, config, is_direct_audio_transcode_enabled
 from bd_to_avp.modules.command import run_ffmpeg_print_errors
 
 
-def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int):
+def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int, audio_selector: str = "a") -> None:
     audio_input = ffmpeg.input(str(input_path))
     audio_transcoded = ffmpeg.output(
-        audio_input["a"],
+        audio_input[audio_selector],
         str(f"file:{transcoded_audio_path}"),
         acodec="aac",
         audio_bitrate=f"{bitrate}k",
@@ -18,13 +18,24 @@ def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int)
 
 
 def create_transcoded_audio_file(original_audio_path: Path, output_folder: Path) -> Path:
-    trancoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.mov"
+    transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.mov"
+    direct_audio_transcode = is_direct_audio_transcode_enabled()
+
     if config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
-        transcode_audio(original_audio_path, trancoded_audio_path, config.audio_bitrate)
-        if not config.keep_files:
+        temporary_audio_path = transcoded_audio_path.with_suffix(".part.mov")
+        audio_selector = "a:0" if direct_audio_transcode and config.remove_extra_languages else "a"
+        try:
+            transcode_audio(original_audio_path, temporary_audio_path, config.audio_bitrate, audio_selector)
+            temporary_audio_path.replace(transcoded_audio_path)
+        finally:
+            temporary_audio_path.unlink(missing_ok=True)
+
+        if not config.keep_files and not direct_audio_transcode:
             original_audio_path.unlink(missing_ok=True)
-        return trancoded_audio_path
-    else:
-        if config.transcode_audio and trancoded_audio_path.exists():
-            return trancoded_audio_path
-        return original_audio_path
+        return transcoded_audio_path
+
+    if config.transcode_audio and transcoded_audio_path.exists():
+        return transcoded_audio_path
+    if direct_audio_transcode and config.transcode_audio:
+        raise FileNotFoundError(f"Direct AAC audio artifact not found: {transcoded_audio_path}")
+    return original_audio_path

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -476,3 +476,7 @@ def is_direct_pipeline_source_reused() -> bool:
         and config.source_path
         and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]
     )
+
+
+def is_direct_audio_transcode_enabled() -> bool:
+    return bool(config.direct_pipeline and config.transcode_audio and not config.keep_files)

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -4,7 +4,7 @@ from typing import Any
 import ffmpeg
 from babelfish import Language
 
-from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.config import Stage, config, is_direct_audio_transcode_enabled
 from bd_to_avp.modules.command import run_command, run_ffmpeg_print_errors
 from bd_to_avp.modules.util import sorted_files_by_creation_filtered_on_suffix
 
@@ -12,16 +12,19 @@ from bd_to_avp.modules.util import sorted_files_by_creation_filtered_on_suffix
 def extract_mvc_and_audio(
     input_path: Path,
     video_output_path: Path,
-    audio_output_path: Path,
+    audio_output_path: Path | None,
 ) -> None:
     stream = ffmpeg.input(str(input_path))
 
     video_stream = ffmpeg.output(stream["v:0"], f"file:{video_output_path}", c="copy", bsf="h264_mp4toannexb")
-    audio_track = ":0" if config.remove_extra_languages else ""
-    audio_stream = ffmpeg.output(stream[f"a{audio_track}"], f"file:{audio_output_path}", c="pcm_s24le")
+    output_streams = [video_stream]
 
-    output_message = "ffmpeg to extract video, audio, and subtitles from MKV"
-    run_ffmpeg_print_errors([video_stream, audio_stream], output_message, overwrite_output=True)
+    if audio_output_path:
+        audio_track = ":0" if config.remove_extra_languages else ""
+        output_streams.append(ffmpeg.output(stream[f"a{audio_track}"], f"file:{audio_output_path}", c="pcm_s24le"))
+
+    output_message = "ffmpeg to extract MVC video and audio from source"
+    run_ffmpeg_print_errors(output_streams, output_message, overwrite_output=True)
 
 
 def create_muxed_file(
@@ -47,15 +50,16 @@ def create_mvc_and_audio(
 ) -> tuple[Path, Path]:
     video_output_path = output_folder / f"{disc_name}_mvc.h264"
     audio_output_path = output_folder / f"{disc_name}_audio_PCM.mov"
+    direct_audio_transcode = is_direct_audio_transcode_enabled()
 
     if config.start_stage.value <= Stage.EXTRACT_MVC_AND_AUDIO.value:
         extract_mvc_and_audio(
             mkv_output_path,
             video_output_path,
-            audio_output_path,
+            None if direct_audio_transcode else audio_output_path,
         )
 
-    return audio_output_path, video_output_path
+    return (mkv_output_path if direct_audio_transcode else audio_output_path), video_output_path
 
 
 def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path, output_folder: Path) -> None:

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -132,10 +132,16 @@ not removing left/right outputs.
 ### Extracted Audio To Transcoded Audio
 
 When AAC transcoding is enabled, BD_to_AVP writes PCM audio and then reads it
-back to produce AAC. This may be a good direct-mode candidate after source reuse
-is understood. The final mux still needs an audio file, so the likely win is
-avoiding the PCM file in one-shot transcode runs, not removing audio
-materialization completely.
+back to produce AAC. The internal direct-mode prototype now skips that PCM file
+when AAC transcoding is enabled and `--keep-files` is not requested. MVC video
+extraction remains its own stage, while the `TRANSCODE_AUDIO` stage reads audio
+from the MKV/MTS/M2TS source and writes the final AAC MOV directly.
+
+The final mux still needs a seekable audio file, so the AAC MOV remains
+materialized. Durable mode and `--keep-files` retain the existing PCM boundary,
+and direct-mode resumes at `TRANSCODE_AUDIO` can recreate AAC from the source.
+As with durable resumes, video artifacts from earlier stages must already exist
+when restarting after `EXTRACT_MVC_AND_AUDIO`.
 
 ### Final Move
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,186 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import ffmpeg
+
+from bd_to_avp.modules import audio
+from bd_to_avp.modules.config import Stage
+
+
+class DirectAudioTranscodeTests(unittest.TestCase):
+    def test_direct_transcode_reads_source_and_atomically_writes_aac(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            def write_audio(_input_path: Path, output_path: Path, _bitrate: int, _selector: str) -> None:
+                output_path.write_bytes(b"aac")
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio.config, "audio_bitrate", 384),
+                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+            ):
+                result = audio.create_transcoded_audio_file(source_path, output_folder)
+
+            final_path = output_folder / "Movie_audio_AAC.mov"
+            temporary_path = output_folder / "Movie_audio_AAC.part.mov"
+            self.assertEqual(result, final_path)
+            self.assertEqual(final_path.read_bytes(), b"aac")
+            self.assertFalse(temporary_path.exists())
+            self.assertFalse((output_folder / "Movie_audio_PCM.mov").exists())
+            self.assertTrue(source_path.exists())
+            transcode.assert_called_once_with(source_path, temporary_path, 384, "a")
+
+    def test_direct_transcode_selects_first_audio_track_when_removing_languages(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            def write_audio(_input_path: Path, output_path: Path, _bitrate: int, _selector: str) -> None:
+                output_path.write_bytes(b"aac")
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", True),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio.config, "audio_bitrate", 384),
+                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+            ):
+                audio.create_transcoded_audio_file(source_path, output_folder)
+
+            self.assertEqual(transcode.call_args.args[3], "a:0")
+
+    def test_failed_direct_transcode_removes_partial_output_but_preserves_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            def fail_after_partial_write(_input_path: Path, output_path: Path, _bitrate: int, _selector: str) -> None:
+                output_path.write_bytes(b"partial")
+                raise RuntimeError("transcode failed")
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio, "transcode_audio", side_effect=fail_after_partial_write),
+                self.assertRaisesRegex(RuntimeError, "transcode failed"),
+            ):
+                audio.create_transcoded_audio_file(source_path, output_folder)
+
+            self.assertTrue(source_path.exists())
+            self.assertFalse((output_folder / "Movie_audio_AAC.part.mov").exists())
+            self.assertFalse((output_folder / "Movie_audio_AAC.mov").exists())
+
+    def test_keep_files_uses_durable_pcm_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir) / "Movie"
+            output_folder.mkdir()
+            pcm_path = output_folder / "Movie_audio_PCM.mov"
+            pcm_path.write_bytes(b"pcm")
+
+            def write_audio(_input_path: Path, output_path: Path, _bitrate: int, _selector: str) -> None:
+                output_path.write_bytes(b"aac")
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", True),
+                patch.object(audio.config, "remove_extra_languages", True),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+            ):
+                audio.create_transcoded_audio_file(pcm_path, output_folder)
+
+            self.assertTrue(pcm_path.exists())
+            self.assertEqual(transcode.call_args.args[0], pcm_path)
+            self.assertEqual(transcode.call_args.args[3], "a")
+
+    def test_final_mux_resume_uses_existing_direct_aac(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            aac_path = output_folder / "Movie_audio_AAC.mov"
+            aac_path.write_bytes(b"aac")
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(audio.config, "audio_bitrate", 384),
+                patch.object(audio, "transcode_audio") as transcode,
+            ):
+                result = audio.create_transcoded_audio_file(source_path, output_folder)
+
+            self.assertEqual(result, aac_path)
+            transcode.assert_not_called()
+
+    def test_final_mux_resume_requires_existing_direct_aac(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            with (
+                patch.object(audio.config, "direct_pipeline", True),
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(audio.config, "audio_bitrate", 384),
+                self.assertRaisesRegex(FileNotFoundError, "Direct AAC audio artifact not found"),
+            ):
+                audio.create_transcoded_audio_file(source_path, output_folder)
+
+    def test_transcode_disabled_returns_original_audio(self) -> None:
+        original_audio_path = Path("Movie_audio_PCM.mov")
+        with (
+            patch.object(audio.config, "direct_pipeline", True),
+            patch.object(audio.config, "transcode_audio", False),
+            patch.object(audio.config, "keep_files", False),
+            patch.object(audio.config, "start_stage", Stage.TRANSCODE_AUDIO),
+            patch.object(audio, "transcode_audio") as transcode,
+        ):
+            result = audio.create_transcoded_audio_file(original_audio_path, Path("Movie"))
+
+        self.assertEqual(result, original_audio_path)
+        transcode.assert_not_called()
+
+    def test_transcode_audio_maps_requested_stream_selector(self) -> None:
+        with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
+            audio.transcode_audio(Path("source.mkv"), Path("audio.mov"), 384, "a:0")
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertIn("0:a:0", command)
+        self.assertIn("file:audio.mov", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -2,7 +2,71 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import ffmpeg
+
 from bd_to_avp.modules import container
+from bd_to_avp.modules.config import Stage
+
+
+class AudioExtractionTests(unittest.TestCase):
+    def test_direct_audio_transcode_extracts_video_without_pcm(self) -> None:
+        with (
+            patch.object(container.config, "direct_pipeline", True),
+            patch.object(container.config, "transcode_audio", True),
+            patch.object(container.config, "keep_files", False),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio_path, video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(audio_path, Path("source.mkv"))
+        self.assertEqual(video_path, Path("output/Movie_mvc.h264"))
+        self.assertNotIn("output/Movie_audio_PCM.mov", " ".join(command))
+        self.assertNotIn("pcm_s24le", command)
+
+    def test_durable_audio_path_still_extracts_pcm(self) -> None:
+        with (
+            patch.object(container.config, "direct_pipeline", False),
+            patch.object(container.config, "transcode_audio", True),
+            patch.object(container.config, "keep_files", False),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio_path, _video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(audio_path, Path("output/Movie_audio_PCM.mov"))
+        self.assertIn("pcm_s24le", command)
+        self.assertIn("file:output/Movie_audio_PCM.mov", command)
+
+    def test_keep_files_preserves_pcm_boundary_in_direct_mode(self) -> None:
+        with (
+            patch.object(container.config, "direct_pipeline", True),
+            patch.object(container.config, "transcode_audio", True),
+            patch.object(container.config, "keep_files", True),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio_path, _video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(audio_path, Path("output/Movie_audio_PCM.mov"))
+        self.assertIn("pcm_s24le", command)
+
+    def test_direct_mode_without_audio_transcode_preserves_pcm_boundary(self) -> None:
+        with (
+            patch.object(container.config, "direct_pipeline", True),
+            patch.object(container.config, "transcode_audio", False),
+            patch.object(container.config, "keep_files", False),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio_path, _video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(audio_path, Path("output/Movie_audio_PCM.mov"))
+        self.assertIn("pcm_s24le", command)
 
 
 class MuxCommandTests(unittest.TestCase):
@@ -28,6 +92,31 @@ class MuxCommandTests(unittest.TestCase):
         self.assertEqual(command[:4], [Path("/tools/MP4Box"), "-new", "-add", "movie_MV-HEVC.mov:forcesync"])
         self.assertIn("audio_PCM.mov#1:lang=eng:group=1:alternate_group=1", command)
         self.assertEqual(command[-1], Path("movie_AVP.mov"))
+
+    def test_final_mux_preserves_multiple_direct_aac_tracks(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {"index": 0, "tags": {"language": "eng"}, "channel_layout": "5.1"},
+                    {"index": 1, "tags": {"language": "fra"}, "channel_layout": "stereo"},
+                ],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("Movie_audio_AAC.mov"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("Movie_audio_AAC.mov#1:lang=eng:group=1:alternate_group=1", command)
+        self.assertIn("Movie_audio_AAC.mov#2:lang=fra:group=1:alternate_group=1:disable", command)
 
     def test_final_mux_marks_forced_subtitles_for_quicktime(self) -> None:
         with (

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import process
+from bd_to_avp.modules.disc import DiscInfo
+
+
+class ProcessAudioWiringTests(unittest.TestCase):
+    def test_direct_audio_source_is_replaced_by_aac_before_final_mux(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            video_path = output_folder / "Movie_mvc.h264"
+            left_path = output_folder / "Movie_left.mov"
+            right_path = output_folder / "Movie_right.mov"
+            mv_hevc_path = output_folder / "Movie_MV-HEVC.mov"
+            aac_path = output_folder / "Movie_audio_AAC.mov"
+            final_path = output_folder / "Movie_AVP.mov"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(process.config, "source_path", source_path))
+                stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
+                stack.enter_context(patch.object(process.config, "overwrite", True))
+                stack.enter_context(patch.object(process.config, "keep_files", True))
+                stack.enter_context(patch.object(process.config, "remove_original", False))
+                stack.enter_context(patch.object(process.config, "language_code", "eng"))
+                stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                stack.enter_context(
+                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
+                )
+                stack.enter_context(
+                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
+                )
+                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                stack.enter_context(patch.object(process, "create_mkv_file", return_value=source_path))
+                stack.enter_context(patch.object(process, "get_video_color_depth", return_value=8))
+                stack.enter_context(patch.object(process, "detect_crop_parameters", return_value=None))
+                stack.enter_context(
+                    patch.object(process, "create_mvc_and_audio", return_value=(source_path, video_path))
+                )
+                stack.enter_context(patch.object(process, "create_srt_from_mkv"))
+                stack.enter_context(
+                    patch.object(process, "create_left_right_files", return_value=(left_path, right_path))
+                )
+                stack.enter_context(patch.object(process, "create_mv_hevc_file", return_value=mv_hevc_path))
+                stack.enter_context(patch.object(process, "create_upscaled_file", return_value=mv_hevc_path))
+                transcode = stack.enter_context(
+                    patch.object(process, "create_transcoded_audio_file", return_value=aac_path)
+                )
+                mux = stack.enter_context(patch.object(process, "create_muxed_file", return_value=final_path))
+                stack.enter_context(patch.object(process, "move_file_to_output_root_folder"))
+                stack.enter_context(patch.dict(process.os.environ, {}, clear=False))
+                process.process_each()
+
+                transcode.assert_called_once_with(source_path, output_folder)
+                mux.assert_called_once_with(aac_path, mv_hevc_path, output_folder, "Movie")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- skip the intermediate PCM audio file in the internal direct pipeline when AAC transcoding is enabled and `--keep-files` is off
- preserve the `TRANSCODE_AUDIO` stage by reading audio directly from the MKV/MTS/M2TS path and atomically materializing only the final AAC MOV
- retain the existing durable PCM path for default mode, `--keep-files`, and non-transcoded audio workflows
- cover source ownership, failure cleanup, stage resumes, stream selection, multi-track muxing, and process-level source-to-AAC wiring

## Real-Media Smoke

30-second, four-track MKV sample:

- direct prototype: 5.6 MB AAC, about 1.0 seconds, no PCM or `.part.mov` artifact
- equivalent durable path: 99 MB PCM plus 5.6 MB AAC, about 1.3 seconds total
- `remove_extra_languages`: one English 5.1 AAC track produced as expected

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` (174 tests)
- `uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'`
- `uv build`
- PyCharm changed-files inspection: green, zero findings
- two independent code reviews: no runtime blockers

## Scope

The final AAC MOV remains materialized because ffprobe and MP4Box require a seekable file. This PR removes the large PCM intermediate; it does not remove restart-critical video artifacts or change the public CLI surface.

Refs #126
Refs #153
