### PR TITLE
Fix Python setup on native preview release runner

### DIFF
--- a/.github/workflows/native-ui-preview.yml
+++ b/.github/workflows/native-ui-preview.yml
@@ -138,18 +138,16 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: "3.12"
-
       - name: Set up uv
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
+          python-version: "3.12"
 
-      - name: Install locked dependencies
-        run: uv sync --locked --all-groups --python 3.12
+      - name: Install Python and locked dependencies
+        run: |
+          uv python install 3.12
+          uv sync --locked --all-groups --python 3.12
 
       - name: Install signing certificate in an ephemeral keychain
         env:

--- a/tests/test_native_preview_release.py
+++ b/tests/test_native_preview_release.py
@@ -204,6 +204,8 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertIn("XCODEGEN_VERSION", str(workflow))
         self.assertIn("sw_vers", str(package))
         self.assertIn("must not override", str(package))
+        self.assertNotIn("actions/setup-python", str(package))
+        self.assertIn("uv python install 3.12", str(package))
 
     def test_workflow_isolated_from_production_channels(self) -> None:
         workflow = load_workflow()


### PR DESCRIPTION
## Summary
- remove `actions/setup-python` from the self-hosted native preview release job
- install Python 3.12 through `uv`, which uses runner-user-writable paths
- lock the runner contract with a workflow regression test

## Why
Native UI Preview run 29206169539 failed before signing because `actions/setup-python` tried to create `/Users/runner/hostedtoolcache` on the ephemeral runner owned by another macOS user.

## Validation
- `uv run python -m unittest discover -s tests -t .` (347 tests)
- `uv run python -m unittest tests.test_native_preview_release`
- `actionlint -oneline .github/workflows/native-ui-preview.yml`
- clean temporary `uv python install 3.12` on macOS 27 arm64

Follow-up to #202.