### PR TITLE
Avoid Xcode version probe pipe failures

### DIFF
--- a/.github/workflows/native-ui-preview.yml
+++ b/.github/workflows/native-ui-preview.yml
@@ -130,7 +130,12 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           test "$(uname -m)" = "arm64"
           test "$(sw_vers -productVersion | cut -d. -f1)" = "27"
-          xcodebuild -version | head -1 | grep -Eq '^Xcode 27([.]|$)'
+          XCODE_VERSION=$(xcodebuild -version)
+          if [[ ! "$XCODE_VERSION" =~ ^Xcode\ 27([.]|$) ]]; then
+            echo "Release builds require Xcode 27." >&2
+            printf '%s\n' "$XCODE_VERSION" >&2
+            exit 1
+          fi
           command -v xcodegen >/dev/null
           test "$(xcodegen --version)" = "Version: $XCODEGEN_VERSION"
           if [ -n "${BD_TO_AVP_NATIVE_DEPLOYMENT_TARGET_OVERRIDE:-}" ]; then

--- a/tests/test_native_preview_release.py
+++ b/tests/test_native_preview_release.py
@@ -204,6 +204,8 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertIn("XCODEGEN_VERSION", str(workflow))
         self.assertIn("sw_vers", str(package))
         self.assertIn("must not override", str(package))
+        self.assertNotIn("head -1", str(package))
+        self.assertNotIn("xcodebuild -version |", str(package))
         self.assertNotIn("actions/setup-python", str(package))
         self.assertIn("uv python install 3.12", str(package))
 


### PR DESCRIPTION
## Summary
- capture the full `xcodebuild -version` output before validating Xcode 27
- prevent `head`/quiet-grep from closing the Xcode 27 process pipe early
- add a workflow regression assertion against piped Xcode version probes

## Why
Native UI Preview run 29207433473 failed in preflight when Xcode 27 raised `NSFileHandleOperationException` after `head -1` closed stdout early.

## Validation
- exact replacement probe repeated 20 times on Xcode 27
- `uv run python -m unittest tests.test_native_preview_release`
- `actionlint -oneline .github/workflows/native-ui-preview.yml`

Follow-up to #202.