### PR TITLE
ci: add Sparkle Pages foundation

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -9,7 +9,11 @@
     "main": {
       "system": "classic",
       "requiresPullRequest": true,
-      "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
+      "requiredStatusChecks": [
+        "validate",
+        "Analyze (actions)",
+        "Analyze (python)"
+      ],
       "requiredApprovals": 0,
       "enforceAdmins": true,
       "blocksForcePushes": true,
@@ -35,6 +39,7 @@
     "lockfile": "uv.lock",
     "releaseWorkflows": [
       ".github/workflows/briefcase.yml",
+      ".github/workflows/sparkle-pages.yml",
       ".github/workflows/publish-to-pypi.yml"
     ]
   },
@@ -80,13 +85,14 @@
     "CI",
     "CodeQL",
     "Package with Briefcase and Create Release",
+    "Publish Sparkle Appcast",
     "Update FFmpeg Vendor Pins",
     "Publish Python distribution to PyPI"
   ],
   "requiredStatusChecks": ["validate", "Analyze (actions)", "Analyze (python)"],
   "qaLabels": [],
   "deployLabels": [],
-  "healthUrls": [],
+  "healthUrls": ["https://cbusillo.github.io/BD_to_AVP/appcast.xml"],
   "relatedRepos": [],
   "githubSignals": {
     "postMerge": {

--- a/.github/workflows/sparkle-pages.yml
+++ b/.github/workflows/sparkle-pages.yml
@@ -1,0 +1,52 @@
+---
+name: Publish Sparkle Appcast
+
+"on":
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/sparkle-pages.yml
+      - sparkle-feed/**
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+      - name: Validate appcast XML
+        run: |
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          ET.parse("sparkle-feed/appcast.xml")
+          PY
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: sparkle-feed
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/sparkle-key-custody.md
+++ b/docs/sparkle-key-custody.md
@@ -1,0 +1,131 @@
+# Sparkle Key Custody and Feed Operations
+
+## Purpose
+
+This runbook owns the production Sparkle EdDSA key boundary and the stable
+GitHub Pages endpoint for direct-DMG updates. It complements the architecture in
+[sparkle-updates.md](sparkle-updates.md).
+
+The private key must never be committed, copied into issue or pull-request text,
+printed in logs, or uploaded as a workflow artifact.
+
+## Provisioned Infrastructure
+
+- Sparkle key account: `cbusillo-BD_to_AVP`.
+- Sparkle working-key service: `https://sparkle-project.org` in the maintainer's
+  login keychain.
+- Recovery store: an Apple Passwords entry synchronized by iCloud Keychain.
+- GitHub environment: `sparkle-release`.
+- Environment protection: required maintainer approval and the `release` branch
+  only.
+- Reserved environment secret: `SPARKLE_EDDSA_PRIVATE_KEY`.
+- Feed URL: `https://cbusillo.github.io/BD_to_AVP/appcast.xml`.
+- Feed source: `sparkle-feed/appcast.xml`, deployed only by
+  `.github/workflows/sparkle-pages.yml`.
+
+The Pages workflow has only `contents: read`, `pages: write`, and
+`id-token: write`. It does not reference the `sparkle-release` environment or
+the private key.
+
+## Current State
+
+GitHub Pages uses the GitHub Actions deployment source, and the
+`sparkle-release` environment is configured. The initial feed is a valid empty
+RSS appcast so clients receive "no update" rather than malformed XML.
+
+Production key generation and the environment secret remain pending until the
+maintainer is available for the one-time Apple Passwords import. No production
+Sparkle key has been generated for this account yet.
+
+## One-Time Provisioning
+
+Perform this sequence on the maintainer's Mac with Sparkle's pinned
+`generate_keys` binary. Verify the archive digest documented in
+[sparkle-updates.md](sparkle-updates.md) before extraction.
+
+1. Disable shell tracing and set `umask 077`.
+2. Create and mount a temporary RAM disk. All exported private-key and Passwords
+   import files must stay on that volume.
+3. Run `generate_keys --account cbusillo-BD_to_AVP` once. The working private
+   key remains in the login keychain.
+4. Read the public key with
+   `generate_keys --account cbusillo-BD_to_AVP -p` and save only that public
+   value in the repository for #163.
+5. Export the private key with
+   `generate_keys --account cbusillo-BD_to_AVP -x <ram-disk-file>`.
+6. Build a one-row Apple Passwords CSV import file on the RAM disk with the
+   header `Title,URL,Username,Password,Notes`. Use:
+   - title: `BD_to_AVP Sparkle EdDSA Recovery`;
+   - URL: `https://sparkle-project.org`;
+   - username: `cbusillo-BD_to_AVP`;
+   - password: the exported private-key value; and
+   - notes: the public key and repository name.
+7. Import that file with the Passwords app and confirm the entry is visible in
+   the maintainer's iCloud-synchronized password collection.
+8. Pipe the RAM-disk key file through standard input with the explicit repository
+   target; never use a command-line `--body` value:
+
+   ```sh
+   gh secret set SPARKLE_EDDSA_PRIVATE_KEY \
+     --env sparkle-release \
+     --repo cbusillo/BD_to_AVP
+   ```
+
+9. Verify GitHub reports the secret name under `sparkle-release`, not at
+   repository scope.
+10. Re-read the working public key and confirm it matches the recorded public
+    key.
+11. Eject the RAM disk, which destroys all temporary plaintext material, and
+    clear any clipboard content used during the import.
+
+The Apple Passwords import is intentionally interactive. An unsigned command-line
+process cannot create an iCloud-synchronizable Keychain item; macOS rejects that
+operation with `errSecMissingEntitlement`.
+
+## Recovery Test
+
+Before enabling appcast signing in #165:
+
+1. Create a fresh RAM disk.
+2. Copy the password value from the iCloud-synchronized recovery entry into a
+   file on that RAM disk.
+3. Import the file with
+   `generate_keys --account bd-to-avp-recovery-test -f <ram-disk-file>`.
+4. Read the throwaway account's public key with
+   `generate_keys --account bd-to-avp-recovery-test -p` and confirm it matches
+   the committed production public key.
+5. Delete only the throwaway item, then eject the RAM disk:
+
+   ```sh
+   security delete-generic-password \
+     -s https://sparkle-project.org \
+     -a bd-to-avp-recovery-test
+   ```
+
+This proves the recovery copy is usable without replacing the production
+working key.
+
+## Environment Use
+
+Future appcast-signing jobs must:
+
+- declare `environment: sparkle-release`;
+- run only from the protected `release` branch;
+- receive the private key only as
+  `${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}`;
+- pipe the secret to Sparkle with `--ed-key-file -`;
+- avoid shell tracing and command-line secret arguments; and
+- never upload signing workspaces or key files as artifacts.
+
+## Feed Disable and Key Loss
+
+- To disable updates without changing installed apps, deploy the valid empty
+  appcast and leave the GitHub Release download path available.
+- If the GitHub secret is lost but the recovery entry remains, restore the
+  secret from the recovery entry through a RAM-disk file and standard input.
+- If the working login-keychain item is lost, restore it from the recovery entry
+  with `generate_keys --account cbusillo-BD_to_AVP -f`, then verify the public
+  key before signing anything.
+- If all approved private-key copies are lost, automatic updates cannot resume
+  with the installed public key. Publish a manually installed app build
+  containing a new public key before a new automatic-update chain begins.

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -33,9 +33,10 @@ compares release tags, and links to the release page. It does not download,
 verify, install, or relaunch an update.
 
 The current release workflow already creates a Developer ID signed and
-notarized DMG with Briefcase. It does not embed Sparkle, publish an appcast, or
-hold a Sparkle signing key. GitHub Pages is not currently configured for this
-repository.
+notarized DMG with Briefcase. It does not embed Sparkle, publish signed appcast
+items, or hold a Sparkle signing key. GitHub Pages is configured for Actions
+deployment, and the #162 foundation provides a separate valid empty appcast;
+production key generation and signed update entries remain pending.
 
 The generated local app bundle also uses `CFBundleVersion = 1`. Sparkle uses
 the bundle build version for update ordering, so a monotonic build-number policy
@@ -136,11 +137,20 @@ is part of the distribution contract. GitHub Release DMGs remain the
 downloadable update archives and must not be replaced after an appcast references
 them.
 
-The Sparkle EdDSA private key must exist only in:
+The Sparkle EdDSA private key may exist only in these approved locations:
 
-1. an approved offline backup with a named owner and recovery procedure; and
-2. a protected GitHub Actions environment secret used by the release/appcast
+1. Sparkle's working item in the maintainer's login keychain;
+2. a maintainer-owned Apple Passwords recovery entry synchronized by iCloud
+   Keychain; and
+3. a protected GitHub Actions environment secret used by the release/appcast
    workflow.
+
+Temporary plaintext material is permitted only on a RAM disk during the
+one-time Passwords import or a documented recovery test.
+
+The operational names, one-time provisioning sequence, recovery test, and feed
+disable procedure are maintained in
+[sparkle-key-custody.md](sparkle-key-custody.md).
 
 Only the public key is embedded in the app. Private key material must never be
 committed, printed, uploaded as an artifact, or copied into issue/PR text.

--- a/sparkle-feed/appcast.xml
+++ b/sparkle-feed/appcast.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+     xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>3D Blu-ray to Vision Pro Updates</title>
+    <link>https://github.com/cbusillo/BD_to_AVP</link>
+    <description>Stable direct-DMG updates for 3D Blu-ray to Vision Pro.</description>
+    <language>en</language>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- add a dedicated least-privilege GitHub Pages workflow for the stable Sparkle appcast URL
- publish a valid empty appcast so future clients receive a clean no-update response
- document key custody, RAM-disk handling, Apple Passwords import, recovery testing, and feed-disable behavior
- register the workflow and live appcast URL in repository readiness metadata

## Repository settings

- GitHub Pages is enabled with the GitHub Actions build source and HTTPS enforcement
- `sparkle-release` exists with required maintainer approval and a custom `release`-branch-only policy
- no `SPARKLE_EDDSA_PRIVATE_KEY` environment or repository secret exists yet

## Deferred scope

The maintainer deferred the one-time interactive Apple Passwords import. This PR does **not** generate a production EdDSA key, provision the environment secret, embed a public key, or complete #162. The issue remains open for that step.

## Validation

- `actionlint .github/workflows/sparkle-pages.yml`
- `yamllint` on the Pages workflow
- Python XML structure and empty-feed contract validation
- `jq empty .github/github.json`
- `markdownlint-cli2 docs/sparkle-updates.md docs/sparkle-key-custody.md`
- `prettier --check` for all changed JSON/YAML/Markdown files
- secret-reference isolation search and `git diff --check`
- three-agent security/Pages review plus two-agent post-fix review; no remaining P0-P2 findings

References #162.
