### PR TITLE
Add Sparkle updater with stable and RC channels

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -85,7 +85,7 @@
     "CI",
     "CodeQL",
     "Package with Briefcase and Create Release",
-    "Publish Sparkle Appcast",
+    "Disable Sparkle Updates",
     "Update FFmpeg Vendor Pins",
     "Publish Python distribution to PyPI"
   ],

--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -22,8 +22,11 @@ name: Package with Briefcase and Create Release
     branches:
       - release
 
-permissions:
-  contents: write
+permissions: {}
+
+concurrency:
+  group: sparkle-pages
+  cancel-in-progress: false
 
 jobs:
   package:
@@ -31,6 +34,15 @@ jobs:
       github.ref == 'refs/heads/release' ||
       github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
+    permissions:
+      contents: write
+    outputs:
+      package_version: ${{ steps.release_metadata.outputs.package_version }}
+      prerelease: ${{ steps.release_metadata.outputs.prerelease }}
+      release_tag: ${{ steps.release_metadata.outputs.release_tag }}
+      dmg_name: ${{ steps.package_artifact.outputs.dmg_name }}
+      dmg_sha256: ${{ steps.package_artifact.outputs.dmg_sha256 }}
+      dmg_size: ${{ steps.package_artifact.outputs.dmg_size }}
     env:
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -49,6 +61,10 @@ jobs:
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.ref }}" != "refs/heads/release" ]; then
+            echo "Manual releases must dispatch this workflow from the protected release branch." >&2
+            exit 1
+          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
             echo "Manual releases must use a branch or tag ref, not a raw SHA. Tag the commit first or package a branch." >&2
             exit 1
@@ -77,10 +93,14 @@ jobs:
           if [ -z "$MESSAGES" ]; then
             MESSAGES="- No user-facing commits found in this release range."
           fi
+          MESSAGES_DELIMITER="MESSAGES_$(openssl rand -hex 16)"
+          while grep -Fqx "$MESSAGES_DELIMITER" <<< "$MESSAGES"; do
+            MESSAGES_DELIMITER="MESSAGES_$(openssl rand -hex 16)"
+          done
           {
-            echo "messages<<EOF"
+            echo "messages<<$MESSAGES_DELIMITER"
             echo "$MESSAGES"
-            echo "EOF"
+            echo "$MESSAGES_DELIMITER"
           } >> "$GITHUB_OUTPUT"
           echo "Commit messages since last release or initial commit:"
           echo "$MESSAGES"
@@ -132,6 +152,14 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.extract_version.outputs.version }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [[ ! "$RELEASE_TAG_SUFFIX_INPUT" =~ ^rc[0-9]+$ ]]; then
+              echo "Manual release suffix must use the rc<number> form." >&2
+              exit 1
+            fi
+            if [ -z "$RELEASE_NAME_INPUT" ] || [[ "$RELEASE_NAME_INPUT" == *$'\n'* ]] || [[ "$RELEASE_NAME_INPUT" == *$'\r'* ]]; then
+              echo "Release name must be a non-empty single line." >&2
+              exit 1
+            fi
             PACKAGE_VERSION="${VERSION}${RELEASE_TAG_SUFFIX_INPUT}"
             RELEASE_NAME="$RELEASE_NAME_INPUT"
             PRERELEASE=true
@@ -146,6 +174,10 @@ jobs:
             RELEASE_TAG="v${PACKAGE_VERSION}"
           fi
 
+          NOTES_DELIMITER="NOTES_$(openssl rand -hex 16)"
+          while grep -Fqx "$NOTES_DELIMITER" <<< "$RELEASE_NOTES_INPUT"; do
+            NOTES_DELIMITER="NOTES_$(openssl rand -hex 16)"
+          done
           {
             echo "package_version=$PACKAGE_VERSION"
             echo "prerelease=$PRERELEASE"
@@ -153,9 +185,9 @@ jobs:
             echo "release_name=$RELEASE_NAME"
             echo "release_tag=$RELEASE_TAG"
             echo "target_commitish=$(git rev-parse HEAD)"
-            echo "release_notes<<EOF"
+            echo "release_notes<<$NOTES_DELIMITER"
             echo "$RELEASE_NOTES_INPUT"
-            echo "EOF"
+            echo "$NOTES_DELIMITER"
           } >> "$GITHUB_OUTPUT"
       - name: Apply prerelease package version
         if: github.event_name == 'workflow_dispatch'
@@ -176,8 +208,46 @@ jobs:
             { print }
           ' pyproject.toml > pyproject.toml.tmp
           mv pyproject.toml.tmp pyproject.toml
-      - name: Package application for GitHub
+      - name: Validate release identity and Sparkle version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ steps.release_metadata.outputs.package_version }}
+          RELEASE_TAG: ${{ steps.release_metadata.outputs.release_tag }}
         run: |
+          set -euo pipefail
+          PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          BRIEFCASE_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['tool']['briefcase']['version'])")
+          if [ "$PROJECT_VERSION" != "$PACKAGE_VERSION" ] || [ "$BRIEFCASE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Project and Briefcase versions must both match $PACKAGE_VERSION." >&2
+            exit 1
+          fi
+          if [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
+            echo "Release tag must be derived from the package version." >&2
+            exit 1
+          fi
+          if git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "Release tag already exists: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub Release already exists: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          curl --fail --location --silent --show-error \
+            https://cbusillo.github.io/BD_to_AVP/appcast.xml \
+            --output /tmp/current-appcast.xml
+          BUILD_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['tool']['briefcase']['app']['bd-to-avp']['macOS']['info']['CFBundleVersion'])")
+          uv run python scripts/sparkle_appcast.py validate --feed /tmp/current-appcast.xml
+          uv run python scripts/sparkle_appcast.py check-release \
+            --feed /tmp/current-appcast.xml \
+            --build-version "$BUILD_VERSION" \
+            --short-version "$PACKAGE_VERSION"
+      - name: Package application for GitHub
+        id: package_artifact
+        env:
+          PACKAGE_VERSION: ${{ steps.release_metadata.outputs.package_version }}
+        run: |
+          set -euo pipefail
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$(pwd)/build.keychain"
           uv run python scripts/briefcase_app.py create
           uv run python scripts/briefcase_app.py build
@@ -187,13 +257,44 @@ jobs:
           find build/bd-to-avp/macos/app -path "*/bd_to_avp/bin/*" -type f -perm +111 -exec codesign --force --options runtime --timestamp --sign "${{ secrets.DEV_ID }}" {} \;
           find build/bd-to-avp/macos/app -name "*.dylib" -exec codesign --force --sign - {} \;
           uv run python scripts/verify_app_tools.py --profile release
+          uv run python scripts/sparkle_bundle.py \
+            --app "build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app" \
+            > app-metadata.json
+          if [ "$(jq -r .short_version app-metadata.json)" != "$PACKAGE_VERSION" ]; then
+            echo "Built app version does not match $PACKAGE_VERSION." >&2
+            exit 1
+          fi
           uv run python scripts/briefcase_app.py package -i "${{ secrets.DEV_ID }}"
+          uv run python scripts/sparkle_bundle.py \
+            --app "build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app" \
+            --verify-signatures
+
+          DMG_COUNT=$(find dist -maxdepth 1 -type f -name '*.dmg' | wc -l | tr -d ' ')
+          if [ "$DMG_COUNT" != "1" ]; then
+            echo "Expected exactly one DMG in dist; found $DMG_COUNT." >&2
+            exit 1
+          fi
+          DMG_PATH=$(find dist -maxdepth 1 -type f -name '*.dmg' -print -quit)
+          uv run python scripts/sparkle_bundle.py \
+            --dmg "$DMG_PATH" \
+            --verify-signatures \
+            --verify-distribution \
+            > dmg-metadata.json
+          if [ "$(jq -r .short_version dmg-metadata.json)" != "$PACKAGE_VERSION" ]; then
+            echo "Packaged DMG version does not match $PACKAGE_VERSION." >&2
+            exit 1
+          fi
+          {
+            echo "dmg_name=$(basename "$DMG_PATH")"
+            echo "dmg_sha256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
+            echo "dmg_size=$(stat -f %z "$DMG_PATH")"
+          } >> "$GITHUB_OUTPUT"
       - name: Upload log on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: briefcase-log
-          path: /Users/runner/work/BD_to_AVP/BD_to_AVP/logs/briefcase.*.build.log
+          path: /Users/runner/work/BD_to_AVP/BD_to_AVP/logs/briefcase.*.log
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
@@ -203,13 +304,14 @@ jobs:
 
             Commits:
             ${{ steps.get_commit_messages.outputs.messages }}
-            
+
             ** The GUI app no longer installs Homebrew or command-line dependencies on first launch. Install MakeMKV separately before converting Blu-ray discs. Power users who use the terminal/PyPI version should follow the manual dependency instructions in the README. **
-            
+
             You can use the terminal version with "/Applications/3D Blu-ray to Vision Pro.app/Contents/MacOS/3D Blu-ray to Vision Pro". If you run the binary with any arguments, it will work like the previous terminal app. No arguments will open the GUI.
           draft: false
           prerelease: ${{ steps.release_metadata.outputs.prerelease }}
           make_latest: ${{ steps.release_metadata.outputs.make_latest }}
+          overwrite_files: false
           tag_name: ${{ steps.release_metadata.outputs.release_tag }}
           target_commitish: ${{ steps.release_metadata.outputs.target_commitish }}
           name: ${{ steps.release_metadata.outputs.release_name }} v${{ steps.release_metadata.outputs.package_version }}
@@ -217,4 +319,173 @@ jobs:
             dist/*.zip
             dist/*.dmg
             dist/*.pkg
-            
+
+  publish-appcast:
+    name: Build signed Sparkle appcast
+    needs: package
+    if: github.ref == 'refs/heads/release'
+    runs-on: macos-latest
+    environment: sparkle-release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout protected release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Download released DMG
+        id: release_asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_DMG_NAME: ${{ needs.package.outputs.dmg_name }}
+          EXPECTED_DMG_SHA256: ${{ needs.package.outputs.dmg_sha256 }}
+          EXPECTED_DMG_SIZE: ${{ needs.package.outputs.dmg_size }}
+          RELEASE_TAG: ${{ needs.package.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p appcast-site release-assets
+          gh release download "$RELEASE_TAG" --pattern '*.dmg' --dir release-assets
+          DMG_COUNT=$(find release-assets -maxdepth 1 -type f -name '*.dmg' | wc -l | tr -d ' ')
+          if [ "$DMG_COUNT" != "1" ]; then
+            echo "Expected exactly one released DMG; found $DMG_COUNT." >&2
+            exit 1
+          fi
+          DMG_PATH=$(find release-assets -maxdepth 1 -type f -name '*.dmg' -print -quit)
+          ASSET_NAME=$(basename "$DMG_PATH")
+          if [ "$ASSET_NAME" != "$EXPECTED_DMG_NAME" ]; then
+            echo "Released DMG name does not match the validated package." >&2
+            exit 1
+          fi
+          ACTUAL_SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_DMG_SHA256" ]; then
+            echo "Released DMG digest does not match the validated package." >&2
+            exit 1
+          fi
+          RELEASE_JSON=$(gh api "repos/${{ github.repository }}/releases/tags/$RELEASE_TAG")
+          ASSET_URL=$(jq -r --arg name "$ASSET_NAME" '.assets[] | select(.name == $name) | .browser_download_url' <<< "$RELEASE_JSON")
+          ASSET_SIZE=$(jq -r --arg name "$ASSET_NAME" '.assets[] | select(.name == $name) | .size' <<< "$RELEASE_JSON")
+          PUBLISHED_AT=$(jq -r '.published_at' <<< "$RELEASE_JSON")
+          if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
+            echo "Released DMG URL was not found." >&2
+            exit 1
+          fi
+          if [ "$ASSET_SIZE" != "$(stat -f %z "$DMG_PATH")" ]; then
+            echo "Released DMG size does not match the downloaded asset." >&2
+            exit 1
+          fi
+          if [ "$ASSET_SIZE" != "$EXPECTED_DMG_SIZE" ]; then
+            echo "Released DMG size does not match the validated package." >&2
+            exit 1
+          fi
+          curl --fail --location --silent --show-error --range 0-0 "$ASSET_URL" --output /dev/null
+          {
+            echo "dmg_path=$DMG_PATH"
+            echo "asset_url=$ASSET_URL"
+            echo "asset_size=$ASSET_SIZE"
+            echo "published_at=$PUBLISHED_AT"
+          } >> "$GITHUB_OUTPUT"
+      - name: Inspect released DMG
+        id: bundle
+        env:
+          DMG_PATH: ${{ steps.release_asset.outputs.dmg_path }}
+          EXPECTED_SHORT_VERSION: ${{ needs.package.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          python scripts/sparkle_bundle.py \
+            --dmg "$DMG_PATH" \
+            --release-artifact \
+            --verify-signatures \
+            --verify-distribution \
+            > bundle-metadata.json
+          if [ "$(jq -r .short_version bundle-metadata.json)" != "$EXPECTED_SHORT_VERSION" ]; then
+            echo "Released DMG version does not match $EXPECTED_SHORT_VERSION." >&2
+            exit 1
+          fi
+          {
+            echo "build_version=$(jq -r .build_version bundle-metadata.json)"
+            echo "short_version=$(jq -r .short_version bundle-metadata.json)"
+            echo "minimum_system_version=$(jq -r .minimum_system_version bundle-metadata.json)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Download and validate current appcast
+        env:
+          BUILD_VERSION: ${{ steps.bundle.outputs.build_version }}
+          SHORT_VERSION: ${{ steps.bundle.outputs.short_version }}
+        run: |
+          set -euo pipefail
+          curl --fail --location --silent --show-error \
+            https://cbusillo.github.io/BD_to_AVP/appcast.xml \
+            --output appcast-site/appcast.xml
+          python scripts/sparkle_appcast.py validate \
+            --feed appcast-site/appcast.xml
+          python scripts/sparkle_appcast.py check-release \
+            --feed appcast-site/appcast.xml \
+            --build-version "$BUILD_VERSION" \
+            --short-version "$SHORT_VERSION"
+      - name: Sign DMG and build appcast
+        env:
+          DMG_PATH: ${{ steps.release_asset.outputs.dmg_path }}
+          ASSET_URL: ${{ steps.release_asset.outputs.asset_url }}
+          ASSET_SIZE: ${{ steps.release_asset.outputs.asset_size }}
+          PUBLISHED_AT: ${{ steps.release_asset.outputs.published_at }}
+          BUILD_VERSION: ${{ steps.bundle.outputs.build_version }}
+          SHORT_VERSION: ${{ steps.bundle.outputs.short_version }}
+          MINIMUM_SYSTEM_VERSION: ${{ steps.bundle.outputs.minimum_system_version }}
+          RELEASE_TAG: ${{ needs.package.outputs.release_tag }}
+          PRERELEASE: ${{ needs.package.outputs.prerelease }}
+          SPARKLE_EDDSA_PRIVATE_KEY: ${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+          SIGN_UPDATE=$(python scripts/sparkle_macos.py --tool sign_update)
+          SIGNATURE=$(printf '%s' "$SPARKLE_EDDSA_PRIVATE_KEY" | "$SIGN_UPDATE" --ed-key-file - -p "$DMG_PATH")
+          if [ -z "$SIGNATURE" ]; then
+            echo "Sparkle did not produce an EdDSA signature." >&2
+            exit 1
+          fi
+          if [ "$PRERELEASE" = "true" ]; then
+            CHANNEL=rc
+          else
+            CHANNEL=stable
+          fi
+          python scripts/sparkle_appcast.py add \
+            --feed appcast-site/appcast.xml \
+            --output appcast-site/appcast.xml \
+            --build-version "$BUILD_VERSION" \
+            --short-version "$SHORT_VERSION" \
+            --channel "$CHANNEL" \
+            --download-url "$ASSET_URL" \
+            --length "$ASSET_SIZE" \
+            --signature "$SIGNATURE" \
+            --release-notes-url "https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG" \
+            --minimum-system-version "$MINIMUM_SYSTEM_VERSION" \
+            --published-at "$PUBLISHED_AT"
+          python scripts/sparkle_appcast.py validate \
+            --feed appcast-site/appcast.xml
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: appcast-site
+
+  deploy-appcast:
+    name: Deploy Sparkle appcast
+    needs: publish-appcast
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/sparkle-pages.yml
+++ b/.github/workflows/sparkle-pages.yml
@@ -1,28 +1,24 @@
 ---
-name: Publish Sparkle Appcast
+name: Disable Sparkle Updates
 
 "on":
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - .github/workflows/sparkle-pages.yml
-      - sparkle-feed/**
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
-  group: pages
+  group: sparkle-pages
   cancel-in-progress: false
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
+    environment: sparkle-release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -30,10 +26,18 @@ jobs:
         uses: actions/configure-pages@v6
       - name: Validate appcast XML
         run: |
+          python scripts/sparkle_appcast.py validate \
+            --feed sparkle-feed/appcast.xml
           python - <<'PY'
           import xml.etree.ElementTree as ET
 
-          ET.parse("sparkle-feed/appcast.xml")
+          channel = (
+              ET.parse("sparkle-feed/appcast.xml")
+              .getroot()
+              .find("channel")
+          )
+          if channel is None or channel.findall("item"):
+              raise SystemExit("Emergency feed must be a valid empty appcast")
           PY
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
@@ -43,6 +47,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/bd_to_avp/gui/dialog.py
+++ b/bd_to_avp/gui/dialog.py
@@ -1,13 +1,8 @@
 from pathlib import Path
 from typing import cast
-from urllib.parse import urlparse
 
 from PySide6.QtCore import QCoreApplication, Qt
-from PySide6.QtWidgets import QApplication, QCheckBox, QDialog, QHBoxLayout, QLabel, QPushButton, QVBoxLayout
-from github import Github, GithubException, UnknownObjectException
-from github.GitRelease import GitRelease
-from packaging import version
-from packaging.version import InvalidVersion
+from PySide6.QtWidgets import QApplication, QDialog, QHBoxLayout, QLabel, QPushButton, QVBoxLayout
 
 
 # noinspection PyAttributeOutsideInit
@@ -23,7 +18,6 @@ class AboutDialog(QDialog):
 
         self.app = app
         self.readme_url = self.app.property("url")
-        self.repo_name = urlparse(self.readme_url).path.lstrip("/")
 
         self.setWindowTitle(f"About {self.app.applicationDisplayName()}")
         self.create_dialog()
@@ -37,7 +31,6 @@ class AboutDialog(QDialog):
         self.add_company_label(layout)
         self.add_authors_label(layout)
         self.add_readme_label(layout)
-        self.add_update_section(layout)
         self.add_description_label(layout)
         self.add_close_button(layout)
 
@@ -93,69 +86,6 @@ class AboutDialog(QDialog):
         readme_label.setOpenExternalLinks(True)
         readme_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(readme_label)
-
-    def add_update_section(self, layout: QVBoxLayout) -> None:
-        self.update_label = QLabel()
-        self.prerelease_checkbox = QCheckBox("Include pre-releases")
-        self.prerelease_checkbox.stateChanged.connect(self.update_github_update_label)
-
-        if self.is_pre_release() or self.is_pre_release() is None:
-            self.prerelease_checkbox.setChecked(True)
-
-        self.update_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.update_label.setTextFormat(Qt.TextFormat.RichText)
-        self.update_label.setOpenExternalLinks(True)
-
-        checkbox_layout = QHBoxLayout()
-        checkbox_layout.addStretch(1)
-        checkbox_layout.addWidget(self.prerelease_checkbox)
-        checkbox_layout.addStretch(1)
-
-        layout.addLayout(checkbox_layout)
-        layout.addWidget(self.update_label)
-
-        self.update_github_update_label()
-
-    def update_github_update_label(self) -> None:
-        try:
-            latest_release = self.fetch_latest_release()
-
-            if not latest_release:
-                self.update_label.setText("No releases found.")
-                return
-
-            latest_release_version = latest_release.tag_name.lstrip("v")
-            latest_release_url = latest_release.html_url
-            latest_version = version.parse(latest_release_version)
-            app_version = version.parse(self.app.applicationVersion())
-            if latest_version > app_version:
-                self.update_label.setText(
-                    f"New version available: <a href='{latest_release_url}'>v{latest_release_version}</a>"
-                )
-
-            else:
-                self.update_label.setText(f"You are using the latest <a href='{latest_release_url}'>version</a>.")
-        except (GithubException, InvalidVersion):
-            self.update_label.setText("Failed to check for updates.")
-
-    def fetch_latest_release(self) -> GitRelease | None:
-        repo = Github().get_repo(self.repo_name)
-        releases = repo.get_releases()
-        for release in releases:
-            if not release.prerelease or self.prerelease_checkbox.isChecked():
-                return release
-        return None
-
-    def is_pre_release(self) -> bool | None:
-        repo = Github().get_repo(self.repo_name)
-        try:
-            current_release = repo.get_release(f"v{self.app.applicationVersion()}")
-        except UnknownObjectException:
-            return None
-
-        if current_release.prerelease:
-            return True
-        return False
 
     def add_description_label(self, layout: QVBoxLayout) -> None:
         description_label = QLabel(self.get_section_from_readme("Introduction"))

--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -1,10 +1,11 @@
 import os
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Callable, ClassVar
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QCloseEvent, QFont, QTextCursor
+from PySide6.QtGui import QAction, QActionGroup, QCloseEvent, QFont, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
     QGroupBox,
@@ -26,6 +27,7 @@ from babelfish import Language
 
 from bd_to_avp.gui.dialog import AboutDialog
 from bd_to_avp.gui.processing import ProcessingController, ProcessingRequest
+from bd_to_avp.gui.updater import UpdateChannel, UpdaterManager
 from bd_to_avp.gui.widget import FileFolderPicker, LabeledComboBox, LabeledLineEdit, LabeledSpinBox
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.disc import DiscInfo, MKVCreationError
@@ -60,6 +62,7 @@ class MainWindow(QMainWindow):
         self.processing_controller.process_completed.connect(self.finished_processing)
         self.processing_controller.process_cancelled.connect(self.processing_cancelled)
         self.processing_controller.process_failed.connect(self.handle_processing_failure)
+        self.updater_manager = UpdaterManager(self.processing_controller, parent=self)
 
     def setup_window(self) -> None:
         app = QApplication.instance()
@@ -266,14 +269,38 @@ class MainWindow(QMainWindow):
 
         file_menu.addAction(QAction("Open", self))
 
-        update_action = QAction("Update", self)
-        update_action.triggered.connect(self.show_about_dialog)
+        self.update_action = QAction("Check for Updates…", self)
+        self.update_action.triggered.connect(self.check_for_updates)
 
         about_action = QAction(f"About {QApplication.applicationName()}", self)
         about_action.triggered.connect(self.show_about_dialog)
 
         app_menu.addAction(about_action)
-        help_menu.addAction(update_action)
+        help_menu.addAction(self.update_action)
+
+        if self.updater_manager.supports_channels:
+            channel_menu = help_menu.addMenu("Update Channel")
+            channel_actions = QActionGroup(self)
+            channel_actions.setExclusive(True)
+            for channel, label in (
+                (UpdateChannel.STABLE, "Stable"),
+                (UpdateChannel.RELEASE_CANDIDATES, "Release Candidates"),
+            ):
+                action = QAction(label, self)
+                action.setCheckable(True)
+                action.setChecked(self.updater_manager.channel is channel)
+                action.triggered.connect(partial(self.set_update_channel, channel))
+                channel_actions.addAction(action)
+                channel_menu.addAction(action)
+            self.update_channel_menu = channel_menu
+            self.update_channel_actions = channel_actions
+
+    def set_update_channel(self, channel: UpdateChannel, checked: bool = True) -> None:
+        if checked:
+            self.updater_manager.set_channel(channel)
+
+    def check_for_updates(self, _checked: bool = False) -> None:
+        self.updater_manager.check_for_updates(self)
 
     def notify_user_with_sound(self, sound_name: str) -> None:
         if self.play_sound_checkbox.isChecked():

--- a/bd_to_avp/gui/processing.py
+++ b/bd_to_avp/gui/processing.py
@@ -245,6 +245,7 @@ class ProcessingController(QObject):
     process_completed = Signal(object)
     process_cancelled = Signal(object)
     process_failed = Signal(object, object)
+    processing_became_idle = Signal()
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -281,6 +282,7 @@ class ProcessingController(QObject):
         if self._thread is thread:
             self._thread = None
             thread.deleteLater()
+            self.processing_became_idle.emit()
         return True
 
     @Slot()
@@ -289,6 +291,7 @@ class ProcessingController(QObject):
         if thread is None:
             return
         self._thread = None
+        self.processing_became_idle.emit()
         outcome = thread.outcome or ProcessingOutcome(
             ProcessingOutcomeKind.FAILED,
             RuntimeError("Processing thread exited without an outcome."),

--- a/bd_to_avp/gui/updater.py
+++ b/bd_to_avp/gui/updater.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import types
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Callable
+
+from PySide6.QtCore import QObject, QSettings, QUrl, Signal
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import QMessageBox, QWidget
+
+
+RELEASES_URL = "https://github.com/cbusillo/BD_to_AVP/releases"
+CHANNEL_SETTINGS_KEY = "BDToAVPUpdateChannel"
+logger = logging.getLogger(__name__)
+
+
+class UpdateChannel(StrEnum):
+    STABLE = "stable"
+    RELEASE_CANDIDATES = "rc"
+
+
+class UpdateMode(StrEnum):
+    SPARKLE = "sparkle"
+    MANUAL = "manual"
+    APP_STORE = "app-store"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True)
+class UpdaterEnvironment:
+    is_gui: bool
+    distribution_channel: str | None
+    framework_path: Path | None
+    feed_url: str | None
+    public_key: str | None
+
+
+def resolve_update_mode(environment: UpdaterEnvironment) -> UpdateMode:
+    if not environment.is_gui:
+        return UpdateMode.DISABLED
+    if environment.distribution_channel == "app-store":
+        return UpdateMode.APP_STORE
+    if (
+        environment.distribution_channel == "direct"
+        and environment.framework_path is not None
+        and environment.framework_path.is_dir()
+        and environment.feed_url
+        and environment.public_key
+    ):
+        return UpdateMode.SPARKLE
+    return UpdateMode.MANUAL
+
+
+def allowed_sparkle_channels(channel: UpdateChannel) -> frozenset[str]:
+    if channel is UpdateChannel.RELEASE_CANDIDATES:
+        return frozenset({"rc"})
+    return frozenset()
+
+
+class UpdatePreferences:
+    def __init__(self, settings: Any | None = None) -> None:
+        if settings is not None:
+            self._settings = settings
+            return
+        try:
+            foundation = importlib.import_module("Foundation")
+            self._settings = foundation.NSUserDefaults.standardUserDefaults()
+        except ImportError:
+            self._settings = QSettings()
+
+    def _value(self) -> object:
+        if hasattr(self._settings, "objectForKey_"):
+            return self._settings.objectForKey_(CHANNEL_SETTINGS_KEY)
+        return self._settings.value(CHANNEL_SETTINGS_KEY, UpdateChannel.STABLE.value)
+
+    def _set_value(self, value: str) -> None:
+        if hasattr(self._settings, "setObject_forKey_"):
+            self._settings.setObject_forKey_(value, CHANNEL_SETTINGS_KEY)
+            self._settings.synchronize()
+            return
+        self._settings.setValue(CHANNEL_SETTINGS_KEY, value)
+        self._settings.sync()
+
+    @property
+    def channel(self) -> UpdateChannel:
+        stored_value = self._value()
+        value = str(stored_value) if stored_value is not None else UpdateChannel.STABLE.value
+        try:
+            return UpdateChannel(value)
+        except ValueError:
+            return UpdateChannel.STABLE
+
+    @channel.setter
+    def channel(self, channel: UpdateChannel) -> None:
+        self._set_value(channel.value)
+
+
+class InstallationPostponement:
+    def __init__(self, processing_controller: Any) -> None:
+        self._processing_controller = processing_controller
+        self._install_handler: Callable[[], None] | None = None
+        self._connected = False
+
+    def postpone_if_processing(self, install_handler: Callable[[], None]) -> bool:
+        if not self._processing_controller.is_active:
+            return False
+        self._install_handler = install_handler
+        if not self._connected:
+            self._processing_controller.processing_became_idle.connect(self._resume_installation)
+            self._connected = True
+        return True
+
+    def _resume_installation(self) -> None:
+        install_handler = self._install_handler
+        if install_handler is None:
+            return
+        self._install_handler = None
+        if self._connected:
+            self._processing_controller.processing_became_idle.disconnect(self._resume_installation)
+            self._connected = False
+        install_handler()
+
+
+def read_updater_environment(*, is_gui: bool = True) -> UpdaterEnvironment:
+    try:
+        foundation = importlib.import_module("Foundation")
+    except ImportError:
+        return UpdaterEnvironment(is_gui, None, None, None, None)
+
+    bundle = foundation.NSBundle.mainBundle()
+
+    def info_value(key: str) -> str | None:
+        value = bundle.objectForInfoDictionaryKey_(key)
+        return str(value).strip() if value is not None else None
+
+    frameworks_path = bundle.privateFrameworksPath()
+    framework_path = Path(str(frameworks_path)) / "Sparkle.framework" if frameworks_path else None
+    return UpdaterEnvironment(
+        is_gui=is_gui,
+        distribution_channel=info_value("BDToAVPDistributionChannel"),
+        framework_path=framework_path,
+        feed_url=info_value("SUFeedURL"),
+        public_key=info_value("SUPublicEDKey"),
+    )
+
+
+_sparkle_delegate_class: Any = None
+
+
+def _make_sparkle_delegate_class(objc_module: Any, foundation: Any) -> Any:
+    global _sparkle_delegate_class
+    if _sparkle_delegate_class is not None:
+        return _sparkle_delegate_class
+
+    updater_protocol = objc_module.protocolNamed("SPUUpdaterDelegate")
+
+    def configure(self: Any, preferences: UpdatePreferences, postponement: InstallationPostponement) -> None:
+        self._preferences = preferences
+        self._postponement = postponement
+
+    def allowed_channels(self: Any, _updater: Any) -> Any:
+        channels = sorted(allowed_sparkle_channels(self._preferences.channel))
+        return foundation.NSSet.setWithArray_(channels)
+
+    def postpone_relaunch(
+        self: Any,
+        _updater: Any,
+        _item: Any,
+        install_handler: Callable[[], None],
+    ) -> bool:
+        return self._postponement.postpone_if_processing(install_handler)
+
+    def populate(namespace: dict[str, Any]) -> None:
+        namespace["configure"] = objc_module.python_method(configure)
+        namespace["allowedChannelsForUpdater_"] = allowed_channels
+        namespace["updater_shouldPostponeRelaunchForUpdate_untilInvokingBlock_"] = postpone_relaunch
+
+    _sparkle_delegate_class = types.new_class(
+        "BDToAVPSparkleDelegate",
+        (foundation.NSObject,),
+        {"protocols": [updater_protocol]},
+        populate,
+    )
+    return _sparkle_delegate_class
+
+
+class UpdaterManager(QObject):
+    channel_changed = Signal(object)
+
+    def __init__(
+        self,
+        processing_controller: Any,
+        parent: QObject | None = None,
+        *,
+        environment: UpdaterEnvironment | None = None,
+        preferences: UpdatePreferences | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.preferences = preferences or UpdatePreferences()
+        self.environment = environment or read_updater_environment()
+        self.mode = resolve_update_mode(self.environment)
+        self.initialization_error: Exception | None = None
+        self._sparkle_controller: Any = None
+        self._sparkle_delegate: Any = None
+        self._postponement = InstallationPostponement(processing_controller)
+        if self.mode is UpdateMode.SPARKLE:
+            try:
+                self._initialize_sparkle()
+            except Exception as error:
+                self.initialization_error = error
+                logger.error("Sparkle initialization failed; falling back to manual updates: %s", error)
+                self.mode = UpdateMode.MANUAL
+
+    @property
+    def channel(self) -> UpdateChannel:
+        return self.preferences.channel
+
+    @property
+    def supports_channels(self) -> bool:
+        return self.mode is UpdateMode.SPARKLE
+
+    def set_channel(self, channel: UpdateChannel) -> None:
+        if channel is self.preferences.channel:
+            return
+        self.preferences.channel = channel
+        if self._sparkle_controller is not None:
+            self._sparkle_controller.updater().resetUpdateCycleAfterShortDelay()
+        self.channel_changed.emit(channel)
+
+    def _initialize_sparkle(self) -> None:
+        framework_path = self.environment.framework_path
+        if framework_path is None:
+            raise RuntimeError("Sparkle framework path is unavailable.")
+        objc_module = importlib.import_module("objc")
+        foundation = importlib.import_module("Foundation")
+        objc_module.loadBundle("Sparkle", {}, bundle_path=framework_path.as_posix())
+        delegate_class = _make_sparkle_delegate_class(objc_module, foundation)
+        delegate = delegate_class.alloc().init()
+        delegate.configure(self.preferences, self._postponement)
+        controller_class = objc_module.lookUpClass("SPUStandardUpdaterController")
+        controller = controller_class.alloc().initWithStartingUpdater_updaterDelegate_userDriverDelegate_(
+            True,
+            delegate,
+            None,
+        )
+        if controller is None:
+            raise RuntimeError("Sparkle updater controller initialization failed.")
+        self._sparkle_delegate = delegate
+        self._sparkle_controller = controller
+
+    def check_for_updates(self, parent: QWidget | None = None) -> bool:
+        if self.mode is UpdateMode.SPARKLE and self._sparkle_controller is not None:
+            self._sparkle_controller.checkForUpdates_(None)
+            return True
+        if self.mode is UpdateMode.APP_STORE:
+            QMessageBox.information(parent, "Updates", "Updates for this build are managed by the App Store.")
+            return True
+        if self.mode is UpdateMode.MANUAL:
+            return QDesktopServices.openUrl(QUrl(RELEASES_URL))
+        return False

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -71,8 +71,8 @@ document it as an external dependency with preflight behavior.
 - PKG artifact policy is tracked in #118. Until that issue decides otherwise,
   PKG output is not the normal-user release path.
 - Homebrew distribution for CLI users is tracked in #119.
-- The accepted Sparkle direct-DMG architecture is documented in
-  [sparkle-updates.md](sparkle-updates.md). Implementation is split across
+- The Sparkle direct-DMG implementation and Stable/Release Candidates policy is
+  documented in [sparkle-updates.md](sparkle-updates.md) and tracked through
   #162 through #165.
 - App Store feasibility and sandbox constraints are tracked in #121.
 - MakeMKV replacement/removal is tracked in #103.
@@ -93,3 +93,5 @@ Before promoting a GUI release beyond tester/RC use:
    release candidate when test media is available.
 8. If a Sparkle appcast is promoted for normal users, an installed-app upgrade
    smoke and appcast validation pass first.
+9. Stable-channel smoke excludes RC items, and Release Candidates smoke proves
+   the client can later select the unchanneled production release.

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -118,6 +118,29 @@ With MakeMKV installed:
   the app bundle is a blocker, because reinstalling the current app will not add
   it.
 
+## Sparkle Packaging Gate
+
+Before a GitHub Release is created, the release workflow must run:
+
+```sh
+uv run python scripts/sparkle_bundle.py \
+  --app "build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app"
+uv run python scripts/sparkle_bundle.py \
+  --app "build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app" \
+  --verify-signatures
+uv run python scripts/sparkle_bundle.py \
+  --dmg dist/<release>.dmg \
+  --verify-signatures \
+  --verify-distribution
+```
+
+The gate must confirm the repository build number, direct-distribution metadata,
+public key, feed URL, automatic-update policy, pinned framework, `Updater.app`,
+both XPC services, nested signatures, containing app signature, notarization,
+and Gatekeeper assessment. The build number must also be newer than every item
+in the live appcast, the short version must be unpublished, and the final
+released DMG digest must match the locally validated artifact.
+
 ## Sparkle Update Smoke (After Enablement)
 
 This is the acceptance smoke for #165. Do not begin it until #162 through #164
@@ -126,21 +149,27 @@ integration described in [sparkle-updates.md](sparkle-updates.md).
 
 1. Install an older signed/notarized DMG build in `/Applications` and launch it
    from there. Do not test the update while running from the mounted DMG.
-2. Confirm Help > `Check for Updates…` opens Sparkle's standard update UI.
-3. Inspect the selected appcast item and confirm its `sparkle:version`,
+2. Confirm Help > `Update Channel` defaults to Stable. With an RC newer than the
+   installed build in the appcast, confirm `Check for Updates…` does not select
+   it.
+3. Select Release Candidates, run `Check for Updates…`, and confirm Sparkle's
+   standard update UI selects the RC item.
+4. Inspect the selected appcast item and confirm its `sparkle:version`,
    `sparkle:shortVersionString`, release-notes content or URL, enclosure URL, and
    enclosure length match the candidate and published GitHub Release DMG, and
    that its `sparkle:edSignature` is present and non-empty.
-4. Confirm Sparkle's update UI displays the candidate version and release notes
+5. Confirm Sparkle's update UI displays the candidate version and release notes
    from that same appcast item.
-5. Install the update, relaunch, and confirm the displayed and packaged versions
+6. Install the update, relaunch, and confirm the displayed and packaged versions
    match the candidate.
-6. Repeat with an unavailable feed and an intentionally invalid test signature;
+7. Publish or stage a newer unchanneled production item and confirm the
+   Release Candidates client selects it without changing its preference.
+8. Repeat with an unavailable feed and an intentionally invalid test signature;
    the installed app must remain unchanged.
-7. Start media processing and confirm installation/relaunch is postponed until
+9. Start media processing and confirm installation/relaunch is postponed until
    processing is idle.
-8. Verify the manual GitHub Releases download remains usable as the recovery
-   path.
+10. Verify the manual GitHub Releases download remains usable as the recovery
+    path.
 
 ## Follow-Up Routing
 

--- a/docs/sparkle-key-custody.md
+++ b/docs/sparkle-key-custody.md
@@ -21,12 +21,13 @@ printed in logs, or uploaded as a workflow artifact.
 - Reserved environment secret: `SPARKLE_EDDSA_PRIVATE_KEY`.
 - Production public key: `sparkle-public-ed-key.txt`.
 - Feed URL: `https://cbusillo.github.io/BD_to_AVP/appcast.xml`.
-- Feed source: `sparkle-feed/appcast.xml`, deployed only by
-  `.github/workflows/sparkle-pages.yml`.
+- Emergency empty-feed source: `sparkle-feed/appcast.xml`, deployed only by the
+  manual `.github/workflows/sparkle-pages.yml` workflow.
 
-The Pages workflow has only `contents: read`, `pages: write`, and
-`id-token: write`. It does not reference the `sparkle-release` environment or
-the private key.
+The release workflow's appcast job uses the `sparkle-release` environment and
+receives the private key only in its signing step. The emergency empty-feed
+workflow uses the same approval environment but never references the private
+key.
 
 ## Current State
 
@@ -110,10 +111,12 @@ working key.
 
 ## Environment Use
 
-Future appcast-signing jobs must:
+The appcast-signing job must:
 
 - declare `environment: sparkle-release`;
 - run only from the protected `release` branch;
+- check out and execute only the protected workflow revision in the key-bearing
+  job, never the selected package source ref;
 - receive the private key only as
   `${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}`;
 - pipe the secret to Sparkle with `--ed-key-file -`;
@@ -122,8 +125,9 @@ Future appcast-signing jobs must:
 
 ## Feed Disable and Key Loss
 
-- To disable updates without changing installed apps, deploy the valid empty
-  appcast and leave the GitHub Release download path available.
+- To disable updates without changing installed apps, dispatch
+  `Disable Sparkle Updates` from the protected `release` branch. It deploys the
+  valid empty appcast and leaves the GitHub Release download path available.
 - If the GitHub secret is lost but the recovery entry remains, restore the
   secret from the recovery entry through a RAM-disk file and standard input.
 - If the working login-keychain item is lost, restore it from the recovery entry

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-This document is the accepted architecture for issue #120. It defines the
-production path, but does not enable Sparkle in current releases.
+This document is the accepted architecture for issue #120 and the implementation
+contract for #163 through #165. Published builds before the first
+Sparkle-enabled release still use manual GitHub Release downloads.
 
 The work is intentionally split across #162 through #165 so key custody,
 framework packaging, runtime integration, appcast publication, and clean-machine
@@ -16,33 +17,31 @@ validation can be reviewed independently.
 - GitHub Pages will host a stable HTTPS appcast. Appcast enclosures will point
   to versioned DMG assets on GitHub Releases that release policy treats as
   immutable after publication.
-- The first production rollout will publish stable updates only. Prerelease
-  DMGs remain manual downloads until the stable path is proven.
+- Stable is the default update channel. Release Candidates are an explicit
+  opt-in and use Sparkle's `rc` channel in the same appcast.
 - Sparkle's standard user interface will own download, signature verification,
   installation, and relaunch. BD_to_AVP will expose `Check for Updates…` and
   will not silently install updates.
-- A production EdDSA key will not be generated until private-key backup and
-  recovery ownership are explicitly approved.
+- The production EdDSA key follows the custody boundary in
+  [sparkle-key-custody.md](sparkle-key-custody.md).
 - The existing GitHub release link remains the fallback until the packaged
   Sparkle path passes an installed-app upgrade smoke.
 
 ## Current State
 
-The current About dialog performs synchronous unauthenticated GitHub API calls,
-compares release tags, and links to the release page. It does not download,
-verify, install, or relaunch an update.
+The implementation embeds pinned Sparkle 2.9.4 in direct-DMG builds, removes the
+synchronous PyGithub About-dialog checker, and exposes Sparkle's standard
+`Check for Updates…` action. Source/development builds retain only a manual
+GitHub Releases link and never initialize Sparkle.
 
-The current release workflow already creates a Developer ID signed and
-notarized DMG with Briefcase. It does not embed Sparkle, publish signed appcast
-items, or consume the Sparkle signing key. GitHub Pages is configured for
-Actions deployment, and the #162 foundation provides a production public key
-and a separate valid empty appcast; signed update entries remain pending.
+Briefcase writes the direct-distribution metadata and repository build counter,
+and the repo-owned signing extension adds nested `.xpc` bundles to Briefcase's
+inside-out signing pass. The release workflow validates the final notarized DMG,
+signs it with the protected environment key, and deploys a validated full-update
+appcast. The live feed remains empty until the first enabled release is
+published.
 
-The generated local app bundle also uses `CFBundleVersion = 1`. Sparkle uses
-the bundle build version for update ordering, so a monotonic build-number policy
-is required before updates can be enabled.
-
-## Feasibility Evidence
+## Implementation Evidence
 
 Research for #120 used Briefcase 0.4.3 and Sparkle 2.9.4.
 
@@ -53,14 +52,16 @@ Research for #120 used Briefcase 0.4.3 and Sparkle 2.9.4.
   and resolved `SPUStandardUpdaterController` in a local feasibility probe.
 - Briefcase 0.4.3 signs Mach-O files, embedded frameworks, and embedded apps,
   but does not treat Sparkle's nested `.xpc` services as bundle-signing targets.
-  #163 must augment the signing path and prove the complete inside-out order.
+  `scripts/briefcase_macos_signing.py` adds `.xpc` targets to the same
+  depth-first signing pass and is guarded to Briefcase 0.4.3.
 - Briefcase 0.4.3 supports arbitrary macOS Info.plist entries through its
   `macOS.info` map. Its v0.4.3 app template hard-codes `CFBundleVersion = 1`
-  and does not consume a `build` value, so #163 must override that plist key
-  explicitly or first upgrade Briefcase and prove the generated value.
+  and does not consume a `build` value, so the macOS `info` map overrides that
+  plist key explicitly.
 
-These checks prove the integration is feasible. They do not replace a signed,
-notarized, installed-app update test.
+Local create/build validation proves metadata resolution, framework layout,
+PyObjC delegate bridging, and ad-hoc nested signing. It does not replace a
+Developer ID signed, notarized, installed-app update test.
 
 ## Build Boundary
 
@@ -90,16 +91,19 @@ missing, the app fails closed to the manual GitHub Releases path.
 A future App Store build will set its channel to `app-store`, omit Sparkle
 metadata, and omit `Sparkle.framework` entirely.
 
-The Sparkle release must be pinned by version and archive digest. The framework
-must be copied after `briefcase build` and before `briefcase package`, preserving
-symlinks and executable permissions.
+`vendor/sparkle-macos.toml` pins the Sparkle version, archive URL, and digest.
+`scripts/sparkle_macos.py` verifies and safely extracts the archive, then copies
+the framework before Briefcase's build/package signing pass while preserving
+symlinks and executable permissions. Production packaging and `sign_update`
+preparation force a fresh extraction from the verified archive instead of
+trusting the extraction cache.
 
 Sparkle 2.9.4 contains `Updater.app`, `Downloader.xpc`, and `Installer.xpc`.
-Briefcase 0.4.3 does not sign `.xpc` bundles as first-class targets, so #163 must
-extend or supplement the signing path. Nested XPC services and apps must be
-signed before `Sparkle.framework`, which must be signed before the containing
-app. Briefcase may own final app signing, DMG packaging, and notarization only
-after that nested-bundle order is proven.
+Briefcase 0.4.3 does not sign `.xpc` bundles as first-class targets, so the
+repo-owned signing patch includes them without modifying site-packages. Nested
+XPC services and apps are signed before `Sparkle.framework`, which is signed
+before the containing app. Sparkle targets do not inherit the host app's Python
+runtime entitlements.
 
 ## Build Versioning
 
@@ -160,34 +164,41 @@ The appcast publication job must:
 
 1. wait until the matching GitHub Release DMG is downloadable;
 2. verify the pinned Sparkle tooling archive;
-3. compute the DMG's EdDSA signature with `generate_appcast --ed-key-file -` or
-   `sign_update`, without modifying the DMG;
-4. disable delta generation with `--maximum-deltas 0` or an equivalent
-   full-update-only path;
+3. compute the DMG's EdDSA signature with `sign_update --ed-key-file -`, without
+   modifying the DMG;
+4. add only a full-DMG enclosure and never generate delta elements;
 5. set each new enclosure to its exact tag-qualified GitHub Release asset URL;
 6. validate the appcast version, URL, length, EdDSA signature, and absence of
    delta enclosures; and
 7. deploy the feed atomically to GitHub Pages.
+
+Release publication rejects an existing tag or short version, disables release
+asset overwrite, and verifies that the downloaded GitHub Release DMG has the
+same name, size, and SHA-256 digest as the locally notarized artifact before it
+is signed into the appcast.
 
 If appcast publication fails, the GitHub Release remains available for manual
 installation and the existing feed remains unchanged.
 
 ## Stable and Prerelease Policy
 
-The initial updater serves stable releases only. This keeps current RC builds
-manual and avoids introducing channel delegates or a user preference before the
-base upgrade path is proven.
+One appcast serves both release policies:
 
-After stable rollout evidence exists, a separate decision may add a prerelease
-feed or Sparkle channel. A prerelease design must guarantee that prerelease
-clients can later receive the stable release and that stable clients never see
-prerelease items.
+- production items omit `sparkle:channel` and are therefore on Sparkle's default
+  channel;
+- release candidates include `<sparkle:channel>rc</sparkle:channel>`;
+- every installation defaults to Stable; and
+- users who opt into Release Candidates allow `rc` while Sparkle continues to
+  include the default channel automatically.
+
+This guarantees that Stable users never select RC items and RC users can later
+receive the production release without changing feeds.
 
 ## Runtime Integration and UX
 
-The runtime integration will use a small wrapper that loads the bundled
-framework on the main thread and retains `SPUStandardUpdaterController` for the
-application lifetime.
+The runtime integration loads the bundled framework on the main thread and
+retains `SPUStandardUpdaterController` and its delegate for the application
+lifetime.
 
 A live packaged-app test must prove that Qt's macOS event loop delivers
 Sparkle's timers, windows, and delegate callbacks. Resolving the Objective-C
@@ -196,6 +207,9 @@ class alone is not sufficient evidence.
 The direct-DMG user experience is:
 
 - Help contains `Check for Updates…`.
+- Help contains an `Update Channel` submenu with Stable and Release Candidates;
+  the preference is persisted in the app's `NSUserDefaults` domain and defaults
+  to Stable.
 - Sparkle uses its standard permission and update windows.
 - Automatic checks may be enabled only through Sparkle's normal consent path.
 - Downloaded updates require user approval to install and relaunch.
@@ -208,8 +222,9 @@ Development and PyPI builds continue to link to GitHub Releases and do not try
 to load Sparkle. A future App Store build reports that updates are managed by
 the App Store.
 
-After Sparkle is active, the synchronous PyGithub update check and the About
-dialog prerelease checkbox become redundant and should be removed.
+The synchronous PyGithub update check and About-dialog prerelease checkbox are
+removed. PyGithub and the now-unused direct `packaging` dependency are also
+removed from application and Briefcase requirements.
 
 ## Failure and Recovery
 
@@ -243,6 +258,8 @@ Before enabling the appcast for normal users:
   build version, `SUAllowsAutomaticUpdates = false`, and
   `SUVerifyUpdateBeforeExtraction = true`;
 - the appcast enclosure URL, size, build version, and EdDSA signature validate;
+- Stable clients reject RC items, while RC clients remain eligible for both RC
+  and default-channel production items;
 - the appcast contains no delta enclosures;
 - Sparkle timers, windows, and delegate callbacks work under the packaged Qt
   event loop;
@@ -258,7 +275,6 @@ Before enabling the appcast for normal users:
 - Silent background installation.
 - Delta updates.
 - Phased rollout.
-- Prerelease opt-in or channel switching.
 - Replacing GitHub Releases as the DMG artifact host.
 
 ## Primary References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,8 @@ dependencies = [
     "humanize>=4.9.0,<5",
     "numpy>=2,<3",
     "opencv-python==4.10.0.84",
-    "packaging>=24.1,<27",
     "psutil>=5.9.8,<8",
     "pyobjc-framework-vision>=11.0,<12",
-    "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
     "pysrt>=1.1.2,<2",
     "trakit>=0.2.2,<0.3",
@@ -43,7 +41,7 @@ bd-to-avp = "bd_to_avp.__main__:main"
 [dependency-groups]
 dev = [
     "black>=26.5.1,<27",
-    "briefcase>=0.4.3,<0.5",
+    "briefcase==0.4.3",
     "mypy>=2.1.0,<3",
     "ruff>=0.15.20,<0.16",
     "types-psutil>=5.9.5.20240516",
@@ -91,10 +89,8 @@ requires = [
     "humanize>=4.9.0,<5",
     "numpy>=2,<3",
     "opencv-python==4.10.0.84",
-    "packaging>=24.1,<27",
     "psutil>=5.9.8,<8",
     "pyobjc-framework-vision>=11.0,<12",
-    "pygithub>=2.3.0,<3",
     "pyside6>=6.7.1,<7",
     "pysrt>=1.1.2,<2",
     "trakit>=0.2.2,<0.3",
@@ -103,6 +99,14 @@ requires = [
 
 [tool.briefcase.app.bd-to-avp.macOS]
 universal_build = false
+
+[tool.briefcase.app.bd-to-avp.macOS.info]
+CFBundleVersion = "144"
+BDToAVPDistributionChannel = "direct"
+SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="
+SUAllowsAutomaticUpdates = false
+SUVerifyUpdateBeforeExtraction = true
 
 [tool.ruff]
 line-length = 120

--- a/scripts/briefcase_app.py
+++ b/scripts/briefcase_app.py
@@ -6,12 +6,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts.sparkle_macos import APP_PATH, FRAMEWORK_RELATIVE_PATH, embed_sparkle, verify_framework_layout
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WHEELHOUSE = REPO_ROOT / ".briefcase-wheelhouse"
 WHEELHOUSE_REQUIREMENTS = ["pysrt==1.1.2"]
 VENDOR_FFMPEG_COMMANDS = {"create", "build", "run"}
 SYNC_TOOL_COMMANDS = {"create", "build", "run"}
+POST_SYNC_TOOL_COMMANDS = {"create"}
+SPARKLE_COMMANDS = {"create", "build", "run", "package"}
+POST_EMBED_SPARKLE_COMMANDS = {"create"}
+FORCE_EXTRACT_SPARKLE_COMMANDS = {"package"}
 APP_RESOURCE_BIN = (
     REPO_ROOT
     / "build"
@@ -30,6 +36,19 @@ VENDORED_TOOLS = ["ffmpeg", "ffprobe", "MP4Box"]
 
 def run(command: list[str]) -> None:
     subprocess.run(command, check=True, cwd=REPO_ROOT)
+
+
+def run_briefcase(briefcase_args: list[str]) -> None:
+    run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.briefcase_cli",
+            *briefcase_args,
+            "-C",
+            briefcase_config_override(),
+        ]
+    )
 
 
 def build_wheelhouse() -> None:
@@ -79,6 +98,31 @@ def should_sync_vendored_tools(briefcase_args: list[str]) -> bool:
     return bool(commands & SYNC_TOOL_COMMANDS)
 
 
+def should_sync_vendored_tools_after(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & POST_SYNC_TOOL_COMMANDS)
+
+
+def should_embed_sparkle(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & SPARKLE_COMMANDS)
+
+
+def should_embed_sparkle_after(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & POST_EMBED_SPARKLE_COMMANDS)
+
+
+def should_force_extract_sparkle(briefcase_args: list[str]) -> bool:
+    commands = {arg for arg in briefcase_args if not arg.startswith("-")}
+    return bool(commands & FORCE_EXTRACT_SPARKLE_COMMANDS)
+
+
+def sync_sparkle_to_existing_app(*, force_extract: bool = False) -> None:
+    if APP_PATH.is_dir():
+        embed_sparkle(APP_PATH, force_extract=force_extract)
+
+
 def main_with_args(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run Briefcase with repo-local packaging fixes.")
     parser.add_argument("briefcase_args", nargs=argparse.REMAINDER)
@@ -92,18 +136,17 @@ def main_with_args(argv: list[str] | None = None) -> None:
         vendor_ffmpeg()
     elif should_sync_vendored_tools(args.briefcase_args):
         sync_vendored_tools_to_existing_app()
-    run(
-        [
-            sys.executable,
-            "-m",
-            "briefcase",
-            *args.briefcase_args,
-            "-C",
-            briefcase_config_override(),
-        ]
-    )
-    if should_sync_vendored_tools(args.briefcase_args):
+    if should_embed_sparkle(args.briefcase_args):
+        sync_sparkle_to_existing_app(force_extract=should_force_extract_sparkle(args.briefcase_args))
+    run_briefcase(args.briefcase_args)
+    if should_sync_vendored_tools_after(args.briefcase_args):
         sync_vendored_tools_to_existing_app()
+    if should_embed_sparkle(args.briefcase_args):
+        if should_embed_sparkle_after(args.briefcase_args) and APP_PATH.is_dir():
+            embed_sparkle(APP_PATH)
+        if not APP_PATH.is_dir():
+            return
+        verify_framework_layout(APP_PATH / FRAMEWORK_RELATIVE_PATH)
 
 
 def main() -> None:

--- a/scripts/briefcase_cli.py
+++ b/scripts/briefcase_cli.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import importlib
+
+from scripts.briefcase_macos_signing import install_patch
+
+
+if __name__ == "__main__":
+    install_patch()
+    raise SystemExit(importlib.import_module("briefcase.__main__").main())

--- a/scripts/briefcase_macos_signing.py
+++ b/scripts/briefcase_macos_signing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import concurrent.futures
+import importlib
+
+from pathlib import Path
+from typing import Any
+
+EXPECTED_BRIEFCASE_VERSION = "0.4.3"
+SPARKLE_FRAMEWORK_NAME = "Sparkle.framework"
+
+
+briefcase = importlib.import_module("briefcase")
+macos_module = importlib.import_module("briefcase.platforms.macOS")
+macos_utils = importlib.import_module("briefcase.platforms.macOS.utils")
+macOSSigningMixin = macos_module.macOSSigningMixin
+is_mach_o_binary = macos_utils.is_mach_o_binary
+
+
+def collect_sign_targets(command: Any, app: Any) -> list[Path]:
+    bundle_path = command.package_path(app)
+    resources_path = bundle_path / "Contents/Resources"
+    frameworks_path = bundle_path / "Contents/Frameworks"
+    sign_targets: list[Path] = []
+
+    for folder in (resources_path, frameworks_path):
+        if not folder.exists():
+            continue
+        sign_targets.extend(
+            path for path in folder.rglob("*") if not path.is_dir() and not path.is_symlink() and is_mach_o_binary(path)
+        )
+        sign_targets.extend(folder.rglob("*.framework"))
+        sign_targets.extend(folder.rglob("*.app"))
+        sign_targets.extend(folder.rglob("*.xpc"))
+
+    sign_targets.append(bundle_path)
+    return list(dict.fromkeys(sign_targets))
+
+
+def is_sparkle_target(path: Path, app_bundle_path: Path) -> bool:
+    sparkle_framework_path = app_bundle_path / "Contents/Frameworks" / SPARKLE_FRAMEWORK_NAME
+    return path == sparkle_framework_path or sparkle_framework_path in path.parents
+
+
+def sign_app_with_xpc(command: Any, app: Any, identity: Any) -> None:
+    bundle_path = command.package_path(app)
+    sign_targets = collect_sign_targets(command, app)
+    progress_bar = command.console.progress_bar()
+    task_id = progress_bar.add_task("Signing App", total=len(sign_targets))
+
+    with progress_bar:
+        for group in command.tools.file.sorted_depth_first_groups(sign_targets):
+            group_paths = list(group)
+            serialize_group = command.console.is_deep_debug or any(
+                is_sparkle_target(path, bundle_path) for path in group_paths
+            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1 if serialize_group else None) as executor:
+                futures = []
+                for path in group_paths:
+                    entitlements = None if is_sparkle_target(path, bundle_path) else command.entitlements_path(app)
+                    futures.append(
+                        executor.submit(
+                            command.sign_file,
+                            path,
+                            entitlements=entitlements,
+                            identity=identity,
+                        )
+                    )
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()
+                    progress_bar.update(task_id, advance=1)
+
+
+def install_patch() -> None:
+    if briefcase.__version__ != EXPECTED_BRIEFCASE_VERSION:
+        raise RuntimeError(
+            f"Sparkle signing integration requires Briefcase {EXPECTED_BRIEFCASE_VERSION}; "
+            f"found {briefcase.__version__}."
+        )
+    if getattr(macOSSigningMixin.sign_app, "_bd_to_avp_xpc_patch", False):
+        return
+    sign_app_with_xpc._bd_to_avp_xpc_patch = True  # type: ignore[attr-defined]
+    macOSSigningMixin.sign_app = sign_app_with_xpc

--- a/scripts/sparkle_appcast.py
+++ b/scripts/sparkle_appcast.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import re
+import xml.etree.ElementTree as ET
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
+REPOSITORY_PATH = "/cbusillo/BD_to_AVP"
+SPARKLE = f"{{{SPARKLE_NAMESPACE}}}"
+SHORT_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:rc[0-9]+)?$")
+ET.register_namespace("sparkle", SPARKLE_NAMESPACE)
+ET.register_namespace("dc", DC_NAMESPACE)
+
+
+class AppcastError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AppcastItem:
+    build_version: str
+    short_version: str
+    channel: str | None
+    download_url: str
+    length: int
+    signature: str
+    release_notes_url: str
+    minimum_system_version: str
+    published_at: datetime
+
+
+def load_appcast(path: Path) -> tuple[Any, ET.Element]:
+    try:
+        tree = ET.parse(path)
+    except (ET.ParseError, OSError) as error:
+        raise AppcastError(f"Unable to parse appcast {path}: {error}") from error
+    root = tree.getroot()
+    if root.tag != "rss" or root.get("version") != "2.0":
+        raise AppcastError("Appcast root must be RSS 2.0.")
+    channel = root.find("channel")
+    if channel is None:
+        raise AppcastError("Appcast is missing its channel element.")
+    return tree, channel
+
+
+def _text(element: ET.Element, tag: str) -> str:
+    child = element.find(tag)
+    return (child.text or "").strip() if child is not None else ""
+
+
+def _parse_build_number(value: str, label: str) -> int:
+    if not value.isdigit():
+        raise AppcastError(f"{label} must be a canonical numeric build greater than 1.")
+    number = int(value)
+    if number <= 1 or str(number) != value:
+        raise AppcastError(f"{label} must be a canonical numeric build greater than 1.")
+    return number
+
+
+def _build_number(item: ET.Element) -> int:
+    return _parse_build_number(_text(item, f"{SPARKLE}version"), "sparkle:version")
+
+
+def _release_channel(short_version: str) -> str | None:
+    if SHORT_VERSION_PATTERN.fullmatch(short_version) is None:
+        raise AppcastError(f"Invalid Sparkle short version: {short_version!r}")
+    return "rc" if re.search(r"rc[0-9]+$", short_version, flags=re.IGNORECASE) else None
+
+
+def maximum_build_version(channel: ET.Element) -> int | None:
+    builds = [_build_number(item) for item in channel.findall("item")]
+    return max(builds) if builds else None
+
+
+def check_new_build(feed_path: Path, build_version: str) -> None:
+    candidate_build = _parse_build_number(build_version, "Candidate build version")
+    _, channel = load_appcast(feed_path)
+    validate_appcast_channel(channel)
+    maximum = maximum_build_version(channel)
+    if maximum is not None and candidate_build <= maximum:
+        raise AppcastError(f"Candidate build {build_version} must be newer than published build {maximum}.")
+
+
+def check_new_release(feed_path: Path, build_version: str, short_version: str) -> None:
+    check_new_build(feed_path, build_version)
+    _release_channel(short_version)
+    _, channel = load_appcast(feed_path)
+    if any(_text(item, f"{SPARKLE}shortVersionString") == short_version for item in channel.findall("item")):
+        raise AppcastError(f"Sparkle short version is already published: {short_version}")
+
+
+def _validate_https_url(value: str, label: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise AppcastError(f"{label} must be an absolute HTTPS URL: {value}")
+
+
+def _validate_release_url(value: str, label: str, *, download: bool) -> tuple[str, str | None]:
+    _validate_https_url(value, label)
+    parsed = urlparse(value)
+    if parsed.netloc != "github.com":
+        raise AppcastError(f"{label} must use github.com: {value}")
+    if parsed.query or parsed.fragment:
+        raise AppcastError(f"{label} must not contain a query string or fragment: {value}")
+    expected_marker = f"{REPOSITORY_PATH}/releases/download/" if download else f"{REPOSITORY_PATH}/releases/tag/"
+    decoded_path = unquote(parsed.path)
+    if not decoded_path.startswith(expected_marker):
+        raise AppcastError(f"{label} must be tag-qualified for cbusillo/BD_to_AVP: {value}")
+    suffix = decoded_path[len(expected_marker) :]
+    if download:
+        tag, separator, asset_name = suffix.partition("/")
+        if not separator or not tag or not asset_name or "/" in asset_name:
+            raise AppcastError(f"{label} must identify one release tag and asset: {value}")
+        if not asset_name.lower().endswith(".dmg"):
+            raise AppcastError(f"{label} must identify a DMG asset: {value}")
+        return tag, asset_name
+    if not suffix or "/" in suffix:
+        raise AppcastError(f"{label} must identify exactly one release tag: {value}")
+    return suffix, None
+
+
+def _validate_signature(value: str) -> None:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise AppcastError("sparkle:edSignature is not valid base64.") from error
+    if len(decoded) != 64:
+        raise AppcastError("sparkle:edSignature must decode to a 64-byte Ed25519 signature.")
+
+
+def validate_appcast_channel(channel: ET.Element) -> None:
+    if channel.find("title") is None or channel.find("description") is None:
+        raise AppcastError("Appcast channel requires title and description elements.")
+    if channel.findall(f".//{SPARKLE}deltas"):
+        raise AppcastError("Delta updates are not allowed in the Sparkle appcast.")
+
+    build_versions: list[int] = []
+    short_versions: set[str] = set()
+    download_urls: set[str] = set()
+    for item in channel.findall("item"):
+        build_version = _build_number(item)
+        short_version = _text(item, f"{SPARKLE}shortVersionString")
+        expected_channel = _release_channel(short_version)
+        item_channel = _text(item, f"{SPARKLE}channel") or None
+        if item_channel not in {None, "rc"}:
+            raise AppcastError(f"Unsupported Sparkle channel: {item_channel}")
+        if item_channel != expected_channel:
+            raise AppcastError(f"Release candidate channel and short version disagree for {short_version!r}.")
+
+        enclosures = item.findall("enclosure")
+        if len(enclosures) != 1:
+            raise AppcastError("Every appcast item requires exactly one full-update enclosure.")
+        enclosure = enclosures[0]
+        download_url = enclosure.get("url", "")
+        download_tag, _ = _validate_release_url(download_url, "Enclosure URL", download=True)
+        length = enclosure.get("length", "")
+        if not length.isdigit() or int(length) <= 0:
+            raise AppcastError("Enclosure length must be a positive integer.")
+        if enclosure.get("type") != "application/octet-stream":
+            raise AppcastError("Enclosure type must be application/octet-stream.")
+        signature = enclosure.get(f"{SPARKLE}edSignature", "")
+        _validate_signature(signature)
+
+        release_notes_url = _text(item, f"{SPARKLE}releaseNotesLink")
+        release_notes_tag, _ = _validate_release_url(release_notes_url, "Release notes URL", download=False)
+        if release_notes_tag != download_tag:
+            raise AppcastError("Release notes and enclosure URLs must use the same release tag.")
+        if download_tag != f"v{short_version}":
+            raise AppcastError("Appcast URLs must use the tag derived from sparkle:shortVersionString.")
+        if _text(item, "link") != release_notes_url:
+            raise AppcastError("Appcast item link must match sparkle:releaseNotesLink.")
+        minimum_system_version = _text(item, f"{SPARKLE}minimumSystemVersion")
+        if not minimum_system_version:
+            raise AppcastError("Every appcast item requires sparkle:minimumSystemVersion.")
+        try:
+            parsedate_to_datetime(_text(item, "pubDate"))
+        except (TypeError, ValueError) as error:
+            raise AppcastError("Every appcast item requires a valid RFC 2822 pubDate.") from error
+
+        if build_version in build_versions:
+            raise AppcastError(f"Duplicate Sparkle build version: {build_version}")
+        if short_version in short_versions:
+            raise AppcastError(f"Duplicate Sparkle short version: {short_version}")
+        if download_url in download_urls:
+            raise AppcastError(f"Duplicate Sparkle download URL: {download_url}")
+        build_versions.append(build_version)
+        short_versions.add(short_version)
+        download_urls.add(download_url)
+
+    if build_versions != sorted(build_versions, reverse=True):
+        raise AppcastError("Appcast items must be ordered from newest to oldest build version.")
+
+
+def validate_appcast(path: Path) -> None:
+    _, channel = load_appcast(path)
+    validate_appcast_channel(channel)
+
+
+def append_item(feed_path: Path, output_path: Path, item: AppcastItem) -> None:
+    check_new_release(feed_path, item.build_version, item.short_version)
+    if item.channel not in {None, "rc"}:
+        raise AppcastError(f"Unsupported Sparkle channel: {item.channel}")
+    expected_channel = _release_channel(item.short_version)
+    if item.channel != expected_channel:
+        raise AppcastError("Sparkle channel and short version disagree.")
+    download_tag, _ = _validate_release_url(item.download_url, "Enclosure URL", download=True)
+    release_notes_tag, _ = _validate_release_url(item.release_notes_url, "Release notes URL", download=False)
+    if release_notes_tag != download_tag:
+        raise AppcastError("Release notes and enclosure URLs must use the same release tag.")
+    if download_tag != f"v{item.short_version}":
+        raise AppcastError("Appcast URLs must use the tag derived from sparkle:shortVersionString.")
+    _validate_signature(item.signature)
+    if item.length <= 0:
+        raise AppcastError("Enclosure length must be positive.")
+
+    tree, channel = load_appcast(feed_path)
+    item_element = ET.Element("item")
+    ET.SubElement(item_element, "title").text = f"Version {item.short_version}"
+    ET.SubElement(item_element, "link").text = item.release_notes_url
+    ET.SubElement(item_element, f"{SPARKLE}version").text = item.build_version
+    ET.SubElement(item_element, f"{SPARKLE}shortVersionString").text = item.short_version
+    if item.channel:
+        ET.SubElement(item_element, f"{SPARKLE}channel").text = item.channel
+    ET.SubElement(item_element, f"{SPARKLE}releaseNotesLink").text = item.release_notes_url
+    ET.SubElement(item_element, "pubDate").text = format_datetime(item.published_at.astimezone(timezone.utc))
+    ET.SubElement(
+        item_element,
+        "enclosure",
+        {
+            "url": item.download_url,
+            "length": str(item.length),
+            "type": "application/octet-stream",
+            f"{SPARKLE}edSignature": item.signature,
+        },
+    )
+    ET.SubElement(item_element, f"{SPARKLE}minimumSystemVersion").text = item.minimum_system_version
+
+    first_item_index = next(
+        (index for index, child in enumerate(channel) if child.tag == "item"),
+        len(channel),
+    )
+    channel.insert(first_item_index, item_element)
+    ET.indent(tree, space="  ")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(output_path, encoding="utf-8", xml_declaration=True)
+    validate_appcast(output_path)
+
+
+def _channel_argument(value: str) -> str | None:
+    return None if value == "stable" else value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create and validate the BD_to_AVP Sparkle appcast.")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    add = commands.add_parser("add", help="Add one signed full-DMG item to an appcast.")
+    add.add_argument("--feed", type=Path, required=True)
+    add.add_argument("--output", type=Path, required=True)
+    add.add_argument("--build-version", required=True)
+    add.add_argument("--short-version", required=True)
+    add.add_argument("--channel", choices=("stable", "rc"), required=True)
+    add.add_argument("--download-url", required=True)
+    add.add_argument("--length", type=int, required=True)
+    add.add_argument("--signature", required=True)
+    add.add_argument("--release-notes-url", required=True)
+    add.add_argument("--minimum-system-version", required=True)
+    add.add_argument("--published-at", help="RFC 3339 publication time; defaults to now in UTC.")
+
+    validate = commands.add_parser("validate", help="Validate all appcast entries.")
+    validate.add_argument("--feed", type=Path, required=True)
+
+    check = commands.add_parser("check-build", help="Require a build number newer than the appcast.")
+    check.add_argument("--feed", type=Path, required=True)
+    check.add_argument("--build-version", required=True)
+
+    check_release = commands.add_parser("check-release", help="Require a new build and short version.")
+    check_release.add_argument("--feed", type=Path, required=True)
+    check_release.add_argument("--build-version", required=True)
+    check_release.add_argument("--short-version", required=True)
+
+    args = parser.parse_args()
+    if args.command == "validate":
+        validate_appcast(args.feed)
+    elif args.command == "check-build":
+        check_new_build(args.feed, args.build_version)
+    elif args.command == "check-release":
+        check_new_release(args.feed, args.build_version, args.short_version)
+    else:
+        published_at = datetime.fromisoformat(args.published_at) if args.published_at else datetime.now(timezone.utc)
+        if published_at.tzinfo is None:
+            published_at = published_at.replace(tzinfo=timezone.utc)
+        append_item(
+            args.feed,
+            args.output,
+            AppcastItem(
+                build_version=args.build_version,
+                short_version=args.short_version,
+                channel=_channel_argument(args.channel),
+                download_url=args.download_url,
+                length=args.length,
+                signature=args.signature,
+                release_notes_url=args.release_notes_url,
+                minimum_system_version=args.minimum_system_version,
+                published_at=published_at,
+            ),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparkle_bundle.py
+++ b/scripts/sparkle_bundle.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import argparse
+import json
+import plistlib
+import re
+import subprocess
+import tomllib
+
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterator
+
+from scripts.sparkle_macos import FRAMEWORK_RELATIVE_PATH, REPO_ROOT, load_release, verify_framework_layout
+
+
+INFO_PLIST_RELATIVE_PATH = Path("Contents/Info.plist")
+PUBLIC_KEY_PATH = REPO_ROOT / "sparkle-public-ed-key.txt"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+SHORT_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:rc[0-9]+)?$")
+SYSTEM_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){1,2}$")
+
+
+class SparkleBundleError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SparkleBundleMetadata:
+    app_path: str
+    bundle_identifier: str
+    build_version: str
+    short_version: str
+    distribution_channel: str
+    feed_url: str
+    minimum_system_version: str
+    public_key: str
+
+
+def load_expected_info(
+    pyproject_path: Path = PYPROJECT_PATH, public_key_path: Path = PUBLIC_KEY_PATH
+) -> dict[str, object]:
+    with pyproject_path.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    info = dict(pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["macOS"]["info"])
+    public_key = public_key_path.read_text(encoding="utf-8").strip()
+    if info.get("SUPublicEDKey") != public_key:
+        raise SparkleBundleError("The Briefcase SUPublicEDKey does not match sparkle-public-ed-key.txt.")
+    return info
+
+
+def _require_equal(info: dict[str, object], key: str, expected: object) -> object:
+    actual = info.get(key)
+    if actual != expected:
+        raise SparkleBundleError(f"Info.plist {key} must be {expected!r}; found {actual!r}.")
+    return actual
+
+
+def verify_code_signatures(app_path: Path) -> None:
+    framework_path = app_path / FRAMEWORK_RELATIVE_PATH
+    targets = [
+        framework_path / "Versions/B/Updater.app",
+        framework_path / "Versions/B/XPCServices/Downloader.xpc",
+        framework_path / "Versions/B/XPCServices/Installer.xpc",
+        framework_path,
+        app_path,
+    ]
+    for target in targets:
+        subprocess.run(
+            ["codesign", "--verify", "--strict", "--verbose=4", target],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    subprocess.run(
+        ["codesign", "--verify", "--deep", "--strict", "--verbose=4", app_path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def verify_dmg_distribution(dmg_path: Path) -> None:
+    subprocess.run(
+        ["xcrun", "stapler", "validate", dmg_path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "spctl",
+            "--assess",
+            "--type",
+            "open",
+            "--context",
+            "context:primary-signature",
+            "--verbose=4",
+            dmg_path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def verify_app_distribution(app_path: Path) -> None:
+    subprocess.run(
+        ["spctl", "--assess", "--type", "execute", "--verbose=4", app_path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def inspect_app_bundle(
+    app_path: Path,
+    *,
+    expected_info: dict[str, object] | None = None,
+    verify_signatures: bool = False,
+    require_repository_build: bool = True,
+) -> SparkleBundleMetadata:
+    info_path = app_path / INFO_PLIST_RELATIVE_PATH
+    if not info_path.is_file():
+        raise SparkleBundleError(f"Info.plist not found: {info_path}")
+    with info_path.open("rb") as handle:
+        info = plistlib.load(handle)
+
+    expected_info = expected_info or load_expected_info()
+    expected_keys = [
+        "BDToAVPDistributionChannel",
+        "SUFeedURL",
+        "SUPublicEDKey",
+        "SUAllowsAutomaticUpdates",
+        "SUVerifyUpdateBeforeExtraction",
+    ]
+    if require_repository_build:
+        expected_keys.insert(0, "CFBundleVersion")
+    for key in expected_keys:
+        _require_equal(info, key, expected_info[key])
+    if "SUEnableAutomaticChecks" in info:
+        raise SparkleBundleError("SUEnableAutomaticChecks must remain unset so Sparkle owns consent prompting.")
+
+    build_version = str(info["CFBundleVersion"])
+    if not build_version.isdigit():
+        raise SparkleBundleError("CFBundleVersion must be a canonical numeric repository counter greater than 1.")
+    build_number = int(build_version)
+    if build_number <= 1 or str(build_number) != build_version:
+        raise SparkleBundleError("CFBundleVersion must be a canonical numeric repository counter greater than 1.")
+    short_version = str(info.get("CFBundleShortVersionString", "")).strip()
+    if SHORT_VERSION_PATTERN.fullmatch(short_version) is None:
+        raise SparkleBundleError("CFBundleShortVersionString must be a three-part version with an optional rc suffix.")
+    minimum_system_version = str(info.get("LSMinimumSystemVersion", "")).strip()
+    if SYSTEM_VERSION_PATTERN.fullmatch(minimum_system_version) is None:
+        raise SparkleBundleError("LSMinimumSystemVersion must be a numeric dotted version.")
+
+    framework_path = app_path / FRAMEWORK_RELATIVE_PATH
+    verify_framework_layout(framework_path, expected_version=load_release().version)
+    if verify_signatures:
+        verify_code_signatures(app_path)
+
+    return SparkleBundleMetadata(
+        app_path=app_path.as_posix(),
+        bundle_identifier=str(info.get("CFBundleIdentifier", "")),
+        build_version=build_version,
+        short_version=short_version,
+        distribution_channel=str(info["BDToAVPDistributionChannel"]),
+        feed_url=str(info["SUFeedURL"]),
+        minimum_system_version=minimum_system_version,
+        public_key=str(info["SUPublicEDKey"]),
+    )
+
+
+@contextmanager
+def mounted_dmg(dmg_path: Path) -> Iterator[Path]:
+    result = subprocess.run(
+        ["hdiutil", "attach", "-readonly", "-nobrowse", "-plist", dmg_path],
+        check=True,
+        capture_output=True,
+    )
+    payload = plistlib.loads(result.stdout)
+    mount_points = [
+        Path(entity["mount-point"]) for entity in payload.get("system-entities", []) if entity.get("mount-point")
+    ]
+    if len(mount_points) != 1:
+        raise SparkleBundleError(f"Expected one mounted DMG volume; found {len(mount_points)}.")
+    mount_point = mount_points[0]
+    try:
+        yield mount_point
+    finally:
+        subprocess.run(["hdiutil", "detach", mount_point], check=True, capture_output=True, text=True)
+
+
+def inspect_dmg(
+    dmg_path: Path,
+    *,
+    verify_signatures: bool = False,
+    require_repository_build: bool = True,
+    verify_distribution: bool = False,
+) -> SparkleBundleMetadata:
+    if verify_distribution:
+        verify_dmg_distribution(dmg_path)
+    with mounted_dmg(dmg_path) as mount_point:
+        app_paths = list(mount_point.glob("*.app"))
+        if len(app_paths) != 1:
+            raise SparkleBundleError(f"Expected one app bundle in the DMG; found {len(app_paths)}.")
+        metadata = inspect_app_bundle(
+            app_paths[0],
+            verify_signatures=verify_signatures,
+            require_repository_build=require_repository_build,
+        )
+        if verify_distribution:
+            verify_app_distribution(app_paths[0])
+        return metadata
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Sparkle metadata, layout, and signatures in a macOS app.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--app", type=Path, help="Path to an unpackaged .app bundle.")
+    source.add_argument("--dmg", type=Path, help="Path to a packaged DMG.")
+    parser.add_argument(
+        "--verify-signatures", action="store_true", help="Verify nested and containing code signatures."
+    )
+    parser.add_argument(
+        "--release-artifact",
+        action="store_true",
+        help="Accept the artifact's numeric build while enforcing the protected release metadata policy.",
+    )
+    parser.add_argument(
+        "--verify-distribution",
+        action="store_true",
+        help="Validate the DMG ticket and Gatekeeper assessments for the DMG and contained app.",
+    )
+    args = parser.parse_args()
+    if args.verify_distribution and args.app:
+        parser.error("--verify-distribution requires --dmg")
+
+    metadata = (
+        inspect_app_bundle(
+            args.app,
+            verify_signatures=args.verify_signatures,
+            require_repository_build=not args.release_artifact,
+        )
+        if args.app
+        else inspect_dmg(
+            args.dmg,
+            verify_signatures=args.verify_signatures,
+            require_repository_build=not args.release_artifact,
+            verify_distribution=args.verify_distribution,
+        )
+    )
+    print(json.dumps(asdict(metadata), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparkle_macos.py
+++ b/scripts/sparkle_macos.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import plistlib
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import tomllib
+import urllib.parse
+import urllib.request
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "vendor" / "sparkle-macos.toml"
+CACHE_ROOT = REPO_ROOT / ".vendor" / "sparkle"
+APP_PATH = REPO_ROOT / "build" / "bd-to-avp" / "macos" / "app" / "3D Blu-ray to Vision Pro.app"
+FRAMEWORK_RELATIVE_PATH = Path("Contents/Frameworks/Sparkle.framework")
+REQUIRED_FRAMEWORK_PATHS = (
+    Path("Versions/B/Sparkle"),
+    Path("Versions/B/Updater.app"),
+    Path("Versions/B/XPCServices/Downloader.xpc"),
+    Path("Versions/B/XPCServices/Installer.xpc"),
+)
+
+
+class SparkleBuildError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SparkleRelease:
+    version: str
+    archive_url: str
+    archive_sha256: str
+
+    @property
+    def archive_name(self) -> str:
+        return Path(urllib.parse.urlparse(self.archive_url).path).name
+
+
+def load_release(manifest_path: Path = MANIFEST_PATH) -> SparkleRelease:
+    with manifest_path.open("rb") as handle:
+        data = tomllib.load(handle)
+    release = SparkleRelease(
+        version=str(data["version"]),
+        archive_url=str(data["archive_url"]),
+        archive_sha256=str(data["archive_sha256"]),
+    )
+    if urllib.parse.urlparse(release.archive_url).scheme != "https":
+        raise SparkleBuildError("Sparkle archive URL must use HTTPS.")
+    if len(release.archive_sha256) != 64:
+        raise SparkleBuildError("Sparkle archive SHA-256 must contain 64 hexadecimal characters.")
+    try:
+        int(release.archive_sha256, 16)
+    except ValueError as error:
+        raise SparkleBuildError("Sparkle archive SHA-256 is not hexadecimal.") from error
+    return release
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_archive(path: Path, release: SparkleRelease) -> None:
+    actual_sha256 = sha256_file(path)
+    if actual_sha256 != release.archive_sha256:
+        raise SparkleBuildError(
+            f"Sparkle archive digest mismatch: expected {release.archive_sha256}, got {actual_sha256}."
+        )
+
+
+def download_archive(release: SparkleRelease, cache_root: Path = CACHE_ROOT) -> Path:
+    cache_root.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_root / release.archive_name
+    if archive_path.exists():
+        try:
+            verify_archive(archive_path, release)
+            return archive_path
+        except SparkleBuildError:
+            archive_path.unlink()
+
+    temporary_path = archive_path.with_suffix(f"{archive_path.suffix}.tmp")
+    temporary_path.unlink(missing_ok=True)
+    try:
+        with urllib.request.urlopen(release.archive_url, timeout=60) as response, temporary_path.open("wb") as output:
+            shutil.copyfileobj(response, output)
+        verify_archive(temporary_path, release)
+        os.replace(temporary_path, archive_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return archive_path
+
+
+def _validate_archive_members(archive: tarfile.TarFile, destination: Path) -> None:
+    destination = destination.resolve()
+    for member in archive.getmembers():
+        member_path = Path(member.name)
+        if member_path.is_absolute():
+            raise SparkleBuildError(f"Sparkle archive contains an absolute path: {member.name}")
+        extracted_path = (destination / member_path).resolve()
+        if not extracted_path.is_relative_to(destination):
+            raise SparkleBuildError(f"Sparkle archive path escapes the extraction root: {member.name}")
+        if member.issym() or member.islnk():
+            link_path = Path(member.linkname)
+            if link_path.is_absolute():
+                raise SparkleBuildError(f"Sparkle archive contains an absolute link: {member.name}")
+            link_target = extracted_path.parent / link_path if member.issym() else destination / link_path
+            if not link_target.resolve().is_relative_to(destination):
+                raise SparkleBuildError(f"Sparkle archive link escapes the extraction root: {member.name}")
+
+
+def extract_archive(
+    archive_path: Path,
+    release: SparkleRelease,
+    cache_root: Path = CACHE_ROOT,
+    *,
+    force: bool = False,
+) -> Path:
+    extract_root = cache_root / release.version
+    marker_path = extract_root / ".archive-sha256"
+    framework_path = extract_root / "Sparkle.framework"
+    if not force and marker_path.exists() and marker_path.read_text(encoding="utf-8").strip() == release.archive_sha256:
+        try:
+            verify_framework_layout(framework_path, expected_version=release.version)
+            return framework_path
+        except SparkleBuildError:
+            shutil.rmtree(extract_root, ignore_errors=True)
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=cache_root, prefix="sparkle-extract-") as temporary_dir:
+        temporary_root = Path(temporary_dir)
+        with tarfile.open(archive_path, mode="r:xz") as archive:
+            _validate_archive_members(archive, temporary_root)
+            archive.extractall(temporary_root, filter="data")
+        temporary_framework = temporary_root / "Sparkle.framework"
+        verify_framework_layout(temporary_framework, expected_version=release.version)
+        (temporary_root / ".archive-sha256").write_text(release.archive_sha256 + "\n", encoding="utf-8")
+        shutil.rmtree(extract_root, ignore_errors=True)
+        shutil.move(temporary_root.as_posix(), extract_root.as_posix())
+
+    verify_framework_layout(framework_path, expected_version=release.version)
+    return framework_path
+
+
+def verify_framework_layout(framework_path: Path, *, expected_version: str | None = None) -> None:
+    if not framework_path.is_dir():
+        raise SparkleBuildError(f"Sparkle framework not found: {framework_path}")
+    for required_path in REQUIRED_FRAMEWORK_PATHS:
+        candidate = framework_path / required_path
+        if not candidate.exists():
+            raise SparkleBuildError(f"Sparkle framework is missing {required_path}.")
+    info_path = framework_path / "Versions/B/Resources/Info.plist"
+    if not info_path.is_file():
+        raise SparkleBuildError("Sparkle framework is missing its Info.plist.")
+    with info_path.open("rb") as handle:
+        info = plistlib.load(handle)
+    if info.get("CFBundleIdentifier") != "org.sparkle-project.Sparkle":
+        raise SparkleBuildError("Sparkle framework has an unexpected bundle identifier.")
+    if expected_version is not None and info.get("CFBundleShortVersionString") != expected_version:
+        raise SparkleBuildError(
+            f"Sparkle framework version must be {expected_version}; found {info.get('CFBundleShortVersionString')!r}."
+        )
+
+
+def verify_framework_architecture(framework_path: Path) -> None:
+    executable_path = framework_path / "Versions/B/Sparkle"
+    result = subprocess.run(
+        ["lipo", "-archs", executable_path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if "arm64" not in result.stdout.split():
+        raise SparkleBuildError("Sparkle framework does not contain an arm64 slice.")
+
+
+def embed_sparkle(
+    app_path: Path = APP_PATH,
+    *,
+    release: SparkleRelease | None = None,
+    cache_root: Path = CACHE_ROOT,
+    verify_architecture: bool = True,
+    force_extract: bool = False,
+) -> Path:
+    if not app_path.is_dir():
+        raise SparkleBuildError(f"Briefcase app bundle not found: {app_path}")
+    release = release or load_release()
+    archive_path = download_archive(release, cache_root)
+    source_framework = extract_archive(archive_path, release, cache_root, force=force_extract)
+    if verify_architecture:
+        verify_framework_architecture(source_framework)
+
+    destination = app_path / FRAMEWORK_RELATIVE_PATH
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(destination, ignore_errors=True)
+    shutil.copytree(source_framework, destination, symlinks=True, copy_function=shutil.copy2)
+    verify_framework_layout(destination, expected_version=release.version)
+    return destination
+
+
+def sparkle_tool_path(
+    tool_name: str,
+    *,
+    release: SparkleRelease | None = None,
+    cache_root: Path = CACHE_ROOT,
+) -> Path:
+    release = release or load_release()
+    archive_path = download_archive(release, cache_root)
+    framework_path = extract_archive(archive_path, release, cache_root, force=True)
+    tool_path = framework_path.parent / "bin" / tool_name
+    if not tool_path.is_file() or not os.access(tool_path, os.X_OK):
+        raise SparkleBuildError(f"Sparkle tool is missing or not executable: {tool_path}")
+    return tool_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Embed the pinned Sparkle framework into the Briefcase app bundle.")
+    parser.add_argument("--app", type=Path, default=APP_PATH, help="Path to the Briefcase .app bundle.")
+    parser.add_argument("--cache", type=Path, default=CACHE_ROOT, help="Sparkle download and extraction cache.")
+    parser.add_argument("--tool", help="Prepare Sparkle and print the path to a bundled command-line tool.")
+    args = parser.parse_args()
+
+    if args.tool:
+        print(sparkle_tool_path(args.tool, cache_root=args.cache))
+        return 0
+    destination = embed_sparkle(args.app, cache_root=args.cache)
+    print(f"Embedded Sparkle {load_release().version}: {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ffmpeg_vendor.py
+++ b/tests/test_ffmpeg_vendor.py
@@ -122,6 +122,18 @@ class BriefcaseVendorHookTests(unittest.TestCase):
         self.assertTrue(briefcase_app.should_sync_vendored_tools(["build"]))
         self.assertFalse(briefcase_app.should_sync_vendored_tools(["package", "-i", "Developer ID"]))
         self.assertFalse(briefcase_app.should_sync_vendored_tools(["--help"]))
+        self.assertTrue(briefcase_app.should_sync_vendored_tools_after(["create", "--no-input"]))
+        self.assertFalse(briefcase_app.should_sync_vendored_tools_after(["build"]))
+
+    def test_embed_sparkle_for_app_commands(self) -> None:
+        self.assertTrue(briefcase_app.should_embed_sparkle(["create", "--no-input"]))
+        self.assertTrue(briefcase_app.should_embed_sparkle(["build"]))
+        self.assertTrue(briefcase_app.should_embed_sparkle(["package", "-i", "Developer ID"]))
+        self.assertFalse(briefcase_app.should_embed_sparkle(["--help"]))
+        self.assertTrue(briefcase_app.should_embed_sparkle_after(["create", "--no-input"]))
+        self.assertFalse(briefcase_app.should_embed_sparkle_after(["build"]))
+        self.assertTrue(briefcase_app.should_force_extract_sparkle(["package", "--no-input"]))
+        self.assertFalse(briefcase_app.should_force_extract_sparkle(["build", "--no-input"]))
 
     def test_do_not_vendor_ffmpeg_for_non_app_commands(self) -> None:
         self.assertFalse(briefcase_app.should_vendor_ffmpeg(["--help"]))
@@ -149,16 +161,43 @@ class BriefcaseVendorHookTests(unittest.TestCase):
                 self.assertTrue((app_bin / tool_name).stat().st_mode & 0o111)
 
     def test_briefcase_package_does_not_resync_signed_tools(self) -> None:
-        with (
-            patch.object(briefcase_app, "run") as run,
-            patch.object(briefcase_app, "build_wheelhouse") as build_wheelhouse,
-            patch.object(briefcase_app, "sync_vendored_tools_to_existing_app") as sync_tools,
-        ):
-            briefcase_app.main_with_args(["package", "--no-input"])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.object(briefcase_app, "APP_PATH", Path(temp_dir) / "missing.app"),
+                patch.object(briefcase_app, "run_briefcase") as run_briefcase,
+                patch.object(briefcase_app, "build_wheelhouse") as build_wheelhouse,
+                patch.object(briefcase_app, "sync_vendored_tools_to_existing_app") as sync_tools,
+                patch.object(briefcase_app, "sync_sparkle_to_existing_app") as sync_sparkle,
+            ):
+                briefcase_app.main_with_args(["package", "--no-input"])
 
         build_wheelhouse.assert_called_once()
-        run.assert_called_once()
+        run_briefcase.assert_called_once()
         sync_tools.assert_not_called()
+        sync_sparkle.assert_called_once_with(force_extract=True)
+
+    def test_briefcase_package_embeds_only_before_final_signing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = Path(temp_dir) / "App.app"
+            app_path.mkdir()
+            events: list[str] = []
+            with (
+                patch.object(briefcase_app, "APP_PATH", app_path),
+                patch.object(briefcase_app, "build_wheelhouse"),
+                patch.object(
+                    briefcase_app,
+                    "sync_sparkle_to_existing_app",
+                    side_effect=lambda **_kwargs: events.append("embed"),
+                ) as sync_sparkle,
+                patch.object(briefcase_app, "run_briefcase", side_effect=lambda _args: events.append("sign")),
+                patch.object(
+                    briefcase_app, "verify_framework_layout", side_effect=lambda _path: events.append("verify")
+                ),
+            ):
+                briefcase_app.main_with_args(["package", "--no-input"])
+
+        self.assertEqual(events, ["embed", "sign", "verify"])
+        sync_sparkle.assert_called_once_with(force_extract=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_processing.py
+++ b/tests/test_gui_processing.py
@@ -316,6 +316,17 @@ class ProcessingControllerTests(unittest.TestCase):
 
         self.assertTrue(self.threads[0].cancel_requested)
 
+    def test_controller_emits_idle_after_attempt_finishes(self) -> None:
+        controller = ProcessingController()
+        idle = Mock()
+        controller.processing_became_idle.connect(idle)
+
+        with patch("bd_to_avp.gui.processing.ProcessingThread", side_effect=self.make_thread):
+            controller.start(self.request)
+            self.threads[0].finish(ProcessingOutcome(ProcessingOutcomeKind.COMPLETED))
+
+        idle.assert_called_once_with()
+
     def test_controller_late_cancel_overrides_completed_outcome(self) -> None:
         controller = ProcessingController()
         cancellations: list[ProcessingRequest] = []

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -1,0 +1,212 @@
+import base64
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts import sparkle_appcast
+
+
+SIGNATURE = base64.b64encode(b"s" * 64).decode("ascii")
+
+
+def make_empty_feed(path: Path) -> None:
+    path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+     xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>3D Blu-ray to Vision Pro Updates</title>
+    <link>https://github.com/cbusillo/BD_to_AVP</link>
+    <description>Updates.</description>
+    <language>en</language>
+  </channel>
+</rss>
+""",
+        encoding="utf-8",
+    )
+
+
+def item(build: str, short_version: str, channel: str | None) -> sparkle_appcast.AppcastItem:
+    tag = f"v{short_version}"
+    return sparkle_appcast.AppcastItem(
+        build_version=build,
+        short_version=short_version,
+        channel=channel,
+        download_url=f"https://github.com/cbusillo/BD_to_AVP/releases/download/{tag}/BD_to_AVP-{short_version}.dmg",
+        length=12345,
+        signature=SIGNATURE,
+        release_notes_url=f"https://github.com/cbusillo/BD_to_AVP/releases/tag/{tag}",
+        minimum_system_version="11.0",
+        published_at=datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+class SparkleAppcastTests(unittest.TestCase):
+    def test_adds_stable_and_rc_items_in_descending_build_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            empty_feed = root / "empty.xml"
+            stable_feed = root / "stable.xml"
+            rc_feed = root / "rc.xml"
+            make_empty_feed(empty_feed)
+
+            sparkle_appcast.append_item(empty_feed, stable_feed, item("144", "0.2.143", None))
+            sparkle_appcast.append_item(stable_feed, rc_feed, item("145", "0.2.144rc1", "rc"))
+            sparkle_appcast.validate_appcast(rc_feed)
+            _, channel = sparkle_appcast.load_appcast(rc_feed)
+            items = channel.findall("item")
+
+        self.assertEqual(
+            [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
+            ["145", "144"],
+        )
+        self.assertEqual(items[0].findtext(f"{sparkle_appcast.SPARKLE}channel"), "rc")
+        self.assertIsNone(items[1].find(f"{sparkle_appcast.SPARKLE}channel"))
+        enclosure = items[0].find("enclosure")
+        if enclosure is None:
+            self.fail("RC appcast item is missing its enclosure")
+        self.assertEqual(
+            enclosure.get(f"{sparkle_appcast.SPARKLE}edSignature"),
+            SIGNATURE,
+        )
+
+    def test_rejects_non_monotonic_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            empty_feed = root / "empty.xml"
+            stable_feed = root / "stable.xml"
+            make_empty_feed(empty_feed)
+            sparkle_appcast.append_item(empty_feed, stable_feed, item("144", "0.2.143", None))
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "newer than published build"):
+                sparkle_appcast.append_item(stable_feed, root / "duplicate.xml", item("144", "0.2.144rc1", "rc"))
+
+    def test_rejects_duplicate_short_version_with_new_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            empty_feed = root / "empty.xml"
+            stable_feed = root / "stable.xml"
+            make_empty_feed(empty_feed)
+            sparkle_appcast.append_item(empty_feed, stable_feed, item("144", "0.2.143", None))
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "already published"):
+                sparkle_appcast.check_new_release(stable_feed, "145", "0.2.143")
+
+    def test_rejects_noncanonical_build_numbers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            for build_version in ("0", "00", "01"):
+                with self.subTest(build_version=build_version):
+                    with self.assertRaisesRegex(sparkle_appcast.AppcastError, "canonical numeric"):
+                        sparkle_appcast.check_new_build(feed, build_version)
+
+    def test_rejects_stable_item_with_rc_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "channel and short version disagree"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", item("144", "0.2.144rc1", None))
+
+    def test_rejects_rc_channel_without_rc_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "channel and short version disagree"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", item("144", "0.2.144", "rc"))
+
+    def test_rejects_delta_enclosures(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+            tree = ET.parse(feed)
+            channel = tree.getroot().find("channel")
+            if channel is None:
+                self.fail("Test appcast is missing its channel")
+            ET.SubElement(channel, f"{sparkle_appcast.SPARKLE}deltas")
+            tree.write(feed, encoding="utf-8", xml_declaration=True)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "Delta updates"):
+                sparkle_appcast.validate_appcast(feed)
+
+    def test_rejects_non_tag_qualified_download_url(self) -> None:
+        invalid_item = sparkle_appcast.AppcastItem(
+            **{
+                **item("144", "0.2.143", None).__dict__,
+                "download_url": "https://github.com/cbusillo/BD_to_AVP/releases/latest/download/app.dmg",
+            }
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "tag-qualified"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", invalid_item)
+
+    def test_rejects_release_notes_for_different_tag(self) -> None:
+        invalid_item = sparkle_appcast.AppcastItem(
+            **{
+                **item("144", "0.2.143", None).__dict__,
+                "release_notes_url": "https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.142",
+            }
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "same release tag"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", invalid_item)
+
+    def test_rejects_urls_not_derived_from_short_version(self) -> None:
+        invalid_item = sparkle_appcast.AppcastItem(
+            **{
+                **item("144", "0.2.143", None).__dict__,
+                "download_url": "https://github.com/cbusillo/BD_to_AVP/releases/download/v0.2.142/app.dmg",
+                "release_notes_url": "https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.142",
+            }
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "derived from"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", invalid_item)
+
+    def test_rejects_non_dmg_enclosure(self) -> None:
+        invalid_item = sparkle_appcast.AppcastItem(
+            **{
+                **item("144", "0.2.143", None).__dict__,
+                "download_url": "https://github.com/cbusillo/BD_to_AVP/releases/download/v0.2.143/app.zip",
+            }
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "DMG asset"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", invalid_item)
+
+    def test_rejects_invalid_signature_length(self) -> None:
+        invalid_item = sparkle_appcast.AppcastItem(
+            **{
+                **item("144", "0.2.143", None).__dict__,
+                "signature": base64.b64encode(b"short").decode("ascii"),
+            }
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            feed = Path(temp_dir) / "appcast.xml"
+            make_empty_feed(feed)
+
+            with self.assertRaisesRegex(sparkle_appcast.AppcastError, "64-byte"):
+                sparkle_appcast.append_item(feed, Path(temp_dir) / "output.xml", invalid_item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -1,0 +1,362 @@
+import concurrent.futures
+import io
+import plistlib
+import tarfile
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from scripts import briefcase_macos_signing, sparkle_bundle, sparkle_macos
+
+
+def make_framework(root: Path, *, version: str = "2.9.4") -> Path:
+    framework = root / "Sparkle.framework"
+    for required_path in sparkle_macos.REQUIRED_FRAMEWORK_PATHS:
+        path = framework / required_path
+        if required_path.suffix in {".app", ".xpc"}:
+            path.mkdir(parents=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"binary")
+    info_path = framework / "Versions/B/Resources/Info.plist"
+    info_path.parent.mkdir(parents=True, exist_ok=True)
+    with info_path.open("wb") as handle:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "org.sparkle-project.Sparkle",
+                "CFBundleShortVersionString": version,
+            },
+            handle,
+        )
+    (framework / "Versions/Current").symlink_to("B")
+    (framework / "Sparkle").symlink_to("Versions/Current/Sparkle")
+    return framework
+
+
+def make_app(root: Path, info: dict[str, object]) -> Path:
+    app_path = root / "Test.app"
+    info_path = app_path / "Contents/Info.plist"
+    info_path.parent.mkdir(parents=True)
+    with info_path.open("wb") as handle:
+        plistlib.dump(info, handle)
+    framework = make_framework(app_path / "Contents/Frameworks")
+    self_contained_framework = app_path / sparkle_macos.FRAMEWORK_RELATIVE_PATH
+    if framework != self_contained_framework:
+        self_contained_framework.parent.mkdir(parents=True, exist_ok=True)
+        framework.rename(self_contained_framework)
+    return app_path
+
+
+class SparkleMacOSTests(unittest.TestCase):
+    def test_manifest_pins_expected_release(self) -> None:
+        release = sparkle_macos.load_release()
+
+        self.assertEqual(release.version, "2.9.4")
+        self.assertEqual(
+            release.archive_sha256,
+            "ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9",
+        )
+        self.assertTrue(release.archive_url.startswith("https://"))
+
+    def test_manifest_rejects_non_https_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "sparkle.toml"
+            manifest_path.write_text(
+                'version = "2.9.4"\narchive_url = "http://example.invalid/Sparkle.tar.xz"\n'
+                f'archive_sha256 = "{"0" * 64}"\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(sparkle_macos.SparkleBuildError, "HTTPS"):
+                sparkle_macos.load_release(manifest_path)
+
+    def test_extract_archive_rejects_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            archive_path = root / "Sparkle.tar.xz"
+            with tarfile.open(archive_path, "w:xz") as archive:
+                member = tarfile.TarInfo("../outside")
+                member.size = 1
+                archive.addfile(member, io.BytesIO(b"x"))
+            release = sparkle_macos.SparkleRelease(
+                version="test",
+                archive_url="https://example.invalid/Sparkle.tar.xz",
+                archive_sha256=sparkle_macos.sha256_file(archive_path),
+            )
+
+            with self.assertRaisesRegex(sparkle_macos.SparkleBuildError, "escapes"):
+                sparkle_macos.extract_archive(archive_path, release, root / "cache")
+
+    def test_extract_archive_rebuilds_corrupt_cached_framework(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            archive_root = root / "archive-root"
+            framework = make_framework(archive_root, version="test")
+            archive_path = root / "Sparkle.tar.xz"
+            with tarfile.open(archive_path, "w:xz") as archive:
+                archive.add(framework, arcname="Sparkle.framework")
+            release = sparkle_macos.SparkleRelease(
+                version="test",
+                archive_url="https://example.invalid/Sparkle.tar.xz",
+                archive_sha256=sparkle_macos.sha256_file(archive_path),
+            )
+            cache_root = root / "cache"
+            cached_root = cache_root / release.version
+            cached_root.mkdir(parents=True)
+            (cached_root / ".archive-sha256").write_text(release.archive_sha256, encoding="utf-8")
+
+            extracted_framework = sparkle_macos.extract_archive(archive_path, release, cache_root)
+
+            sparkle_macos.verify_framework_layout(extracted_framework)
+
+    def test_embed_preserves_framework_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            app_path = root / "App.app"
+            app_path.mkdir()
+            source_framework = make_framework(root / "source", version="test")
+            release = sparkle_macos.SparkleRelease(
+                version="test",
+                archive_url="https://example.invalid/Sparkle.tar.xz",
+                archive_sha256="0" * 64,
+            )
+
+            with (
+                patch.object(sparkle_macos, "download_archive", return_value=root / "archive"),
+                patch.object(sparkle_macos, "extract_archive", return_value=source_framework),
+            ):
+                destination = sparkle_macos.embed_sparkle(
+                    app_path,
+                    release=release,
+                    cache_root=root / "cache",
+                    verify_architecture=False,
+                )
+
+            self.assertTrue((destination / "Versions/Current").is_symlink())
+            self.assertEqual((destination / "Versions/Current").readlink(), Path("B"))
+            sparkle_macos.verify_framework_layout(destination)
+
+    def test_framework_version_must_match_pin(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            framework = make_framework(Path(temp_dir), version="2.9.3")
+
+            with self.assertRaisesRegex(sparkle_macos.SparkleBuildError, "version must be 2.9.4"):
+                sparkle_macos.verify_framework_layout(framework, expected_version="2.9.4")
+
+
+class BriefcaseSigningTests(unittest.TestCase):
+    def test_collect_sign_targets_includes_xpc_bundles(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = Path(temp_dir) / "App.app"
+            downloader = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
+            installer = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc"
+            updater = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+            framework = app_path / "Contents/Frameworks/Sparkle.framework"
+            for path in (downloader, installer, updater):
+                path.mkdir(parents=True)
+            (app_path / "Contents/Resources").mkdir(parents=True)
+
+            class Command:
+                @staticmethod
+                def package_path(_app):
+                    return app_path
+
+            targets = briefcase_macos_signing.collect_sign_targets(Command(), object())
+
+        self.assertIn(downloader, targets)
+        self.assertIn(installer, targets)
+        self.assertIn(updater, targets)
+        self.assertIn(framework, targets)
+        self.assertEqual(targets[-1], app_path)
+
+    def test_sparkle_targets_do_not_receive_app_entitlements(self) -> None:
+        app_path = Path("/tmp/App.app")
+        sparkle_path = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+        other_path = app_path / "Contents/Frameworks/Other.framework"
+
+        self.assertTrue(briefcase_macos_signing.is_sparkle_target(sparkle_path, app_path))
+        self.assertFalse(briefcase_macos_signing.is_sparkle_target(other_path, app_path))
+
+    def test_signing_patch_rejects_unexpected_briefcase_version(self) -> None:
+        with patch.object(briefcase_macos_signing.briefcase, "__version__", "0.4.4"):
+            with self.assertRaisesRegex(RuntimeError, "requires Briefcase 0.4.3"):
+                briefcase_macos_signing.install_patch()
+
+    def test_sign_app_uses_inside_out_order_and_no_host_entitlements_for_sparkle(self) -> None:
+        app_path = Path("/tmp/App.app")
+        downloader = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
+        updater_app = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+        framework = app_path / "Contents/Frameworks/Sparkle.framework"
+        other_framework = app_path / "Contents/Frameworks/Other.framework"
+        groups = [[downloader], [updater_app], [framework, other_framework], [app_path]]
+        signed: list[tuple[Path, object]] = []
+
+        class ProgressBar:
+            def add_task(self, _label: str, *, total: int) -> int:
+                self.total = total
+                return 1
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def update(self, _task_id: int, *, advance: int) -> None:
+                self.advance = advance
+
+        class Command:
+            console = Mock(is_deep_debug=False)
+            tools = Mock()
+
+            @staticmethod
+            def package_path(_app):
+                return app_path
+
+            @staticmethod
+            def entitlements_path(_app):
+                return Path("host.entitlements")
+
+            @staticmethod
+            def sign_file(path, *, entitlements, identity):
+                signed.append((path, entitlements))
+
+        command = Command()
+        command.console.progress_bar.return_value = ProgressBar()
+        command.tools.file.sorted_depth_first_groups.return_value = (iter(group) for group in groups)
+        real_executor = concurrent.futures.ThreadPoolExecutor
+        executor_workers: list[int | None] = []
+
+        def create_executor(*, max_workers=None):
+            executor_workers.append(max_workers)
+            return real_executor(max_workers=max_workers)
+
+        with (
+            patch.object(
+                briefcase_macos_signing,
+                "collect_sign_targets",
+                return_value=[path for group in groups for path in group],
+            ),
+            patch.object(
+                briefcase_macos_signing.concurrent.futures,
+                "ThreadPoolExecutor",
+                side_effect=create_executor,
+            ),
+        ):
+            briefcase_macos_signing.sign_app_with_xpc(command, object(), "Developer ID")
+
+        self.assertEqual([path for path, _ in signed], [path for group in groups for path in group])
+        self.assertEqual(executor_workers, [1, 1, 1, None])
+        entitlements_by_path = dict(signed)
+        self.assertIsNone(entitlements_by_path[downloader])
+        self.assertIsNone(entitlements_by_path[updater_app])
+        self.assertIsNone(entitlements_by_path[framework])
+        self.assertEqual(entitlements_by_path[other_framework], Path("host.entitlements"))
+        self.assertEqual(entitlements_by_path[app_path], Path("host.entitlements"))
+
+
+class SparkleBundleTests(unittest.TestCase):
+    def expected_info(self) -> dict[str, object]:
+        return {
+            "CFBundleVersion": "144",
+            "BDToAVPDistributionChannel": "direct",
+            "SUFeedURL": "https://example.invalid/appcast.xml",
+            "SUPublicEDKey": "public-key",
+            "SUAllowsAutomaticUpdates": False,
+            "SUVerifyUpdateBeforeExtraction": True,
+        }
+
+    def test_inspect_app_bundle_validates_metadata_and_layout(self) -> None:
+        expected = self.expected_info()
+        info = {
+            **expected,
+            "CFBundleIdentifier": "com.example.test",
+            "CFBundleShortVersionString": "1.2.3rc1",
+            "LSMinimumSystemVersion": "11.0",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_app(Path(temp_dir), info)
+
+            metadata = sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+
+        self.assertEqual(metadata.build_version, "144")
+        self.assertEqual(metadata.short_version, "1.2.3rc1")
+        self.assertEqual(metadata.distribution_channel, "direct")
+        self.assertEqual(metadata.minimum_system_version, "11.0")
+
+    def test_inspect_app_bundle_rejects_default_build_number(self) -> None:
+        expected = self.expected_info()
+        expected["CFBundleVersion"] = "1"
+        info = {
+            **expected,
+            "CFBundleIdentifier": "com.example.test",
+            "CFBundleShortVersionString": "1.2.3",
+            "LSMinimumSystemVersion": "11.0",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_app(Path(temp_dir), info)
+
+            with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "greater than 1"):
+                sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+
+    def test_inspect_app_bundle_rejects_noncanonical_build_numbers(self) -> None:
+        for build_version in ("0", "00", "01"):
+            with self.subTest(build_version=build_version), tempfile.TemporaryDirectory() as temp_dir:
+                expected = self.expected_info()
+                expected["CFBundleVersion"] = build_version
+                info = {
+                    **expected,
+                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleShortVersionString": "1.2.3",
+                    "LSMinimumSystemVersion": "11.0",
+                }
+                app_path = make_app(Path(temp_dir), info)
+
+                with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "canonical numeric"):
+                    sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+
+    def test_release_artifact_accepts_newer_numeric_build(self) -> None:
+        expected = self.expected_info()
+        info = {
+            **expected,
+            "CFBundleVersion": "145",
+            "CFBundleIdentifier": "com.example.test",
+            "CFBundleShortVersionString": "1.2.4rc1",
+            "LSMinimumSystemVersion": "11.0",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_app(Path(temp_dir), info)
+
+            metadata = sparkle_bundle.inspect_app_bundle(
+                app_path,
+                expected_info=expected,
+                require_repository_build=False,
+            )
+
+        self.assertEqual(metadata.build_version, "145")
+
+    def test_inspect_app_bundle_rejects_output_unsafe_versions(self) -> None:
+        expected = self.expected_info()
+        info = {
+            **expected,
+            "CFBundleIdentifier": "com.example.test",
+            "CFBundleShortVersionString": "1.2.3\nforged=value",
+            "LSMinimumSystemVersion": "11.0",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_app(Path(temp_dir), info)
+
+            with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "three-part version"):
+                sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+
+    def test_repository_public_key_matches_briefcase_metadata(self) -> None:
+        info = sparkle_bundle.load_expected_info()
+
+        self.assertEqual(info["CFBundleVersion"], "144")
+        self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1,0 +1,76 @@
+import importlib
+import unittest
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+yaml = importlib.import_module("yaml")
+
+
+def load_workflow(name: str) -> dict:
+    with (REPO_ROOT / ".github" / "workflows" / name).open(encoding="utf-8") as handle:
+        return yaml.load(handle, Loader=yaml.BaseLoader)
+
+
+class SparkleWorkflowTests(unittest.TestCase):
+    def test_release_workflow_uses_protected_appcast_job(self) -> None:
+        workflow = load_workflow("briefcase.yml")
+        jobs = workflow["jobs"]
+        publish = jobs["publish-appcast"]
+        deploy = jobs["deploy-appcast"]
+
+        self.assertEqual(publish["environment"], "sparkle-release")
+        self.assertEqual(publish["needs"], "package")
+        self.assertEqual(deploy["needs"], "publish-appcast")
+        self.assertEqual(deploy["environment"]["name"], "github-pages")
+        self.assertEqual(publish["permissions"]["contents"], "read")
+        self.assertEqual(deploy["permissions"]["pages"], "write")
+        checkout = publish["steps"][0]
+        self.assertEqual(checkout["name"], "Checkout protected release tooling")
+        self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+        self.assertNotIn("target_commitish", str(publish))
+        self.assertIn("--release-artifact", str(publish))
+        self.assertIn("--verify-distribution", str(publish))
+        self.assertIn("EXPECTED_DMG_SHA256", str(publish))
+
+    def test_private_key_is_only_exposed_to_signing_step(self) -> None:
+        workflow = load_workflow("briefcase.yml")
+        publish_steps = workflow["jobs"]["publish-appcast"]["steps"]
+        secret_expression = "${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}"
+        matching_steps = [step for step in publish_steps if secret_expression in str(step)]
+
+        self.assertEqual(len(matching_steps), 1)
+        self.assertEqual(matching_steps[0]["name"], "Sign DMG and build appcast")
+        self.assertNotIn(secret_expression, str(workflow["jobs"]["package"]))
+        self.assertNotIn(secret_expression, str(workflow["jobs"]["deploy-appcast"]))
+
+    def test_release_assets_are_immutable_and_preflighted(self) -> None:
+        workflow = load_workflow("briefcase.yml")
+        package = workflow["jobs"]["package"]
+        release_step = next(step for step in package["steps"] if step["name"] == "Create Release")
+
+        self.assertEqual(release_step["with"]["overwrite_files"], "false")
+        self.assertIn("check-release", str(package))
+        self.assertIn("gh release view", str(package))
+        self.assertIn("dmg_sha256", package["outputs"])
+
+    def test_workflow_outputs_use_random_multiline_delimiters(self) -> None:
+        workflow_text = (REPO_ROOT / ".github" / "workflows" / "briefcase.yml").read_text(encoding="utf-8")
+
+        self.assertIn("MESSAGES_$(openssl rand -hex 16)", workflow_text)
+        self.assertIn("NOTES_$(openssl rand -hex 16)", workflow_text)
+        self.assertNotIn("<<EOF", workflow_text)
+
+    def test_emergency_workflow_is_manual_only_and_deploys_empty_feed(self) -> None:
+        workflow = load_workflow("sparkle-pages.yml")
+
+        self.assertEqual(set(workflow["on"]), {"workflow_dispatch"})
+        self.assertEqual(workflow["jobs"]["build"]["environment"], "sparkle-release")
+        self.assertEqual(workflow["jobs"]["build"]["if"], "github.ref == 'refs/heads/release'")
+        self.assertEqual(workflow["jobs"]["deploy"]["environment"]["name"], "github-pages")
+        self.assertIn("Emergency feed must be a valid empty appcast", str(workflow))
+        self.assertNotIn("SPARKLE_EDDSA_PRIVATE_KEY", str(workflow))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,227 @@
+import os
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QObject, QSettings, Signal
+from PySide6.QtWidgets import QApplication
+
+from bd_to_avp.gui.dialog import AboutDialog
+from bd_to_avp.gui.main_window import MainWindow
+from bd_to_avp.gui import updater
+
+
+class FakeProcessingController(QObject):
+    processing_became_idle = Signal()
+
+    def __init__(self, is_active: bool) -> None:
+        super().__init__()
+        self.is_active = is_active
+
+
+class FakeUserDefaults:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.synchronize_calls = 0
+
+    def objectForKey_(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def setObject_forKey_(self, value: str, key: str) -> None:
+        self.values[key] = value
+
+    def synchronize(self) -> None:
+        self.synchronize_calls += 1
+
+
+class UpdaterDecisionTests(unittest.TestCase):
+    def test_update_mode_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            framework_path = Path(temp_dir) / "Sparkle.framework"
+            framework_path.mkdir()
+            complete = updater.UpdaterEnvironment(
+                is_gui=True,
+                distribution_channel="direct",
+                framework_path=framework_path,
+                feed_url="https://example.invalid/appcast.xml",
+                public_key="public-key",
+            )
+
+            self.assertEqual(updater.resolve_update_mode(complete), updater.UpdateMode.SPARKLE)
+            self.assertEqual(
+                updater.resolve_update_mode(updater.UpdaterEnvironment(False, "direct", framework_path, "feed", "key")),
+                updater.UpdateMode.DISABLED,
+            )
+            self.assertEqual(
+                updater.resolve_update_mode(updater.UpdaterEnvironment(True, "app-store", None, None, None)),
+                updater.UpdateMode.APP_STORE,
+            )
+            self.assertEqual(
+                updater.resolve_update_mode(updater.UpdaterEnvironment(True, "direct", None, "feed", "key")),
+                updater.UpdateMode.MANUAL,
+            )
+            self.assertEqual(
+                updater.resolve_update_mode(updater.UpdaterEnvironment(True, None, None, None, None)),
+                updater.UpdateMode.MANUAL,
+            )
+
+    def test_allowed_channels_keep_stable_as_default(self) -> None:
+        self.assertEqual(updater.allowed_sparkle_channels(updater.UpdateChannel.STABLE), frozenset())
+        self.assertEqual(
+            updater.allowed_sparkle_channels(updater.UpdateChannel.RELEASE_CANDIDATES),
+            frozenset({"rc"}),
+        )
+
+    def test_preferences_default_to_stable_and_persist_rc(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = QSettings((Path(temp_dir) / "updates.ini").as_posix(), QSettings.Format.IniFormat)
+            preferences = updater.UpdatePreferences(settings)
+
+            self.assertEqual(preferences.channel, updater.UpdateChannel.STABLE)
+            preferences.channel = updater.UpdateChannel.RELEASE_CANDIDATES
+
+            reloaded = updater.UpdatePreferences(
+                QSettings((Path(temp_dir) / "updates.ini").as_posix(), QSettings.Format.IniFormat)
+            )
+            self.assertEqual(reloaded.channel, updater.UpdateChannel.RELEASE_CANDIDATES)
+
+    def test_invalid_persisted_channel_falls_back_to_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = QSettings((Path(temp_dir) / "updates.ini").as_posix(), QSettings.Format.IniFormat)
+            settings.setValue(updater.CHANNEL_SETTINGS_KEY, "nightly")
+
+            self.assertEqual(updater.UpdatePreferences(settings).channel, updater.UpdateChannel.STABLE)
+
+    def test_preferences_support_app_user_defaults(self) -> None:
+        settings = FakeUserDefaults()
+        preferences = updater.UpdatePreferences(settings)
+
+        self.assertEqual(preferences.channel, updater.UpdateChannel.STABLE)
+        preferences.channel = updater.UpdateChannel.RELEASE_CANDIDATES
+
+        self.assertEqual(preferences.channel, updater.UpdateChannel.RELEASE_CANDIDATES)
+        self.assertEqual(settings.synchronize_calls, 1)
+
+
+class InstallationPostponementTests(unittest.TestCase):
+    def test_idle_processing_does_not_postpone(self) -> None:
+        processing = FakeProcessingController(False)
+        install = Mock()
+
+        postponed = updater.InstallationPostponement(processing).postpone_if_processing(install)
+
+        self.assertFalse(postponed)
+        install.assert_not_called()
+
+    def test_active_processing_resumes_install_once_when_idle(self) -> None:
+        processing = FakeProcessingController(True)
+        install = Mock()
+        postponement = updater.InstallationPostponement(processing)
+
+        self.assertTrue(postponement.postpone_if_processing(install))
+        processing.is_active = False
+        processing.processing_became_idle.emit()
+        processing.processing_became_idle.emit()
+
+        install.assert_called_once_with()
+
+
+class UpdaterManagerTests(unittest.TestCase):
+    def test_manual_mode_opens_release_page_without_github_api(self) -> None:
+        processing = FakeProcessingController(False)
+        environment = updater.UpdaterEnvironment(True, None, None, None, None)
+        manager = updater.UpdaterManager(processing, environment=environment)
+
+        with patch.object(updater.QDesktopServices, "openUrl", return_value=True) as open_url:
+            self.assertTrue(manager.check_for_updates())
+
+        open_url.assert_called_once()
+        self.assertEqual(open_url.call_args.args[0].toString(), updater.RELEASES_URL)
+
+    def test_sparkle_initialization_failure_falls_back_to_manual(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            framework_path = Path(temp_dir) / "Sparkle.framework"
+            framework_path.mkdir()
+            environment = updater.UpdaterEnvironment(True, "direct", framework_path, "feed", "key")
+            processing = FakeProcessingController(False)
+
+            with (
+                patch.object(updater.UpdaterManager, "_initialize_sparkle", side_effect=RuntimeError("failed")),
+                self.assertLogs(updater.logger, level="ERROR") as logs,
+            ):
+                manager = updater.UpdaterManager(processing, environment=environment)
+
+        self.assertEqual(manager.mode, updater.UpdateMode.MANUAL)
+        self.assertIsInstance(manager.initialization_error, RuntimeError)
+        self.assertIn("falling back to manual updates", logs.output[0])
+
+    def test_channel_change_resets_sparkle_update_cycle(self) -> None:
+        processing = FakeProcessingController(False)
+        environment = updater.UpdaterEnvironment(True, None, None, None, None)
+        settings = FakeUserDefaults()
+        manager = updater.UpdaterManager(
+            processing,
+            environment=environment,
+            preferences=updater.UpdatePreferences(settings),
+        )
+        sparkle_updater = Mock()
+        manager._sparkle_controller = Mock()
+        manager._sparkle_controller.updater.return_value = sparkle_updater
+
+        manager.set_channel(updater.UpdateChannel.RELEASE_CANDIDATES)
+
+        sparkle_updater.resetUpdateCycleAfterShortDelay.assert_called_once_with()
+
+
+class UpdaterGuiTests(unittest.TestCase):
+    app: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = QApplication.instance()
+        cls.app = app if isinstance(app, QApplication) else QApplication([])
+        cls.app.setApplicationName("bd-to-avp-tests")
+        cls.app.setApplicationDisplayName("BD_to_AVP Test")
+
+    def test_help_menu_exposes_check_and_channel_actions(self) -> None:
+        window = MainWindow()
+        fake_manager = Mock()
+        fake_manager.supports_channels = True
+        fake_manager.channel = updater.UpdateChannel.STABLE
+        window.updater_manager = fake_manager
+
+        window.create_menu_bar()
+
+        self.assertEqual(window.update_action.text(), "Check for Updates…")
+        channel_actions = {action.text(): action for action in window.update_channel_actions.actions()}
+        self.assertEqual(set(channel_actions), {"Stable", "Release Candidates"})
+        self.assertTrue(channel_actions["Stable"].isChecked())
+        channel_actions["Release Candidates"].trigger()
+        fake_manager.set_channel.assert_called_once_with(updater.UpdateChannel.RELEASE_CANDIDATES)
+        window.close()
+
+    def test_about_dialog_has_no_legacy_network_checker(self) -> None:
+        dialog = AboutDialog()
+
+        self.assertFalse(hasattr(dialog, "prerelease_checkbox"))
+        self.assertFalse(hasattr(dialog, "update_label"))
+        self.assertFalse(hasattr(dialog, "fetch_latest_release"))
+        dialog.close()
+
+
+class LegacyDependencyTests(unittest.TestCase):
+    def test_runtime_sources_no_longer_import_github_or_packaging(self) -> None:
+        source_root = Path(__file__).resolve().parents[1] / "bd_to_avp"
+        source = "\n".join(path.read_text(encoding="utf-8") for path in source_root.rglob("*.py"))
+
+        self.assertNotIn("from github", source)
+        self.assertNotIn("import github", source)
+        self.assertNotIn("from packaging", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -97,9 +97,7 @@ dependencies = [
     { name = "humanize" },
     { name = "numpy" },
     { name = "opencv-python" },
-    { name = "packaging" },
     { name = "psutil" },
-    { name = "pygithub" },
     { name = "pyobjc-framework-vision" },
     { name = "pyside6" },
     { name = "pysrt" },
@@ -125,9 +123,7 @@ requires-dist = [
     { name = "humanize", specifier = ">=4.9.0,<5" },
     { name = "numpy", specifier = ">=2,<3" },
     { name = "opencv-python", specifier = "==4.10.0.84" },
-    { name = "packaging", specifier = ">=24.1,<27" },
     { name = "psutil", specifier = ">=5.9.8,<8" },
-    { name = "pygithub", specifier = ">=2.3.0,<3" },
     { name = "pyobjc-framework-vision", specifier = ">=11.0,<12" },
     { name = "pyside6", specifier = ">=6.7.1,<7" },
     { name = "pysrt", specifier = ">=1.1.2,<2" },
@@ -138,7 +134,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=26.5.1,<27" },
-    { name = "briefcase", specifier = ">=0.4.3,<0.5" },
+    { name = "briefcase", specifier = "==0.4.3" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
     { name = "ruff", specifier = ">=0.15.20,<0.16" },
     { name = "types-psutil", specifier = ">=5.9.5.20240516" },
@@ -231,29 +227,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-]
-
-[[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -340,43 +313,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/03/f4c96d8fd4f5e8af0210bf896eb63927f35d3014a8e8f3bf9d2c43ad3332/cookiecutter-2.7.1.tar.gz", hash = "sha256:ca7bb7bc8c6ff441fbf53921b5537668000e38d56e28d763a1b73975c66c6138", size = 142854, upload-time = "2026-03-04T04:06:02.786Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a9/8c855c14b401dc67d20739345295af5afce5e930a69600ab20f6cfa50b5c/cookiecutter-2.7.1-py3-none-any.whl", hash = "sha256:cee50defc1eaa7ad0071ee9b9893b746c1b3201b66bf4d3686d0f127c8ed6cf9", size = 41317, upload-time = "2026-03-04T04:06:01.221Z" },
-]
-
-[[package]]
-name = "cryptography"
-version = "49.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
-    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
-    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
-    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
-    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
-    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
-    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -743,74 +679,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pygithub"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "pynacl" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyjwt"
-version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
-]
-
-[package.optional-dependencies]
-crypto = [
-    { name = "cryptography" },
-]
-
-[[package]]
-name = "pynacl"
-version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
-    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
-    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]

--- a/vendor/sparkle-macos.toml
+++ b/vendor/sparkle-macos.toml
@@ -1,0 +1,3 @@
+version = "2.9.4"
+archive_url = "https://github.com/sparkle-project/Sparkle/releases/download/2.9.4/Sparkle-2.9.4.tar.xz"
+archive_sha256 = "ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"


### PR DESCRIPTION
## Summary

- pin and embed Sparkle 2.9.4 in direct-DMG builds, set the monotonic macOS build number, and extend Briefcase 0.4.3 signing to cover Sparkle's nested app and XPC services inside-out
- replace the synchronous PyGithub About-dialog checker with Sparkle's standard update UI, Stable and Release Candidates preferences, manual/App Store fallbacks, and processing-aware relaunch postponement
- publish one signed full-DMG appcast with production on Sparkle's default channel and RCs on `rc`, protected by immutable release checks, exact artifact digest validation, protected signing tooling, and an emergency empty-feed workflow

## Validation

- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` — 266 tests
- import smoke, CLI help smoke, and `uv build`
- `actionlint` for both changed workflows and Prettier checks for workflows/docs/metadata
- real Briefcase create/build plus ad-hoc package; app and DMG metadata/nested signature validation passed
- packaged native UI smoke confirmed Stable default, persisted RC selection, and Sparkle's standard user-initiated up-to-date window under Qt's event loop
- JetBrains changed-files inspection: GREEN with zero findings
- independent runtime, packaging, and release-security reviews: no blockers after fixes
- live GitHub Pages appcast, `sparkle-release` reviewer/branch policy, release ruleset, and environment secret presence verified

## Follow-up

The implementation closes the packaging and runtime work. Issue #165 still requires the controlled first Sparkle-enabled RC publication and installed older-to-newer upgrade smoke before normal-user promotion.

Closes #163
Closes #164
Advances #165
