### PR TITLE
Correct release protection metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -22,7 +22,7 @@
       "target": "refs/heads/release",
       "requiresPullRequest": true,
       "allowedMergeMethods": ["merge"],
-      "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
+      "requiredStatusChecks": ["validate"],
       "requiredApprovals": 0,
       "blocksForcePushes": true,
       "blocksDeletion": true,


### PR DESCRIPTION
## Summary
- keep the intentional advanced CodeQL workflow and its stable required checks on `main`
- correct repository metadata for the `release` ruleset, which requires only `validate`

## Validation
- confirmed `.github/workflows/codeql.yml` is active advanced setup for Actions and Python
- confirmed the live `protect-release` ruleset requires only `validate`
- `jq empty .github/github.json`
- `prettier --check .github/github.json`
- `git diff --check`
