### PR TITLE
Refactor GUI processing lifecycle boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ bd-to-avp
 
 As long as you provide no arguments, the GUI will open.
 
+The GUI locks configuration load/save actions while a job is active so each
+run uses the settings captured at startup. Choosing **Stop Processing**
+requests a cooperative stop and keeps the button in a stopping state until the
+worker exits. For source-folder jobs, accepted MKV or subtitle error
+continuations resume the failed source and then continue through the original
+batch queue.
+
 ## Terminal Usage
 
 Navigate to the tool's directory in your terminal and execute the command with the required and optional parameters:

--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Callable, ClassVar
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QFont, QTextCursor
+from PySide6.QtGui import QAction, QCloseEvent, QFont, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
     QGroupBox,
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
 from babelfish import Language
 
 from bd_to_avp.gui.dialog import AboutDialog
-from bd_to_avp.gui.processing import ProcessingThread
+from bd_to_avp.gui.processing import ProcessingController, ProcessingRequest
 from bd_to_avp.gui.widget import FileFolderPicker, LabeledComboBox, LabeledLineEdit, LabeledSpinBox
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.disc import DiscInfo, MKVCreationError
@@ -39,6 +39,7 @@ from bd_to_avp.modules.command import Spinner
 class MainWindow(QMainWindow):
     START_PROCESSING_TEXT = "Start Processing (⌘+P)"
     STOP_PROCESSING_TEXT = "Stop Processing (⌘+P)"
+    STOPPING_PROCESSING_TEXT = "Stopping Processing…"
     MAIN_WIDGET_MIN_WIDTH = 300
     SPLITTER_INITIAL_SIZES: ClassVar[list[int]] = [400, 400]
     SPLITTER_MINIMUM_SIZE = 300
@@ -50,14 +51,15 @@ class MainWindow(QMainWindow):
         self.setup_window()
         self.create_main_layout()
 
-        self.processing_thread = ProcessingThread(parent=self)
-        self.processing_thread.signals.progress_updated.connect(self.update_processing_output)
-        self.processing_thread.error_occurred.connect(self.handle_processing_error)
-        self.processing_thread.mkv_creation_error.connect(self.handle_mkv_creation_error)
-        self.processing_thread.srt_creation_error.connect(self.handle_srt_creation_error)
-        self.processing_thread.file_exists_error.connect(self.handle_file_exists_error)
-        self.processing_thread.process_completed.connect(self.finished_processing)
-        self.processing_thread.process_failed.connect(self.reset_processing_button)
+        self.processing_controller = ProcessingController(parent=self)
+        self.processing_controller.progress_updated.connect(self.update_processing_output)
+        self.processing_controller.error_occurred.connect(self.handle_processing_error)
+        self.processing_controller.mkv_creation_error.connect(self.handle_mkv_creation_error)
+        self.processing_controller.srt_creation_error.connect(self.handle_srt_creation_error)
+        self.processing_controller.file_exists_error.connect(self.handle_file_exists_error)
+        self.processing_controller.process_completed.connect(self.finished_processing)
+        self.processing_controller.process_cancelled.connect(self.processing_cancelled)
+        self.processing_controller.process_failed.connect(self.handle_processing_failure)
 
     def setup_window(self) -> None:
         app = QApplication.instance()
@@ -279,15 +281,14 @@ class MainWindow(QMainWindow):
             if sound_path.exists():
                 os.system(f"afplay /System/Library/Sounds/{sound_name}.aiff")
 
-    def handle_processing_error(self, error: Exception) -> None:
+    def handle_processing_error(self, _request: ProcessingRequest, error: Exception) -> None:
         self.notify_user_with_sound("Sosumi")
         QMessageBox.warning(self, "", "Failure in processing.\n\n" + str(error))
         time_elapsed = formatted_time_elapsed(self.process_start_time)
         self.update_processing_output(str(error) + f"\n❌ Processing failed in {time_elapsed} ❌")
-        self.stop_processing()
-        self.process_button.setText(self.START_PROCESSING_TEXT)
+        self.reset_processing_button()
 
-    def handle_mkv_creation_error(self, error: MKVCreationError) -> None:
+    def handle_mkv_creation_error(self, request: ProcessingRequest, error: MKVCreationError) -> None:
         self.notify_user_with_sound("Sosumi")
         result = QMessageBox.critical(
             self,
@@ -297,14 +298,12 @@ class MainWindow(QMainWindow):
         )
 
         if result == QMessageBox.StandardButton.Yes:
-            config.continue_on_error = True
-            config.start_stage = Stage.EXTRACT_MVC_AND_AUDIO
-            self.start_processing(is_continuing=True)
+            self.start_processing(is_continuing=True, request=request.continue_after_mkv_error())
             return
 
-        self.handle_processing_error(error)
+        self.handle_processing_error(request, error)
 
-    def handle_file_exists_error(self, error: FileExistsError) -> None:
+    def handle_file_exists_error(self, request: ProcessingRequest, error: FileExistsError) -> None:
         self.notify_user_with_sound("Sosumi")
         result = QMessageBox.critical(
             self,
@@ -314,13 +313,12 @@ class MainWindow(QMainWindow):
         )
 
         if result == QMessageBox.StandardButton.Yes:
-            config.overwrite = True
-            self.start_processing(is_continuing=True)
+            self.start_processing(is_continuing=True, request=request.overwrite_existing_output())
             return
 
-        self.handle_processing_error(error)
+        self.handle_processing_error(request, error)
 
-    def handle_srt_creation_error(self, error: SRTCreationError) -> None:
+    def handle_srt_creation_error(self, request: ProcessingRequest, error: SRTCreationError) -> None:
         self.notify_user_with_sound("Sosumi")
         message_box = QMessageBox(
             QMessageBox.Icon.Critical,
@@ -335,16 +333,18 @@ class MainWindow(QMainWindow):
         clicked_button = message_box.clickedButton()
 
         if result == QMessageBox.StandardButton.Abort or clicked_button is None:
-            self.handle_processing_error(error)
+            self.handle_processing_error(request, error)
             return
 
         if clicked_button == skip_button:
-            config.skip_subtitles = True
+            continuation = request.continue_after_srt_error(skip_subtitles=True)
         elif clicked_button == continue_button:
-            config.continue_on_error = True
+            continuation = request.continue_after_srt_error(skip_subtitles=False)
+        else:
+            self.handle_processing_error(request, error)
+            return
 
-        config.start_stage = Stage.CREATE_LEFT_RIGHT_FILES
-        self.start_processing(is_continuing=True)
+        self.start_processing(is_continuing=True, request=continuation)
 
     def toggle_read_from_disc(self) -> None:
         self.source_folder_widget.setEnabled(not self.read_from_disc_checkbox.isChecked())
@@ -389,6 +389,8 @@ class MainWindow(QMainWindow):
                 self.mv_hevc_quality_spinbox.set_value(value)
 
     def load_config_and_update_ui(self) -> None:
+        if self.processing_controller.is_active:
+            return
         config.load_config_from_file()
         self.source_folder_widget.set_text(config.source_folder_path.as_posix() if config.source_folder_path else "")
         self.source_file_widget.set_text(config.source_path.as_posix() if config.source_path else "")
@@ -418,7 +420,7 @@ class MainWindow(QMainWindow):
         self.keep_awake_checkbox.setChecked(config.keep_awake)
 
     def toggle_processing(self) -> None:
-        if self.process_button.text() == self.START_PROCESSING_TEXT:
+        if not self.processing_controller.is_active:
             self.processing_output_textedit.clear()
             self.source_folder_widget.set_text(self.source_folder_widget.text().strip())
             self.source_file_widget.set_text(self.source_file_widget.text().strip())
@@ -443,7 +445,7 @@ class MainWindow(QMainWindow):
 
         self.process_button.setShortcut("Ctrl+P")
 
-    def start_processing(self, is_continuing: bool = False) -> None:
+    def start_processing(self, is_continuing: bool = False, request: ProcessingRequest | None = None) -> None:
         if not is_continuing:
             start_time = format_timestamp(datetime.now())
             self.processing_output_textedit.append(
@@ -451,27 +453,52 @@ class MainWindow(QMainWindow):
             )
             self.save_config()
             self.process_start_time = datetime.now()
-        self.processing_thread.start_stage = config.start_stage
-        self.processing_thread.start()
-        self.process_button.setText(self.STOP_PROCESSING_TEXT)
+            request = ProcessingRequest.from_config()
+        elif request is None:
+            raise ValueError("A continuation request is required when resuming processing.")
 
-    def finished_processing(self) -> None:
+        if self.processing_controller.start(request):
+            self.set_config_actions_enabled(False)
+            self.process_button.setEnabled(True)
+            self.process_button.setText(self.STOP_PROCESSING_TEXT)
+
+    def finished_processing(self, _request: ProcessingRequest) -> None:
         time_elapsed = formatted_time_elapsed(self.process_start_time)
         message = (
             f"✅ Processing completed in {time_elapsed} with version {config.app.code_version}. "
             "You can now play from the Files or Screenlit app on the AVP ✅"
         )
         self.processing_output_textedit.append(message)
-        self.process_button.setText(self.START_PROCESSING_TEXT)
+        self.reset_processing_button()
         self.notify_user_with_sound("Glass")
         QMessageBox.information(self, "", message)
 
     def reset_processing_button(self) -> None:
+        self.set_config_actions_enabled(True)
+        self.process_button.setEnabled(True)
         self.process_button.setText(self.START_PROCESSING_TEXT)
 
+    def processing_cancelled(self, _request: ProcessingRequest) -> None:
+        time_elapsed = formatted_time_elapsed(self.process_start_time)
+        self.processing_output_textedit.append(f"🛑 Processing stopped after {time_elapsed} 🛑")
+        self.reset_processing_button()
+
+    def handle_processing_failure(self, _request: ProcessingRequest, error: BaseException | None) -> None:
+        message = (
+            f"Processing worker exited unexpectedly: {error}" if error else "Processing worker exited unexpectedly."
+        )
+        self.update_processing_output(message)
+        self.reset_processing_button()
+
     def save_config_to_file(self) -> None:
+        if self.processing_controller.is_active:
+            return
         self.save_config()
         config.save_config_to_file()
+
+    def set_config_actions_enabled(self, enabled: bool) -> None:
+        self.load_config_button.setEnabled(enabled)
+        self.save_config_button.setEnabled(enabled)
 
     def save_config(self) -> None:
         if self.read_from_disc_checkbox.isChecked():
@@ -510,10 +537,17 @@ class MainWindow(QMainWindow):
         config.keep_awake = self.keep_awake_checkbox.isChecked()
 
     def stop_processing(self) -> None:
-        time_elapsed = formatted_time_elapsed(self.process_start_time)
-        self.processing_output_textedit.append(f"🛑 Processing stopped after {time_elapsed} 🛑")
-        self.processing_thread.terminate()
-        self.process_button.setText(self.START_PROCESSING_TEXT)
+        if self.processing_controller.request_cancel():
+            self.processing_output_textedit.append("🛑 Stopping processing…")
+            self.process_button.setText(self.STOPPING_PROCESSING_TEXT)
+            self.process_button.setEnabled(False)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        if self.processing_controller.shutdown():
+            event.accept()
+            return
+        event.ignore()
+        QMessageBox.warning(self, "", "Processing is still stopping. Please wait before closing the app.")
 
     def update_processing_output(self, message: str) -> None:
         output_textedit = self.processing_output_textedit

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -1,60 +1,317 @@
 import sys
+from copy import deepcopy
+from dataclasses import dataclass, replace
+from enum import Enum, auto
+from pathlib import Path
+from threading import Event, get_ident
+from typing import Callable, Iterable, Protocol
 
-from PySide6.QtCore import QObject, QThread, Signal
-from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import QObject, QThread, Signal, Slot
 
+from bd_to_avp.modules.command import Spinner, terminate_process
+from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.disc import MKVCreationError
+from bd_to_avp.modules.process import BatchProcessingError, start_process
+from bd_to_avp.modules.sub import SRTCreationError
 from .util import OutputHandler
-from ..modules.command import terminate_process, Spinner
-from bd_to_avp.modules.process import start_process
-from ..modules.config import Stage
-from ..modules.sub import SRTCreationError
 
 
-class ProcessingSignals(QObject):
-    progress_updated = Signal(str)
+class TextOutputStream(Protocol):
+    def write(self, text: str, /) -> int: ...
+
+    def writelines(self, lines: Iterable[str], /) -> None: ...
+
+    def flush(self) -> None: ...
+
+
+class NullOutput:
+    def write(self, text: str, /) -> int:
+        return len(text)
+
+    def writelines(self, lines: Iterable[str], /) -> None:
+        for line in lines:
+            self.write(line)
+
+    def flush(self) -> None:
+        pass
+
+
+class ThreadScopedOutput:
+    def __init__(
+        self,
+        owner_thread_id: int,
+        owner_stream: TextOutputStream,
+        fallback_stream: TextOutputStream,
+    ) -> None:
+        self._owner_thread_id = owner_thread_id
+        self._owner_stream = owner_stream
+        self._fallback_stream = fallback_stream
+
+    def _stream(self) -> TextOutputStream:
+        return self._owner_stream if get_ident() == self._owner_thread_id else self._fallback_stream
+
+    def current_writer(self) -> Callable[[str], int]:
+        return self._stream().write
+
+    def write(self, text: str) -> int:
+        return self._stream().write(text)
+
+    def writelines(self, lines: Iterable[str]) -> None:
+        self._stream().writelines(lines)
+
+    def flush(self) -> None:
+        self._stream().flush()
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._fallback_stream, name)
+
+
+@dataclass(frozen=True)
+class ProcessingConfigSnapshot:
+    values: tuple[tuple[str, object], ...]
+
+    @classmethod
+    def from_config(cls) -> "ProcessingConfigSnapshot":
+        return cls(tuple((name, deepcopy(value)) for name, value in vars(config).items() if name != "app"))
+
+    def apply(self) -> None:
+        for name, value in self.values:
+            setattr(config, name, deepcopy(value))
+
+
+@dataclass(frozen=True)
+class ProcessingRequest:
+    start_stage: Stage
+    overwrite: bool
+    continue_on_error: bool
+    skip_subtitles: bool
+    config_snapshot: ProcessingConfigSnapshot | None = None
+    batch_start_stage: Stage | None = None
+    resume_source_path: Path | None = None
+    batch_sources: tuple[Path, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.batch_start_stage is None:
+            object.__setattr__(self, "batch_start_stage", self.start_stage)
+
+    @classmethod
+    def from_config(cls) -> "ProcessingRequest":
+        return cls(
+            start_stage=config.start_stage,
+            overwrite=config.overwrite,
+            continue_on_error=config.continue_on_error,
+            skip_subtitles=config.skip_subtitles,
+            config_snapshot=ProcessingConfigSnapshot.from_config(),
+        )
+
+    def apply(self) -> None:
+        if self.config_snapshot is not None:
+            self.config_snapshot.apply()
+        config.start_stage = self.start_stage
+        config.overwrite = self.overwrite
+        config.continue_on_error = self.continue_on_error
+        config.skip_subtitles = self.skip_subtitles
+
+    def continue_after_mkv_error(self) -> "ProcessingRequest":
+        return replace(self, start_stage=Stage.EXTRACT_MVC_AND_AUDIO, continue_on_error=True)
+
+    def overwrite_existing_output(self) -> "ProcessingRequest":
+        return replace(self, overwrite=True)
+
+    def continue_after_srt_error(self, *, skip_subtitles: bool) -> "ProcessingRequest":
+        return replace(
+            self,
+            start_stage=Stage.CREATE_LEFT_RIGHT_FILES,
+            skip_subtitles=self.skip_subtitles or skip_subtitles,
+            continue_on_error=self.continue_on_error or not skip_subtitles,
+        )
+
+
+class ProcessingOutcomeKind(Enum):
+    COMPLETED = auto()
+    CANCELLED = auto()
+    MKV_CREATION_ERROR = auto()
+    SRT_CREATION_ERROR = auto()
+    FILE_EXISTS_ERROR = auto()
+    ERROR = auto()
+    FAILED = auto()
+
+
+@dataclass(frozen=True)
+class ProcessingOutcome:
+    kind: ProcessingOutcomeKind
+    error: BaseException | None = None
+    source_path: Path | None = None
+    batch_sources: tuple[Path, ...] | None = None
+
+
+ProcessRunner = Callable[[ProcessingRequest], None]
+StopRunner = Callable[[], None]
+
+
+def run_processing_request(request: ProcessingRequest, cancellation_event: Event) -> None:
+    start_process(
+        request.start_stage,
+        cancellation_event=cancellation_event,
+        resume_source_path=request.resume_source_path,
+        batch_start_stage=request.batch_start_stage,
+        batch_sources=request.batch_sources,
+    )
 
 
 class ProcessingThread(QThread):
-    error_occurred = Signal(Exception)
-    mkv_creation_error = Signal(MKVCreationError)
-    srt_creation_error = Signal(SRTCreationError)
-    file_exists_error = Signal(FileExistsError)
-    process_completed = Signal()
-    process_failed = Signal()
+    progress_updated = Signal(str)
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        request: ProcessingRequest,
+        parent: QObject | None = None,
+        *,
+        process_runner: ProcessRunner | None = None,
+        stop_runner: StopRunner | None = None,
+    ) -> None:
         super().__init__(parent)
-        self.signals = ProcessingSignals()
-        self.output_handler = OutputHandler(self.signals.progress_updated.emit)
-        self.start_stage = Stage.CREATE_MKV
+        self.request = request
+        self.outcome: ProcessingOutcome | None = None
+        self.output_handler = OutputHandler(self.progress_updated.emit)
+        self._process_runner = process_runner
+        self._stop_runner = stop_runner or terminate_process
+        self._cancellation_event = Event()
+
+    @property
+    def cancel_requested(self) -> bool:
+        return self._cancellation_event.is_set()
 
     def run(self) -> None:
-        sys.stdout = self.output_handler  # type: ignore
-        signal_emitted = False
-
+        previous_stdout = sys.stdout
+        fallback_stdout = previous_stdout or NullOutput()
+        sys.stdout = ThreadScopedOutput(get_ident(), self.output_handler, fallback_stdout)  # type: ignore[assignment]
         try:
-            start_process(self.start_stage)
-            self.process_completed.emit()
-            signal_emitted = True
-        except MKVCreationError as error:
-            self.mkv_creation_error.emit(error)
-            signal_emitted = True
-        except SRTCreationError as error:
-            self.srt_creation_error.emit(error)
-            signal_emitted = True
-        except FileExistsError as error:
-            self.file_exists_error.emit(error)
-            signal_emitted = True
-        except Exception as error:
-            self.error_occurred.emit(error)
-            signal_emitted = True
+            if self.cancel_requested:
+                self.outcome = ProcessingOutcome(ProcessingOutcomeKind.CANCELLED)
+                return
+            if self._process_runner is None:
+                run_processing_request(self.request, self._cancellation_event)
+            else:
+                self._process_runner(self.request)
+            outcome_kind = ProcessingOutcomeKind.CANCELLED if self.cancel_requested else ProcessingOutcomeKind.COMPLETED
+            self.outcome = ProcessingOutcome(outcome_kind)
+        except BaseException as error:
+            self.outcome = self._outcome_for_error(error)
         finally:
+            if self.cancel_requested:
+                self.outcome = ProcessingOutcome(ProcessingOutcomeKind.CANCELLED)
             Spinner.stop_all()
-            sys.stdout = sys.__stdout__
-            if not signal_emitted:
-                self.process_failed.emit()
+            sys.stdout = previous_stdout
 
-    def terminate(self) -> None:
-        terminate_process()
-        super().terminate()
+    def request_cancel(self) -> None:
+        if self.cancel_requested:
+            return
+        self._cancellation_event.set()
+        self.requestInterruption()
+        self._stop_runner()
+
+    def _outcome_for_error(self, error: BaseException) -> ProcessingOutcome:
+        source_path = None
+        batch_sources = None
+        if isinstance(error, BatchProcessingError):
+            source_path = error.source_path
+            batch_sources = error.batch_sources
+            error = error.error
+        if self.cancel_requested:
+            return ProcessingOutcome(ProcessingOutcomeKind.CANCELLED)
+        if isinstance(error, MKVCreationError):
+            return ProcessingOutcome(ProcessingOutcomeKind.MKV_CREATION_ERROR, error, source_path, batch_sources)
+        if isinstance(error, SRTCreationError):
+            return ProcessingOutcome(ProcessingOutcomeKind.SRT_CREATION_ERROR, error, source_path, batch_sources)
+        if isinstance(error, FileExistsError):
+            return ProcessingOutcome(ProcessingOutcomeKind.FILE_EXISTS_ERROR, error, source_path, batch_sources)
+        if isinstance(error, Exception):
+            return ProcessingOutcome(ProcessingOutcomeKind.ERROR, error, source_path, batch_sources)
+        return ProcessingOutcome(ProcessingOutcomeKind.FAILED, error, source_path, batch_sources)
+
+
+class ProcessingController(QObject):
+    progress_updated = Signal(str)
+    error_occurred = Signal(object, object)
+    mkv_creation_error = Signal(object, object)
+    srt_creation_error = Signal(object, object)
+    file_exists_error = Signal(object, object)
+    process_completed = Signal(object)
+    process_cancelled = Signal(object)
+    process_failed = Signal(object, object)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._thread: ProcessingThread | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return self._thread is not None
+
+    def start(self, request: ProcessingRequest) -> bool:
+        if self._thread is not None:
+            return False
+        request.apply()
+        thread = ProcessingThread(request, parent=self)
+        self._thread = thread
+        thread.progress_updated.connect(self.progress_updated.emit)
+        thread.finished.connect(self._thread_finished)
+        thread.start()
+        return True
+
+    def request_cancel(self) -> bool:
+        if self._thread is None:
+            return False
+        self._thread.request_cancel()
+        return True
+
+    def shutdown(self, timeout_ms: int = 5000) -> bool:
+        thread = self._thread
+        if thread is None:
+            return True
+        thread.request_cancel()
+        if not thread.wait(timeout_ms):
+            return False
+        if self._thread is thread:
+            self._thread = None
+            thread.deleteLater()
+        return True
+
+    @Slot()
+    def _thread_finished(self) -> None:
+        thread = self._thread
+        if thread is None:
+            return
+        self._thread = None
+        outcome = thread.outcome or ProcessingOutcome(
+            ProcessingOutcomeKind.FAILED,
+            RuntimeError("Processing thread exited without an outcome."),
+        )
+        if thread.cancel_requested:
+            outcome = ProcessingOutcome(ProcessingOutcomeKind.CANCELLED)
+        request = thread.request
+        if outcome.source_path is not None:
+            request = replace(
+                request,
+                resume_source_path=outcome.source_path,
+                batch_sources=outcome.batch_sources,
+            )
+        thread.deleteLater()
+        self._emit_outcome(request, outcome)
+
+    def _emit_outcome(self, request: ProcessingRequest, outcome: ProcessingOutcome) -> None:
+        if outcome.kind == ProcessingOutcomeKind.COMPLETED:
+            self.process_completed.emit(request)
+        elif outcome.kind == ProcessingOutcomeKind.CANCELLED:
+            self.process_cancelled.emit(request)
+        elif outcome.kind == ProcessingOutcomeKind.MKV_CREATION_ERROR:
+            self.mkv_creation_error.emit(request, outcome.error)
+        elif outcome.kind == ProcessingOutcomeKind.SRT_CREATION_ERROR:
+            self.srt_creation_error.emit(request, outcome.error)
+        elif outcome.kind == ProcessingOutcomeKind.FILE_EXISTS_ERROR:
+            self.file_exists_error.emit(request, outcome.error)
+        elif outcome.kind == ProcessingOutcomeKind.ERROR:
+            self.error_occurred.emit(request, outcome.error)
+        else:
+            self.process_failed.emit(request, outcome.error)

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -17,11 +17,14 @@ from .util import OutputHandler
 
 
 class TextOutputStream(Protocol):
-    def write(self, text: str, /) -> int: ...
+    def write(self, text: str, /) -> int:
+        raise NotImplementedError
 
-    def writelines(self, lines: Iterable[str], /) -> None: ...
+    def writelines(self, lines: Iterable[str], /) -> None:
+        raise NotImplementedError
 
-    def flush(self) -> None: ...
+    def flush(self) -> None:
+        raise NotImplementedError
 
 
 class NullOutput:
@@ -196,8 +199,10 @@ class ProcessingThread(QThread):
                 self._process_runner(self.request)
             outcome_kind = ProcessingOutcomeKind.CANCELLED if self.cancel_requested else ProcessingOutcomeKind.COMPLETED
             self.outcome = ProcessingOutcome(outcome_kind)
-        except BaseException as error:
+        except Exception as error:
             self.outcome = self._outcome_for_error(error)
+        except (SystemExit, KeyboardInterrupt, GeneratorExit) as error:
+            self.outcome = ProcessingOutcome(ProcessingOutcomeKind.FAILED, error)
         finally:
             if self.cancel_requested:
                 self.outcome = ProcessingOutcome(ProcessingOutcomeKind.CANCELLED)

--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -5,12 +5,23 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, ClassVar
+from typing import Any, Callable, ClassVar, cast
 
 import ffmpeg
 
 from bd_to_avp.modules.config import config
 from bd_to_avp.modules.util import formatted_time_elapsed
+
+
+SpinnerUpdate = Callable[[str], object]
+
+
+def get_spinner_update_func() -> SpinnerUpdate | None:
+    stdout = cast(Any, sys.stdout)
+    if not hasattr(stdout, "current_writer"):
+        return None
+    writer = stdout.current_writer()
+    return writer if callable(writer) else None
 
 
 class Spinner:
@@ -24,13 +35,17 @@ class Spinner:
         self.current_symbol = 0
         self.start_time = datetime.now()
 
-    def _update_spinner(self) -> None:
+    def _update_spinner(self, update_func: SpinnerUpdate | None = None) -> None:
         if not self.stop_spinner_flag:
-            sys.stdout.write(f"\rRunning {self.command_name} {self.symbols[self.current_symbol]}")
-            sys.stdout.flush()
+            message = f"\rRunning {self.command_name} {self.symbols[self.current_symbol]}"
+            if update_func:
+                update_func(message)
+            else:
+                sys.stdout.write(message)
+                sys.stdout.flush()
             self.current_symbol = (self.current_symbol + 1) % len(self.symbols)
 
-    def start(self, update_func: Callable[[str], None] | None = None) -> None:
+    def start(self, update_func: SpinnerUpdate | None = None) -> None:
         self.stop_spinner_flag = False
         Spinner._stop_all_spinners = False
         if update_func:
@@ -39,10 +54,10 @@ class Spinner:
             print(f"Running {self.command_name}", end="", flush=True)
 
         while not self.stop_spinner_flag and not Spinner._stop_all_spinners:
-            self._update_spinner()
+            self._update_spinner(update_func)
             time.sleep(self.update_interval)
 
-    def stop(self, update_func: Callable[[str], None] | None = None) -> None:
+    def stop(self, update_func: SpinnerUpdate | None = None) -> None:
         self.stop_spinner_flag = True
         time_elapsed_formatted = formatted_time_elapsed(self.start_time)
         message = f"\rFinished {self.command_name} in {time_elapsed_formatted}"
@@ -84,7 +99,8 @@ def run_command(commands: list[Any], command_name: str = "", env: dict[str, str]
     env = env if env else os.environ.copy()
     output_lines = []
     spinner = Spinner(command_name)
-    spinner_thread = threading.Thread(target=spinner.start)
+    spinner_update_func = get_spinner_update_func()
+    spinner_thread = threading.Thread(target=spinner.start, args=(spinner_update_func,))
     spinner_thread.start()
     process = None
     try:
@@ -113,7 +129,7 @@ def run_command(commands: list[Any], command_name: str = "", env: dict[str, str]
         raise
 
     finally:
-        spinner.stop()
+        spinner.stop(spinner_update_func)
         spinner_thread.join()
     return "".join(output_lines)
 
@@ -128,7 +144,8 @@ def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, 
 
         print(f"Running command:\n{output_commands_str}")
     spinner = Spinner(message)
-    spinner_thread = threading.Thread(target=spinner.start)
+    spinner_update_func = get_spinner_update_func()
+    spinner_thread = threading.Thread(target=spinner.start, args=(spinner_update_func,))
     spinner_thread.start()
     try:
         ffmpeg.run(stream_spec, cmd=config.FFMPEG_PATH.as_posix(), **kwargs)
@@ -138,7 +155,7 @@ def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, 
         print("STDERR:", e.stderr.decode("utf-8") if e.stderr else "")
         raise
     finally:
-        spinner.stop()
+        spinner.stop(spinner_update_func)
         spinner_thread.join()
 
 

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+from threading import Event
 
 from wakepy.modes import keep
 
@@ -8,7 +9,7 @@ from bd_to_avp import preflight
 from bd_to_avp.modules.audio import create_transcoded_audio_file
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.container import create_muxed_file, create_mvc_and_audio
-from bd_to_avp.modules.disc import create_mkv_file, get_disc_and_mvc_video_info
+from bd_to_avp.modules.disc import create_mkv_file, get_disc_and_mvc_video_info, MKVCreationError
 from bd_to_avp.modules.file import (
     file_exists_normalized,
     move_file_to_output_root_folder,
@@ -17,7 +18,7 @@ from bd_to_avp.modules.file import (
     remove_output_folder_if_safe,
     remove_folder_if_exists,
 )
-from bd_to_avp.modules.sub import create_srt_from_mkv
+from bd_to_avp.modules.sub import create_srt_from_mkv, SRTCreationError
 from bd_to_avp.modules.video import (
     create_left_right_files,
     create_mv_hevc_file,
@@ -27,32 +28,92 @@ from bd_to_avp.modules.video import (
 )
 
 
-def process(gui_start_stage: Stage) -> None:
+class ProcessingCancelled(Exception):
+    pass
+
+
+class BatchProcessingError(Exception):
+    def __init__(self, source_path: Path, error: Exception, batch_sources: tuple[Path, ...]) -> None:
+        super().__init__(str(error))
+        self.source_path = source_path
+        self.error = error
+        self.batch_sources = batch_sources
+
+
+def raise_if_cancelled(cancellation_event: Event | None) -> None:
+    if cancellation_event is not None and cancellation_event.is_set():
+        raise ProcessingCancelled("Processing was cancelled.")
+
+
+def find_batch_sources(source_folder_path: Path) -> tuple[Path, ...]:
+    supported_extensions = config.IMAGE_EXTENSIONS + config.MTS_EXTENSIONS + [".mkv"]
+    return tuple(
+        sorted(
+            (
+                source
+                for source in source_folder_path.rglob("*")
+                if source.is_file() and source.suffix.lower() in supported_extensions
+            ),
+            key=lambda source: source.as_posix().casefold(),
+        )
+    )
+
+
+def process(
+    gui_start_stage: Stage,
+    cancellation_event: Event | None = None,
+    *,
+    resume_source_path: Path | None = None,
+    batch_start_stage: Stage | None = None,
+    batch_sources: tuple[Path, ...] | None = None,
+) -> None:
+    raise_if_cancelled(cancellation_event)
+    batch_start_stage = batch_start_stage or gui_start_stage
+    waiting_for_resume = resume_source_path is not None
     if config.source_folder_path:
-        for source in config.source_folder_path.rglob("*"):
-            if not source.is_file() or source.suffix.lower() not in config.IMAGE_EXTENSIONS + config.MTS_EXTENSIONS + [
-                ".mkv"
-            ]:
+        batch_sources = batch_sources if batch_sources is not None else find_batch_sources(config.source_folder_path)
+        for source in batch_sources:
+            raise_if_cancelled(cancellation_event)
+            if not source.is_file():
                 continue
+            is_resume_source = waiting_for_resume and source == resume_source_path
+            if waiting_for_resume and not is_resume_source:
+                continue
+            waiting_for_resume = False
             config.source_path = source
+            config.start_stage = gui_start_stage if is_resume_source else batch_start_stage
             try:
-                process_each()
+                process_each(cancellation_event)
+                raise_if_cancelled(cancellation_event)
             except preflight.DependencyPreflightError:
                 raise
-            except (RuntimeError, ValueError, FileExistsError, subprocess.CalledProcessError):
+            except (MKVCreationError, SRTCreationError) as error:
+                raise BatchProcessingError(source, error, batch_sources) from error
+            except FileExistsError:
+                continue
+            except (RuntimeError, ValueError, subprocess.CalledProcessError):
+                raise_if_cancelled(cancellation_event)
+                if is_resume_source:
+                    raise
                 continue
             finally:
                 config.source_path = None
-                config.start_stage = gui_start_stage
+                config.start_stage = batch_start_stage
+
+        if waiting_for_resume:
+            raise FileNotFoundError(f"Could not resume batch source: {resume_source_path}")
 
     else:
-        process_each()
+        process_each(cancellation_event)
 
 
-def process_each() -> None:
+def process_each(cancellation_event: Event | None = None) -> None:
+    raise_if_cancelled(cancellation_event)
     print(f"\nProcessing {config.source_path}")
     preflight.verify_runtime_ready()
+    raise_if_cancelled(cancellation_event)
     disc_info = get_disc_and_mvc_video_info()
+    raise_if_cancelled(cancellation_event)
     output_folder = prepare_output_folder_for_source(disc_info.name)
 
     tmp_folder = config.output_root_path / "temp_files"
@@ -68,29 +129,42 @@ def process_each() -> None:
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
 
+    raise_if_cancelled(cancellation_event)
     mkv_output_path = create_mkv_file(output_folder, disc_info, config.language_code)
+    raise_if_cancelled(cancellation_event)
     disc_info.color_depth = get_video_color_depth(mkv_output_path)
+    raise_if_cancelled(cancellation_event)
     crop_params = detect_crop_parameters(mkv_output_path)
+    raise_if_cancelled(cancellation_event)
     audio_output_path, video_output_path = create_mvc_and_audio(disc_info.name, mkv_output_path, output_folder)
+    raise_if_cancelled(cancellation_event)
     create_srt_from_mkv(mkv_output_path, output_folder)
+    raise_if_cancelled(cancellation_event)
     left_output_path, right_output_path = create_left_right_files(
         disc_info, output_folder, video_output_path, crop_params
     )
+    raise_if_cancelled(cancellation_event)
     mv_hevc_path = create_mv_hevc_file(left_output_path, right_output_path, output_folder, disc_info)
+    raise_if_cancelled(cancellation_event)
     mv_hevc_path = create_upscaled_file(mv_hevc_path)
 
+    raise_if_cancelled(cancellation_event)
     audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder)
+    raise_if_cancelled(cancellation_event)
     muxed_output_path = create_muxed_file(
         audio_output_path,
         mv_hevc_path,
         output_folder,
         disc_info.name,
     )
+    raise_if_cancelled(cancellation_event)
     move_file_to_output_root_folder(muxed_output_path)
 
+    raise_if_cancelled(cancellation_event)
     if not config.keep_files:
         remove_output_folder_if_safe(tmp_folder)
 
+    raise_if_cancelled(cancellation_event)
     if config.remove_original:
         remove_original_source(completed_path)
 
@@ -109,12 +183,32 @@ def remove_original_source(completed_path: Path) -> bool:
     return True
 
 
-def start_process(gui_start_stage: Stage = config.start_stage) -> None:
+def start_process(
+    gui_start_stage: Stage | None = None,
+    cancellation_event: Event | None = None,
+    *,
+    resume_source_path: Path | None = None,
+    batch_start_stage: Stage | None = None,
+    batch_sources: tuple[Path, ...] | None = None,
+) -> None:
+    gui_start_stage = gui_start_stage or config.start_stage
     if config.keep_awake:
         with keep.running():
-            process(gui_start_stage)
+            process(
+                gui_start_stage,
+                cancellation_event,
+                resume_source_path=resume_source_path,
+                batch_start_stage=batch_start_stage,
+                batch_sources=batch_sources,
+            )
     else:
-        process(gui_start_stage)
+        process(
+            gui_start_stage,
+            cancellation_event,
+            resume_source_path=resume_source_path,
+            batch_start_stage=batch_start_stage,
+            batch_sources=batch_sources,
+        )
 
 
 if __name__ == "__main__":

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -10,7 +10,7 @@ from bd_to_avp.vendor.pgsrip import Mkv, Options, pgsrip
 from bd_to_avp.vendor.pgsrip.mkv import MkvPgs
 
 from bd_to_avp.modules.config import config, Stage
-from bd_to_avp.modules.command import Spinner
+from bd_to_avp.modules.command import get_spinner_update_func, Spinner
 
 
 class SRTCreationError(Exception):
@@ -41,7 +41,8 @@ def extract_subtitle_to_srt(mkv_path: Path, output_path: Path | None = None) -> 
     sub_options = subtitle_rip_options()
 
     spinner = Spinner("Sup subtitles extraction and SRT conversion")
-    spinner_thread = threading.Thread(target=spinner.start)
+    spinner_update_func = get_spinner_update_func()
+    spinner_thread = threading.Thread(target=spinner.start, args=(spinner_update_func,))
     spinner_thread.start()
 
     try:
@@ -60,7 +61,7 @@ def extract_subtitle_to_srt(mkv_path: Path, output_path: Path | None = None) -> 
 
             mark_forced_srt_files(selected_subtitle_tracks)
     finally:
-        spinner.stop()
+        spinner.stop(spinner_update_func)
         spinner_thread.join()
 
 

--- a/tests/test_gui_processing.py
+++ b/tests/test_gui_processing.py
@@ -1,40 +1,582 @@
+import os
+import sys
+import threading
+import time
 import unittest
-from unittest.mock import patch
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+from unittest.mock import Mock, patch
 
-from bd_to_avp.gui.processing import ProcessingThread
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from bd_to_avp.gui.main_window import MainWindow
+from bd_to_avp.gui.processing import (
+    ProcessingConfigSnapshot,
+    ProcessingController,
+    ProcessingOutcome,
+    ProcessingOutcomeKind,
+    ProcessingRequest,
+    ProcessingThread,
+    ThreadScopedOutput,
+)
+from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.command import get_spinner_update_func
+from bd_to_avp.modules.disc import MKVCreationError
+from bd_to_avp.modules.process import BatchProcessingError
+from bd_to_avp.modules.sub import SRTCreationError
+
+
+class ProcessingRequestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.request = ProcessingRequest(
+            start_stage=Stage.CREATE_MKV,
+            overwrite=False,
+            continue_on_error=False,
+            skip_subtitles=False,
+        )
+
+    def test_mkv_continuation_preserves_prior_policy(self) -> None:
+        failed_source = Path("failed.m2ts")
+        continuation = (
+            ProcessingRequest(
+                start_stage=self.request.start_stage,
+                overwrite=self.request.overwrite,
+                continue_on_error=self.request.continue_on_error,
+                skip_subtitles=self.request.skip_subtitles,
+                resume_source_path=failed_source,
+            )
+            .overwrite_existing_output()
+            .continue_after_mkv_error()
+        )
+
+        self.assertEqual(continuation.start_stage, Stage.EXTRACT_MVC_AND_AUDIO)
+        self.assertTrue(continuation.overwrite)
+        self.assertTrue(continuation.continue_on_error)
+        self.assertFalse(continuation.skip_subtitles)
+        self.assertEqual(continuation.batch_start_stage, Stage.CREATE_MKV)
+        self.assertEqual(continuation.resume_source_path, failed_source)
+        self.assertEqual(self.request.start_stage, Stage.CREATE_MKV)
+
+    def test_srt_continuations_select_skip_or_continue_policy(self) -> None:
+        skip = self.request.continue_after_srt_error(skip_subtitles=True)
+        continue_on_error = self.request.continue_after_srt_error(skip_subtitles=False)
+
+        self.assertEqual(skip.start_stage, Stage.CREATE_LEFT_RIGHT_FILES)
+        self.assertTrue(skip.skip_subtitles)
+        self.assertFalse(skip.continue_on_error)
+        self.assertEqual(continue_on_error.start_stage, Stage.CREATE_LEFT_RIGHT_FILES)
+        self.assertFalse(continue_on_error.skip_subtitles)
+        self.assertTrue(continue_on_error.continue_on_error)
+
+    def test_config_snapshot_restores_all_run_values(self) -> None:
+        source_path = Path("original.mkv")
+        with (
+            patch.object(config, "source_path", source_path),
+            patch.object(config, "remove_original", False),
+            patch.object(config, "start_stage", Stage.CREATE_MKV),
+            patch.object(config, "overwrite", False),
+            patch.object(config, "continue_on_error", False),
+            patch.object(config, "skip_subtitles", False),
+        ):
+            snapshot = ProcessingConfigSnapshot.from_config()
+            request = ProcessingRequest(
+                start_stage=Stage.EXTRACT_SUBTITLES,
+                overwrite=True,
+                continue_on_error=True,
+                skip_subtitles=False,
+                config_snapshot=snapshot,
+            )
+            config.source_path = Path("replacement.mkv")
+            config.remove_original = True
+
+            request.apply()
+
+            self.assertEqual(config.source_path, source_path)
+            self.assertFalse(config.remove_original)
+            self.assertEqual(config.start_stage, Stage.EXTRACT_SUBTITLES)
+            self.assertTrue(config.overwrite)
 
 
 class ProcessingThreadTests(unittest.TestCase):
-    def test_processing_exception_emits_error_signal(self) -> None:
-        thread = ProcessingThread()
-        errors: list[Exception] = []
-        failures: list[bool] = []
-        thread.error_occurred.connect(errors.append)  # type: ignore[arg-type]
-        thread.process_failed.connect(lambda: failures.append(True))
+    def setUp(self) -> None:
+        self.request = ProcessingRequest(
+            start_stage=Stage.EXTRACT_SUBTITLES,
+            overwrite=True,
+            continue_on_error=False,
+            skip_subtitles=False,
+        )
 
-        with (
-            patch("bd_to_avp.gui.processing.start_process", side_effect=StopIteration("missing subtitle output")),
-            patch("bd_to_avp.gui.processing.Spinner.stop_all"),
-        ):
+    def test_thread_runs_explicit_request_and_restores_stdout(self) -> None:
+        runner = Mock()
+        previous_stdout = sys.stdout
+        thread = ProcessingThread(self.request, process_runner=runner, stop_runner=Mock())
+
+        with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
             thread.run()
 
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], StopIteration)
-        self.assertEqual(failures, [])
+        runner.assert_called_once_with(self.request)
+        self.assertEqual(thread.outcome, ProcessingOutcome(ProcessingOutcomeKind.COMPLETED))
+        self.assertIs(sys.stdout, previous_stdout)
 
-    def test_non_exception_worker_exit_emits_failure_signal(self) -> None:
-        thread = ProcessingThread()
-        failures: list[bool] = []
-        thread.process_failed.connect(lambda: failures.append(True))
+    def test_processing_exception_is_stored_as_error_outcome(self) -> None:
+        error = RuntimeError("missing subtitle output")
+        thread = ProcessingThread(
+            self.request,
+            process_runner=Mock(side_effect=error),
+            stop_runner=Mock(),
+        )
 
+        with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
+            thread.run()
+
+        self.assertEqual(thread.outcome, ProcessingOutcome(ProcessingOutcomeKind.ERROR, error))
+
+    def test_known_processing_errors_have_specific_outcomes(self) -> None:
+        cases = (
+            (MKVCreationError("mkv"), ProcessingOutcomeKind.MKV_CREATION_ERROR),
+            (SRTCreationError("srt"), ProcessingOutcomeKind.SRT_CREATION_ERROR),
+            (FileExistsError("file"), ProcessingOutcomeKind.FILE_EXISTS_ERROR),
+        )
+
+        for error, expected_kind in cases:
+            with self.subTest(expected_kind=expected_kind):
+                thread = ProcessingThread(
+                    self.request,
+                    process_runner=Mock(side_effect=error),
+                    stop_runner=Mock(),
+                )
+                with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
+                    thread.run()
+                self.assertEqual(thread.outcome, ProcessingOutcome(expected_kind, error))
+
+    def test_batch_error_source_is_preserved_in_outcome(self) -> None:
+        source_path = Path("failed.m2ts")
+        batch_sources = (Path("before.m2ts"), source_path, Path("after.m2ts"))
+        error = MKVCreationError("mkv")
+        thread = ProcessingThread(
+            self.request,
+            process_runner=Mock(side_effect=BatchProcessingError(source_path, error, batch_sources)),
+            stop_runner=Mock(),
+        )
+
+        with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
+            thread.run()
+
+        self.assertEqual(
+            thread.outcome,
+            ProcessingOutcome(ProcessingOutcomeKind.MKV_CREATION_ERROR, error, source_path, batch_sources),
+        )
+
+    def test_non_exception_worker_exit_is_stored_as_failed_outcome(self) -> None:
+        error = SystemExit("boom")
+        thread = ProcessingThread(
+            self.request,
+            process_runner=Mock(side_effect=error),
+            stop_runner=Mock(),
+        )
+
+        with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
+            thread.run()
+
+        self.assertEqual(thread.outcome, ProcessingOutcome(ProcessingOutcomeKind.FAILED, error))
+
+    def test_cancel_requests_cooperative_stop_without_running_work(self) -> None:
+        runner = Mock()
+        stop_runner = Mock()
+        thread = ProcessingThread(self.request, process_runner=runner, stop_runner=stop_runner)
+
+        thread.request_cancel()
+        thread.request_cancel()
+        with patch("bd_to_avp.gui.processing.Spinner.stop_all"):
+            thread.run()
+
+        stop_runner.assert_called_once_with()
+        runner.assert_not_called()
+        self.assertEqual(thread.outcome, ProcessingOutcome(ProcessingOutcomeKind.CANCELLED))
+
+    def test_cancel_during_real_thread_run_wins_over_completion(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(_request: ProcessingRequest) -> None:
+            started.set()
+            release.wait(timeout=2)
+
+        thread = ProcessingThread(self.request, process_runner=runner, stop_runner=release.set)
+        thread.start()
+        self.assertTrue(started.wait(timeout=1))
+
+        thread.request_cancel()
+        self.assertTrue(thread.wait(2000))
+
+        self.assertEqual(thread.outcome, ProcessingOutcome(ProcessingOutcomeKind.CANCELLED))
+        self.assertTrue(thread.cancel_requested)
+
+    def test_stdout_router_only_redirects_owner_thread(self) -> None:
+        owner_stream = StringIO()
+        fallback_stream = StringIO()
+        router = ThreadScopedOutput(threading.get_ident(), owner_stream, fallback_stream)
+        other_thread = threading.Thread(target=router.write, args=("other",))
+
+        router.write("owner")
+        other_thread.start()
+        other_thread.join()
+
+        self.assertEqual(owner_stream.getvalue(), "owner")
+        self.assertEqual(fallback_stream.getvalue(), "other")
+
+    def test_stdout_router_exposes_owner_writer_for_child_threads(self) -> None:
+        owner_stream = StringIO()
+        fallback_stream = StringIO()
+        router = ThreadScopedOutput(threading.get_ident(), owner_stream, fallback_stream)
+        owner_writer = router.current_writer()
+        child_thread = threading.Thread(target=owner_writer, args=("spinner",))
+
+        child_thread.start()
+        child_thread.join()
+
+        self.assertEqual(owner_stream.getvalue(), "spinner")
+        self.assertEqual(fallback_stream.getvalue(), "")
+
+    def test_spinner_helper_captures_worker_output_writer(self) -> None:
+        owner_stream = StringIO()
+        fallback_stream = StringIO()
+        router = ThreadScopedOutput(threading.get_ident(), owner_stream, fallback_stream)
+
+        with patch("bd_to_avp.modules.command.sys.stdout", router):
+            update_func = get_spinner_update_func()
+
+        self.assertIsNotNone(update_func)
+        child_thread = threading.Thread(target=update_func, args=("spinner",))
+        child_thread.start()
+        child_thread.join()
+
+        self.assertEqual(owner_stream.getvalue(), "spinner")
+        self.assertEqual(fallback_stream.getvalue(), "")
+
+
+class ProcessingControllerTests(unittest.TestCase):
+    app: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = QApplication.instance()
+        cls.app = app if isinstance(app, QApplication) else QApplication([])
+
+    def setUp(self) -> None:
+        self.config_snapshot = ProcessingConfigSnapshot.from_config()
+        self.request = ProcessingRequest(
+            start_stage=Stage.CREATE_MKV,
+            overwrite=False,
+            continue_on_error=False,
+            skip_subtitles=False,
+        )
+        self.threads: list[_FakeProcessingThread] = []
+
+    def tearDown(self) -> None:
+        self.config_snapshot.apply()
+
+    def make_thread(self, request: ProcessingRequest, parent: QObject | None = None) -> "_FakeProcessingThread":
+        thread = _FakeProcessingThread(request, parent)
+        self.threads.append(thread)
+        return thread
+
+    def test_controller_owns_one_attempt_and_dispatches_after_finish(self) -> None:
+        controller = ProcessingController()
+        completions: list[ProcessingRequest] = []
+        controller.process_completed.connect(completions.append)  # type: ignore[arg-type]
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            self.assertTrue(controller.start(self.request))
+            self.assertTrue(controller.is_active)
+            self.assertFalse(controller.start(self.request.overwrite_existing_output()))
+            first_thread = self.threads[0]
+            self.assertTrue(first_thread.started)
+
+            first_thread.finish(ProcessingOutcome(ProcessingOutcomeKind.COMPLETED))
+
+            self.assertFalse(controller.is_active)
+            self.assertEqual(completions, [self.request])
+            self.assertTrue(first_thread.deleted)
+            self.assertTrue(controller.start(self.request.overwrite_existing_output()))
+            self.assertIsNot(self.threads[1], first_thread)
+
+    def test_controller_cancel_targets_only_active_attempt(self) -> None:
+        controller = ProcessingController()
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            self.assertFalse(controller.request_cancel())
+            controller.start(self.request)
+            self.assertTrue(controller.request_cancel())
+
+        self.assertTrue(self.threads[0].cancel_requested)
+
+    def test_controller_late_cancel_overrides_completed_outcome(self) -> None:
+        controller = ProcessingController()
+        cancellations: list[ProcessingRequest] = []
+        completions: list[ProcessingRequest] = []
+        controller.process_cancelled.connect(cancellations.append)  # type: ignore[arg-type]
+        controller.process_completed.connect(completions.append)  # type: ignore[arg-type]
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            controller.request_cancel()
+            self.threads[0].finish(ProcessingOutcome(ProcessingOutcomeKind.COMPLETED))
+
+        self.assertEqual(cancellations, [self.request])
+        self.assertEqual(completions, [])
+
+    def test_controller_shutdown_waits_for_active_attempt(self) -> None:
+        controller = ProcessingController()
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            self.assertTrue(controller.shutdown(timeout_ms=250))
+
+        thread = self.threads[0]
+        self.assertTrue(thread.cancel_requested)
+        self.assertEqual(thread.wait_timeouts, [250])
+        self.assertTrue(thread.deleted)
+        self.assertFalse(controller.is_active)
+
+    def test_controller_shutdown_timeout_keeps_active_attempt(self) -> None:
+        controller = ProcessingController()
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            thread = self.threads[0]
+            thread.wait_result = False
+            self.assertFalse(controller.shutdown(timeout_ms=250))
+
+        self.assertTrue(thread.cancel_requested)
+        self.assertEqual(thread.wait_timeouts, [250])
+        self.assertFalse(thread.deleted)
+        self.assertTrue(controller.is_active)
+
+    def test_controller_relays_progress_and_error_outcome(self) -> None:
+        controller = ProcessingController()
+        progress: list[str] = []
+        errors: list[tuple[ProcessingRequest, BaseException]] = []
+        controller.progress_updated.connect(progress.append)  # type: ignore[arg-type]
+        controller.error_occurred.connect(lambda request, error: errors.append((request, error)))
+        error = RuntimeError("failed")
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            self.threads[0].progress_updated.emit("working")
+            self.threads[0].finish(ProcessingOutcome(ProcessingOutcomeKind.ERROR, error))
+
+        self.assertEqual(progress, ["working"])
+        self.assertEqual(errors, [(self.request, error)])
+
+    def test_controller_adds_failed_batch_source_to_emitted_request(self) -> None:
+        controller = ProcessingController()
+        failures: list[tuple[ProcessingRequest, BaseException]] = []
+        controller.mkv_creation_error.connect(lambda request, error: failures.append((request, error)))
+        source_path = Path("failed.m2ts")
+        batch_sources = (Path("before.m2ts"), source_path, Path("after.m2ts"))
+        error = MKVCreationError("failed")
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            self.threads[0].finish(
+                ProcessingOutcome(
+                    ProcessingOutcomeKind.MKV_CREATION_ERROR,
+                    error,
+                    source_path,
+                    batch_sources,
+                )
+            )
+
+        emitted_request, emitted_error = failures[0]
+        self.assertEqual(emitted_request.resume_source_path, source_path)
+        self.assertEqual(emitted_request.batch_sources, batch_sources)
+        self.assertEqual(emitted_request.batch_start_stage, self.request.start_stage)
+        self.assertIs(emitted_error, error)
+
+    def test_real_controller_cancel_clears_active_thread(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(_request: ProcessingRequest) -> None:
+            started.set()
+            release.wait(timeout=2)
+
+        def make_real_thread(request: ProcessingRequest, parent: QObject | None = None) -> ProcessingThread:
+            return ProcessingThread(request, parent, process_runner=runner, stop_runner=release.set)
+
+        controller = ProcessingController()
+        cancellations: list[ProcessingRequest] = []
+        controller.process_cancelled.connect(cancellations.append)  # type: ignore[arg-type]
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=make_real_thread):
+            self.assertTrue(controller.start(self.request))
+            self.assertTrue(started.wait(timeout=1))
+            self.assertTrue(controller.request_cancel())
+
+            deadline = time.monotonic() + 2
+            while controller.is_active and time.monotonic() < deadline:
+                self.app.processEvents()
+                time.sleep(0.01)
+
+        self.assertFalse(controller.is_active)
+        self.assertEqual(cancellations, [self.request])
+
+
+class MainWindowProcessingLifecycleTests(unittest.TestCase):
+    app: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = QApplication.instance()
+        cls.app = app if isinstance(app, QApplication) else QApplication([])
+        cls.app.setApplicationDisplayName("BD_to_AVP Test")
+
+    def setUp(self) -> None:
+        self.config_snapshot = ProcessingConfigSnapshot.from_config()
+        self.window = MainWindow()
+        self.request = ProcessingRequest(
+            start_stage=Stage.CREATE_LEFT_RIGHT_FILES,
+            overwrite=True,
+            continue_on_error=False,
+            skip_subtitles=False,
+        )
+
+    def tearDown(self) -> None:
+        self.window.close()
+        self.config_snapshot.apply()
+
+    def test_continuation_starts_explicit_request_and_updates_button(self) -> None:
+        with patch.object(self.window.processing_controller, "start", return_value=True) as start:
+            self.window.start_processing(is_continuing=True, request=self.request)
+
+        start.assert_called_once_with(self.request)
+        self.assertTrue(self.window.process_button.isEnabled())
+        self.assertEqual(self.window.process_button.text(), self.window.STOP_PROCESSING_TEXT)
+        self.assertFalse(self.window.load_config_button.isEnabled())
+        self.assertFalse(self.window.save_config_button.isEnabled())
+
+    def test_continuation_requires_explicit_request(self) -> None:
+        with self.assertRaisesRegex(ValueError, "continuation request"):
+            self.window.start_processing(is_continuing=True)
+
+    def test_stop_waits_for_cancelled_outcome_before_reset(self) -> None:
+        self.window.process_start_time = datetime.now()
+        with patch.object(self.window.processing_controller, "request_cancel", return_value=True):
+            self.window.stop_processing()
+
+        self.assertFalse(self.window.process_button.isEnabled())
+        self.assertEqual(self.window.process_button.text(), self.window.STOPPING_PROCESSING_TEXT)
+
+        self.window.processing_cancelled(self.request)
+
+        self.assertTrue(self.window.process_button.isEnabled())
+        self.assertEqual(self.window.process_button.text(), self.window.START_PROCESSING_TEXT)
+        self.assertIn("Processing stopped", self.window.processing_output_textedit.toPlainText())
+
+    def test_process_button_stops_real_active_attempt(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(_request: ProcessingRequest) -> None:
+            started.set()
+            release.wait(timeout=2)
+
+        def make_thread(request: ProcessingRequest, parent: QObject | None = None) -> ProcessingThread:
+            return ProcessingThread(request, parent, process_runner=runner, stop_runner=release.set)
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=make_thread):
+            self.window.process_start_time = datetime.now()
+            self.window.start_processing(is_continuing=True, request=self.request)
+            self.assertTrue(started.wait(timeout=1))
+
+            self.window.process_button.click()
+            self.assertEqual(self.window.process_button.text(), self.window.STOPPING_PROCESSING_TEXT)
+
+            deadline = time.monotonic() + 2
+            while self.window.processing_controller.is_active and time.monotonic() < deadline:
+                self.app.processEvents()
+                time.sleep(0.01)
+
+        self.assertFalse(self.window.processing_controller.is_active)
+        self.assertEqual(self.window.process_button.text(), self.window.START_PROCESSING_TEXT)
+        self.assertIn("Processing stopped", self.window.processing_output_textedit.toPlainText())
+
+    def test_mkv_error_continuation_starts_transformed_request(self) -> None:
+        error = MKVCreationError("mkv failed")
         with (
-            patch("bd_to_avp.gui.processing.start_process", side_effect=SystemExit("boom")),
-            patch("bd_to_avp.gui.processing.Spinner.stop_all"),
+            patch.object(self.window, "notify_user_with_sound"),
+            patch.object(QMessageBox, "critical", return_value=QMessageBox.StandardButton.Yes),
+            patch.object(self.window, "start_processing") as start,
         ):
-            with self.assertRaises(SystemExit):
-                thread.run()
+            self.window.handle_mkv_creation_error(self.request, error)
 
-        self.assertEqual(failures, [True])
+        start.assert_called_once_with(
+            is_continuing=True,
+            request=self.request.continue_after_mkv_error(),
+        )
+
+    def test_file_exists_continuation_starts_transformed_request(self) -> None:
+        error = FileExistsError("exists")
+        with (
+            patch.object(self.window, "notify_user_with_sound"),
+            patch.object(QMessageBox, "critical", return_value=QMessageBox.StandardButton.Yes),
+            patch.object(self.window, "start_processing") as start,
+        ):
+            self.window.handle_file_exists_error(self.request, error)
+
+        start.assert_called_once_with(
+            is_continuing=True,
+            request=self.request.overwrite_existing_output(),
+        )
+
+    def test_close_is_blocked_until_processing_shutdown_finishes(self) -> None:
+        event = QCloseEvent()
+        with (
+            patch.object(self.window.processing_controller, "shutdown", return_value=False),
+            patch.object(QMessageBox, "warning") as warning,
+        ):
+            self.window.closeEvent(event)
+
+        self.assertFalse(event.isAccepted())
+        warning.assert_called_once()
+
+
+class _FakeProcessingThread(QObject):
+    progress_updated = Signal(str)
+    finished = Signal()
+
+    def __init__(self, request: ProcessingRequest, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self.request = request
+        self.outcome: ProcessingOutcome | None = None
+        self.started = False
+        self.cancel_requested = False
+        self.deleted = False
+        self.wait_timeouts: list[int] = []
+        self.wait_result = True
+
+    def start(self) -> None:
+        self.started = True
+
+    def request_cancel(self) -> None:
+        self.cancel_requested = True
+
+    def deleteLater(self) -> None:
+        self.deleted = True
+
+    def wait(self, timeout_ms: int) -> bool:
+        self.wait_timeouts.append(timeout_ms)
+        return self.wait_result
+
+    def finish(self, outcome: ProcessingOutcome) -> None:
+        self.outcome = outcome
+        self.finished.emit()
 
 
 if __name__ == "__main__":

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -1,11 +1,13 @@
 import tempfile
+import threading
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from bd_to_avp import preflight
 from bd_to_avp.modules import process
 from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
+from bd_to_avp.modules.disc import MKVCreationError
 from bd_to_avp.modules.file import (
     move_file_to_output_root_folder,
     prepare_output_folder_for_source,
@@ -25,6 +27,98 @@ class ProcessPreflightTests(unittest.TestCase):
                 self.assertRaisesRegex(preflight.DependencyPreflightError, "missing tool"),
             ):
                 process.process(Stage.CREATE_MKV)
+
+    def test_batch_processing_stops_after_cancellation(self) -> None:
+        cancellation_event = threading.Event()
+        processed_sources: list[Path | None] = []
+
+        def cancel_after_first_source(_cancellation_event: threading.Event | None = None) -> None:
+            processed_sources.append(process.config.source_path)
+            cancellation_event.set()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir)
+            (source_folder / "first.m2ts").touch()
+            (source_folder / "second.m2ts").touch()
+
+            with (
+                patch.object(process.config, "source_folder_path", source_folder),
+                patch.object(process, "process_each", side_effect=cancel_after_first_source),
+                self.assertRaises(process.ProcessingCancelled),
+            ):
+                process.process(Stage.CREATE_MKV, cancellation_event)
+
+        self.assertEqual(len(processed_sources), 1)
+
+    def test_batch_resume_stage_only_applies_to_failed_source(self) -> None:
+        processed_sources: list[tuple[Path | None, Stage]] = []
+
+        def record_source(_cancellation_event: threading.Event | None = None) -> None:
+            processed_sources.append((process.config.source_path, process.config.start_stage))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir)
+            first_source = source_folder / "first.m2ts"
+            failed_source = source_folder / "failed.m2ts"
+            next_source = source_folder / "next.m2ts"
+            for source in (first_source, failed_source, next_source):
+                source.touch()
+            batch_folder = Mock()
+            batch_folder.rglob.return_value = [next_source, failed_source, first_source]
+            batch_sources = (first_source, failed_source, next_source)
+
+            with (
+                patch.object(process.config, "source_folder_path", batch_folder),
+                patch.object(process, "process_each", side_effect=record_source),
+            ):
+                process.process(
+                    Stage.EXTRACT_MVC_AND_AUDIO,
+                    resume_source_path=failed_source,
+                    batch_start_stage=Stage.CREATE_MKV,
+                    batch_sources=batch_sources,
+                )
+
+        self.assertEqual(
+            processed_sources,
+            [
+                (failed_source, Stage.EXTRACT_MVC_AND_AUDIO),
+                (next_source, Stage.CREATE_MKV),
+            ],
+        )
+
+    def test_batch_source_manifest_is_sorted_once(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir)
+            first_source = source_folder / "a.m2ts"
+            second_source = source_folder / "b.mkv"
+            third_source = source_folder / "c.iso"
+            for source in (first_source, second_source, third_source):
+                source.touch()
+            batch_folder = Mock()
+            batch_folder.rglob.return_value = [third_source, first_source, second_source]
+
+            batch_sources = process.find_batch_sources(batch_folder)
+
+        self.assertEqual(batch_sources, (first_source, second_source, third_source))
+
+    def test_batch_error_records_failed_source_for_continuation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "failed.m2ts"
+            source.touch()
+            batch_folder = Mock()
+            batch_folder.rglob.return_value = [source]
+            error = MKVCreationError("failed")
+
+            with (
+                patch.object(process.config, "source_folder_path", batch_folder),
+                patch.object(process, "process_each", side_effect=error),
+                self.assertRaises(process.BatchProcessingError) as raised,
+            ):
+                process.process(Stage.CREATE_MKV)
+
+        self.assertEqual(raised.exception.source_path, source)
+        self.assertIs(raised.exception.error, error)
+        self.assertEqual(raised.exception.batch_sources, (source,))
 
     def test_direct_pipeline_reused_file_source_is_not_cleanup_owned(self) -> None:
         with (


### PR DESCRIPTION
## Summary
- replace the reused GUI processing thread with immutable requests/outcomes and a one-attempt `ProcessingController`
- snapshot run configuration, isolate worker stdout routing, and guard config load/save while a job is active
- add cooperative cancellation, safe shutdown handling, and deterministic folder-batch continuation from the failed source
- preserve spinner updates from helper threads and document the GUI lifecycle behavior

## Validation
- `uv run python -m unittest discover -s tests -t .` — 217 passed
- `uv run ruff format --check .`
- `uv run ruff check --no-fix .`
- `uv run mypy bd_to_avp`
- import smoke and `uv run bd-to-avp --help`
- `uv build`
- PyCharm changed-files inspection — clean, 0 findings
- final independent agent reviews — no blockers

## Review Notes
The change is split into two commits: the cancellable batch-processing context first, then the GUI lifecycle boundary and regression coverage.

Refs #111
