### PR TITLE
Make minimum-materialization the default pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.
 
 See [Direct Pipeline Contracts](docs/direct-pipeline-contracts.md) for the
-restartable-stage design constraints behind future direct/no-intermediate mode
-work.
+automatic minimum-materialization behavior and the durable `--keep-files`
+stage contracts.
 
 ## Terminal install or update (power users)
 
@@ -51,11 +51,12 @@ Ensure the following are installed on your Mac *(if using the terminal/PyPI vers
 - **[spatial-media-kit-tool]**: A tool for injecting 360° metadata into video files.
 - **[MP4Box]**: A multimedia packager available for Windows, Mac, and Linux.
 
-Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction. Extracted MVC `.h264` video, including
-MVC video extracted from direct `.mts`/`.m2ts` sources, now uses a bundled native Apple Silicon MVC splitter when
-available. Native MVC splitting supports 8-bit Blu-ray 3D MVC sources only. Disc image sources are probed for up to
-30 seconds before splitting; if the multi-threaded native splitter is unstable for that stream, BD_to_AVP automatically
-continues in slower single-threaded mode.
+Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction. By default, existing MKV/MTS/M2TS
+sources are reused in place, MVC video streams directly into the bundled native Apple Silicon splitter, and AAC
+transcoding avoids an intermediate PCM file. `--keep-files` restores the durable source copy, extracted MVC `.h264`,
+and PCM boundaries for inspection, stage resume, and external workflows. Native MVC splitting supports 8-bit Blu-ray
+3D MVC sources only. Disc image sources using durable MVC input are probed for up to 30 seconds before splitting; if
+the multi-threaded native splitter is unstable for that stream, BD_to_AVP continues in slower single-threaded mode.
 
 Runtime tool lookup prefers explicit `BD_TO_AVP_<TOOL>_PATH` environment overrides, bundled tools in `bd_to_avp/bin`,
 tools already available in `PATH`, and finally the legacy `/opt/homebrew/bin` location. The GUI app uses bundled tools
@@ -115,9 +116,11 @@ bd-to-avp --source <source> [--source-folder <source-folder>] [options]
 - `--source-folder`: Source folder path. This option will recurively scan for image files or mkv files. Will take
   precedence over --source if both are provided.
 - `--fx-upscale`: Upscale video to 4K resolution using fx-upscale (disabled by default).
-- `--remove-original`: Remove original file after processing.
+- `--remove-original`: Remove the original source after processing completes successfully.
 - `--overwrite`: Overwrite existing output file.
-- `--keep-files`: Keep intermediate files (disabled by default).
+- `--keep-files`: Use durable stage boundaries and keep the source copy, extracted MVC, PCM audio, and later
+  intermediates. Without this option, BD_to_AVP automatically uses the minimum-materialization pipeline. An explicit
+  `--remove-original` still removes the selected source after a successful conversion.
 - `--output-root-folder`: Output folder path. Defaults to the current directory.
 - `--transcode-audio`: Enable audio transcoding to AAC (disabled by default).
 - `--audio-bitrate`: Audio bitrate for transcoding in kb/s do not include unit (default: "384").

--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -177,13 +177,13 @@ class MainWindow(QMainWindow):
     def create_misc_options(self, config_layout: QVBoxLayout) -> None:
         self.crop_black_bars_checkbox = self.create_checkbox("Crop Black Bars", config.crop_black_bars)
         self.swap_eyes_checkbox = self.create_checkbox("Swap Eyes", config.swap_eyes)
-        self.keep_files_checkbox = self.create_checkbox("Keep Temporary Files", config.keep_files)
+        self.keep_files_checkbox = self.create_checkbox("Keep Durable Stage Files", config.keep_files)
         self.output_commands_checkbox = self.create_checkbox("Output Commands", config.output_commands)
         self.software_encoder_checkbox = self.create_checkbox("Use Software Encoder", config.software_encoder)
         self.fx_upscale_checkbox = self.create_checkbox(
             "AI FX Upscale (2x resolution)", config.fx_upscale, self.toggle_upscale
         )
-        self.remove_original_checkbox = self.create_checkbox("Remove Original", config.remove_original)
+        self.remove_original_checkbox = self.create_checkbox("Remove Original After Success", config.remove_original)
         self.overwrite_checkbox = self.create_checkbox("Overwrite", config.overwrite)
         self.transcode_audio_checkbox = self.create_checkbox(
             "Transcode Audio", config.transcode_audio, self.toggle_transcode

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -214,7 +214,6 @@ class Config:
         self.remove_extra_languages = False
         self.keep_awake = True
         self.smoke_apple_vision_ocr = False
-        self.direct_pipeline = False
 
     def configure_tool_environment(self) -> None:
         configured_dirs = [
@@ -326,7 +325,7 @@ class Config:
             "--remove-original",
             "-r",
             action="store_true",
-            help="Remove original file after processing.",
+            help="Remove the original source after processing completes successfully.",
         )
         parser.add_argument(
             "--overwrite",
@@ -396,7 +395,7 @@ class Config:
         parser.add_argument(
             "--keep-files",
             action="store_true",
-            help="Keep temporary files after processing.",
+            help="Use durable stage files for restart, inspection, and external processing.",
         )
         parser.add_argument(
             "--start-stage",
@@ -444,12 +443,6 @@ class Config:
             action="store_false",
             help="Prevent the computer from sleeping during processing.",
         )
-        parser.add_argument(
-            "--direct-pipeline",
-            action="store_true",
-            help=argparse.SUPPRESS,
-        )
-
         args = parser.parse_args()
 
         if not args.smoke_apple_vision_ocr and not args.source and not args.source_folder:
@@ -473,15 +466,15 @@ config = Config()
 
 def is_direct_pipeline_source_reused() -> bool:
     return bool(
-        config.direct_pipeline
+        not config.keep_files
         and config.source_path
         and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]
     )
 
 
 def is_direct_audio_transcode_enabled() -> bool:
-    return bool(config.direct_pipeline and config.transcode_audio and not config.keep_files)
+    return bool(config.transcode_audio and not config.keep_files)
 
 
 def is_direct_mvc_stream_enabled() -> bool:
-    return bool(config.direct_pipeline and not config.keep_files)
+    return not config.keep_files

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -163,11 +163,15 @@ def create_custom_makemkv_profile(custom_profile_path: Path, language_code: str)
 
 def create_mkv_file(output_folder: Path, disc_info: DiscInfo, language_code: str) -> Path:
     if config.source_path and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]:
+        if not config.source_path.is_file():
+            raise FileNotFoundError(f"Source file not found: {config.source_path}")
         if is_direct_pipeline_source_reused():
-            if not config.source_path.is_file():
-                raise FileNotFoundError(f"Direct source file not found: {config.source_path}")
             return config.source_path
-        shutil.copy(config.source_path, output_folder)
+        destination_path = output_folder / config.source_path.name
+        if config.source_path.resolve() == destination_path.resolve():
+            return config.source_path
+        if config.start_stage.value <= Stage.CREATE_MKV.value:
+            shutil.copy2(config.source_path, destination_path)
         if mkv_file := find_largest_file_with_extensions(output_folder, [".mkv", *config.MTS_EXTENSIONS]):
             return mkv_file
 

--- a/bd_to_avp/modules/file.py
+++ b/bd_to_avp/modules/file.py
@@ -4,7 +4,7 @@ import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 
-from bd_to_avp.modules.config import Stage, config, is_direct_pipeline_source_reused
+from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.command import run_command
 
 
@@ -58,17 +58,17 @@ def path_is_relative_to(path: Path, parent: Path) -> bool:
     return False
 
 
-def output_folder_contains_reused_source(output_path: Path) -> bool:
+def output_folder_contains_source(output_path: Path) -> bool:
     return bool(
-        is_direct_pipeline_source_reused()
-        and config.source_path
+        config.source_path
+        and (config.source_path.exists() or config.source_path.is_symlink())
         and path_is_relative_to(config.source_path, output_path)
     )
 
 
 def remove_output_folder_if_safe(output_path: Path, *, raise_if_unsafe: bool = False) -> bool:
-    if output_folder_contains_reused_source(output_path):
-        message = f"Refusing to clear output folder containing direct source media: {config.source_path}"
+    if output_folder_contains_source(output_path):
+        message = f"Refusing to clear folder containing source media: {config.source_path}"
         if raise_if_unsafe:
             raise ValueError(message)
         print(message)

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -1,17 +1,20 @@
 import os
 import subprocess
+from pathlib import Path
 
 from wakepy.modes import keep
 
 from bd_to_avp import preflight
 from bd_to_avp.modules.audio import create_transcoded_audio_file
-from bd_to_avp.modules.config import config, is_direct_pipeline_source_reused, Stage
+from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.container import create_muxed_file, create_mvc_and_audio
 from bd_to_avp.modules.disc import create_mkv_file, get_disc_and_mvc_video_info
 from bd_to_avp.modules.file import (
     file_exists_normalized,
     move_file_to_output_root_folder,
+    path_is_relative_to,
     prepare_output_folder_for_source,
+    remove_output_folder_if_safe,
     remove_folder_if_exists,
 )
 from bd_to_avp.modules.sub import create_srt_from_mkv
@@ -86,13 +89,24 @@ def process_each() -> None:
     move_file_to_output_root_folder(muxed_output_path)
 
     if not config.keep_files:
-        remove_folder_if_exists(tmp_folder)
+        remove_output_folder_if_safe(tmp_folder)
 
-    if config.remove_original and config.source_path and not is_direct_pipeline_source_reused():
-        if config.source_path.is_dir():
-            remove_folder_if_exists(config.source_path)
-        else:
-            config.source_path.unlink(missing_ok=True)
+    if config.remove_original:
+        remove_original_source(completed_path)
+
+
+def remove_original_source(completed_path: Path) -> bool:
+    source_path = config.source_path
+    if not source_path:
+        return False
+    if source_path.is_dir():
+        if path_is_relative_to(completed_path, source_path):
+            print(f"Refusing to remove source directory containing final output: {source_path}")
+            return False
+        remove_folder_if_exists(source_path)
+    else:
+        source_path.unlink(missing_ok=True)
+    return True
 
 
 def start_process(gui_start_stage: Stage = config.start_stage) -> None:

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -1,29 +1,31 @@
 # Direct Pipeline Contracts
 
-BD_to_AVP currently uses named files as the contract between processing stages.
-That is simple, debuggable, and important for users who stop at a stage, run an
-external AI upscaler, inspect an intermediate, and later resume with
-`--start-stage`.
+BD_to_AVP preserves named files as the durable contract between processing
+stages while using fewer intermediates for a normal unattended run. Named files
+remain important for users who stop at a stage, run an external AI upscaler,
+inspect an intermediate, and later resume with `--start-stage`.
 
-Issue #126 investigates whether a one-shot mode can reduce disk writes without
-creating a second conversion pipeline. The design constraint is DRY: direct mode
-must reuse the same stage code and stage contracts. The only difference should
-be whether a stage output is materialized as a named restartable file or treated
-as an ephemeral stream/artifact for a full unattended run.
+The design constraint is DRY: automatic minimum-materialization and
+`--keep-files` reuse the same stage code and logical contracts. The difference
+is whether an eligible stage output is streamed/reused or materialized as a
+named restartable file.
 
 ## Current Stage Contracts
 
 ### `CREATE_MKV`
 
 - Input: disc, ISO/image, MKV, MTS, or M2TS source plus selected title metadata.
-- Output: largest MKV/MTS/M2TS in the per-title output folder.
+- Output: the selected MKV/MTS/M2TS source in default mode; a copy in the
+  per-title output folder with `--keep-files`; MakeMKV output for disc/images.
 - Restart/debug value: high. This is the common resume point and MakeMKV
   boundary.
 
 ### `EXTRACT_MVC_AND_AUDIO`
 
 - Input: MKV/MTS/M2TS source.
-- Output: `<name>_mvc.h264` and `<name>_audio_PCM.mov`.
+- Output: the source container as the logical MVC input in default mode; the
+  source as audio input when AAC transcoding is enabled; PCM audio otherwise;
+  `<name>_mvc.h264` and `<name>_audio_PCM.mov` with `--keep-files`.
 - Restart/debug value: high. These files feed video split, audio mux/transcode,
   and subtitle timing context.
 
@@ -36,7 +38,8 @@ as an ephemeral stream/artifact for a full unattended run.
 
 ### `CREATE_LEFT_RIGHT_FILES`
 
-- Input: extracted MVC elementary stream plus crop/title metadata.
+- Input: streamed source container in default mode or extracted MVC elementary
+  stream with `--keep-files`, plus crop/title metadata.
 - Output: `<name>_left_movie.mov` and `<name>_right_movie.mov`.
 - Restart/debug value: very high. External AI upscaling workflows often start
   here.
@@ -57,7 +60,8 @@ as an ephemeral stream/artifact for a full unattended run.
 
 ### `TRANSCODE_AUDIO`
 
-- Input: PCM audio movie.
+- Input: source container in default AAC mode or PCM audio movie with
+  `--keep-files`.
 - Output: `<folder>_audio_AAC.mov` when enabled.
 - Restart/debug value: medium. This is the final mux input and useful for audio
   debugging.
@@ -88,36 +92,36 @@ explicit materialization decision per stage:
 - `stream-only`: allowed only when both producer and consumer can share one
   process pipeline without losing restart/debug behavior for normal mode.
 
-Default mode remains persistent. Direct mode should be opt-in until benchmarks
-prove that it is safe and worth the complexity.
+Default mode uses minimum materialization. `--keep-files` selects persistent
+stage boundaries for restart, inspection, and external-tool workflows.
 
-## Internal Direct-Pipeline Prototype
+## Automatic Direct Pipeline
 
-The runtime prototype uses an internal direct-pipeline toggle. It is
-intentionally hidden from the supported CLI surface until benchmark evidence
-and the final UX decision are available. Direct MKV/MTS/M2TS inputs reuse the
-original source path, AAC transcoding reads audio from that source without an
+When `--keep-files` is absent, direct MKV/MTS/M2TS inputs reuse the original
+source path, AAC transcoding reads audio from that source without an
 intermediate PCM MOV, and MVC video is demuxed as Annex B into the native
 splitter without an intermediate `.h264` file.
 
 The MVC path is a bounded three-process pipeline: source FFmpeg to
 `edge264_test` to encoding FFmpeg. Subtitles, AAC, left/right eye files,
-MV-HEVC, and the final movie remain named files. Disc/ISO inputs retain their
-MakeMKV materialization, while restart and external-upscaler artifacts remain
-unchanged. `--keep-files` disables the direct MVC and audio boundaries so the
-durable PCM and MVC files are available for inspection and staged workflows.
+MV-HEVC, and the final movie remain named stage artifacts. Default mode removes
+consumed intermediates after the final output is complete; `--keep-files`
+retains them. Disc/ISO inputs retain their MakeMKV materialization.
 
-The reused source is user-owned. Cleanup and `--remove-original` do not delete
-it while this prototype is active. The supported CLI surface and boundaries
-remain subject to the benchmark and UX decisions tracked by GitHub issue #126.
+The reused source is user-owned. Automatic cleanup never deletes it.
+`--remove-original` is the explicit exception and removes the source only after
+the complete conversion succeeds. With `--keep-files`, the source is copied
+into the per-title output folder and the durable stage contract applies. If the
+selected source is already that retained copy, `--remove-original` explicitly
+removes it while leaving the other durable stage artifacts intact.
 
-## Likely Safe Boundaries
+## Supported Direct Boundaries
 
 ### Source Reuse For Existing MKV/MTS/M2TS Inputs
 
-For direct file inputs, `CREATE_MKV` currently copies the source into the output
-folder and then downstream stages read that copy. A direct mode can likely reuse
-the original source path as an unowned artifact instead.
+For direct file inputs, default mode reuses the original source path as an
+unowned artifact. `--keep-files` copies it into the output folder so downstream
+stages have a durable source boundary.
 
 That keeps downstream stage code path-based and avoids one large copy. The
 ownership rule is the critical part: direct mode must never delete a user source
@@ -130,17 +134,16 @@ This boundary streams internally: source FFmpeg writes Annex B MVC to
 produces left/right eye movie files. The output files remain important because
 they are the main external upscaler/restart boundary.
 
-Initial work here should focus on measuring and tightening the existing stream,
-not removing left/right outputs.
+Left/right outputs remain materialized as the external-upscaler and restart
+boundary during processing and are retained after completion with
+`--keep-files`.
 
 ### Extracted Audio To Transcoded Audio
 
-When AAC transcoding is enabled, BD_to_AVP writes PCM audio and then reads it
-back to produce AAC. The internal direct-mode prototype now skips that PCM file
-when AAC transcoding is enabled and `--keep-files` is not requested. MVC video
-uses the same source container through the direct splitter pipeline, while the
+When AAC transcoding is enabled without `--keep-files`, the
 `TRANSCODE_AUDIO` stage reads audio from the MKV/MTS/M2TS source and writes the
-final AAC MOV directly.
+final AAC MOV directly. MVC video uses the same source container through the
+direct splitter pipeline.
 
 The final mux still needs a seekable audio file, so the AAC MOV remains
 materialized. Durable mode and `--keep-files` retain the existing PCM boundary,
@@ -161,7 +164,7 @@ The direct MVC implementation uses anonymous subprocess pipes, not filesystem
 FIFOs. The patched native splitter supports stdin with bounded NAL buffering;
 regular-file input remains available for durable mode.
 
-Risks to prove first:
+Constraints retained by the implementation:
 
 - FFmpeg cannot write every container format, especially MOV, to a non-seekable
   output.
@@ -176,10 +179,10 @@ remain outside the Python pipeline.
 
 ### MKV Materialization
 
-The MKV is currently the shared source for color-depth probing, crop detection,
-MVC/audio extraction, subtitle OCR, and restart. It is also the boundary most
-likely to change if MakeMKV is replaced later. Do not optimize this away in this
-issue.
+The MKV remains the shared source for color-depth probing, crop detection,
+MVC/audio extraction, subtitle OCR, and restart. Existing MKV/MTS/M2TS inputs
+are reused in place by default, while disc/image inputs retain MakeMKV output as
+a seekable source boundary.
 
 ### MVC And PCM Extraction
 
@@ -192,55 +195,34 @@ transcode have completed.
 ### Left/Right Eye Files
 
 These are large, but they are user-facing workflow artifacts. External AI
-upscaling users depend on stopping here. Direct mode must not remove this
-boundary from the standard staged pipeline.
+upscaling users depend on stopping here. They are retained after completion
+when `--keep-files` is enabled.
 
 ### MV-HEVC File
 
 The MV-HEVC intermediate is the input to optional upscaling and final MP4Box
-muxing. It is also useful for Apple playback debugging. Treat it as persistent
-until final-mux benchmarks prove there is a safe replacement.
+muxing. Default mode removes it after the final mux; `--keep-files` retains it
+for Apple playback debugging and staged resumes.
 
 ### Subtitle Files
 
-`.srt` files are both final mux inputs and debugging artifacts. Keep them named
-and persistent for now.
+`.srt` files are named final-mux inputs. Default mode removes the completed
+output folder after muxing; `--keep-files` retains subtitles for debugging and
+resume workflows.
 
-## Benchmark Plan
+## Benchmark Evidence
 
-Use existing artifacts on the external volume to avoid re-ripping discs while
-measuring the expensive boundaries:
+- Reusing a 7.4 GB MKV took about 0.15 seconds and wrote no copy; durable mode
+  took about 8.55 seconds and wrote 7.4 GB.
+- A five-minute four-track direct audio transcode produced a 56 MB AAC file in
+  about 9.9 seconds without PCM or partial artifacts.
+- A real MVC container streamed through source FFmpeg, `edge264_test`, and
+  encoding FFmpeg into matching 1920x1080 left/right HEVC outputs without an
+  extracted `.h264` intermediate.
+- Existing left/right outputs remain the external-upscaler and stage-resume
+  checkpoint.
 
-- Representative manual workspace:
-  `/Volumes/Docker-External/BD_to_AVP_artifacts/bd-to-avp-125/manual`
-- Rainforest fallback workspace:
-  `/Volumes/Docker-External/BD_to_AVP_artifacts/rainforest-main-probe-test`
-
-Record, per run:
-
-- wall-clock time
-- peak disk usage in the output folder
-- size of each stage artifact
-- whether the stage can be resumed with `--start-stage`
-- whether external upscaling can still use the same files
-
-## Recommended First Prototype
-
-Do not add a user-facing direct mode immediately. First, introduce a small
-internal vocabulary for stage artifacts and materialization decisions. A useful
-prototype would be a pure planning/refactor step:
-
-1. Define each stage's logical output in one place.
-2. Keep current filenames and behavior unchanged.
-3. Add tests that prove `--start-stage` still resolves the same expected files.
-4. Add ownership tests proving unowned source files are never deleted.
-5. Only after that, experiment with one ephemeral boundary behind tests.
-
-This keeps MakeMKV replacement compatible with #126. A future source-ingest
-implementation can produce the same logical MKV/source artifact contract, while
-the rest of the pipeline keeps using shared stage code.
-
-## Tests Before Runtime Changes
+## Regression Coverage
 
 - Durable mode keeps the current deterministic filenames for every stage.
 - `--start-stage` continues to find the same expected files in durable mode.
@@ -251,5 +233,5 @@ the rest of the pipeline keeps using shared stage code.
 - Subtitle extraction still produces SRT files discoverable by final mux.
 - Audio transcode direct experiments preserve stream count, language metadata,
   and final mux command construction.
-- Any FIFO experiment has cancellation and failure tests for both producer and
-  consumer processes.
+- The MVC pipe has cancellation, timeout, retry, SIGPIPE cascade, and producer,
+  splitter, and encoder failure-attribution tests.

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -22,7 +22,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 output_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", False),
                 patch.object(audio.config, "remove_extra_languages", False),
@@ -53,7 +52,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 output_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", False),
                 patch.object(audio.config, "remove_extra_languages", True),
@@ -78,7 +76,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 raise RuntimeError("transcode failed")
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", False),
                 patch.object(audio.config, "remove_extra_languages", False),
@@ -103,7 +100,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 output_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", True),
                 patch.object(audio.config, "remove_extra_languages", True),
@@ -127,7 +123,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             aac_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", False),
                 patch.object(audio.config, "remove_extra_languages", False),
@@ -149,7 +144,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             output_folder.mkdir()
 
             with (
-                patch.object(audio.config, "direct_pipeline", True),
                 patch.object(audio.config, "transcode_audio", True),
                 patch.object(audio.config, "keep_files", False),
                 patch.object(audio.config, "remove_extra_languages", False),
@@ -162,7 +156,6 @@ class DirectAudioTranscodeTests(unittest.TestCase):
     def test_transcode_disabled_returns_original_audio(self) -> None:
         original_audio_path = Path("Movie_audio_PCM.mov")
         with (
-            patch.object(audio.config, "direct_pipeline", True),
             patch.object(audio.config, "transcode_audio", False),
             patch.object(audio.config, "keep_files", False),
             patch.object(audio.config, "start_stage", Stage.TRANSCODE_AUDIO),

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -11,7 +11,6 @@ from bd_to_avp.modules.config import Stage
 class AudioExtractionTests(unittest.TestCase):
     def test_direct_pipeline_skips_intermediate_video_and_pcm(self) -> None:
         with (
-            patch.object(container.config, "direct_pipeline", True),
             patch.object(container.config, "transcode_audio", True),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
@@ -23,25 +22,8 @@ class AudioExtractionTests(unittest.TestCase):
         self.assertEqual(video_path, Path("source.mkv"))
         run_ffmpeg.assert_not_called()
 
-    def test_durable_audio_path_still_extracts_pcm(self) -> None:
+    def test_keep_files_preserves_mvc_and_pcm_boundaries(self) -> None:
         with (
-            patch.object(container.config, "direct_pipeline", False),
-            patch.object(container.config, "transcode_audio", True),
-            patch.object(container.config, "keep_files", False),
-            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
-            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
-        ):
-            audio_path, video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
-
-        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
-        self.assertEqual(audio_path, Path("output/Movie_audio_PCM.mov"))
-        self.assertEqual(video_path, Path("output/Movie_mvc.h264"))
-        self.assertIn("pcm_s24le", command)
-        self.assertIn("file:output/Movie_audio_PCM.mov", command)
-
-    def test_keep_files_preserves_pcm_boundary_in_direct_mode(self) -> None:
-        with (
-            patch.object(container.config, "direct_pipeline", True),
             patch.object(container.config, "transcode_audio", True),
             patch.object(container.config, "keep_files", True),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
@@ -57,7 +39,6 @@ class AudioExtractionTests(unittest.TestCase):
 
     def test_direct_mode_without_audio_transcode_preserves_pcm_boundary(self) -> None:
         with (
-            patch.object(container.config, "direct_pipeline", True),
             patch.object(container.config, "transcode_audio", False),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -8,7 +8,7 @@ from bd_to_avp.modules.config import Stage
 
 
 class DiscStageArtifactTests(unittest.TestCase):
-    def test_mkv_source_copies_to_output_folder_by_default(self) -> None:
+    def test_keep_files_copies_mkv_source_to_output_folder(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -18,7 +18,7 @@ class DiscStageArtifactTests(unittest.TestCase):
 
             with (
                 patch.object(disc.config, "source_path", source_path),
-                patch.object(disc.config, "direct_pipeline", False),
+                patch.object(disc.config, "keep_files", True),
                 patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             ):
                 result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
@@ -38,7 +38,7 @@ class DiscStageArtifactTests(unittest.TestCase):
 
             with (
                 patch.object(disc.config, "source_path", source_path),
-                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "keep_files", False),
                 patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             ):
                 result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
@@ -57,7 +57,7 @@ class DiscStageArtifactTests(unittest.TestCase):
 
             with (
                 patch.object(disc.config, "source_path", source_path),
-                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "keep_files", False),
                 patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             ):
                 result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
@@ -75,11 +75,52 @@ class DiscStageArtifactTests(unittest.TestCase):
 
             with (
                 patch.object(disc.config, "source_path", source_path),
-                patch.object(disc.config, "direct_pipeline", True),
+                patch.object(disc.config, "keep_files", False),
                 patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-                self.assertRaisesRegex(FileNotFoundError, "Direct source file not found"),
+                self.assertRaisesRegex(FileNotFoundError, "Source file not found"),
             ):
                 disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+    def test_keep_files_resume_uses_source_already_in_output_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir)
+            source_path = output_folder / "movie.mkv"
+            source_path.write_bytes(b"mkv")
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "keep_files", True),
+                patch.object(disc.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                patch.object(disc.shutil, "copy2") as copy_source,
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            self.assertEqual(result, source_path)
+            copy_source.assert_not_called()
+
+    def test_keep_files_resume_uses_existing_copy_without_recopying_external_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source" / "movie.mkv"
+            output_folder = temp_path / "output"
+            source_path.parent.mkdir()
+            output_folder.mkdir()
+            source_path.write_bytes(b"source")
+            existing_copy = output_folder / source_path.name
+            existing_copy.write_bytes(b"copy")
+
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "keep_files", True),
+                patch.object(disc.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
+                patch.object(disc.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
+                patch.object(disc.shutil, "copy2") as copy_source,
+            ):
+                result = disc.create_mkv_file(output_folder, disc.DiscInfo(name="Movie"), "eng")
+
+            self.assertEqual(result, existing_copy)
+            copy_source.assert_not_called()
 
     def test_resume_from_existing_mkv_still_uses_output_folder_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -110,7 +110,6 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
             with (
                 patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
-                patch.object(video.config, "direct_pipeline", True),
                 patch.object(video.config, "keep_files", False),
                 patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
                 patch(
@@ -241,7 +240,6 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         with (
             tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "direct_pipeline", True),
             patch.object(video.config, "keep_files", False),
             patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             patch("bd_to_avp.modules.video.prepare_native_mvc_input") as prepare_input,
@@ -284,7 +282,6 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
         with (
             tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "direct_pipeline", True),
             patch.object(video.config, "keep_files", False),
             patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
             patch(

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -9,7 +9,7 @@ from bd_to_avp.modules.disc import DiscInfo
 
 
 class ProcessAudioWiringTests(unittest.TestCase):
-    def test_direct_audio_source_is_replaced_by_aac_before_final_mux(self) -> None:
+    def test_direct_audio_source_is_replaced_by_aac_and_removed_after_success(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -27,8 +27,8 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.object(process.config, "source_path", source_path))
                 stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
                 stack.enter_context(patch.object(process.config, "overwrite", True))
-                stack.enter_context(patch.object(process.config, "keep_files", True))
-                stack.enter_context(patch.object(process.config, "remove_original", False))
+                stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "remove_original", True))
                 stack.enter_context(patch.object(process.config, "language_code", "eng"))
                 stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
                 stack.enter_context(
@@ -60,6 +60,7 @@ class ProcessAudioWiringTests(unittest.TestCase):
 
                 transcode.assert_called_once_with(source_path, output_folder)
                 mux.assert_called_once_with(aac_path, mv_hevc_path, output_folder, "Movie")
+                self.assertFalse(source_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -6,7 +6,11 @@ from unittest.mock import patch
 from bd_to_avp import preflight
 from bd_to_avp.modules import process
 from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
-from bd_to_avp.modules.file import move_file_to_output_root_folder, prepare_output_folder_for_source
+from bd_to_avp.modules.file import (
+    move_file_to_output_root_folder,
+    prepare_output_folder_for_source,
+    remove_output_folder_if_safe,
+)
 
 
 class ProcessPreflightTests(unittest.TestCase):
@@ -24,15 +28,15 @@ class ProcessPreflightTests(unittest.TestCase):
 
     def test_direct_pipeline_reused_file_source_is_not_cleanup_owned(self) -> None:
         with (
-            patch.object(process.config, "direct_pipeline", True),
+            patch.object(process.config, "keep_files", False),
             patch.object(process.config, "source_path", Path("movie.mkv")),
             patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
         ):
             self.assertTrue(is_direct_pipeline_source_reused())
 
-    def test_default_pipeline_file_source_remains_cleanup_owned(self) -> None:
+    def test_keep_files_source_remains_cleanup_owned(self) -> None:
         with (
-            patch.object(process.config, "direct_pipeline", False),
+            patch.object(process.config, "keep_files", True),
             patch.object(process.config, "source_path", Path("movie.mkv")),
             patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
         ):
@@ -40,7 +44,7 @@ class ProcessPreflightTests(unittest.TestCase):
 
     def test_direct_pipeline_iso_source_remains_cleanup_owned(self) -> None:
         with (
-            patch.object(process.config, "direct_pipeline", True),
+            patch.object(process.config, "keep_files", False),
             patch.object(process.config, "source_path", Path("movie.iso")),
             patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
         ):
@@ -55,16 +59,78 @@ class ProcessPreflightTests(unittest.TestCase):
             source_path.write_bytes(b"source")
 
             with (
-                patch.object(process.config, "direct_pipeline", True),
+                patch.object(process.config, "keep_files", False),
                 patch.object(process.config, "source_path", source_path),
                 patch.object(process.config, "output_root_path", output_root),
                 patch.object(process.config, "start_stage", Stage.CREATE_MKV),
                 patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-                self.assertRaisesRegex(ValueError, "direct source media"),
+                self.assertRaisesRegex(ValueError, "source media"),
             ):
                 prepare_output_folder_for_source("Movie")
 
             self.assertTrue(source_path.exists())
+
+    def test_keep_files_create_mkv_start_refuses_to_clear_folder_containing_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            output_folder = output_root / "Movie"
+            output_folder.mkdir()
+            source_path = output_folder / "Movie.mkv"
+            source_path.write_bytes(b"source")
+
+            with (
+                patch.object(process.config, "keep_files", True),
+                patch.object(process.config, "source_path", source_path),
+                patch.object(process.config, "output_root_path", output_root),
+                patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+                self.assertRaisesRegex(ValueError, "source media"),
+            ):
+                prepare_output_folder_for_source("Movie")
+
+            self.assertTrue(source_path.exists())
+
+    def test_temp_cleanup_preserves_source_inside_temp_folder(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_folder = Path(temp_dir) / "temp_files"
+            temp_folder.mkdir()
+            source_path = temp_folder / "Movie.mkv"
+            source_path.write_bytes(b"source")
+
+            with patch.object(process.config, "source_path", source_path):
+                removed = remove_output_folder_if_safe(temp_folder)
+
+            self.assertFalse(removed)
+            self.assertTrue(source_path.exists())
+
+    def test_remove_original_refuses_source_directory_containing_final_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir) / "source"
+            final_path = source_folder / "output" / "Movie_AVP.mov"
+            final_path.parent.mkdir(parents=True)
+            final_path.write_bytes(b"final")
+
+            with patch.object(process.config, "source_path", source_folder):
+                removed = process.remove_original_source(final_path)
+
+            self.assertFalse(removed)
+            self.assertEqual(final_path.read_bytes(), b"final")
+
+    def test_remove_original_file_preserves_sibling_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir) / "source"
+            source_folder.mkdir()
+            source_path = source_folder / "Movie.mkv"
+            sibling_path = source_folder / "notes.txt"
+            final_path = Path(temp_dir) / "output" / "Movie_AVP.mov"
+            source_path.write_bytes(b"source")
+            sibling_path.write_bytes(b"notes")
+
+            with patch.object(process.config, "source_path", source_path):
+                removed = process.remove_original_source(final_path)
+
+            self.assertTrue(removed)
+            self.assertFalse(source_path.exists())
+            self.assertEqual(sibling_path.read_bytes(), b"notes")
 
     def test_output_move_preserves_folder_containing_direct_source(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -77,7 +143,6 @@ class ProcessPreflightTests(unittest.TestCase):
             muxed_path.write_bytes(b"final")
 
             with (
-                patch.object(process.config, "direct_pipeline", True),
                 patch.object(process.config, "source_path", source_path),
                 patch.object(process.config, "output_root_path", output_root),
                 patch.object(process.config, "keep_files", False),
@@ -103,12 +168,12 @@ class ProcessPreflightTests(unittest.TestCase):
             source_path.symlink_to(external_source)
 
             with (
-                patch.object(process.config, "direct_pipeline", True),
+                patch.object(process.config, "keep_files", False),
                 patch.object(process.config, "source_path", source_path),
                 patch.object(process.config, "output_root_path", output_root),
                 patch.object(process.config, "start_stage", Stage.CREATE_MKV),
                 patch.object(process.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-                self.assertRaisesRegex(ValueError, "direct source media"),
+                self.assertRaisesRegex(ValueError, "source media"),
             ):
                 prepare_output_folder_for_source("Movie")
 


### PR DESCRIPTION
## Summary
- make minimum-materialization automatic whenever `--keep-files` is absent and remove the hidden experimental flag
- make `--keep-files` the single durable-mode control for source copies, MVC, PCM, restart, and external-processing artifacts
- harden source ownership, same-file resume, temp/output cleanup, and `--remove-original` containment safety
- align CLI, GUI, README, and the direct-pipeline contract with the supported behavior

## Validation
- `uv run python -m unittest discover -s tests -t .` (187 tests)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv build`
- JetBrains changed-files inspection: green, 0 findings
- two independent post-fix reviews: no blockers

Closes #154
Refs #126