### PR TITLE
Centralize native preview release metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -113,7 +113,7 @@
     "CI",
     "CodeQL",
     "Release from protected main",
-    "Publish Native UI Preview 1",
+    "Publish Native UI Preview",
     "Manage Sparkle Pages",
     "Update FFmpeg Vendor Pins"
   ],

--- a/.github/workflows/native-ui-preview.yml
+++ b/.github/workflows/native-ui-preview.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish Native UI Preview 1
+name: Publish Native UI Preview
 
 "on":
   workflow_dispatch:
@@ -8,10 +8,6 @@ permissions:
   contents: read
 
 env:
-  PREVIEW_APP_NAME: 3D Blu-ray to Vision Pro Native Preview.app
-  PREVIEW_DMG_NAME: 3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg
-  PREVIEW_RELEASE_NAME: Native UI Preview 1
-  PREVIEW_TAG: native-ui-preview-1
   XCODEGEN_VERSION: 2.45.4
 
 concurrency:
@@ -26,7 +22,11 @@ jobs:
     permissions:
       contents: read
     outputs:
+      app_name: ${{ steps.metadata.outputs.app_name }}
+      dmg_name: ${{ steps.metadata.outputs.dmg_name }}
       latest_release_tag: ${{ steps.release_identity.outputs.latest_release_tag }}
+      release_name: ${{ steps.metadata.outputs.release_name }}
+      release_tag: ${{ steps.metadata.outputs.release_tag }}
     steps:
       - name: Checkout dispatch commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -51,17 +51,28 @@ jobs:
             echo "The dispatch commit is no longer the current main HEAD." >&2
             exit 1
           fi
-          if [[ "$PREVIEW_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "Native preview tags must stay outside the production semver namespace." >&2
-            exit 1
-          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Derive committed native preview metadata
+        id: metadata
+        run: python -m scripts.native_preview_release metadata --github-output "$GITHUB_OUTPUT"
 
       - name: Reject conflicting release identity
         id: release_identity
         env:
           GH_TOKEN: ${{ github.token }}
+          PREVIEW_RELEASE_NAME: ${{ steps.metadata.outputs.release_name }}
+          PREVIEW_TAG: ${{ steps.metadata.outputs.release_tag }}
         run: |
           set -euo pipefail
+          if [[ "$PREVIEW_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Native preview tags must stay outside the production semver namespace." >&2
+            exit 1
+          fi
           TAG_REFS=$(git ls-remote --tags origin \
             "refs/tags/$PREVIEW_TAG" \
             "refs/tags/$PREVIEW_TAG^{}")
@@ -108,6 +119,9 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, bd-to-avp-release]
     timeout-minutes: 180
     environment: macos-signing
+    env:
+      PREVIEW_APP_NAME: ${{ needs.prepare.outputs.app_name }}
+      PREVIEW_DMG_NAME: ${{ needs.prepare.outputs.dmg_name }}
     permissions:
       attestations: write
       contents: read
@@ -232,36 +246,36 @@ jobs:
           uv run python scripts/native_app.py package \
             --sign-identity "$DEV_ID" \
             --sign-keychain "$KEYCHAIN_PATH"
-          uv run python scripts/native_preview_release.py verify-app \
+          uv run python -m scripts.native_preview_release verify-app \
             --app "$APP_PATH" \
             --verify-signatures \
             > dist/native-preview-app-metadata.json
 
           ditto -c -k --keepParent "$APP_PATH" "$APP_ARCHIVE"
-          uv run python scripts/native_preview_release.py notarize \
+          uv run python -m scripts.native_preview_release notarize \
             --submission "$APP_ARCHIVE" \
             --staple "$APP_PATH" \
             --keychain-profile "$NOTARY_PROFILE" \
             --keychain "$KEYCHAIN_PATH" \
             --log dist/notary/app-notary.json
-          uv run python scripts/native_preview_release.py verify-app \
+          uv run python -m scripts.native_preview_release verify-app \
             --app "$APP_PATH" \
             --verify-signatures \
             --verify-distribution \
             --smoke-worker \
             > dist/native-preview-app-metadata.json
 
-          uv run python scripts/native_preview_release.py create-dmg \
+          uv run python -m scripts.native_preview_release create-dmg \
             --app "$APP_PATH" \
             --output "$DMG_PATH"
           codesign --force --timestamp --sign "$DEV_ID" --keychain "$KEYCHAIN_PATH" "$DMG_PATH"
-          uv run python scripts/native_preview_release.py notarize \
+          uv run python -m scripts.native_preview_release notarize \
             --submission "$DMG_PATH" \
             --staple "$DMG_PATH" \
             --keychain-profile "$NOTARY_PROFILE" \
             --keychain "$KEYCHAIN_PATH" \
             --log dist/notary/dmg-notary.json
-          uv run python scripts/native_preview_release.py verify-dmg \
+          uv run python -m scripts.native_preview_release verify-dmg \
             --dmg "$DMG_PATH" \
             --verify-signatures \
             --verify-distribution \
@@ -326,6 +340,9 @@ jobs:
       - package
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PREVIEW_RELEASE_NAME: ${{ needs.prepare.outputs.release_name }}
+      PREVIEW_TAG: ${{ needs.prepare.outputs.release_tag }}
     permissions:
       attestations: read
       contents: write
@@ -380,7 +397,7 @@ jobs:
               --latest=false \
               --target "$GITHUB_SHA" \
               --title "$PREVIEW_RELEASE_NAME" \
-              --notes-file docs/native-ui-preview-1.md
+              --notes-file docs/native-ui-preview.md
             for attempt in {1..12}; do
               RELEASE_ID=$(resolve_release_id)
               if [ -n "$RELEASE_ID" ]; then

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -76,9 +76,12 @@ document it as an external dependency with preflight behavior.
   production app and does not enter either Sparkle channel, GitHub latest, or
   PyPI. The first native production-replacement candidate is reserved for the
   `0.3.0rc1` line after real conversion and updater prerequisites are complete.
-  `Native UI Preview 1` is published by its own protected-main workflow using
-  fixed tag `native-ui-preview-1`, a dedicated macOS 27/Xcode 27 release runner,
-  and an exact two-asset allowlist: the notarized DMG and `SHA256SUMS`.
+  Native UI previews are published by their own protected-main workflow using a
+  version-first title and tag derived from the committed, monotonically
+  increasing native build number. Version `0.3.0` build `1` uses title
+  `v0.3.0 (Build 1) — Native UI Preview` and tag `native-ui-preview-1`. The lane
+  uses a dedicated macOS 27/Xcode 27 release runner and an exact two-asset
+  allowlist: the notarized DMG and `SHA256SUMS`.
 - PKG artifact policy is tracked in #118. Until that issue decides otherwise,
   PKG output is not the normal-user release path.
 - Homebrew distribution for CLI users is tracked in #119.

--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -81,8 +81,8 @@ worker-only runtime after the native shell exercises more representative engine
 paths; slimming it now would create a third dependency graph before the worker
 surface is known.
 
-`Publish Native UI Preview 1` is the isolated distribution workflow for issue
-#202. It runs only from the current protected `main` commit, uses the reviewed
+`Publish Native UI Preview` is the isolated distribution workflow for native UI
+feedback builds. It runs only from the current protected `main` commit, uses the reviewed
 `macos-signing` environment, Developer-ID signs and notarizes both the app and
 DMG, staples and Gatekeeper-validates the result, repeats the packaged-worker
 smoke from the mounted DMG, attests the artifact, and publishes only the DMG and
@@ -111,12 +111,16 @@ line while Start Processing remains unavailable. Publishing this bundle through
 the normal Release Candidates appcast would replace a working converter with a
 UI-only build and would leave testers without the current updater path.
 
-Issue #202 owns the bounded feedback release. `Native UI Preview 1` uses a
-separate product name and bundle identifier, installs beside the production app,
-targets Apple Silicon macOS 27, and is published only as a GitHub prerelease. It
-does not mutate Sparkle Pages, either appcast channel, GitHub latest, or PyPI.
-The fixed tag is `native-ui-preview-1`; repeated runs may resume only a matching
-draft with byte-identical assets, and fail closed after publication.
+The preview uses a separate product name and bundle identifier, installs beside
+the production app, targets Apple Silicon macOS 27, and is published only as a
+GitHub prerelease. It does not mutate Sparkle Pages, either appcast channel,
+GitHub latest, or PyPI. Release identity is derived from the committed native
+version and monotonically increasing build number. Version `0.3.0` build `1`
+uses tag `native-ui-preview-1` and title
+`v0.3.0 (Build 1) — Native UI Preview`. Repeated runs may resume only a matching
+draft with byte-identical assets, and fail closed after publication. Published
+tags and assets remain immutable even if the human-readable title or notes need
+a metadata-only correction.
 
 The first native build eligible to replace production is reserved for
 `0.3.0rc1`. That candidate must use a production `CFBundleVersion` greater than

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -1,5 +1,3 @@
-# Native UI Preview 1
-
 This is an opt-in preview of the new native macOS interface for 3D Blu-ray to
 Vision Pro. It installs beside the current production app and does not replace
 or update it.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -84,9 +84,9 @@ For Stable releases, PyPI publication and Sparkle Pages deployment are
 independent post-publication jobs. Either channel can be retried without
 rebuilding or changing the published GitHub Release.
 
-### Native UI Preview 1
+### Native UI Preview
 
-The one-time native UI feedback release uses
+The native UI feedback release lane uses
 `.github/workflows/native-ui-preview.yml`, not the production Briefcase release
 workflow. Dispatch it only from the current protected `main` commit after CI is
 green and an ephemeral Apple Silicon runner labeled `bd-to-avp-release` is ready
@@ -94,10 +94,16 @@ with macOS 27, Xcode 27, and XcodeGen 2.45.4.
 
 The workflow uses the existing reviewed `macos-signing` environment to sign and
 notarize the side-by-side Preview bundle, creates and revalidates a DMG, and
-publishes fixed tag `native-ui-preview-1` as `Native UI Preview 1`. It never
-derives metadata from `pyproject.toml`, invokes the Sparkle/Pages workflows,
-publishes Python distributions, or marks the preview as GitHub latest. A failed
-run may resume only an exact matching draft; a published preview is immutable.
+derives its tag, version-first release title, app name, and DMG filename from the
+committed native app version and build metadata. Version `0.3.0` build `1`, for
+example, uses tag `native-ui-preview-1` and title
+`v0.3.0 (Build 1) — Native UI Preview`. Preview build numbers are monotonically
+increasing and may not be reused. The workflow never derives metadata from
+`pyproject.toml`, invokes the Sparkle/Pages workflows, publishes Python
+distributions, or marks a preview as GitHub latest. A failed run may resume only
+an exact matching draft. Published tags and assets are immutable; maintainers
+may correct the human-readable title or notes without replacing artifacts or
+changing the target commit.
 
 The cumulative `appcast.xml` attached to every published GitHub Release is the
 recovery source of truth. Pages also publishes `appcast-state.json`, which binds

--- a/scripts/native_preview_release.py
+++ b/scripts/native_preview_release.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import plistlib
+import re
 import subprocess
 import sys
 import tempfile
@@ -26,15 +27,25 @@ from scripts.native_app import (
     verify_layout,
 )
 
-PREVIEW_TAG = "native-ui-preview-1"
-PREVIEW_RELEASE_NAME = "Native UI Preview 1"
-PREVIEW_DMG_NAME = "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg"
 PREVIEW_VOLUME_NAME = NATIVE_PRODUCT_NAME
 INFO_PLIST_RELATIVE_PATH = Path("Contents/Info.plist")
 
 
 class NativePreviewReleaseError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class NativePreviewReleaseMetadata:
+    app_name: str
+    build_version: str
+    dmg_name: str
+    release_name: str
+    release_tag: str
+    short_version: str
+
+    def github_outputs(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
 
 
 @dataclass(frozen=True)
@@ -45,6 +56,32 @@ class NativePreviewMetadata:
     minimum_system_version: str
     product_name: str
     short_version: str
+
+
+def create_preview_release_metadata(
+    *,
+    app_name: str = NATIVE_APP_NAME,
+    build_version: str = NATIVE_BUILD_VERSION,
+    product_name: str = NATIVE_PRODUCT_NAME,
+    short_version: str = NATIVE_SHORT_VERSION,
+) -> NativePreviewReleaseMetadata:
+    if re.fullmatch(r"\d+\.\d+\.\d+", short_version) is None:
+        raise NativePreviewReleaseError("Native preview short version must contain three numeric components.")
+    if re.fullmatch(r"[1-9]\d*", build_version) is None:
+        raise NativePreviewReleaseError("Native preview build version must be a positive integer.")
+
+    file_stem = product_name.replace(" ", "-")
+    return NativePreviewReleaseMetadata(
+        app_name=app_name,
+        build_version=build_version,
+        dmg_name=f"{file_stem}-{short_version}-{build_version}.dmg",
+        release_name=f"v{short_version} (Build {build_version}) — Native UI Preview",
+        release_tag=f"native-ui-preview-{build_version}",
+        short_version=short_version,
+    )
+
+
+PREVIEW_RELEASE_METADATA = create_preview_release_metadata()
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -284,6 +321,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Assemble and validate the Native UI Preview release artifact.")
     commands = parser.add_subparsers(dest="command", required=True)
 
+    metadata_parser = commands.add_parser("metadata")
+    metadata_parser.add_argument("--github-output", type=Path)
+
     verify_app_parser = commands.add_parser("verify-app")
     verify_app_parser.add_argument("--app", type=Path, required=True)
     add_verification_flags(verify_app_parser)
@@ -307,7 +347,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
-    if args.command == "verify-app":
+    if args.command == "metadata":
+        if args.github_output:
+            with args.github_output.open("a", encoding="utf-8") as handle:
+                for key, value in PREVIEW_RELEASE_METADATA.github_outputs().items():
+                    handle.write(f"{key}={value}\n")
+        print(json.dumps(asdict(PREVIEW_RELEASE_METADATA), sort_keys=True))
+    elif args.command == "verify-app":
         metadata = verify_preview_app(
             args.app,
             verify_signatures=args.verify_signatures,

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import plistlib
 import subprocess
@@ -32,6 +33,8 @@ from scripts.native_app import (
     verify_product_source_copy,
 )
 
+yaml = importlib.import_module("yaml")
+
 
 class NativeAppPackagingTests(unittest.TestCase):
     def test_uses_side_by_side_preview_identity(self) -> None:
@@ -47,6 +50,9 @@ class NativeAppPackagingTests(unittest.TestCase):
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:
         project_spec = (MACOS_ROOT / "project.yml").read_text(encoding="utf-8")
+        project = yaml.load(project_spec, Loader=yaml.BaseLoader)
+        target_settings = project["targets"]["BluRayToVisionPro"]["settings"]
+        preview_settings = target_settings["configs"]["Preview"]
         app_source = (MACOS_ROOT / "BluRayToVisionPro" / "App" / "BluRayToVisionProApp.swift").read_text(
             encoding="utf-8"
         )
@@ -59,9 +65,10 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn("CommandGroup(replacing: .appSettings)", app_source)
         self.assertIn("openWindow(id: AppWindowID.settings)", app_source)
         self.assertIn(".windowResizability(.contentMinSize)", app_source)
-        self.assertIn("MARKETING_VERSION: 0.3.0", project_spec)
-        self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.native-preview", project_spec)
-        self.assertIn("PRODUCT_NAME: 3D Blu-ray to Vision Pro Native Preview", project_spec)
+        self.assertEqual(target_settings["base"]["CURRENT_PROJECT_VERSION"], NATIVE_BUILD_VERSION)
+        self.assertEqual(preview_settings["MARKETING_VERSION"], NATIVE_SHORT_VERSION)
+        self.assertEqual(preview_settings["PRODUCT_BUNDLE_IDENTIFIER"], NATIVE_BUNDLE_IDENTIFIER)
+        self.assertEqual(preview_settings["PRODUCT_NAME"], NATIVE_PRODUCT_NAME)
         self.assertIn("Preview: release", project_spec)
 
     def test_native_ui_keeps_discs_primary_and_original_job_controls_visible(self) -> None:

--- a/tests/test_native_preview_release.py
+++ b/tests/test_native_preview_release.py
@@ -18,12 +18,12 @@ from scripts.native_app import (
     NATIVE_SHORT_VERSION,
 )
 from scripts.native_preview_release import (
-    PREVIEW_DMG_NAME,
-    PREVIEW_RELEASE_NAME,
-    PREVIEW_TAG,
+    PREVIEW_RELEASE_METADATA,
     NativePreviewReleaseError,
+    create_preview_release_metadata,
     create_preview_dmg,
     inspect_preview_info,
+    main,
     mounted_dmg,
     notarize_and_staple,
 )
@@ -63,11 +63,35 @@ def load_workflow() -> dict:
 
 
 class NativePreviewIdentityTests(unittest.TestCase):
-    def test_preview_release_identity_is_fixed_and_non_production(self) -> None:
-        self.assertEqual(PREVIEW_TAG, "native-ui-preview-1")
-        self.assertEqual(PREVIEW_RELEASE_NAME, "Native UI Preview 1")
-        self.assertEqual(PREVIEW_DMG_NAME, "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg")
+    def test_preview_release_identity_is_derived_and_non_production(self) -> None:
+        self.assertEqual(PREVIEW_RELEASE_METADATA.release_tag, f"native-ui-preview-{NATIVE_BUILD_VERSION}")
+        self.assertEqual(
+            PREVIEW_RELEASE_METADATA.release_name,
+            f"v{NATIVE_SHORT_VERSION} (Build {NATIVE_BUILD_VERSION}) — Native UI Preview",
+        )
+        self.assertTrue(PREVIEW_RELEASE_METADATA.release_name.startswith(f"v{NATIVE_SHORT_VERSION} "))
+        self.assertEqual(
+            PREVIEW_RELEASE_METADATA.dmg_name,
+            f"3D-Blu-ray-to-Vision-Pro-Native-Preview-{NATIVE_SHORT_VERSION}-{NATIVE_BUILD_VERSION}.dmg",
+        )
+        self.assertEqual(PREVIEW_RELEASE_METADATA.app_name, NATIVE_APP_NAME)
         self.assertNotEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
+
+    def test_metadata_command_writes_github_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output"
+            with patch("builtins.print"):
+                main(["metadata", "--github-output", str(output_path)])
+
+            outputs = dict(line.split("=", maxsplit=1) for line in output_path.read_text(encoding="utf-8").splitlines())
+
+        self.assertEqual(outputs, PREVIEW_RELEASE_METADATA.github_outputs())
+
+    def test_release_metadata_rejects_invalid_version_or_build(self) -> None:
+        with self.assertRaisesRegex(NativePreviewReleaseError, "three numeric components"):
+            create_preview_release_metadata(short_version="0.3")
+        with self.assertRaisesRegex(NativePreviewReleaseError, "positive integer"):
+            create_preview_release_metadata(build_version="0")
 
     def test_accepts_exact_preview_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -97,7 +121,7 @@ class NativePreviewIdentityTests(unittest.TestCase):
     def test_refuses_to_replace_an_existing_dmg(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
-            output_path = temporary_path / PREVIEW_DMG_NAME
+            output_path = temporary_path / PREVIEW_RELEASE_METADATA.dmg_name
             output_path.touch()
 
             with self.assertRaisesRegex(NativePreviewReleaseError, "Refusing to replace"):
@@ -208,6 +232,10 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertNotIn("xcodebuild -version |", str(package))
         self.assertNotIn("actions/setup-python", str(package))
         self.assertIn("uv python install 3.12", str(package))
+        self.assertEqual(workflow["name"], "Publish Native UI Preview")
+        self.assertIn("python -m scripts.native_preview_release metadata", str(prepare))
+        self.assertIn("needs.prepare.outputs.app_name", str(package))
+        self.assertIn("needs.prepare.outputs.dmg_name", str(package))
 
     def test_workflow_isolated_from_production_channels(self) -> None:
         workflow = load_workflow()
@@ -248,8 +276,16 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertIn("native-ui-preview.yml", str(publish))
         self.assertIn("SHA256SUMS", str(publish))
         self.assertIn("PREVIEW_TAG", str(publish))
+        self.assertIn("needs.prepare.outputs.release_name", str(publish))
+        self.assertIn("needs.prepare.outputs.release_tag", str(publish))
+        self.assertIn("docs/native-ui-preview.md", str(publish))
+        self.assertNotIn("Native UI Preview 1", str(workflow))
+        self.assertNotIn(PREVIEW_RELEASE_METADATA.app_name, str(workflow))
+        self.assertNotIn(PREVIEW_RELEASE_METADATA.dmg_name, str(workflow))
+        self.assertNotIn(PREVIEW_RELEASE_METADATA.release_name, str(workflow))
+        self.assertNotIn(PREVIEW_RELEASE_METADATA.release_tag, str(workflow))
         self.assertIn(".github/workflows/native-ui-preview.yml", config["docs"]["releaseWorkflows"])
-        self.assertIn("Publish Native UI Preview 1", config["importantWorkflows"])
+        self.assertIn("Publish Native UI Preview", config["importantWorkflows"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- derive the native preview tag, version-first GitHub title, app name, and DMG name from committed native version/build metadata
- make `Publish Native UI Preview` reusable for later build numbers through prepare-job outputs
- replace Preview-1-specific workflow/docs fixtures with generic release-lane documentation
- verify Xcode Preview settings remain aligned with the script metadata

The resulting release title for the shipped build is `v0.3.0 (Build 1) — Native UI Preview`; the isolated tag remains `native-ui-preview-1`.

## Release safety
- protected-main, environment approval, draft-resume, exact asset allowlist, attestation, and latest-release rollback remain unchanged
- no Sparkle, Pages, PyPI, or production-semver coupling was added
- the metadata command runs with hosted Python before the self-hosted package job

## Validation
- 350 Python tests passed
- 33 native Swift tests passed
- Actionlint passed
- Ruff format and lint passed
- `uv lock --check` and release metadata validation passed
- PyCharm changed-files inspection: GREEN
- independent release-safety review: no code/workflow findings

Issue freshness is intentionally deferred to a later pass.