### PR TITLE
docs: correct Sparkle build and appcast guidance

### DIFF
--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -127,15 +127,19 @@ integration described in [sparkle-updates.md](sparkle-updates.md).
 1. Install an older signed/notarized DMG build in `/Applications` and launch it
    from there. Do not test the update while running from the mounted DMG.
 2. Confirm Help > `Check for Updates…` opens Sparkle's standard update UI.
-3. Confirm the candidate version, release notes, and download size match the
-   GitHub Release DMG.
-4. Install the update, relaunch, and confirm the displayed and packaged versions
+3. Inspect the selected appcast item and confirm its `sparkle:version`,
+   `sparkle:shortVersionString`, release-notes content or URL, enclosure URL, and
+   enclosure length match the candidate and published GitHub Release DMG, and
+   that its `sparkle:edSignature` is present and non-empty.
+4. Confirm Sparkle's update UI displays the candidate version and release notes
+   from that same appcast item.
+5. Install the update, relaunch, and confirm the displayed and packaged versions
    match the candidate.
-5. Repeat with an unavailable feed and an intentionally invalid test signature;
+6. Repeat with an unavailable feed and an intentionally invalid test signature;
    the installed app must remain unchanged.
-6. Start media processing and confirm installation/relaunch is postponed until
+7. Start media processing and confirm installation/relaunch is postponed until
    processing is idle.
-7. Verify the manual GitHub Releases download remains usable as the recovery
+8. Verify the manual GitHub Releases download remains usable as the recovery
    path.
 
 ## Follow-Up Routing

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -53,8 +53,10 @@ Research for #120 used Briefcase 0.4.3 and Sparkle 2.9.4.
 - Briefcase 0.4.3 signs Mach-O files, embedded frameworks, and embedded apps,
   but does not treat Sparkle's nested `.xpc` services as bundle-signing targets.
   #163 must augment the signing path and prove the complete inside-out order.
-- Briefcase supports arbitrary macOS Info.plist entries and a dedicated integer
-  `build` value for `CFBundleVersion`.
+- Briefcase 0.4.3 supports arbitrary macOS Info.plist entries through its
+  `macOS.info` map. Its v0.4.3 app template hard-codes `CFBundleVersion = 1`
+  and does not consume a `build` value, so #163 must override that plist key
+  explicitly or first upgrade Briefcase and prove the generated value.
 
 These checks prove the integration is feasible. They do not replace a signed,
 notarized, installed-app update test.
@@ -102,9 +104,24 @@ after that nested-bundle order is proven.
 `CFBundleShortVersionString` remains the human release version, such as
 `0.2.144` or `0.2.144rc1`.
 
-`CFBundleVersion` must be a repository-tracked monotonic integer supplied
-through Briefcase's `build` setting. It must increment for every published
-direct-DMG build, including prereleases, independently of the human version.
+`CFBundleVersion` must be a repository-tracked monotonic integer string. With
+the currently locked Briefcase 0.4.3, #163 must set it explicitly through the
+macOS Info.plist map, for example:
+
+```toml
+[tool.briefcase.app.bd-to-avp.macOS.info]
+CFBundleVersion = "144"
+```
+
+It must increment for every published direct-DMG build, including prereleases,
+independently of the human version. If #163 upgrades Briefcase instead, the
+generated app must prove that the replacement configuration writes the expected
+`CFBundleVersion` before this direct override can be removed.
+
+Because the v0.4.3 template emits its default before custom `info` entries,
+implementation issue #163 must inspect the generated plist with
+`plutil -extract CFBundleVersion raw <Info.plist>` and fail unless the resolved
+value exactly matches the repository counter.
 
 The workflow must fail before release publication if the build number is
 missing, still `1`, non-numeric, duplicated by an existing release, or not newer


### PR DESCRIPTION
## Summary

- replace the nonexistent Briefcase 0.4.3 `build` mechanism with an explicit macOS `info` override for `CFBundleVersion`
- require post-build `plutil` verification that the resolved bundle version matches the repository counter
- validate release notes and enclosure metadata from the selected appcast item, including a non-empty `sparkle:edSignature`

## Context

This addresses findings `f1` and `f2` from post-merge Auto Review run `d2294126-1bc1-4e5f-8bdc-0696f101d8c2` against PR #166. Issue #120 was reopened until this correction lands.

## Validation

- `markdownlint-cli2 docs/sparkle-updates.md docs/release-smoke.md`
- `prettier --check docs/sparkle-updates.md docs/release-smoke.md`
- `git diff --check`
- verified Briefcase 0.4.3's generated `CFBundleVersion = 1`, v0.4.3 template behavior, and `macOS.info` override semantics
- two-agent focused review; all actionable P0-P2 findings resolved

Runtime tests were not run because this is a documentation-only correction.

Tracks #120.
