### PR TITLE
Enable native conversion for MKV, MTS, and M2TS sources

### DIFF
--- a/bd_to_avp/modules/file.py
+++ b/bd_to_avp/modules/file.py
@@ -86,11 +86,12 @@ def prepare_output_folder_for_source(disc_name: str) -> Path:
     return output_path
 
 
-def move_file_to_output_root_folder(muxed_output_path: Path) -> None:
+def move_file_to_output_root_folder(muxed_output_path: Path) -> Path:
     final_path = config.output_root_path / muxed_output_path.name
     muxed_output_path.replace(final_path)
     if not config.keep_files:
         remove_output_folder_if_safe(muxed_output_path.parent)
+    return final_path
 
 
 @contextmanager

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -42,9 +42,11 @@ class BatchProcessingError(Exception):
 
 
 class ActivityReporter(Protocol):
-    def stage_started(self, stage: str, message: str) -> None: ...
+    def stage_started(self, stage: str, message: str) -> None:
+        raise NotImplementedError
 
-    def log(self, message: str, *, stage: str | None = None, **fields: object) -> None: ...
+    def log(self, message: str, *, stage: str | None = None, **fields: object) -> None:
+        raise NotImplementedError
 
 
 def raise_if_cancelled(cancellation_event: Event | None) -> None:

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 from threading import Event
+from typing import Protocol
 
 from wakepy.modes import keep
 
@@ -40,6 +41,12 @@ class BatchProcessingError(Exception):
         self.batch_sources = batch_sources
 
 
+class ActivityReporter(Protocol):
+    def stage_started(self, stage: str, message: str) -> None: ...
+
+    def log(self, message: str, *, stage: str | None = None, **fields: object) -> None: ...
+
+
 def raise_if_cancelled(cancellation_event: Event | None) -> None:
     if cancellation_event is not None and cancellation_event.is_set():
         raise ProcessingCancelled("Processing was cancelled.")
@@ -66,10 +73,12 @@ def process(
     resume_source_path: Path | None = None,
     batch_start_stage: Stage | None = None,
     batch_sources: tuple[Path, ...] | None = None,
-) -> None:
+    activity: ActivityReporter | None = None,
+) -> Path | None:
     raise_if_cancelled(cancellation_event)
     batch_start_stage = batch_start_stage or gui_start_stage
     waiting_for_resume = resume_source_path is not None
+    final_output_path = None
     if config.source_folder_path:
         batch_sources = batch_sources if batch_sources is not None else find_batch_sources(config.source_folder_path)
         for source in batch_sources:
@@ -83,7 +92,11 @@ def process(
             config.source_path = source
             config.start_stage = gui_start_stage if is_resume_source else batch_start_stage
             try:
-                process_each(cancellation_event)
+                final_output_path = (
+                    process_each(cancellation_event, activity=activity)
+                    if activity
+                    else process_each(cancellation_event)
+                )
                 raise_if_cancelled(cancellation_event)
             except preflight.DependencyPreflightError:
                 raise
@@ -104,16 +117,26 @@ def process(
             raise FileNotFoundError(f"Could not resume batch source: {resume_source_path}")
 
     else:
-        process_each(cancellation_event)
+        final_output_path = (
+            process_each(cancellation_event, activity=activity) if activity else process_each(cancellation_event)
+        )
+
+    return final_output_path
 
 
-def process_each(cancellation_event: Event | None = None) -> None:
+def process_each(cancellation_event: Event | None = None, activity: ActivityReporter | None = None) -> Path:
     raise_if_cancelled(cancellation_event)
     print(f"\nProcessing {config.source_path}")
+    if activity:
+        activity.stage_started("preflight", "Checking required conversion tools")
     preflight.verify_runtime_ready()
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("inspect_source", "Reading video metadata")
     disc_info = get_disc_and_mvc_video_info()
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.log("Source metadata loaded", stage="inspect_source", name=disc_info.name)
     output_folder = prepare_output_folder_for_source(disc_info.name)
 
     tmp_folder = config.output_root_path / "temp_files"
@@ -124,33 +147,55 @@ def process_each(cancellation_event: Event | None = None) -> None:
         raise RuntimeError(f"Failed to create temporary folder: {tmp_folder}")
 
     print(f"Using temporary folder: {os.environ['TMPDIR']}")
+    if activity:
+        activity.log("Temporary workspace ready", stage="preflight", path=os.environ["TMPDIR"])
 
     completed_path = config.output_root_path / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
 
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("create_mkv", "Preparing source video")
     mkv_output_path = create_mkv_file(output_folder, disc_info, config.language_code)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("probe_color", "Reading video color depth")
     disc_info.color_depth = get_video_color_depth(mkv_output_path)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("detect_crop", "Checking frame crop parameters")
     crop_params = detect_crop_parameters(mkv_output_path)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("extract_mvc_and_audio", "Extracting MVC video and audio")
     audio_output_path, video_output_path = create_mvc_and_audio(disc_info.name, mkv_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("extract_subtitles", "Extracting subtitles")
     create_srt_from_mkv(mkv_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("create_left_right_files", "Creating left and right eye video")
     left_output_path, right_output_path = create_left_right_files(
         disc_info, output_folder, video_output_path, crop_params
     )
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("combine_to_mv_hevc", "Combining stereo video into MV-HEVC")
     mv_hevc_path = create_mv_hevc_file(left_output_path, right_output_path, output_folder, disc_info)
     raise_if_cancelled(cancellation_event)
+    if activity and config.fx_upscale:
+        activity.stage_started("upscale_video", "Upscaling video")
     mv_hevc_path = create_upscaled_file(mv_hevc_path)
 
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("transcode_audio", "Preparing audio")
     audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
+    if activity:
+        activity.stage_started("create_final_file", "Muxing final spatial video")
     muxed_output_path = create_muxed_file(
         audio_output_path,
         mv_hevc_path,
@@ -158,7 +203,9 @@ def process_each(cancellation_event: Event | None = None) -> None:
         disc_info.name,
     )
     raise_if_cancelled(cancellation_event)
-    move_file_to_output_root_folder(muxed_output_path)
+    if activity:
+        activity.stage_started("move_files", "Moving completed video")
+    final_output_path = move_file_to_output_root_folder(muxed_output_path)
 
     raise_if_cancelled(cancellation_event)
     if not config.keep_files:
@@ -166,7 +213,9 @@ def process_each(cancellation_event: Event | None = None) -> None:
 
     raise_if_cancelled(cancellation_event)
     if config.remove_original:
-        remove_original_source(completed_path)
+        remove_original_source(final_output_path)
+
+    return final_output_path
 
 
 def remove_original_source(completed_path: Path) -> bool:
@@ -190,25 +239,27 @@ def start_process(
     resume_source_path: Path | None = None,
     batch_start_stage: Stage | None = None,
     batch_sources: tuple[Path, ...] | None = None,
-) -> None:
+    activity: ActivityReporter | None = None,
+) -> Path | None:
     gui_start_stage = gui_start_stage or config.start_stage
     if config.keep_awake:
         with keep.running():
-            process(
+            return process(
                 gui_start_stage,
                 cancellation_event,
                 resume_source_path=resume_source_path,
                 batch_start_stage=batch_start_stage,
                 batch_sources=batch_sources,
+                activity=activity,
             )
-    else:
-        process(
-            gui_start_stage,
-            cancellation_event,
-            resume_source_path=resume_source_path,
-            batch_start_stage=batch_start_stage,
-            batch_sources=batch_sources,
-        )
+    return process(
+        gui_start_stage,
+        cancellation_event,
+        resume_source_path=resume_source_path,
+        batch_start_stage=batch_start_stage,
+        batch_sources=batch_sources,
+        activity=activity,
+    )
 
 
 if __name__ == "__main__":

--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -59,7 +59,7 @@ def dedupe_paths(paths: list[Path]) -> list[Path]:
 
 def needs_makemkv() -> bool:
     source_path = config.source_path
-    if source_path and source_path.suffix.lower() in config.MTS_EXTENSIONS:
+    if source_path and source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]:
         return False
     return True
 

--- a/bd_to_avp/worker/__main__.py
+++ b/bd_to_avp/worker/__main__.py
@@ -9,18 +9,20 @@ from contextlib import redirect_stdout
 from typing import Callable, TextIO
 
 from bd_to_avp.modules.config import config
-from bd_to_avp.worker.operations import WorkerOperationError, run_operation
+from bd_to_avp.worker.operations import WorkerDecisionRequired, WorkerOperationError, run_operation
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
 from bd_to_avp.worker.protocol import (
     MAX_REQUEST_BYTES,
     ZERO_JOB_ID,
     JobSpec,
+    WorkerActivityReporter,
     WorkerEventEmitter,
     WorkerEventType,
     WorkerProtocolError,
+    bounded_detail,
 )
 
-OperationRunner = Callable[[JobSpec, WorkerProcessOwner], dict[str, object]]
+OperationRunner = Callable[[JobSpec, WorkerProcessOwner, WorkerActivityReporter], dict[str, object]]
 
 
 def run_worker(
@@ -56,27 +58,27 @@ def run_worker(
             },
         )
         emitter.emit(WorkerEventType.JOB_STARTED, {"operation": job.operation.value})
-        emitter.emit(
-            WorkerEventType.STAGE_STARTED,
-            {"stage": "inspect_source", "message": "Reading video metadata"},
-        )
+        activity = WorkerActivityReporter(emitter)
+        if job.operation.value == "inspect_source":
+            activity.stage_started("inspect_source", "Reading video metadata")
 
         heartbeat_stop = threading.Event()
         heartbeat_thread = threading.Thread(
             target=_emit_heartbeats,
-            args=(emitter, owner, heartbeat_stop, heartbeat_interval),
+            args=(emitter, activity, owner, heartbeat_stop, heartbeat_interval),
             daemon=True,
         )
         heartbeat_thread.start()
         try:
             with redirect_stdout(diagnostic_stream):
-                result = operation_runner(job, owner)
+                result = operation_runner(job, owner, activity)
         finally:
             heartbeat_stop.set()
             heartbeat_thread.join(timeout=max(heartbeat_interval * 2, 0.2))
 
         owner.check_cancelled()
-        emitter.emit(WorkerEventType.JOB_COMPLETED, {"result": result})
+        result_key = "conversion_result" if job.operation.value == "convert_source" else "result"
+        emitter.emit(WorkerEventType.JOB_COMPLETED, {result_key: result})
         return 0
     except WorkerProtocolError as error:
         emitter = emitter or WorkerEventEmitter(output_stream, error.job_id or ZERO_JOB_ID)
@@ -87,16 +89,27 @@ def run_worker(
         if emitter is not None and not emitter.terminal_emitted:
             emitter.emit(
                 WorkerEventType.JOB_CANCELLED,
-                {"message": "Source inspection cancelled."},
+                {"message": "Worker job cancelled."},
             )
         return 130
+    except WorkerDecisionRequired as error:
+        if emitter is not None and not emitter.terminal_emitted:
+            decision: dict[str, object] = {
+                "id": error.code,
+                "prompt": error.message,
+                "choices": list(error.choices),
+            }
+            if error.details:
+                decision["details"] = bounded_detail(error.details)
+            emitter.emit(WorkerEventType.JOB_DECISION_REQUIRED, {"decision": decision})
+        return 3
     except WorkerOperationError as error:
         if owner.cancellation_event.is_set():
             owner.terminate_descendants()
             if emitter is not None and not emitter.terminal_emitted:
                 emitter.emit(
                     WorkerEventType.JOB_CANCELLED,
-                    {"message": "Source inspection cancelled."},
+                    {"message": "Worker job cancelled."},
                 )
             return 130
         if emitter is not None and not emitter.terminal_emitted:
@@ -122,6 +135,7 @@ def run_worker(
 
 def _emit_heartbeats(
     emitter: WorkerEventEmitter,
+    activity: WorkerActivityReporter,
     owner: WorkerProcessOwner,
     stop_event: threading.Event,
     interval: float,
@@ -130,13 +144,13 @@ def _emit_heartbeats(
     while not stop_event.wait(interval):
         if owner.cancellation_event.is_set() or emitter.terminal_emitted:
             return
-        emitter.emit(
-            WorkerEventType.HEARTBEAT,
-            {
-                "stage": "inspect_source",
-                "elapsed_seconds": max(0, int(time.monotonic() - started_at)),
-            },
-        )
+        try:
+            emitter.emit(
+                WorkerEventType.HEARTBEAT,
+                activity.heartbeat_payload(int(time.monotonic() - started_at)),
+            )
+        except RuntimeError:
+            return
 
 
 def main() -> None:

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import subprocess
+
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,15 +10,49 @@ from typing import Iterator
 
 import ffmpeg
 
-from bd_to_avp.modules.config import config
+from bd_to_avp import preflight
+from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.disc import get_disc_and_mvc_video_info
+from bd_to_avp.modules.process import ProcessingCancelled, start_process
+from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
-from bd_to_avp.worker.protocol import JobSpec, WorkerOperation
+from bd_to_avp.worker.protocol import JobSpec, WorkerActivityReporter, WorkerOperation
 
 SUPPORTED_INSPECTION_EXTENSIONS = frozenset({".mkv", ".mts", ".m2ts"})
+SUPPORTED_CONVERSION_EXTENSIONS = SUPPORTED_INSPECTION_EXTENSIONS
+TOOL_ENVIRONMENT_KEYS = ("PATH", "FFMPEG_BINARY", "FFPROBE_BINARY", "TMPDIR")
+CONFIG_SNAPSHOT_FIELDS = (
+    "source_str",
+    "source_path",
+    "source_folder_path",
+    "output_root_path",
+    "overwrite",
+    "transcode_audio",
+    "audio_bitrate",
+    "left_right_bitrate",
+    "link_quality",
+    "mv_hevc_quality",
+    "upscale_quality",
+    "fov",
+    "frame_rate",
+    "resolution",
+    "keep_files",
+    "start_stage",
+    "remove_original",
+    "swap_eyes",
+    "skip_subtitles",
+    "crop_black_bars",
+    "output_commands",
+    "software_encoder",
+    "fx_upscale",
+    "continue_on_error",
+    "language_code",
+    "remove_extra_languages",
+    "keep_awake",
+)
 
 
-@dataclass(frozen=True)
+@dataclass
 class WorkerOperationError(Exception):
     code: str
     message: str
@@ -26,9 +63,25 @@ class WorkerOperationError(Exception):
         return self.message
 
 
-def run_operation(job: JobSpec, owner: WorkerProcessOwner) -> dict[str, object]:
+@dataclass
+class WorkerDecisionRequired(Exception):
+    code: str
+    message: str
+    details: str | None = None
+    choices: tuple[str, ...] = ()
+
+
+def run_operation(
+    job: JobSpec,
+    owner: WorkerProcessOwner,
+    activity: WorkerActivityReporter | None = None,
+) -> dict[str, object]:
     if job.operation is WorkerOperation.INSPECT_SOURCE:
         return inspect_source(job.source.path, owner)
+    if job.operation is WorkerOperation.CONVERT_SOURCE:
+        if activity is None:
+            raise WorkerOperationError("internal_error", "Conversion requires an activity reporter.")
+        return convert_source(job, owner, activity)
     raise WorkerOperationError("unsupported_operation", f"Unsupported worker operation: {job.operation.value}.")
 
 
@@ -73,6 +126,98 @@ def inspect_source(source_path: Path, owner: WorkerProcessOwner) -> dict[str, ob
     }
 
 
+def convert_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActivityReporter) -> dict[str, object]:
+    source_path = job.source.path
+    destination = job.destination
+    encoding = job.encoding
+    job_options = job.job
+    if destination is None or encoding is None or job_options is None:
+        raise WorkerOperationError(
+            "invalid_request", "Conversion requests require destination, encoding, and job options."
+        )
+    if not source_path.exists():
+        raise WorkerOperationError("source_not_found", "The selected source no longer exists.")
+    if not source_path.is_file():
+        raise WorkerOperationError("source_not_file", "The selected source is not a regular file.")
+    if source_path.suffix.lower() not in SUPPORTED_CONVERSION_EXTENSIONS:
+        raise WorkerOperationError(
+            "unsupported_source",
+            "Conversion currently supports single existing MKV, MTS, and M2TS files only.",
+        )
+    if destination.path.exists() and not destination.path.is_dir():
+        raise WorkerOperationError("destination_not_directory", "The destination path must be a folder.")
+
+    owner.check_cancelled()
+    with configured_conversion(job):
+        try:
+            activity.stage_started("configure", "Preparing conversion settings")
+            config.configure_tool_environment()
+            activity.log("Tool environment configured", stage="configure")
+            final_output_path = start_process(
+                cancellation_event=owner.cancellation_event,
+                activity=activity,
+            )
+            owner.check_cancelled()
+        except ProcessingCancelled as error:
+            raise WorkerCancelled("The conversion was cancelled.") from error
+        except SRTCreationError as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            raise WorkerDecisionRequired(
+                "subtitle_decision_required",
+                "Subtitle extraction did not produce usable subtitle files.",
+                f"Turn off Include subtitles to retry without subtitles.\n\n{error}",
+                ("retry_without_subtitles", "cancel"),
+            ) from error
+        except preflight.DependencyPreflightError as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            raise WorkerOperationError(
+                "dependency_preflight_failed",
+                "A required conversion helper is missing or unavailable.",
+                str(error),
+            ) from error
+        except FileExistsError as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            raise WorkerOperationError("output_exists", str(error), retryable=True) from error
+        except ffmpeg.Error as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            stderr = error.stderr.decode("utf-8", errors="replace") if error.stderr else None
+            raise WorkerOperationError("ffmpeg_failed", "FFmpeg failed during conversion.", stderr) from error
+        except subprocess.CalledProcessError as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            details = error.output if isinstance(error.output, str) else None
+            raise WorkerOperationError(
+                "tool_failed",
+                "A conversion helper failed.",
+                details,
+            ) from error
+        except (OSError, RuntimeError, ValueError) as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            raise WorkerOperationError(
+                "conversion_failed",
+                "The source could not be converted.",
+                str(error),
+            ) from error
+
+    if final_output_path is None or not final_output_path.exists():
+        raise WorkerOperationError(
+            "output_missing",
+            "The conversion finished without producing the expected output file.",
+        )
+    activity.log("Conversion output ready", stage="move_files", output_path=final_output_path.as_posix())
+    return {
+        "source_path": source_path.as_posix(),
+        "destination_path": destination.path.as_posix(),
+        "output_path": final_output_path.as_posix(),
+        "size_bytes": final_output_path.stat().st_size,
+    }
+
+
 @contextmanager
 def configured_source(source_path: Path) -> Iterator[None]:
     previous_source_path = config.source_path
@@ -87,3 +232,49 @@ def configured_source(source_path: Path) -> Iterator[None]:
         config.source_path = previous_source_path
         config.source_str = previous_source_str
         config.source_folder_path = previous_source_folder_path
+
+
+@contextmanager
+def configured_conversion(job: JobSpec) -> Iterator[None]:
+    assert job.destination is not None
+    assert job.encoding is not None
+    assert job.job is not None
+    config_snapshot = {field: getattr(config, field) for field in CONFIG_SNAPSHOT_FIELDS}
+    environment_snapshot = {key: os.environ.get(key) for key in TOOL_ENVIRONMENT_KEYS}
+    try:
+        config.source_str = None
+        config.source_path = job.source.path
+        config.source_folder_path = None
+        config.output_root_path = job.destination.path
+        config.overwrite = job.job.overwrite
+        config.transcode_audio = job.encoding.transcode_audio
+        config.audio_bitrate = job.encoding.audio_bitrate
+        config.left_right_bitrate = job.encoding.left_right_bitrate
+        config.link_quality = job.encoding.link_quality
+        config.mv_hevc_quality = job.encoding.mv_hevc_quality
+        config.upscale_quality = job.encoding.upscale_quality
+        config.fov = job.encoding.fov
+        config.frame_rate = job.encoding.frame_rate
+        config.resolution = job.encoding.resolution
+        config.keep_files = job.job.keep_files
+        config.start_stage = Stage.get_stage(job.job.start_stage)
+        config.remove_original = job.job.remove_original
+        config.swap_eyes = job.encoding.swap_eyes
+        config.skip_subtitles = job.encoding.skip_subtitles
+        config.crop_black_bars = job.encoding.crop_black_bars
+        config.output_commands = job.job.output_commands
+        config.software_encoder = job.job.software_encoder
+        config.fx_upscale = job.encoding.fx_upscale
+        config.continue_on_error = job.job.continue_on_error
+        config.language_code = job.encoding.language_code
+        config.remove_extra_languages = job.encoding.remove_extra_languages
+        config.keep_awake = job.job.keep_awake
+        yield
+    finally:
+        for field, value in config_snapshot.items():
+            setattr(config, field, value)
+        for key, value in environment_snapshot.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -12,11 +12,22 @@ from uuid import UUID
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_EVENT_BYTES = 1024 * 1024
+MAX_DETAIL_BYTES = 64 * 1024
 ZERO_JOB_ID = str(UUID(int=0))
+
+
+def bounded_detail(value: str) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= MAX_DETAIL_BYTES:
+        return value
+    suffix = "\n… details truncated"
+    available = MAX_DETAIL_BYTES - len(suffix.encode("utf-8"))
+    return encoded[:available].decode("utf-8", errors="ignore") + suffix
 
 
 class WorkerOperation(StrEnum):
     INSPECT_SOURCE = "inspect_source"
+    CONVERT_SOURCE = "convert_source"
 
 
 class WorkerEventType(StrEnum):
@@ -55,11 +66,51 @@ class JobSource:
 
 
 @dataclass(frozen=True)
+class JobDestination:
+    path: Path
+
+
+@dataclass(frozen=True)
+class EncodingOptions:
+    transcode_audio: bool
+    audio_bitrate: int
+    left_right_bitrate: int
+    link_quality: bool
+    mv_hevc_quality: int
+    upscale_quality: int
+    fov: int
+    frame_rate: str
+    resolution: str
+    skip_subtitles: bool
+    crop_black_bars: bool
+    swap_eyes: bool
+    fx_upscale: bool
+    language_code: str
+    remove_extra_languages: bool
+
+
+@dataclass(frozen=True)
+class JobOptions:
+    start_stage: int
+    keep_files: bool
+    overwrite: bool
+    remove_original: bool
+    continue_on_error: bool
+    software_encoder: bool
+    output_commands: bool
+    keep_awake: bool
+    output_length: str
+
+
+@dataclass(frozen=True)
 class JobSpec:
     protocol_version: int
     job_id: str
     operation: WorkerOperation
     source: JobSource
+    destination: JobDestination | None = None
+    encoding: EncodingOptions | None = None
+    job: JobOptions | None = None
 
     @classmethod
     def from_json_line(cls, line: str) -> "JobSpec":
@@ -77,6 +128,7 @@ class JobSpec:
             raise WorkerProtocolError("invalid_request", "The worker request must be a JSON object.")
 
         job_id = cls._parse_job_id(raw.get("job_id"))
+        base_keys = {"protocol_version", "type", "job_id", "operation", "source"}
         protocol_version = raw.get("protocol_version")
         if (
             not isinstance(protocol_version, int)
@@ -111,6 +163,12 @@ class JobSpec:
                 job_id=job_id,
             ) from error
 
+        operation_keys = {
+            WorkerOperation.INSPECT_SOURCE: base_keys,
+            WorkerOperation.CONVERT_SOURCE: base_keys | {"destination", "encoding", "job"},
+        }[operation]
+        cls._reject_unknown_keys(raw, operation_keys, "request", job_id)
+
         source = raw.get("source")
         if not isinstance(source, Mapping) or not isinstance(source.get("path"), str):
             raise WorkerProtocolError(
@@ -118,20 +176,27 @@ class JobSpec:
                 "The request must contain a source path.",
                 job_id=job_id,
             )
+        cls._reject_unknown_keys(source, {"path"}, "source", job_id)
+        source_path = cls._parse_absolute_path(source["path"], "source", job_id)
 
-        source_path = Path(source["path"]).expanduser()
-        if not source_path.is_absolute():
-            raise WorkerProtocolError(
-                "source_not_absolute",
-                "The source path must be absolute.",
-                job_id=job_id,
+        destination: JobDestination | None = None
+        encoding: EncodingOptions | None = None
+        job_options: JobOptions | None = None
+        if operation is WorkerOperation.CONVERT_SOURCE:
+            destination = JobDestination(
+                path=cls._parse_destination(raw.get("destination"), job_id),
             )
+            encoding = cls._parse_encoding(raw.get("encoding"), job_id)
+            job_options = cls._parse_job_options(raw.get("job"), job_id)
 
         return cls(
             protocol_version=protocol_version,
             job_id=job_id,
             operation=operation,
             source=JobSource(path=source_path),
+            destination=destination,
+            encoding=encoding,
+            job=job_options,
         )
 
     @staticmethod
@@ -142,6 +207,232 @@ class JobSpec:
             return str(UUID(value))
         except ValueError as error:
             raise WorkerProtocolError("invalid_job_id", "The request job_id must be a UUID.") from error
+
+    @classmethod
+    def _parse_destination(cls, value: Any, job_id: str) -> Path:
+        if not isinstance(value, Mapping) or not isinstance(value.get("path"), str):
+            raise WorkerProtocolError(
+                "invalid_destination",
+                "The conversion request must contain a destination path.",
+                job_id=job_id,
+            )
+        cls._reject_unknown_keys(value, {"path"}, "destination", job_id)
+        return cls._parse_absolute_path(value["path"], "destination", job_id)
+
+    @staticmethod
+    def _parse_absolute_path(value: str, label: str, job_id: str) -> Path:
+        path = Path(value)
+        if not path.is_absolute():
+            raise WorkerProtocolError(
+                f"{label}_not_absolute",
+                f"The {label} path must be absolute.",
+                job_id=job_id,
+            )
+        return path
+
+    @classmethod
+    def _parse_encoding(cls, value: Any, job_id: str) -> EncodingOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "The conversion request must contain encoding options.",
+                job_id=job_id,
+            )
+        required_keys = {
+            "transcode_audio",
+            "audio_bitrate",
+            "left_right_bitrate",
+            "link_quality",
+            "mv_hevc_quality",
+            "upscale_quality",
+            "fov",
+            "frame_rate",
+            "resolution",
+            "skip_subtitles",
+            "crop_black_bars",
+            "swap_eyes",
+            "fx_upscale",
+            "language_code",
+            "remove_extra_languages",
+        }
+        cls._require_exact_keys(value, required_keys, "encoding", job_id)
+        language_code = cls._parse_string(value, "language_code", "encoding", job_id)
+        if len(language_code) != 3 or not language_code.isalpha() or language_code != language_code.lower():
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.language_code must be a lowercase ISO 639-2 code.",
+                job_id=job_id,
+            )
+        return EncodingOptions(
+            transcode_audio=cls._parse_bool(value, "transcode_audio", "encoding", job_id),
+            audio_bitrate=cls._parse_int(value, "audio_bitrate", "encoding", job_id, minimum=1, maximum=4096),
+            left_right_bitrate=cls._parse_int(value, "left_right_bitrate", "encoding", job_id, minimum=1, maximum=500),
+            link_quality=cls._parse_bool(value, "link_quality", "encoding", job_id),
+            mv_hevc_quality=cls._parse_int(value, "mv_hevc_quality", "encoding", job_id, minimum=0, maximum=100),
+            upscale_quality=cls._parse_int(value, "upscale_quality", "encoding", job_id, minimum=0, maximum=100),
+            fov=cls._parse_int(value, "fov", "encoding", job_id, minimum=0, maximum=360),
+            frame_rate=cls._parse_string(value, "frame_rate", "encoding", job_id),
+            resolution=cls._parse_string(value, "resolution", "encoding", job_id),
+            skip_subtitles=cls._parse_bool(value, "skip_subtitles", "encoding", job_id),
+            crop_black_bars=cls._parse_bool(value, "crop_black_bars", "encoding", job_id),
+            swap_eyes=cls._parse_bool(value, "swap_eyes", "encoding", job_id),
+            fx_upscale=cls._parse_bool(value, "fx_upscale", "encoding", job_id),
+            language_code=language_code,
+            remove_extra_languages=cls._parse_bool(value, "remove_extra_languages", "encoding", job_id),
+        )
+
+    @classmethod
+    def _parse_job_options(cls, value: Any, job_id: str) -> JobOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_job_options",
+                "The conversion request must contain job options.",
+                job_id=job_id,
+            )
+        required_keys = {
+            "start_stage",
+            "keep_files",
+            "overwrite",
+            "remove_original",
+            "continue_on_error",
+            "software_encoder",
+            "output_commands",
+            "keep_awake",
+            "output_length",
+        }
+        cls._require_exact_keys(value, required_keys, "job", job_id)
+        output_length = cls._parse_string(value, "output_length", "job", job_id)
+        if output_length != "full_movie":
+            raise WorkerProtocolError(
+                "invalid_job_options",
+                "job.output_length must be 'full_movie'.",
+                job_id=job_id,
+            )
+        return JobOptions(
+            start_stage=cls._parse_int(value, "start_stage", "job", job_id, minimum=1, maximum=9),
+            keep_files=cls._parse_bool(value, "keep_files", "job", job_id),
+            overwrite=cls._parse_bool(value, "overwrite", "job", job_id),
+            remove_original=cls._parse_bool(value, "remove_original", "job", job_id),
+            continue_on_error=cls._parse_bool(value, "continue_on_error", "job", job_id),
+            software_encoder=cls._parse_bool(value, "software_encoder", "job", job_id),
+            output_commands=cls._parse_bool(value, "output_commands", "job", job_id),
+            keep_awake=cls._parse_bool(value, "keep_awake", "job", job_id),
+            output_length=output_length,
+        )
+
+    @classmethod
+    def _require_exact_keys(
+        cls,
+        value: Mapping[str, Any],
+        expected_keys: set[str],
+        label: str,
+        job_id: str,
+    ) -> None:
+        missing_keys = expected_keys - set(value.keys())
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys))
+            raise WorkerProtocolError(
+                f"invalid_{label}_options" if label in {"encoding", "job"} else f"invalid_{label}",
+                f"The {label} object is missing required field(s): {missing}.",
+                job_id=job_id,
+            )
+        cls._reject_unknown_keys(value, expected_keys, label, job_id)
+
+    @staticmethod
+    def _reject_unknown_keys(
+        value: Mapping[str, Any],
+        expected_keys: set[str],
+        label: str,
+        job_id: str,
+    ) -> None:
+        unknown_keys = set(value.keys()) - expected_keys
+        if unknown_keys:
+            unknown = ", ".join(sorted(str(key) for key in unknown_keys))
+            raise WorkerProtocolError(
+                "invalid_request",
+                f"The {label} object contains unsupported field(s): {unknown}.",
+                job_id=job_id,
+            )
+
+    @staticmethod
+    def _parse_bool(value: Mapping[str, Any], key: str, label: str, job_id: str) -> bool:
+        field_value = value.get(key)
+        if not isinstance(field_value, bool):
+            raise WorkerProtocolError(
+                f"invalid_{label}_options",
+                f"{label}.{key} must be a boolean.",
+                job_id=job_id,
+            )
+        return field_value
+
+    @staticmethod
+    def _parse_int(
+        value: Mapping[str, Any],
+        key: str,
+        label: str,
+        job_id: str,
+        *,
+        minimum: int,
+        maximum: int,
+    ) -> int:
+        field_value = value.get(key)
+        if not isinstance(field_value, int) or isinstance(field_value, bool):
+            raise WorkerProtocolError(
+                f"invalid_{label}_options",
+                f"{label}.{key} must be an integer.",
+                job_id=job_id,
+            )
+        if not minimum <= field_value <= maximum:
+            raise WorkerProtocolError(
+                f"invalid_{label}_options",
+                f"{label}.{key} must be between {minimum} and {maximum}.",
+                job_id=job_id,
+            )
+        return field_value
+
+    @staticmethod
+    def _parse_string(value: Mapping[str, Any], key: str, label: str, job_id: str) -> str:
+        field_value = value.get(key)
+        if not isinstance(field_value, str):
+            raise WorkerProtocolError(
+                f"invalid_{label}_options",
+                f"{label}.{key} must be a string.",
+                job_id=job_id,
+            )
+        return field_value
+
+
+class WorkerActivityReporter:
+    def __init__(self, emitter: "WorkerEventEmitter") -> None:
+        self._emitter = emitter
+        self._current_stage: str | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def current_stage(self) -> str | None:
+        with self._lock:
+            return self._current_stage
+
+    def stage_started(self, stage: str, message: str) -> None:
+        with self._lock:
+            self._current_stage = stage
+        self._emitter.emit(WorkerEventType.STAGE_STARTED, {"stage": stage, "message": message})
+
+    def log(self, message: str, *, stage: str | None = None, **fields: Any) -> None:
+        payload: dict[str, Any] = {"message": message, **fields}
+        payload["stage"] = stage or self.current_stage
+        self._emitter.emit(WorkerEventType.LOG, payload)
+
+    def warning(self, message: str, *, stage: str | None = None, **fields: Any) -> None:
+        payload: dict[str, Any] = {"message": message, **fields}
+        payload["stage"] = stage or self.current_stage
+        self._emitter.emit(WorkerEventType.WARNING, payload)
+
+    def heartbeat_payload(self, elapsed_seconds: int) -> dict[str, Any]:
+        return {
+            "stage": self.current_stage,
+            "elapsed_seconds": max(0, elapsed_seconds),
+        }
 
 
 class WorkerEventEmitter:
@@ -195,5 +486,5 @@ class WorkerEventEmitter:
             "retryable": retryable,
         }
         if details:
-            error["details"] = details
+            error["details"] = bounded_detail(details)
         self.emit(WorkerEventType.JOB_FAILED, {"error": error})

--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -106,10 +106,11 @@ dispatch then removed after the job exits.
 
 ## Release Placement
 
-The native shell does not replace the current `0.2.x` Briefcase/Sparkle release
-line while Start Processing remains unavailable. Publishing this bundle through
-the normal Release Candidates appcast would replace a working converter with a
-UI-only build and would leave testers without the current updater path.
+The native shell does not yet replace the current `0.2.x` Briefcase/Sparkle
+release line. Native Start Processing is initially limited to inspected MKV,
+MTS, and M2TS files; disc, image, folder, batch, interactive recovery, and the
+native updater path still need release-level completion before promotion through
+the normal Release Candidates appcast.
 
 The preview uses a separate product name and bundle identifier, installs beside
 the production app, targets Apple Silicon macOS 27, and is published only as a

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -8,6 +8,8 @@ or update it.
 - Choose a physical disc, disc image, Blu-ray folder, MKV, source folder, or
   MTS/M2TS transport stream.
 - Inspect MKV, MTS, and M2TS source metadata through the bundled engine.
+- Convert an inspected MKV, MTS, or M2TS source to a completed MV-HEVC `.mov`
+  through the bundled engine, with native progress, cancellation, and results.
 - Review the Video, Audio & Subtitles, and Files & Recovery controls.
 - Create, duplicate, edit, import, export, and delete named encoding profiles.
 - Open Settings with `Command-,`, resize the window, and scroll through the
@@ -17,8 +19,12 @@ or update it.
 
 ## Important Limits
 
-- **Start Processing is intentionally unavailable.** Keep the production app
-  installed for real conversions.
+- **Start Processing currently supports MKV, MTS, and M2TS files only.** Keep
+  the production app installed for physical discs, disc images, Blu-ray
+  folders, source-folder batches, and recovery decisions that require a second
+  interactive step.
+- Native conversion currently creates the full movie. Short sample outputs are
+  not yet available.
 - This preview has no automatic updater. Future preview builds must be
   downloaded manually.
 - Live playback of a file while it is still being generated is not supported.

--- a/docs/native-worker-protocol-v1.md
+++ b/docs/native-worker-protocol-v1.md
@@ -18,6 +18,9 @@ owns native lifecycle, presentation, and process supervision.
 
 ## Job Request
 
+`inspect_source` reads metadata from one existing `.mkv`, `.mts`, or `.m2ts`
+file. It is read-only and reuses the production FFprobe metadata path.
+
 ```json
 {
   "protocol_version": 1,
@@ -30,8 +33,57 @@ owns native lifecycle, presentation, and process supervision.
 }
 ```
 
-The v1 prototype supports only `inspect_source` for `.mts` and `.m2ts` files.
-The operation is read-only and reuses the production FFprobe metadata path.
+`convert_source` converts one existing `.mkv`, `.mts`, or `.m2ts` file through
+the production conversion engine. The request is immutable: source and
+destination paths must be absolute, all conversion options must be present, and
+unknown fields are rejected. This slice does not enable physical disc, ISO,
+Blu-ray folder, source-folder, queue, or batch conversion through the worker.
+
+`destination.path` is an absolute output folder. The worker returns the actual
+final `.mov` file path produced by the existing engine.
+
+```json
+{
+  "protocol_version": 1,
+  "type": "job.start",
+  "job_id": "d870b63d-939e-4584-a2a4-cd441f628cbe",
+  "operation": "convert_source",
+  "source": {
+    "path": "/absolute/path/to/movie.mkv"
+  },
+  "destination": {
+    "path": "/absolute/path/to/output-folder"
+  },
+  "encoding": {
+    "transcode_audio": true,
+    "audio_bitrate": 384,
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "skip_subtitles": false,
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "language_code": "eng",
+    "remove_extra_languages": false
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true,
+    "output_length": "full_movie"
+  }
+}
+```
 
 ## Event Envelope
 
@@ -58,19 +110,42 @@ rather than leaving the interface in an ambiguous state.
 
 | Type | Terminal | Purpose |
 | --- | --- | --- |
-| `worker.ready` | No | Confirms worker version and its owned process-group ID. |
+| `worker.ready` | No | Confirms worker version and owned process group. |
 | `job.started` | No | Confirms the immutable job was accepted. |
-| `stage.started` | No | Names the current processing stage and user-facing activity. |
+| `stage.started` | No | Names the current stage and user-facing activity. |
 | `heartbeat` | No | Reports elapsed activity while a stage is still alive. |
-| `log` | No | Optional structured diagnostic activity; raw logs remain on stderr. |
+| `log` | No | Structured diagnostic activity; raw logs remain on stderr. |
 | `warning` | No | Reports a recoverable warning without ending the job. |
-| `job.decision_required` | Yes | Stops safely when future work requires an unsupported user decision. |
+| `job.decision_required` | Yes | Stops safely when user input is required. |
 | `job.completed` | Yes | Returns the operation result. |
-| `job.failed` | Yes | Returns a stable error code, message, optional details, and retryability. |
+| `job.failed` | Yes | Returns a stable error object. |
 | `job.cancelled` | Yes | Confirms cancellation and owned-descendant cleanup. |
 
-The current inspection result contains `name`, `resolution`, `frame_rate`,
-`interlaced`, and `size_bytes`.
+The inspection result contains `name`, `resolution`, `frame_rate`, `interlaced`,
+and `size_bytes`.
+
+Inspection completion places its metadata under `payload.result`. Conversion
+completion places `source_path`, `destination_path`, `output_path`, and
+`size_bytes` under `payload.conversion_result`. `output_path` is the completed
+`.mov` file and is emitted only after the file exists. Existing output collisions
+fail with retryable `output_exists` unless `job.overwrite` is true; unsupported
+source kinds fail rather than being silently skipped or routed into disc/folder
+conversion. Protocol v1 accepts only `job.output_length = "full_movie"`.
+
+Conversion stages use the existing engine boundaries: `configure`, `preflight`,
+`inspect_source`, `create_mkv`, `probe_color`, `detect_crop`,
+`extract_mvc_and_audio`, `extract_subtitles`, `create_left_right_files`,
+`combine_to_mv_hevc`, optional `upscale_video`, `transcode_audio`,
+`create_final_file`, and `move_files`. Heartbeats report the current stage.
+Structured `log` and `warning` events are protocol events; raw helper output and
+Python diagnostics remain on standard error.
+
+Subtitle extraction failures that require a user choice end with
+`job.decision_required` with a structured `decision` containing `id`, `prompt`,
+`choices`, and optional `details` instead of guessing. Cancellation maps to
+`job.cancelled`; dependency failures, helper failures, FFmpeg failures, existing
+outputs, missing outputs, and unsupported sources map to `job.failed` with stable
+error codes and optional details.
 
 ## Cancellation And Ownership
 

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -102,6 +102,51 @@ final class ConversionViewModel: ObservableObject {
         }
     }
 
+    func startConversion(draft: ConversionDraft) {
+        guard !hasActiveWorker else {
+            return
+        }
+        guard draft.source.kind.supportsConversion else {
+            return
+        }
+
+        let job = WorkerJobSpec(draft: draft)
+        do {
+            try state.begin(jobID: job.jobID, operationKind: .conversion)
+            pendingTerminalEvent = nil
+            let client = try clientFactory()
+            self.client = client
+            runTask = Task { [weak self] in
+                guard let self else {
+                    return
+                }
+                do {
+                    let runResult = try await client.run(job: job) { [weak self] event in
+                        guard let self else {
+                            return
+                        }
+                        try await self.receive(event)
+                    }
+                    self.finish(runResult)
+                } catch {
+                    self.fail(error)
+                }
+            }
+        } catch {
+            state.failTransport(message: error.localizedDescription)
+            client = nil
+            runTask = nil
+        }
+    }
+
+    func stopActiveWorker() {
+        guard hasActiveWorker else {
+            return
+        }
+        state.requestStop()
+        client?.cancel()
+    }
+
     func stopInspection() {
         guard hasActiveWorker else {
             return

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -106,7 +106,32 @@ final class ConversionViewModel: ObservableObject {
         guard !hasActiveWorker else {
             return
         }
-        guard draft.source.kind.supportsConversion else {
+        guard let selectedSource = source,
+              selectedSource == draft.source,
+              state.sourceURL == selectedSource.url,
+              state.result != nil
+        else {
+            state.failTransport(
+                message: "Analyze the selected source before starting conversion.",
+                retryable: false
+            )
+            return
+        }
+        guard draft.source.kind.supportsConversion,
+              Self.supportedExtensions.contains(draft.source.url.pathExtension.lowercased()),
+              FileManager.default.fileExists(atPath: draft.source.url.path)
+        else {
+            state.failTransport(
+                message: "Conversion requires an existing MKV, MTS, or M2TS source.",
+                retryable: false
+            )
+            return
+        }
+        guard draft.outputLength == .fullMovie else {
+            state.failTransport(
+                message: "Short sample conversion is not available yet. Choose Full Movie.",
+                retryable: false
+            )
             return
         }
 
@@ -114,6 +139,7 @@ final class ConversionViewModel: ObservableObject {
         do {
             try state.begin(jobID: job.jobID, operationKind: .conversion)
             pendingTerminalEvent = nil
+            diagnosticLog = ""
             let client = try clientFactory()
             self.client = client
             runTask = Task { [weak self] in
@@ -140,14 +166,6 @@ final class ConversionViewModel: ObservableObject {
     }
 
     func stopActiveWorker() {
-        guard hasActiveWorker else {
-            return
-        }
-        state.requestStop()
-        client?.cancel()
-    }
-
-    func stopInspection() {
         guard hasActiveWorker else {
             return
         }
@@ -211,16 +229,17 @@ final class ConversionViewModel: ObservableObject {
             pendingTerminalEvent = event
             return
         }
+        if event.type == .log || event.type == .warning, let message = event.payload.message {
+            appendDiagnostic(message)
+        }
         var nextState = state
         try nextState.receive(event)
         state = nextState
     }
 
     private func finish(_ result: WorkerRunResult) {
-        diagnosticLog = result.diagnostics
-        if state.phase == .stopping {
-            state.completeStop()
-        } else if let pendingTerminalEvent {
+        appendDiagnostic(result.diagnostics)
+        if let pendingTerminalEvent {
             do {
                 var nextState = state
                 try nextState.receive(pendingTerminalEvent)
@@ -231,9 +250,13 @@ final class ConversionViewModel: ObservableObject {
                     details: result.diagnostics.isEmpty ? nil : result.diagnostics
                 )
             }
+        } else if state.phase == .stopping {
+            state.completeStop()
         } else {
             state.failTransport(
-                message: "The source analysis ended before results were available.",
+                message: state.operationKind == .inspection
+                    ? "The source analysis ended before results were available."
+                    : "The conversion ended before an output was available.",
                 details: result.diagnostics.isEmpty ? nil : result.diagnostics
             )
         }
@@ -244,7 +267,7 @@ final class ConversionViewModel: ObservableObject {
 
     private func fail(_ error: Error) {
         let clientError = error as? WorkerClientError
-        diagnosticLog = clientError?.technicalDetails ?? ""
+        appendDiagnostic(clientError?.technicalDetails ?? "")
         if state.phase == .stopping {
             state.completeStop()
         } else {
@@ -256,5 +279,17 @@ final class ConversionViewModel: ObservableObject {
         pendingTerminalEvent = nil
         client = nil
         runTask = nil
+    }
+
+    private func appendDiagnostic(_ message: String) {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return
+        }
+        if diagnosticLog.isEmpty {
+            diagnosticLog = trimmed
+        } else {
+            diagnosticLog += "\n\(trimmed)"
+        }
     }
 }

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -48,6 +48,10 @@ enum ConversionSourceKind: String, CaseIterable, Identifiable {
         self == .matroska || self == .transportStream
     }
 
+    var supportsConversion: Bool {
+        self == .matroska || self == .transportStream
+    }
+
     var isDiscWorkflow: Bool {
         self == .physicalDisc || self == .discImage || self == .bluRayFolder
     }

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -123,12 +123,12 @@ struct AppCapabilities: Equatable {
     let automaticUpdateChecksAvailable: Bool
 
     static let current = AppCapabilities(
-        conversionAvailable: false,
+        conversionAvailable: true,
         automaticUpdateChecksAvailable: false
     )
 
     var conversionUnavailableReason: String {
-        "This build can analyze sources and prepare a conversion, but it cannot start one."
+        "Conversion requires an MKV, MTS, or M2TS source."
     }
 
     var automaticUpdatesUnavailableReason: String {

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+struct ConversionResult: Decodable, Equatable {
+    let outputPath: String
+    let durationSeconds: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case outputPath = "output_path"
+        case durationSeconds = "duration_seconds"
+    }
+}
+
 enum WorkerEventType: String, Decodable, Equatable {
     case workerReady = "worker.ready"
     case jobStarted = "job.started"
@@ -50,6 +60,7 @@ struct WorkerEventPayload: Decodable, Equatable {
     let elapsedSeconds: Int?
     let level: String?
     let result: SourceInspection?
+    let conversionResult: ConversionResult?
     let error: WorkerFailure?
     let decision: WorkerDecision?
 
@@ -62,6 +73,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         elapsedSeconds: Int? = nil,
         level: String? = nil,
         result: SourceInspection? = nil,
+        conversionResult: ConversionResult? = nil,
         error: WorkerFailure? = nil,
         decision: WorkerDecision? = nil
     ) {
@@ -73,6 +85,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         self.elapsedSeconds = elapsedSeconds
         self.level = level
         self.result = result
+        self.conversionResult = conversionResult
         self.error = error
         self.decision = decision
     }
@@ -86,6 +99,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         case elapsedSeconds = "elapsed_seconds"
         case level
         case result
+        case conversionResult = "conversion_result"
         case error
         case decision
     }

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -3,10 +3,22 @@ import Foundation
 struct ConversionResult: Decodable, Equatable {
     let outputPath: String
     let durationSeconds: Double?
+    let sizeBytes: Int64?
+
+    var outputURL: URL {
+        URL(fileURLWithPath: outputPath)
+    }
+
+    init(outputPath: String, durationSeconds: Double? = nil, sizeBytes: Int64? = nil) {
+        self.outputPath = outputPath
+        self.durationSeconds = durationSeconds
+        self.sizeBytes = sizeBytes
+    }
 
     enum CodingKeys: String, CodingKey {
         case outputPath = "output_path"
         case durationSeconds = "duration_seconds"
+        case sizeBytes = "size_bytes"
     }
 }
 
@@ -43,11 +55,13 @@ struct WorkerDecision: Decodable, Equatable {
     let identifier: String
     let prompt: String
     let choices: [String]
+    let details: String?
 
     enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case prompt
         case choices
+        case details
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -7,11 +7,98 @@ struct WorkerJobSpec: Encodable, Equatable {
         let path: String
     }
 
+    struct ConversionSettings: Encodable, Equatable {
+        struct Destination: Encodable, Equatable {
+            let path: String
+        }
+
+        struct Video: Encodable, Equatable {
+            let hevcQuality: Int
+            let leftRightBitrate: Int
+            let upscaleEnabled: Bool
+            let upscaleQuality: Int
+            let linkQuality: Bool
+            let fieldOfView: Int
+            let frameRateOverride: String?
+            let resolutionOverride: String?
+            let cropBlackBars: Bool
+            let swapEyes: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case hevcQuality = "hevc_quality"
+                case leftRightBitrate = "left_right_bitrate"
+                case upscaleEnabled = "upscale_enabled"
+                case upscaleQuality = "upscale_quality"
+                case linkQuality = "link_quality"
+                case fieldOfView = "field_of_view"
+                case frameRateOverride = "frame_rate_override"
+                case resolutionOverride = "resolution_override"
+                case cropBlackBars = "crop_black_bars"
+                case swapEyes = "swap_eyes"
+            }
+        }
+
+        struct Audio: Encodable, Equatable {
+            let handling: String
+            let bitrate: Int
+            let language: String
+            let includeSubtitles: Bool
+            let keepExtraLanguages: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case handling
+                case bitrate
+                case language
+                case includeSubtitles = "include_subtitles"
+                case keepExtraLanguages = "keep_extra_languages"
+            }
+        }
+
+        struct Job: Encodable, Equatable {
+            let startStage: Int
+            let keepStageFiles: Bool
+            let overwriteExisting: Bool
+            let removeOriginalAfterSuccess: Bool
+            let continueOnError: Bool
+            let softwareEncoder: Bool
+            let outputCommands: Bool
+            let keepAwake: Bool
+            let playSound: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case startStage = "start_stage"
+                case keepStageFiles = "keep_stage_files"
+                case overwriteExisting = "overwrite_existing"
+                case removeOriginalAfterSuccess = "remove_original_after_success"
+                case continueOnError = "continue_on_error"
+                case softwareEncoder = "software_encoder"
+                case outputCommands = "output_commands"
+                case keepAwake = "keep_awake"
+                case playSound = "play_sound"
+            }
+        }
+
+        let destination: Destination
+        let outputLength: String
+        let video: Video
+        let audio: Audio
+        let job: Job
+
+        enum CodingKeys: String, CodingKey {
+            case destination
+            case outputLength = "output_length"
+            case video
+            case audio
+            case job
+        }
+    }
+
     let protocolVersion: Int
     let type: String
     let jobID: UUID
     let operation: String
     let source: Source
+    let conversionSettings: ConversionSettings?
 
     init(sourceURL: URL, jobID: UUID = UUID()) {
         protocolVersion = Self.protocolVersion
@@ -19,6 +106,61 @@ struct WorkerJobSpec: Encodable, Equatable {
         self.jobID = jobID
         operation = "inspect_source"
         source = Source(path: sourceURL.path)
+        conversionSettings = nil
+    }
+
+    init(draft: ConversionDraft, jobID: UUID = UUID()) {
+        protocolVersion = Self.protocolVersion
+        type = "job.start"
+        self.jobID = jobID
+        operation = "convert_source"
+        source = Source(path: draft.source.url.path)
+        let enc = draft.options.encoding
+        let job = draft.options.job
+        conversionSettings = ConversionSettings(
+            destination: ConversionSettings.Destination(path: draft.destinationURL.path),
+            outputLength: "full_movie",
+            video: ConversionSettings.Video(
+                hevcQuality: enc.hevcQuality,
+                leftRightBitrate: enc.leftRightBitrate,
+                upscaleEnabled: enc.upscaleEnabled,
+                upscaleQuality: enc.upscaleQuality,
+                linkQuality: enc.linkQuality,
+                fieldOfView: enc.fieldOfView,
+                frameRateOverride: enc.frameRateOverride.isEmpty ? nil : enc.frameRateOverride,
+                resolutionOverride: enc.resolutionOverride.isEmpty ? nil : enc.resolutionOverride,
+                cropBlackBars: enc.cropBlackBars,
+                swapEyes: enc.swapEyes
+            ),
+            audio: ConversionSettings.Audio(
+                handling: enc.audioHandling == .transcodeAAC ? "transcode_aac" : "preserve",
+                bitrate: enc.audioBitrate,
+                language: enc.language.rawValue,
+                includeSubtitles: enc.includeSubtitles,
+                keepExtraLanguages: enc.keepExtraLanguages
+            ),
+            job: ConversionSettings.Job(
+                startStage: job.startStage.rawValue,
+                keepStageFiles: job.keepStageFiles,
+                overwriteExisting: job.overwriteExisting,
+                removeOriginalAfterSuccess: job.removeOriginalAfterSuccess,
+                continueOnError: job.continueOnError,
+                softwareEncoder: job.softwareEncoder,
+                outputCommands: job.outputCommands,
+                keepAwake: job.keepAwake,
+                playSound: job.playSound
+            )
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(protocolVersion, forKey: .protocolVersion)
+        try container.encode(type, forKey: .type)
+        try container.encode(jobID, forKey: .jobID)
+        try container.encode(operation, forKey: .operation)
+        try container.encode(source, forKey: .source)
+        try container.encodeIfPresent(conversionSettings, forKey: .conversionSettings)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -27,5 +169,6 @@ struct WorkerJobSpec: Encodable, Equatable {
         case jobID = "job_id"
         case operation
         case source
+        case conversionSettings = "conversion_settings"
     }
 }

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -7,89 +7,67 @@ struct WorkerJobSpec: Encodable, Equatable {
         let path: String
     }
 
-    struct ConversionSettings: Encodable, Equatable {
-        struct Destination: Encodable, Equatable {
-            let path: String
-        }
+    struct Destination: Encodable, Equatable {
+        let path: String
+    }
 
-        struct Video: Encodable, Equatable {
-            let hevcQuality: Int
-            let leftRightBitrate: Int
-            let upscaleEnabled: Bool
-            let upscaleQuality: Int
-            let linkQuality: Bool
-            let fieldOfView: Int
-            let frameRateOverride: String?
-            let resolutionOverride: String?
-            let cropBlackBars: Bool
-            let swapEyes: Bool
-
-            enum CodingKeys: String, CodingKey {
-                case hevcQuality = "hevc_quality"
-                case leftRightBitrate = "left_right_bitrate"
-                case upscaleEnabled = "upscale_enabled"
-                case upscaleQuality = "upscale_quality"
-                case linkQuality = "link_quality"
-                case fieldOfView = "field_of_view"
-                case frameRateOverride = "frame_rate_override"
-                case resolutionOverride = "resolution_override"
-                case cropBlackBars = "crop_black_bars"
-                case swapEyes = "swap_eyes"
-            }
-        }
-
-        struct Audio: Encodable, Equatable {
-            let handling: String
-            let bitrate: Int
-            let language: String
-            let includeSubtitles: Bool
-            let keepExtraLanguages: Bool
-
-            enum CodingKeys: String, CodingKey {
-                case handling
-                case bitrate
-                case language
-                case includeSubtitles = "include_subtitles"
-                case keepExtraLanguages = "keep_extra_languages"
-            }
-        }
-
-        struct Job: Encodable, Equatable {
-            let startStage: Int
-            let keepStageFiles: Bool
-            let overwriteExisting: Bool
-            let removeOriginalAfterSuccess: Bool
-            let continueOnError: Bool
-            let softwareEncoder: Bool
-            let outputCommands: Bool
-            let keepAwake: Bool
-            let playSound: Bool
-
-            enum CodingKeys: String, CodingKey {
-                case startStage = "start_stage"
-                case keepStageFiles = "keep_stage_files"
-                case overwriteExisting = "overwrite_existing"
-                case removeOriginalAfterSuccess = "remove_original_after_success"
-                case continueOnError = "continue_on_error"
-                case softwareEncoder = "software_encoder"
-                case outputCommands = "output_commands"
-                case keepAwake = "keep_awake"
-                case playSound = "play_sound"
-            }
-        }
-
-        let destination: Destination
-        let outputLength: String
-        let video: Video
-        let audio: Audio
-        let job: Job
+    struct Encoding: Encodable, Equatable {
+        let transcodeAudio: Bool
+        let audioBitrate: Int
+        let leftRightBitrate: Int
+        let linkQuality: Bool
+        let mvHEVCQuality: Int
+        let upscaleQuality: Int
+        let fieldOfView: Int
+        let frameRate: String
+        let resolution: String
+        let skipSubtitles: Bool
+        let cropBlackBars: Bool
+        let swapEyes: Bool
+        let fxUpscale: Bool
+        let languageCode: String
+        let removeExtraLanguages: Bool
 
         enum CodingKeys: String, CodingKey {
-            case destination
+            case transcodeAudio = "transcode_audio"
+            case audioBitrate = "audio_bitrate"
+            case leftRightBitrate = "left_right_bitrate"
+            case linkQuality = "link_quality"
+            case mvHEVCQuality = "mv_hevc_quality"
+            case upscaleQuality = "upscale_quality"
+            case fieldOfView = "fov"
+            case frameRate = "frame_rate"
+            case resolution
+            case skipSubtitles = "skip_subtitles"
+            case cropBlackBars = "crop_black_bars"
+            case swapEyes = "swap_eyes"
+            case fxUpscale = "fx_upscale"
+            case languageCode = "language_code"
+            case removeExtraLanguages = "remove_extra_languages"
+        }
+    }
+
+    struct Job: Encodable, Equatable {
+        let startStage: Int
+        let keepFiles: Bool
+        let overwrite: Bool
+        let removeOriginal: Bool
+        let continueOnError: Bool
+        let softwareEncoder: Bool
+        let outputCommands: Bool
+        let keepAwake: Bool
+        let outputLength: String
+
+        enum CodingKeys: String, CodingKey {
+            case startStage = "start_stage"
+            case keepFiles = "keep_files"
+            case overwrite
+            case removeOriginal = "remove_original"
+            case continueOnError = "continue_on_error"
+            case softwareEncoder = "software_encoder"
+            case outputCommands = "output_commands"
+            case keepAwake = "keep_awake"
             case outputLength = "output_length"
-            case video
-            case audio
-            case job
         }
     }
 
@@ -98,7 +76,9 @@ struct WorkerJobSpec: Encodable, Equatable {
     let jobID: UUID
     let operation: String
     let source: Source
-    let conversionSettings: ConversionSettings?
+    let destination: Destination?
+    let encoding: Encoding?
+    let job: Job?
 
     init(sourceURL: URL, jobID: UUID = UUID()) {
         protocolVersion = Self.protocolVersion
@@ -106,7 +86,9 @@ struct WorkerJobSpec: Encodable, Equatable {
         self.jobID = jobID
         operation = "inspect_source"
         source = Source(path: sourceURL.path)
-        conversionSettings = nil
+        destination = nil
+        encoding = nil
+        job = nil
     }
 
     init(draft: ConversionDraft, jobID: UUID = UUID()) {
@@ -115,41 +97,38 @@ struct WorkerJobSpec: Encodable, Equatable {
         self.jobID = jobID
         operation = "convert_source"
         source = Source(path: draft.source.url.path)
-        let enc = draft.options.encoding
-        let job = draft.options.job
-        conversionSettings = ConversionSettings(
-            destination: ConversionSettings.Destination(path: draft.destinationURL.path),
-            outputLength: "full_movie",
-            video: ConversionSettings.Video(
-                hevcQuality: enc.hevcQuality,
-                leftRightBitrate: enc.leftRightBitrate,
-                upscaleEnabled: enc.upscaleEnabled,
-                upscaleQuality: enc.upscaleQuality,
-                linkQuality: enc.linkQuality,
-                fieldOfView: enc.fieldOfView,
-                frameRateOverride: enc.frameRateOverride.isEmpty ? nil : enc.frameRateOverride,
-                resolutionOverride: enc.resolutionOverride.isEmpty ? nil : enc.resolutionOverride,
-                cropBlackBars: enc.cropBlackBars,
-                swapEyes: enc.swapEyes
-            ),
-            audio: ConversionSettings.Audio(
-                handling: enc.audioHandling == .transcodeAAC ? "transcode_aac" : "preserve",
-                bitrate: enc.audioBitrate,
-                language: enc.language.rawValue,
-                includeSubtitles: enc.includeSubtitles,
-                keepExtraLanguages: enc.keepExtraLanguages
-            ),
-            job: ConversionSettings.Job(
-                startStage: job.startStage.rawValue,
-                keepStageFiles: job.keepStageFiles,
-                overwriteExisting: job.overwriteExisting,
-                removeOriginalAfterSuccess: job.removeOriginalAfterSuccess,
-                continueOnError: job.continueOnError,
-                softwareEncoder: job.softwareEncoder,
-                outputCommands: job.outputCommands,
-                keepAwake: job.keepAwake,
-                playSound: job.playSound
-            )
+        destination = Destination(path: draft.destinationURL.path)
+
+        let encodingOptions = draft.options.encoding
+        encoding = Encoding(
+            transcodeAudio: encodingOptions.audioHandling == .transcodeAAC,
+            audioBitrate: encodingOptions.audioBitrate,
+            leftRightBitrate: encodingOptions.leftRightBitrate,
+            linkQuality: encodingOptions.linkQuality,
+            mvHEVCQuality: encodingOptions.hevcQuality,
+            upscaleQuality: encodingOptions.upscaleQuality,
+            fieldOfView: encodingOptions.fieldOfView,
+            frameRate: encodingOptions.frameRateOverride,
+            resolution: encodingOptions.resolutionOverride,
+            skipSubtitles: !encodingOptions.includeSubtitles,
+            cropBlackBars: encodingOptions.cropBlackBars,
+            swapEyes: encodingOptions.swapEyes,
+            fxUpscale: encodingOptions.upscaleEnabled,
+            languageCode: encodingOptions.language.rawValue,
+            removeExtraLanguages: !encodingOptions.keepExtraLanguages
+        )
+
+        let jobOptions = draft.options.job
+        job = Job(
+            startStage: jobOptions.startStage.rawValue,
+            keepFiles: jobOptions.keepStageFiles,
+            overwrite: jobOptions.overwriteExisting,
+            removeOriginal: jobOptions.removeOriginalAfterSuccess,
+            continueOnError: jobOptions.continueOnError,
+            softwareEncoder: jobOptions.softwareEncoder,
+            outputCommands: jobOptions.outputCommands,
+            keepAwake: jobOptions.keepAwake,
+            outputLength: "full_movie"
         )
     }
 
@@ -160,7 +139,9 @@ struct WorkerJobSpec: Encodable, Equatable {
         try container.encode(jobID, forKey: .jobID)
         try container.encode(operation, forKey: .operation)
         try container.encode(source, forKey: .source)
-        try container.encodeIfPresent(conversionSettings, forKey: .conversionSettings)
+        try container.encodeIfPresent(destination, forKey: .destination)
+        try container.encodeIfPresent(encoding, forKey: .encoding)
+        try container.encodeIfPresent(job, forKey: .job)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -169,6 +150,8 @@ struct WorkerJobSpec: Encodable, Equatable {
         case jobID = "job_id"
         case operation
         case source
-        case conversionSettings = "conversion_settings"
+        case destination
+        case encoding
+        case job
     }
 }

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -19,6 +19,11 @@ enum WorkerPhase: String, Equatable {
     }
 }
 
+enum WorkerOperationKind: Equatable {
+    case inspection
+    case conversion
+}
+
 enum WorkerLifecycleError: Error, LocalizedError, Equatable {
     case noSource
     case protocolMismatch(received: Int)
@@ -47,6 +52,7 @@ enum WorkerLifecycleError: Error, LocalizedError, Equatable {
 
 struct WorkerLifecycleState: Equatable {
     private(set) var phase: WorkerPhase = .empty
+    private(set) var operationKind: WorkerOperationKind = .inspection
     private(set) var sourceURL: URL?
     private(set) var jobID: UUID?
     private(set) var lastSequence: Int?
@@ -55,6 +61,7 @@ struct WorkerLifecycleState: Equatable {
     private(set) var warningMessage: String?
     private(set) var elapsedSeconds = 0
     private(set) var result: SourceInspection?
+    private(set) var conversionResult: ConversionResult?
     private(set) var failureMessage: String?
     private(set) var failureDetails: String?
     private(set) var failureRetryable = false
@@ -65,14 +72,15 @@ struct WorkerLifecycleState: Equatable {
         resetJobState()
     }
 
-    mutating func begin(jobID: UUID) throws {
+    mutating func begin(jobID: UUID, operationKind: WorkerOperationKind = .inspection) throws {
         guard sourceURL != nil else {
             throw WorkerLifecycleError.noSource
         }
         resetJobState()
         self.jobID = jobID
+        self.operationKind = operationKind
         phase = .inspecting
-        stageMessage = "Preparing analysis"
+        stageMessage = operationKind == .inspection ? "Preparing analysis" : "Preparing conversion"
     }
 
     mutating func receive(_ event: WorkerEvent) throws {
@@ -97,17 +105,17 @@ struct WorkerLifecycleState: Equatable {
             if phase != .stopping {
                 phase = .inspecting
             }
-            stageMessage = "Preparing source"
+            stageMessage = operationKind == .inspection ? "Preparing source" : "Preparing conversion"
         case .jobStarted:
             if phase != .stopping {
                 phase = .inspecting
             }
-            stageMessage = "Reading video details"
+            stageMessage = operationKind == .inspection ? "Reading video details" : "Starting conversion"
         case .stageStarted:
             if phase != .stopping {
                 phase = .processing
             }
-            stageMessage = event.payload.message ?? event.payload.stage ?? "Analyzing source"
+            stageMessage = event.payload.message ?? event.payload.stage ?? "Processing"
         case .heartbeat:
             if phase != .stopping {
                 phase = .processing
@@ -117,13 +125,22 @@ struct WorkerLifecycleState: Equatable {
         case .log:
             activityMessage = event.payload.message
         case .warning:
-            warningMessage = event.payload.message ?? "The source analysis reported a warning."
+            warningMessage = event.payload.message ?? "The operation reported a warning."
         case .jobCompleted:
-            guard let result = event.payload.result else {
-                throw WorkerLifecycleError.missingPayload(event: event.type)
+            switch operationKind {
+            case .inspection:
+                guard let inspectionResult = event.payload.result else {
+                    throw WorkerLifecycleError.missingPayload(event: event.type)
+                }
+                result = inspectionResult
+                stageMessage = "Analysis complete"
+            case .conversion:
+                guard let convResult = event.payload.conversionResult else {
+                    throw WorkerLifecycleError.missingPayload(event: event.type)
+                }
+                conversionResult = convResult
+                stageMessage = "Conversion complete"
             }
-            self.result = result
-            stageMessage = "Analysis complete"
             phase = .completed
         case .jobFailed:
             guard let failure = event.payload.error else {
@@ -134,7 +151,7 @@ struct WorkerLifecycleState: Equatable {
             failureRetryable = failure.retryable
             phase = .failed
         case .jobCancelled:
-            activityMessage = event.payload.message ?? "Analysis stopped."
+            activityMessage = event.payload.message ?? (operationKind == .inspection ? "Analysis stopped." : "Conversion stopped.")
             phase = .cancelled
         case .jobDecisionRequired:
             failureMessage = event.payload.decision?.prompt ?? event.payload.message ?? "This source needs a choice before it can continue."
@@ -159,8 +176,8 @@ struct WorkerLifecycleState: Equatable {
         phase = .failed
     }
 
-    mutating func completeStop(message: String = "Inspection stopped.") {
-        activityMessage = message
+    mutating func completeStop() {
+        activityMessage = operationKind == .inspection ? "Inspection stopped." : "Conversion stopped."
         phase = .cancelled
     }
 
@@ -185,6 +202,7 @@ struct WorkerLifecycleState: Equatable {
         warningMessage = nil
         elapsedSeconds = 0
         result = nil
+        conversionResult = nil
         failureMessage = nil
         failureDetails = nil
         failureRetryable = false

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -37,15 +37,15 @@ enum WorkerLifecycleError: Error, LocalizedError, Equatable {
         case .noSource:
             return "Choose a source before continuing."
         case .protocolMismatch:
-            return "The app could not read the source analysis."
+            return "The app could not read the engine response."
         case .unexpectedJob:
-            return "The app received an unexpected source response."
+            return "The app received an unexpected engine response."
         case .unexpectedSequence:
-            return "The source analysis ended unexpectedly."
+            return "The operation ended unexpectedly."
         case .eventAfterTerminal:
-            return "The source analysis returned extra data after it finished."
+            return "The operation returned extra data after it finished."
         case .missingPayload:
-            return "The source analysis did not return all required details."
+            return "The operation did not return all required details."
         }
     }
 }
@@ -76,10 +76,14 @@ struct WorkerLifecycleState: Equatable {
         guard sourceURL != nil else {
             throw WorkerLifecycleError.noSource
         }
+        let inspectionResult = result
         resetJobState()
+        if operationKind == .conversion {
+            result = inspectionResult
+        }
         self.jobID = jobID
         self.operationKind = operationKind
-        phase = .inspecting
+        phase = operationKind == .inspection ? .inspecting : .processing
         stageMessage = operationKind == .inspection ? "Preparing analysis" : "Preparing conversion"
     }
 
@@ -103,12 +107,12 @@ struct WorkerLifecycleState: Equatable {
         switch event.type {
         case .workerReady:
             if phase != .stopping {
-                phase = .inspecting
+                phase = operationKind == .inspection ? .inspecting : .processing
             }
             stageMessage = operationKind == .inspection ? "Preparing source" : "Preparing conversion"
         case .jobStarted:
             if phase != .stopping {
-                phase = .inspecting
+                phase = operationKind == .inspection ? .inspecting : .processing
             }
             stageMessage = operationKind == .inspection ? "Reading video details" : "Starting conversion"
         case .stageStarted:
@@ -155,8 +159,8 @@ struct WorkerLifecycleState: Equatable {
             phase = .cancelled
         case .jobDecisionRequired:
             failureMessage = event.payload.decision?.prompt ?? event.payload.message ?? "This source needs a choice before it can continue."
-            failureDetails = "Choose another source or try again."
-            failureRetryable = false
+            failureDetails = event.payload.decision?.details ?? "Adjust the conversion settings and try again."
+            failureRetryable = true
             phase = .failed
         }
     }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -56,7 +56,7 @@ struct ContentView: View {
                     profile: selectedProfile,
                     options: options,
                     profileModified: profileModified,
-                    outputOptionsAvailable: conversionCanStart,
+                    outputOptionsAvailable: false,
                     destinationURL: $destinationURL,
                     outputLength: $outputLength,
                     samplePosition: $samplePosition,
@@ -274,7 +274,7 @@ struct ContentView: View {
             .accessibilityLabel(isShowingActivity ? "Hide activity details" : "Show activity details")
 
             if viewModel.hasActiveWorker {
-                Button("Stop", role: .destructive, action: viewModel.stopInspection)
+                Button("Stop", role: .destructive, action: viewModel.stopActiveWorker)
                     .keyboardShortcut("p", modifiers: .command)
             } else if viewModel.source == nil || !conversionCanStart {
                 Button("Start Processing") {}
@@ -283,10 +283,12 @@ struct ContentView: View {
                     .help(viewModel.source == nil ? "Choose a source before processing." : conversionUnavailableReason)
             } else {
                 Button("Start Processing") {
-                    startConversion?()
+                    if let draft {
+                        viewModel.startConversion(draft: draft)
+                    }
                 }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut("p", modifiers: .command)
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut("p", modifiers: .command)
             }
         }
         .padding(.horizontal, 16)
@@ -367,13 +369,21 @@ struct ContentView: View {
     }
 
     private var conversionCanStart: Bool {
-        capabilities.conversionAvailable && startConversion != nil
+        capabilities.conversionAvailable && viewModel.source?.kind.supportsConversion == true
     }
 
     private var conversionUnavailableReason: String {
-        capabilities.conversionAvailable
-            ? "Conversion is not connected in this build."
-            : capabilities.conversionUnavailableReason
+        guard capabilities.conversionAvailable else {
+            return capabilities.conversionUnavailableReason
+        }
+        switch viewModel.source?.kind {
+        case .physicalDisc, .discImage, .bluRayFolder:
+            return "Disc and folder sources are not yet supported for native conversion."
+        case .sourceFolder:
+            return "Batch folder conversion is not yet available."
+        case .none, .matroska, .transportStream:
+            return capabilities.conversionUnavailableReason
+        }
     }
 
     private func resetProfile() {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct ContentView: View {
@@ -5,7 +6,6 @@ struct ContentView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var profileStore: ProfileStore
     let capabilities: AppCapabilities
-    let startConversion: (() -> Void)?
 
     @State private var selectedProfileID: String
     @State private var options: ConversionOptions
@@ -25,14 +25,12 @@ struct ContentView: View {
         viewModel: ConversionViewModel,
         settings: AppSettings,
         profileStore: ProfileStore,
-        capabilities: AppCapabilities,
-        startConversion: (() -> Void)? = nil
+        capabilities: AppCapabilities
     ) {
         _viewModel = ObservedObject(wrappedValue: viewModel)
         _settings = ObservedObject(wrappedValue: settings)
         _profileStore = ObservedObject(wrappedValue: profileStore)
         self.capabilities = capabilities
-        self.startConversion = startConversion
 
         let profile = profileStore.profile(withID: settings.selectedProfileID)
         let initialOptions = ConversionOptions(
@@ -145,6 +143,17 @@ struct ContentView: View {
         .onChange(of: defaultJobOptions) { _, newValue in
             if viewModel.source == nil, !viewModel.hasActiveWorker {
                 options.job = newValue
+            }
+        }
+        .onChange(of: viewModel.state.conversionResult) { _, result in
+            guard let result else {
+                return
+            }
+            if settings.revealOutput {
+                NSWorkspace.shared.activateFileViewerSelecting([result.outputURL])
+            }
+            if settings.playSound {
+                NSSound(named: "Glass")?.play()
             }
         }
         .onChange(of: profileStore.customProfiles) { previousProfiles, currentProfiles in
@@ -325,10 +334,14 @@ struct ContentView: View {
 
     private var statusText: String {
         if viewModel.hasActiveWorker {
-            return viewModel.state.stageMessage ?? "Reading source details"
+            return viewModel.state.stageMessage
+                ?? (viewModel.state.operationKind == .inspection ? "Reading source details" : "Converting video")
         }
         if viewModel.state.phase == .failed {
             return "Source needs attention"
+        }
+        if viewModel.state.conversionResult != nil {
+            return "Conversion complete"
         }
         guard let source = viewModel.source else {
             return "Insert a 3D Blu-ray disc or choose another source"
@@ -347,13 +360,17 @@ struct ContentView: View {
 
     private var secondaryStatusText: String? {
         if viewModel.hasActiveWorker {
-            return viewModel.state.activityMessage ?? "Inspecting video streams"
+            return viewModel.state.activityMessage
+                ?? (viewModel.state.operationKind == .inspection ? "Inspecting video streams" : "Processing video")
         }
         guard viewModel.source != nil else {
             return DiscSourceDetector.makeMKVAvailable ? "MakeMKV is ready for physical discs" : "MakeMKV is required for physical discs"
         }
         if !conversionCanStart {
             return conversionUnavailableReason
+        }
+        if let outputPath = viewModel.state.conversionResult?.outputPath {
+            return outputPath
         }
         return draft?.proposedOutputURL.path
     }
@@ -369,7 +386,9 @@ struct ContentView: View {
     }
 
     private var conversionCanStart: Bool {
-        capabilities.conversionAvailable && viewModel.source?.kind.supportsConversion == true
+        capabilities.conversionAvailable
+            && viewModel.source?.kind.supportsConversion == true
+            && viewModel.state.result != nil
     }
 
     private var conversionUnavailableReason: String {
@@ -381,6 +400,8 @@ struct ContentView: View {
             return "Disc and folder sources are not yet supported for native conversion."
         case .sourceFolder:
             return "Batch folder conversion is not yet available."
+        case .matroska, .transportStream where viewModel.state.result == nil:
+            return "Source analysis must complete before conversion can start."
         case .none, .matroska, .transportStream:
             return capabilities.conversionUnavailableReason
         }
@@ -521,7 +542,13 @@ private struct ActivityDrawer: View {
     let showTechnicalDetails: Bool
 
     private var activityText: String {
-        var entries = [state.stageMessage, state.activityMessage, state.warningMessage, state.failureDetails]
+        var entries = [
+            state.stageMessage,
+            state.activityMessage,
+            state.warningMessage,
+            state.failureMessage,
+            state.failureDetails,
+        ]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
         if showTechnicalDetails, !diagnosticLog.isEmpty, !entries.contains(diagnosticLog) {

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -182,12 +182,34 @@ struct SourceWorkspaceView: View {
                         ProgressView()
                             .controlSize(.small)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("Reading source details…")
+                            Text(state.operationKind == .inspection ? "Reading source details…" : "Converting video…")
                                 .fontWeight(.medium)
-                            Text(state.stageMessage ?? "Inspecting video streams")
+                            Text(
+                                state.stageMessage
+                                    ?? (state.operationKind == .inspection ? "Inspecting video streams" : "Processing video")
+                            )
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
+                    }
+                } else if state.phase == .failed {
+                    Divider()
+                    Label(
+                        state.failureMessage
+                            ?? (state.operationKind == .inspection
+                                ? "The source could not be analyzed."
+                                : "The source could not be converted."),
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.red)
+                    if let details = state.failureDetails, !details.isEmpty {
+                        Text(details)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                    if state.operationKind == .inspection, state.failureRetryable {
+                        Button("Analyze Again", action: retryAnalysis)
                     }
                 } else if let result = state.result {
                     Divider()
@@ -209,13 +231,6 @@ struct SourceWorkspaceView: View {
                                 SourceFact(label: "Size", value: result.formattedSize)
                             }
                         }
-                    }
-                } else if state.phase == .failed {
-                    Divider()
-                    Label(state.failureMessage ?? "The source could not be analyzed.", systemImage: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.red)
-                    if state.failureRetryable {
-                        Button("Analyze Again", action: retryAnalysis)
                     }
                 } else if source.kind.isDiscWorkflow {
                     Divider()

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class ConversionViewModelTests: XCTestCase {
     @MainActor
-    func testTerminalEventWaitsForProcessExitAndQuitCancellationWins() async throws {
+    func testTerminalCompletionWinsIfStopIsRequestedBeforeProcessExit() async throws {
         let terminalDelivered = expectation(description: "terminal delivered")
         let worker = ControlledWorkerClient(terminalDelivered: terminalDelivered)
         let viewModel = ConversionViewModel { worker }
@@ -20,7 +20,8 @@ final class ConversionViewModelTests: XCTestCase {
             await viewModel.stopForQuit()
 
             XCTAssertFalse(viewModel.hasActiveWorker)
-            XCTAssertEqual(viewModel.state.phase, .cancelled)
+            XCTAssertEqual(viewModel.state.phase, .completed)
+            XCTAssertEqual(viewModel.state.result?.name, "movie")
         }
     }
 
@@ -84,8 +85,9 @@ final class ConversionViewModelTests: XCTestCase {
             onInspectionComplete: { inspectionDone.fulfill() },
             onConversionJobReceived: { spec in
                 XCTAssertEqual(spec.operation, "convert_source")
-                XCTAssertNotNil(spec.conversionSettings)
-                XCTAssertEqual(spec.conversionSettings?.outputLength, "full_movie")
+                XCTAssertNotNil(spec.destination)
+                XCTAssertNotNil(spec.encoding)
+                XCTAssertEqual(spec.job?.outputLength, "full_movie")
                 conversionStarted.fulfill()
             }
         )
@@ -109,8 +111,10 @@ final class ConversionViewModelTests: XCTestCase {
             viewModel.startConversion(draft: draft)
 
             await fulfillment(of: [conversionStarted], timeout: 2)
-            XCTAssertTrue(viewModel.hasActiveWorker)
+            while viewModel.hasActiveWorker { await Task.yield() }
             XCTAssertEqual(viewModel.state.operationKind, .conversion)
+            XCTAssertEqual(viewModel.state.phase, .completed)
+            XCTAssertEqual(viewModel.state.conversionResult?.outputPath, "/Movies/movie_AVP.mov")
         }
     }
 
@@ -120,7 +124,8 @@ final class ConversionViewModelTests: XCTestCase {
         let conversionStarted = expectation(description: "conversion started")
         let worker = TwoPhaseWorkerClient(
             onInspectionComplete: { inspectionDone.fulfill() },
-            onConversionJobReceived: { _ in conversionStarted.fulfill() }
+            onConversionJobReceived: { _ in conversionStarted.fulfill() },
+            waitsForConversionCancellation: true
         )
         let viewModel = ConversionViewModel { worker }
 
@@ -147,6 +152,71 @@ final class ConversionViewModelTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testStartConversionRejectsDraftForDifferentSource() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let viewModel = ConversionViewModel {
+            TwoPhaseWorkerClient(onInspectionComplete: { inspectionDone.fulfill() })
+        }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            let otherURL = sourceURL.deletingLastPathComponent().appendingPathComponent("other.m2ts")
+            _ = FileManager.default.createFile(atPath: otherURL.path, contents: Data("video".utf8))
+            let draft = ConversionDraft(
+                source: ConversionSource(kind: .transportStream, url: otherURL),
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+
+            viewModel.startConversion(draft: draft)
+
+            XCTAssertFalse(viewModel.hasActiveWorker)
+            XCTAssertEqual(viewModel.state.phase, .failed)
+            XCTAssertEqual(viewModel.state.failureMessage, "Analyze the selected source before starting conversion.")
+        }
+    }
+
+    @MainActor
+    func testStartConversionRejectsSampleOutput() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let viewModel = ConversionViewModel {
+            TwoPhaseWorkerClient(onInspectionComplete: { inspectionDone.fulfill() })
+        }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            let draft = ConversionDraft(
+                source: viewModel.source!,
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .oneMinute,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+
+            viewModel.startConversion(draft: draft)
+
+            XCTAssertFalse(viewModel.hasActiveWorker)
+            XCTAssertEqual(viewModel.state.phase, .failed)
+            XCTAssertEqual(
+                viewModel.state.failureMessage,
+                "Short sample conversion is not available yet. Choose Full Movie."
+            )
+        }
+    }
+
     private func withTemporarySource(_ operation: @MainActor (URL) async throws -> Void) async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -166,10 +236,16 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
 
     var onInspectionComplete: (() -> Void)?
     var onConversionJobReceived: ((WorkerJobSpec) -> Void)?
+    private let waitsForConversionCancellation: Bool
 
-    init(onInspectionComplete: (() -> Void)? = nil, onConversionJobReceived: ((WorkerJobSpec) -> Void)? = nil) {
+    init(
+        onInspectionComplete: (() -> Void)? = nil,
+        onConversionJobReceived: ((WorkerJobSpec) -> Void)? = nil,
+        waitsForConversionCancellation: Bool = false
+    ) {
         self.onInspectionComplete = onInspectionComplete
         self.onConversionJobReceived = onConversionJobReceived
+        self.waitsForConversionCancellation = waitsForConversionCancellation
     }
 
     func run(job: WorkerJobSpec, onEvent: @escaping (WorkerEvent) async throws -> Void) async throws -> WorkerRunResult {
@@ -190,16 +266,30 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
         if isConversion {
             onConversionJobReceived?(job)
             try await onEvent(ready)
-            await waitForConversionCancellation()
-            let cancelled = WorkerEvent(
+            if waitsForConversionCancellation {
+                await waitForConversionCancellation()
+                let cancelled = WorkerEvent(
+                    protocolVersion: WorkerJobSpec.protocolVersion,
+                    type: .jobCancelled,
+                    jobID: job.jobID,
+                    sequence: 1,
+                    payload: WorkerEventPayload(message: "Conversion stopped.")
+                )
+                try await onEvent(cancelled)
+                return WorkerRunResult(terminalEvent: cancelled, exitStatus: SIGTERM, diagnostics: "")
+            }
+
+            let completed = WorkerEvent(
                 protocolVersion: WorkerJobSpec.protocolVersion,
-                type: .jobCancelled,
+                type: .jobCompleted,
                 jobID: job.jobID,
                 sequence: 1,
-                payload: WorkerEventPayload(message: "Conversion stopped.")
+                payload: WorkerEventPayload(
+                    conversionResult: ConversionResult(outputPath: "/Movies/movie_AVP.mov")
+                )
             )
-            try await onEvent(cancelled)
-            return WorkerRunResult(terminalEvent: cancelled, exitStatus: SIGTERM, diagnostics: "")
+            try await onEvent(completed)
+            return WorkerRunResult(terminalEvent: completed, exitStatus: 0, diagnostics: "")
         } else {
             let result = SourceInspection(name: "movie", resolution: "1920x1080", frameRate: "24/1", interlaced: false, sizeBytes: 10)
             let completed = WorkerEvent(

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -56,6 +56,97 @@ final class ConversionViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasActiveWorker)
     }
 
+    @MainActor
+    func testStartConversionForUnsupportedSourceKindDoesNotStartWorker() {
+        let viewModel = ConversionViewModel()
+        let discSource = ConversionSource(kind: .physicalDisc, url: URL(fileURLWithPath: "/Volumes/Disc"))
+        viewModel.selectSource(discSource)
+
+        let draft = ConversionDraft(
+            source: discSource,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+        viewModel.startConversion(draft: draft)
+
+        XCTAssertFalse(viewModel.hasActiveWorker)
+    }
+
+    @MainActor
+    func testStartConversionStartsWorkerWithConvertSourceJobSpec() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { spec in
+                XCTAssertEqual(spec.operation, "convert_source")
+                XCTAssertNotNil(spec.conversionSettings)
+                XCTAssertEqual(spec.conversionSettings?.outputLength, "full_movie")
+                conversionStarted.fulfill()
+            }
+        )
+        let viewModel = ConversionViewModel { worker }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            // Drain the inspection Task so finish() runs and hasActiveWorker becomes false
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            let draft = ConversionDraft(
+                source: viewModel.source!,
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+            viewModel.startConversion(draft: draft)
+
+            await fulfillment(of: [conversionStarted], timeout: 2)
+            XCTAssertTrue(viewModel.hasActiveWorker)
+            XCTAssertEqual(viewModel.state.operationKind, .conversion)
+        }
+    }
+
+    @MainActor
+    func testStopActiveWorkerCancelsConversionAndTransitionsToStopping() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { _ in conversionStarted.fulfill() }
+        )
+        let viewModel = ConversionViewModel { worker }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            let draft = ConversionDraft(
+                source: viewModel.source!,
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+            viewModel.startConversion(draft: draft)
+            await fulfillment(of: [conversionStarted], timeout: 2)
+
+            viewModel.stopActiveWorker()
+
+            XCTAssertEqual(viewModel.state.phase, .stopping)
+        }
+    }
+
     private func withTemporarySource(_ operation: @MainActor (URL) async throws -> Void) async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -64,6 +155,88 @@ final class ConversionViewModelTests: XCTestCase {
         _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try await operation(sourceURL)
+    }
+}
+
+private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var callCount = 0
+    private var conversionCancellationContinuation: CheckedContinuation<Void, Never>?
+    private var conversionCancellationRequested = false
+
+    var onInspectionComplete: (() -> Void)?
+    var onConversionJobReceived: ((WorkerJobSpec) -> Void)?
+
+    init(onInspectionComplete: (() -> Void)? = nil, onConversionJobReceived: ((WorkerJobSpec) -> Void)? = nil) {
+        self.onInspectionComplete = onInspectionComplete
+        self.onConversionJobReceived = onConversionJobReceived
+    }
+
+    func run(job: WorkerJobSpec, onEvent: @escaping (WorkerEvent) async throws -> Void) async throws -> WorkerRunResult {
+        let isConversion: Bool
+        lock.lock()
+        callCount += 1
+        isConversion = callCount > 1
+        lock.unlock()
+
+        let ready = WorkerEvent(
+            protocolVersion: WorkerJobSpec.protocolVersion,
+            type: .workerReady,
+            jobID: job.jobID,
+            sequence: 0,
+            payload: WorkerEventPayload(workerVersion: "test", processGroupID: 1)
+        )
+
+        if isConversion {
+            onConversionJobReceived?(job)
+            try await onEvent(ready)
+            await waitForConversionCancellation()
+            let cancelled = WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .jobCancelled,
+                jobID: job.jobID,
+                sequence: 1,
+                payload: WorkerEventPayload(message: "Conversion stopped.")
+            )
+            try await onEvent(cancelled)
+            return WorkerRunResult(terminalEvent: cancelled, exitStatus: SIGTERM, diagnostics: "")
+        } else {
+            let result = SourceInspection(name: "movie", resolution: "1920x1080", frameRate: "24/1", interlaced: false, sizeBytes: 10)
+            let completed = WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .jobCompleted,
+                jobID: job.jobID,
+                sequence: 1,
+                payload: WorkerEventPayload(result: result)
+            )
+            try await onEvent(ready)
+            try await onEvent(completed)
+            onInspectionComplete?()
+            return WorkerRunResult(terminalEvent: completed, exitStatus: 0, diagnostics: "")
+        }
+    }
+
+    func cancel() {
+        let continuation: CheckedContinuation<Void, Never>?
+        lock.lock()
+        conversionCancellationRequested = true
+        continuation = conversionCancellationContinuation
+        conversionCancellationContinuation = nil
+        lock.unlock()
+        continuation?.resume()
+    }
+
+    private func waitForConversionCancellation() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if conversionCancellationRequested {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            conversionCancellationContinuation = continuation
+            lock.unlock()
+        }
     }
 }
 

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -86,13 +86,15 @@ final class ConversionWorkflowTests: XCTestCase {
         let draft = makeDraft(kind: .matroska, extension: "mkv")
         let spec = WorkerJobSpec(draft: draft)
         XCTAssertEqual(spec.operation, "convert_source")
-        XCTAssertNotNil(spec.conversionSettings)
+        XCTAssertNotNil(spec.destination)
+        XCTAssertNotNil(spec.encoding)
+        XCTAssertNotNil(spec.job)
     }
 
     func testConversionJobSpecAlwaysSendsFullMovie() {
         let draft = makeDraft(kind: .transportStream, extension: "m2ts", outputLength: .threeMinutes)
         let spec = WorkerJobSpec(draft: draft)
-        XCTAssertEqual(spec.conversionSettings?.outputLength, "full_movie")
+        XCTAssertEqual(spec.job?.outputLength, "full_movie")
     }
 
     func testConversionJobSpecEncodesSourceAndDestination() {
@@ -109,7 +111,7 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let spec = WorkerJobSpec(draft: draft)
         XCTAssertEqual(spec.source.path, "/src/movie.mkv")
-        XCTAssertEqual(spec.conversionSettings?.destination.path, "/Movies")
+        XCTAssertEqual(spec.destination?.path, "/Movies")
     }
 
     func testConversionJobSpecEncodesVideoAndAudioSettings() {
@@ -130,11 +132,11 @@ final class ConversionWorkflowTests: XCTestCase {
             options: ConversionOptions(encoding: encoding)
         )
         let spec = WorkerJobSpec(draft: draft)
-        XCTAssertEqual(spec.conversionSettings?.video.hevcQuality, 80)
-        XCTAssertTrue(spec.conversionSettings?.video.upscaleEnabled == true)
-        XCTAssertEqual(spec.conversionSettings?.video.fieldOfView, 120)
-        XCTAssertEqual(spec.conversionSettings?.audio.handling, "transcode_aac")
-        XCTAssertEqual(spec.conversionSettings?.audio.bitrate, 512)
+        XCTAssertEqual(spec.encoding?.mvHEVCQuality, 80)
+        XCTAssertTrue(spec.encoding?.fxUpscale == true)
+        XCTAssertEqual(spec.encoding?.fieldOfView, 120)
+        XCTAssertTrue(spec.encoding?.transcodeAudio == true)
+        XCTAssertEqual(spec.encoding?.audioBitrate, 512)
     }
 
     func testConversionJobSpecEncodesJobSettings() {
@@ -153,18 +155,63 @@ final class ConversionWorkflowTests: XCTestCase {
             options: ConversionOptions(job: job)
         )
         let spec = WorkerJobSpec(draft: draft)
-        XCTAssertEqual(spec.conversionSettings?.job.startStage, ConversionStage.extractMVCAndAudio.rawValue)
-        XCTAssertTrue(spec.conversionSettings?.job.keepStageFiles == true)
-        XCTAssertTrue(spec.conversionSettings?.job.softwareEncoder == true)
+        XCTAssertEqual(spec.job?.startStage, ConversionStage.extractMVCAndAudio.rawValue)
+        XCTAssertTrue(spec.job?.keepFiles == true)
+        XCTAssertTrue(spec.job?.softwareEncoder == true)
     }
 
     func testInspectionJobSpecOmitsConversionSettings() throws {
         let spec = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/src/m.mkv"))
         XCTAssertEqual(spec.operation, "inspect_source")
-        XCTAssertNil(spec.conversionSettings)
+        XCTAssertNil(spec.destination)
+        XCTAssertNil(spec.encoding)
+        XCTAssertNil(spec.job)
         let data = try JSONEncoder().encode(spec)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        XCTAssertNil(json?["conversion_settings"], "inspection spec must not include conversion_settings key")
+        XCTAssertNil(json?["destination"], "inspection spec must not include destination")
+        XCTAssertNil(json?["encoding"], "inspection spec must not include encoding")
+        XCTAssertNil(json?["job"], "inspection spec must not include job options")
+    }
+
+    func testConversionJobSpecWireFormatMatchesWorkerContract() throws {
+        let spec = WorkerJobSpec(draft: makeDraft(kind: .matroska, extension: "mkv"))
+        let data = try JSONEncoder().encode(spec)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        let job = try XCTUnwrap(json["job"] as? [String: Any])
+
+        XCTAssertEqual(json["operation"] as? String, "convert_source")
+        XCTAssertEqual((json["destination"] as? [String: Any])?["path"] as? String, "/Movies")
+        XCTAssertEqual(encoding["mv_hevc_quality"] as? Int, 75)
+        XCTAssertEqual(encoding["language_code"] as? String, "eng")
+        XCTAssertEqual(job["start_stage"] as? Int, 1)
+        XCTAssertEqual(job["output_length"] as? String, "full_movie")
+        XCTAssertNil(json["conversion_settings"])
+    }
+
+    func testConversionJobSpecMatchesSharedPythonFixture() throws {
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+        let spec = WorkerJobSpec(
+            draft: draft,
+            jobID: try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        )
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/native_worker_convert_v1.json")
+        let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
+
+        XCTAssertEqual(encoded, fixture)
     }
 
     private func makeDraft(

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -66,8 +66,121 @@ final class ConversionWorkflowTests: XCTestCase {
     }
 
     func testCurrentCapabilitiesStayHonest() {
-        XCTAssertFalse(AppCapabilities.current.conversionAvailable)
+        XCTAssertTrue(AppCapabilities.current.conversionAvailable)
         XCTAssertFalse(AppCapabilities.current.automaticUpdateChecksAvailable)
+    }
+
+    func testMKVAndTransportStreamKindsSupportConversion() {
+        XCTAssertTrue(ConversionSourceKind.matroska.supportsConversion)
+        XCTAssertTrue(ConversionSourceKind.transportStream.supportsConversion)
+    }
+
+    func testDiscAndFolderKindsDoNotSupportConversion() {
+        XCTAssertFalse(ConversionSourceKind.physicalDisc.supportsConversion)
+        XCTAssertFalse(ConversionSourceKind.discImage.supportsConversion)
+        XCTAssertFalse(ConversionSourceKind.bluRayFolder.supportsConversion)
+        XCTAssertFalse(ConversionSourceKind.sourceFolder.supportsConversion)
+    }
+
+    func testConversionJobSpecUsesConvertSourceOperation() {
+        let draft = makeDraft(kind: .matroska, extension: "mkv")
+        let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.operation, "convert_source")
+        XCTAssertNotNil(spec.conversionSettings)
+    }
+
+    func testConversionJobSpecAlwaysSendsFullMovie() {
+        let draft = makeDraft(kind: .transportStream, extension: "m2ts", outputLength: .threeMinutes)
+        let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.conversionSettings?.outputLength, "full_movie")
+    }
+
+    func testConversionJobSpecEncodesSourceAndDestination() {
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/src/movie.mkv"))
+        let destination = URL(fileURLWithPath: "/Movies", isDirectory: true)
+        let draft = ConversionDraft(
+            source: source,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: destination,
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+        let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.source.path, "/src/movie.mkv")
+        XCTAssertEqual(spec.conversionSettings?.destination.path, "/Movies")
+    }
+
+    func testConversionJobSpecEncodesVideoAndAudioSettings() {
+        var encoding = EncodingOptions()
+        encoding.hevcQuality = 80
+        encoding.upscaleEnabled = true
+        encoding.fieldOfView = 120
+        encoding.audioHandling = .transcodeAAC
+        encoding.audioBitrate = 512
+
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/src/m.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions(encoding: encoding)
+        )
+        let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.conversionSettings?.video.hevcQuality, 80)
+        XCTAssertTrue(spec.conversionSettings?.video.upscaleEnabled == true)
+        XCTAssertEqual(spec.conversionSettings?.video.fieldOfView, 120)
+        XCTAssertEqual(spec.conversionSettings?.audio.handling, "transcode_aac")
+        XCTAssertEqual(spec.conversionSettings?.audio.bitrate, 512)
+    }
+
+    func testConversionJobSpecEncodesJobSettings() {
+        var job = JobOptions()
+        job.startStage = .extractMVCAndAudio
+        job.keepStageFiles = true
+        job.softwareEncoder = true
+
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/src/m.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions(job: job)
+        )
+        let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.conversionSettings?.job.startStage, ConversionStage.extractMVCAndAudio.rawValue)
+        XCTAssertTrue(spec.conversionSettings?.job.keepStageFiles == true)
+        XCTAssertTrue(spec.conversionSettings?.job.softwareEncoder == true)
+    }
+
+    func testInspectionJobSpecOmitsConversionSettings() throws {
+        let spec = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/src/m.mkv"))
+        XCTAssertEqual(spec.operation, "inspect_source")
+        XCTAssertNil(spec.conversionSettings)
+        let data = try JSONEncoder().encode(spec)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNil(json?["conversion_settings"], "inspection spec must not include conversion_settings key")
+    }
+
+    private func makeDraft(
+        kind: ConversionSourceKind,
+        extension ext: String,
+        outputLength: OutputLength = .fullMovie
+    ) -> ConversionDraft {
+        ConversionDraft(
+            source: ConversionSource(kind: kind, url: URL(fileURLWithPath: "/src/movie.\(ext)")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            outputLength: outputLength,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
     }
 
     private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -84,7 +84,7 @@ final class WorkerLifecycleTests: XCTestCase {
 
         try state.begin(jobID: jobID, operationKind: .conversion)
 
-        XCTAssertEqual(state.phase, .inspecting)
+        XCTAssertEqual(state.phase, .processing)
         XCTAssertEqual(state.stageMessage, "Preparing conversion")
         XCTAssertEqual(state.operationKind, .conversion)
     }
@@ -102,6 +102,26 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(state.conversionResult, convResult)
         XCTAssertNil(state.result)
         XCTAssertEqual(state.stageMessage, "Conversion complete")
+    }
+
+    func testConversionPreservesInspectionResult() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID)
+        try state.receive(event(.workerReady, sequence: 0))
+        let inspection = SourceInspection(
+            name: "movie",
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            interlaced: false,
+            sizeBytes: 10
+        )
+        try state.receive(event(.jobCompleted, sequence: 1, payload: .init(result: inspection)))
+
+        try state.begin(jobID: UUID(), operationKind: .conversion)
+
+        XCTAssertEqual(state.result, inspection)
+        XCTAssertEqual(state.phase, .processing)
     }
 
     func testConversionCompleteStopUsesConversionMessage() throws {
@@ -158,6 +178,46 @@ final class WorkerLifecycleTests: XCTestCase {
         }
     }
 
+    func testConversionDecisionPreservesActionableFailure() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["retry_without_subtitles", "cancel"],
+            details: "Disable subtitle extraction to retry."
+        )
+
+        try state.receive(event(.jobDecisionRequired, sequence: 0, payload: .init(decision: decision)))
+
+        XCTAssertEqual(state.phase, .failed)
+        XCTAssertEqual(state.failureMessage, "Subtitle extraction needs attention.")
+        XCTAssertEqual(state.failureDetails, "Disable subtitle extraction to retry.")
+        XCTAssertTrue(state.failureRetryable)
+    }
+
+    func testDecodesAndAppliesSharedPythonConversionCompletionFixture() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/native_worker_conversion_completed_v1.json")
+        let completed = try JSONDecoder().decode(WorkerEvent.self, from: Data(contentsOf: fixtureURL))
+        let fixtureJobID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: fixtureJobID, operationKind: .conversion)
+        try state.receive(event(.workerReady, sequence: 0, jobID: fixtureJobID))
+        try state.receive(event(.jobStarted, sequence: 1, jobID: fixtureJobID))
+
+        try state.receive(completed)
+
+        XCTAssertEqual(state.phase, .completed)
+        XCTAssertEqual(state.conversionResult?.outputPath, "/tmp/output/movie_AVP.mov")
+        XCTAssertEqual(state.conversionResult?.sizeBytes, 1024)
+    }
+
     func testRejectsSequenceGap() throws {
         var state = WorkerLifecycleState()
         state.selectSource(sourceURL)
@@ -174,12 +234,13 @@ final class WorkerLifecycleTests: XCTestCase {
     private func event(
         _ type: WorkerEventType,
         sequence: Int,
-        payload: WorkerEventPayload = WorkerEventPayload()
+        payload: WorkerEventPayload = WorkerEventPayload(),
+        jobID: UUID? = nil
     ) -> WorkerEvent {
         WorkerEvent(
             protocolVersion: WorkerJobSpec.protocolVersion,
             type: type,
-            jobID: jobID,
+            jobID: jobID ?? self.jobID,
             sequence: sequence,
             payload: payload
         )

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -78,6 +78,86 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertTrue(state.failureRetryable)
     }
 
+    func testConversionBeginSetsConversionStageMessage() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        XCTAssertEqual(state.phase, .inspecting)
+        XCTAssertEqual(state.stageMessage, "Preparing conversion")
+        XCTAssertEqual(state.operationKind, .conversion)
+    }
+
+    func testConversionJobCompletedStoresConversionResult() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(event(.workerReady, sequence: 0, payload: .init(workerVersion: "1.0")))
+
+        let convResult = ConversionResult(outputPath: "/Movies/movie_AVP.mov", durationSeconds: 7200)
+        try state.receive(event(.jobCompleted, sequence: 1, payload: .init(conversionResult: convResult)))
+
+        XCTAssertEqual(state.phase, .completed)
+        XCTAssertEqual(state.conversionResult, convResult)
+        XCTAssertNil(state.result)
+        XCTAssertEqual(state.stageMessage, "Conversion complete")
+    }
+
+    func testConversionCompleteStopUsesConversionMessage() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(event(.workerReady, sequence: 0))
+
+        state.requestStop()
+        state.completeStop()
+
+        XCTAssertEqual(state.phase, .cancelled)
+        XCTAssertEqual(state.activityMessage, "Conversion stopped.")
+    }
+
+    func testInspectionCompleteStopUsesInspectionMessage() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID)
+        try state.receive(event(.workerReady, sequence: 0))
+
+        state.requestStop()
+        state.completeStop()
+
+        XCTAssertEqual(state.phase, .cancelled)
+        XCTAssertEqual(state.activityMessage, "Inspection stopped.")
+    }
+
+    func testInspectionJobCompletedRejectsConversionResultPayload() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID)
+        try state.receive(event(.workerReady, sequence: 0))
+
+        let convResult = ConversionResult(outputPath: "/out.mov", durationSeconds: nil)
+        XCTAssertThrowsError(
+            try state.receive(event(.jobCompleted, sequence: 1, payload: .init(conversionResult: convResult)))
+        ) { error in
+            XCTAssertEqual(error as? WorkerLifecycleError, .missingPayload(event: .jobCompleted))
+        }
+    }
+
+    func testConversionJobCompletedRejectsInspectionResultPayload() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(event(.workerReady, sequence: 0))
+
+        let inspResult = SourceInspection(name: "m", resolution: "1920x1080", frameRate: "24/1", interlaced: false, sizeBytes: 10)
+        XCTAssertThrowsError(
+            try state.receive(event(.jobCompleted, sequence: 1, payload: .init(result: inspResult)))
+        ) { error in
+            XCTAssertEqual(error as? WorkerLifecycleError, .missingPayload(event: .jobCompleted))
+        }
+    }
+
     func testRejectsSequenceGap() throws {
         var state = WorkerLifecycleState()
         state.selectSource(sourceURL)

--- a/tests/fixtures/native_worker_conversion_completed_v1.json
+++ b/tests/fixtures/native_worker_conversion_completed_v1.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 1,
+  "type": "job.completed",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 2,
+  "payload": {
+    "conversion_result": {
+      "source_path": "/tmp/movie.mkv",
+      "destination_path": "/tmp/output",
+      "output_path": "/tmp/output/movie_AVP.mov",
+      "size_bytes": 1024
+    }
+  }
+}

--- a/tests/fixtures/native_worker_convert_v1.json
+++ b/tests/fixtures/native_worker_convert_v1.json
@@ -1,0 +1,40 @@
+{
+  "protocol_version": 1,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "transcode_audio": false,
+    "audio_bitrate": 384,
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "skip_subtitles": false,
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "language_code": "eng",
+    "remove_extra_languages": false
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true,
+    "output_length": "full_movie"
+  }
+}

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import signal
 import stat
 import subprocess
@@ -8,17 +9,20 @@ import time
 import unittest
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
 
 from bd_to_avp.modules.config import config
 from bd_to_avp.worker.__main__ import run_worker
-from bd_to_avp.worker.operations import WorkerOperationError, inspect_source
-from bd_to_avp.worker.ownership import WorkerProcessOwner
+from bd_to_avp.worker.operations import WorkerOperationError, convert_source, inspect_source
+from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
 from bd_to_avp.worker.protocol import (
     MAX_EVENT_BYTES,
     MAX_REQUEST_BYTES,
+    MAX_DETAIL_BYTES,
     PROTOCOL_VERSION,
+    WorkerActivityReporter,
     JobSpec,
     WorkerEventEmitter,
     WorkerEventType,
@@ -38,7 +42,48 @@ def request_line(source_path: Path, **overrides: object) -> str:
     return json.dumps(request) + "\n"
 
 
-def decoded_events(output: io.StringIO) -> list[dict[str, object]]:
+def conversion_request_line(source_path: Path, destination_path: Path, **overrides: object) -> str:
+    request: dict[str, object] = {
+        "protocol_version": PROTOCOL_VERSION,
+        "type": "job.start",
+        "job_id": str(uuid4()),
+        "operation": "convert_source",
+        "source": {"path": str(source_path)},
+        "destination": {"path": str(destination_path)},
+        "encoding": {
+            "transcode_audio": True,
+            "audio_bitrate": 384,
+            "left_right_bitrate": 20,
+            "link_quality": True,
+            "mv_hevc_quality": 75,
+            "upscale_quality": 75,
+            "fov": 90,
+            "frame_rate": "",
+            "resolution": "",
+            "skip_subtitles": False,
+            "crop_black_bars": False,
+            "swap_eyes": False,
+            "fx_upscale": False,
+            "language_code": "eng",
+            "remove_extra_languages": False,
+        },
+        "job": {
+            "start_stage": 1,
+            "keep_files": False,
+            "overwrite": False,
+            "remove_original": False,
+            "continue_on_error": False,
+            "software_encoder": False,
+            "output_commands": False,
+            "keep_awake": False,
+            "output_length": "full_movie",
+        },
+    }
+    request.update(overrides)
+    return json.dumps(request) + "\n"
+
+
+def decoded_events(output: io.StringIO) -> list[dict[str, Any]]:
     return [json.loads(line) for line in output.getvalue().splitlines()]
 
 
@@ -50,6 +95,70 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.protocol_version, PROTOCOL_VERSION)
         self.assertEqual(job.operation.value, "inspect_source")
         self.assertEqual(job.source.path, source_path)
+
+    def test_parses_strict_conversion_request(self) -> None:
+        source_path = Path("/tmp/movie.mkv")
+        destination_path = Path("/tmp/output")
+
+        job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+
+        self.assertEqual(job.operation.value, "convert_source")
+        self.assertEqual(job.source.path, source_path)
+        self.assertEqual(job.destination.path if job.destination else None, destination_path)
+        self.assertTrue(job.encoding.transcode_audio if job.encoding else False)
+        self.assertEqual(job.job.start_stage if job.job else None, 1)
+        self.assertEqual(job.job.output_length if job.job else None, "full_movie")
+
+    def test_parses_shared_swift_conversion_fixture(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v1.json"
+
+        job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(job.operation.value, "convert_source")
+        self.assertEqual(job.source.path, Path("/tmp/movie.mkv"))
+        self.assertEqual(job.destination.path if job.destination else None, Path("/tmp/output"))
+        self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
+
+    def test_rejects_sample_conversion_request(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["job"]["output_length"] = "three_minutes"
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_job_options")
+
+    def test_accepts_zero_field_of_view_used_by_existing_ui(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["fov"] = 0
+
+        job = JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(job.encoding.fov if job.encoding else None, 0)
+
+    def test_rejects_relative_conversion_destination_path(self) -> None:
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(conversion_request_line(Path("/tmp/movie.mkv"), Path("output")))
+
+        self.assertEqual(context.exception.code, "destination_not_absolute")
+
+    def test_rejects_unknown_conversion_option(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["surprise"] = True
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_request")
+
+    def test_rejects_missing_conversion_options(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        del request["job"]["overwrite"]
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_job_options")
 
     def test_rejects_protocol_mismatch_with_job_id(self) -> None:
         job_id = str(uuid4())
@@ -121,9 +230,14 @@ class WorkerRuntimeTests(unittest.TestCase):
             output = io.StringIO()
             diagnostics = io.StringIO()
 
-            def operation(job: JobSpec, _owner: WorkerProcessOwner) -> dict[str, object]:
+            def operation(
+                job: JobSpec,
+                _owner: WorkerProcessOwner,
+                activity: WorkerActivityReporter,
+            ) -> dict[str, object]:
                 print("legacy output")
                 self.assertEqual(job.source.path, source_path)
+                activity.log("structured progress")
                 time.sleep(0.02)
                 return {"name": "movie", "resolution": "1920x1080"}
 
@@ -141,6 +255,7 @@ class WorkerRuntimeTests(unittest.TestCase):
         self.assertEqual(events[0]["type"], "worker.ready")
         self.assertEqual(events[-1]["type"], "job.completed")
         self.assertIn("heartbeat", [event["type"] for event in events])
+        self.assertIn("log", [event["type"] for event in events])
         self.assertNotIn("legacy output", output.getvalue())
         self.assertIn("legacy output", diagnostics.getvalue())
 
@@ -150,7 +265,11 @@ class WorkerRuntimeTests(unittest.TestCase):
             source_path.touch()
             output = io.StringIO()
 
-            def operation(_job: JobSpec, owner: WorkerProcessOwner) -> dict[str, object]:
+            def operation(
+                _job: JobSpec,
+                owner: WorkerProcessOwner,
+                _activity: WorkerActivityReporter,
+            ) -> dict[str, object]:
                 owner.request_cancel()
                 owner.check_cancelled()
                 return {"name": "unreachable"}
@@ -186,7 +305,7 @@ class WorkerRuntimeTests(unittest.TestCase):
             io_output := io.StringIO(),
             io.StringIO(),
             establish_session=False,
-            operation_runner=lambda _job, _owner: {"blob": "x" * MAX_EVENT_BYTES},
+            operation_runner=lambda _job, _owner, _activity: {"blob": "x" * MAX_EVENT_BYTES},
         )
 
         events = decoded_events(io_output)
@@ -194,6 +313,107 @@ class WorkerRuntimeTests(unittest.TestCase):
         self.assertEqual([event["sequence"] for event in events], list(range(len(events))))
         self.assertEqual(events[-1]["type"], "job.failed")
         self.assertEqual(events[-1]["payload"]["error"]["code"], "internal_error")
+
+    def test_emits_shared_swift_conversion_completion_fixture(self) -> None:
+        output = io.StringIO()
+        emitter = WorkerEventEmitter(output, "11111111-1111-4111-8111-111111111111")
+        emitter.emit(WorkerEventType.WORKER_READY)
+        emitter.emit(WorkerEventType.JOB_STARTED, {"operation": "convert_source"})
+        emitter.emit(
+            WorkerEventType.JOB_COMPLETED,
+            {
+                "conversion_result": {
+                    "source_path": "/tmp/movie.mkv",
+                    "destination_path": "/tmp/output",
+                    "output_path": "/tmp/output/movie_AVP.mov",
+                    "size_bytes": 1024,
+                }
+            },
+        )
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v1.json"
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(decoded_events(output)[-1], fixture)
+
+    def test_oversized_error_details_are_truncated_and_terminal(self) -> None:
+        source_path = Path("/tmp/movie.m2ts")
+
+        def operation(
+            _job: JobSpec,
+            _owner: WorkerProcessOwner,
+            _activity: WorkerActivityReporter,
+        ) -> dict[str, object]:
+            raise WorkerOperationError("tool_failed", "A conversion helper failed.", "x" * MAX_EVENT_BYTES)
+
+        exit_code = run_worker(
+            io.StringIO(request_line(source_path)),
+            output := io.StringIO(),
+            io.StringIO(),
+            establish_session=False,
+            operation_runner=operation,
+        )
+
+        events = decoded_events(output)
+        details = events[-1]["payload"]["error"]["details"]
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(events[-1]["type"], "job.failed")
+        self.assertLessEqual(len(details.encode("utf-8")), MAX_DETAIL_BYTES)
+        self.assertTrue(details.endswith("details truncated"))
+
+    def test_decision_required_is_terminal(self) -> None:
+        source_path = Path("/tmp/movie.m2ts")
+
+        def operation(
+            _job: JobSpec,
+            _owner: WorkerProcessOwner,
+            _activity: WorkerActivityReporter,
+        ) -> dict[str, object]:
+            from bd_to_avp.worker.operations import WorkerDecisionRequired
+
+            raise WorkerDecisionRequired("subtitle_decision_required", "Choose how to continue.", "details")
+
+        exit_code = run_worker(
+            io.StringIO(request_line(source_path)),
+            io_output := io.StringIO(),
+            io.StringIO(),
+            establish_session=False,
+            operation_runner=operation,
+        )
+
+        events = decoded_events(io_output)
+        self.assertEqual(exit_code, 3)
+        self.assertEqual(events[-1]["type"], "job.decision_required")
+        self.assertEqual(events[-1]["payload"]["decision"]["id"], "subtitle_decision_required")
+        self.assertEqual(events[-1]["payload"]["decision"]["prompt"], "Choose how to continue.")
+        self.assertEqual(events[-1]["payload"]["decision"]["details"], "details")
+
+    def test_conversion_completion_uses_conversion_result_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.mkv"
+            source_path.touch()
+            output = io.StringIO()
+
+            def operation(
+                _job: JobSpec,
+                _owner: WorkerProcessOwner,
+                _activity: WorkerActivityReporter,
+            ) -> dict[str, object]:
+                return {"output_path": "/tmp/Movie_AVP.mov", "size_bytes": 10}
+
+            exit_code = run_worker(
+                io.StringIO(conversion_request_line(source_path, temporary_path / "output")),
+                output,
+                io.StringIO(),
+                establish_session=False,
+                operation_runner=operation,
+            )
+
+        events = decoded_events(output)
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(events[-1]["type"], "job.completed")
+        self.assertEqual(events[-1]["payload"]["conversion_result"]["output_path"], "/tmp/Movie_AVP.mov")
+        self.assertNotIn("result", events[-1]["payload"])
 
 
 class SourceInspectionTests(unittest.TestCase):
@@ -228,6 +448,236 @@ class SourceInspectionTests(unittest.TestCase):
 
             with self.assertRaisesRegex(WorkerOperationError, "supports MKV, MTS, and M2TS"):
                 inspect_source(source_path, WorkerProcessOwner())
+
+
+class SourceConversionTests(unittest.TestCase):
+    def test_rejects_disc_iso_and_folder_sources(self) -> None:
+        for name in ("movie.iso", "BDMV"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary_directory:
+                temporary_path = Path(temporary_directory)
+                source_path = temporary_path / name
+                if name == "BDMV":
+                    source_path.mkdir()
+                else:
+                    source_path.touch()
+                destination_path = temporary_path / "output"
+                job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+                emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+                activity = WorkerActivityReporter(emitter)
+
+                with self.assertRaises(WorkerOperationError) as context:
+                    convert_source(job, WorkerProcessOwner(), activity)
+
+                self.assertIn(context.exception.code, {"unsupported_source", "source_not_file"})
+
+    def test_conversion_restores_global_config_and_tool_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.mkv"
+            source_path.write_bytes(b"source")
+            destination_path = temporary_path / "output"
+            final_path = destination_path / "movie_AVP.mov"
+            final_path.parent.mkdir()
+            final_path.write_bytes(b"final")
+            job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+            previous_source_path = config.source_path
+            previous_output_root_path = config.output_root_path
+            previous_transcode_audio = config.transcode_audio
+            previous_remove_original = config.remove_original
+            previous_environment = {
+                key: os.environ.get(key) for key in ("PATH", "FFMPEG_BINARY", "FFPROBE_BINARY", "TMPDIR")
+            }
+
+            def mutate_environment() -> None:
+                os.environ.update(
+                    {
+                        "PATH": "worker-path",
+                        "FFMPEG_BINARY": "worker-ffmpeg",
+                        "FFPROBE_BINARY": "worker-ffprobe",
+                        "TMPDIR": "worker-tmp",
+                    }
+                )
+
+            with (
+                patch.object(config, "configure_tool_environment", side_effect=mutate_environment),
+                patch("bd_to_avp.modules.process.process_each", return_value=final_path) as process_each_mock,
+            ):
+                result = convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(result["output_path"], final_path.as_posix())
+            self.assertEqual(result["destination_path"], destination_path.as_posix())
+            process_each_mock.assert_called_once()
+            self.assertEqual(config.source_path, previous_source_path)
+            self.assertEqual(config.output_root_path, previous_output_root_path)
+            self.assertEqual(config.transcode_audio, previous_transcode_audio)
+            self.assertEqual(config.remove_original, previous_remove_original)
+            for key, value in previous_environment.items():
+                self.assertEqual(os.environ.get(key), value)
+
+    def test_conversion_passes_request_options_to_existing_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.m2ts"
+            source_path.write_bytes(b"source")
+            destination_path = temporary_path / "output"
+            final_path = destination_path / "movie_AVP.mov"
+            final_path.parent.mkdir()
+            final_path.write_bytes(b"final")
+            request = json.loads(conversion_request_line(source_path, destination_path))
+            request["encoding"].update(
+                {
+                    "transcode_audio": False,
+                    "audio_bitrate": 512,
+                    "left_right_bitrate": 42,
+                    "mv_hevc_quality": 88,
+                    "upscale_quality": 66,
+                    "fov": 110,
+                    "frame_rate": "24000/1001",
+                    "resolution": "1920x1080",
+                    "skip_subtitles": True,
+                    "crop_black_bars": True,
+                    "swap_eyes": True,
+                    "fx_upscale": True,
+                    "language_code": "jpn",
+                    "remove_extra_languages": True,
+                }
+            )
+            request["job"].update(
+                {
+                    "start_stage": 7,
+                    "keep_files": True,
+                    "overwrite": True,
+                    "remove_original": True,
+                    "continue_on_error": True,
+                    "software_encoder": True,
+                    "output_commands": True,
+                    "keep_awake": True,
+                }
+            )
+            job = JobSpec.from_json_line(json.dumps(request) + "\n")
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+            observed: dict[str, object] = {}
+
+            def fake_process_each(_cancellation_event: object, activity: object | None = None) -> Path:
+                observed.update(
+                    {
+                        "source_path": config.source_path,
+                        "output_root_path": config.output_root_path,
+                        "transcode_audio": config.transcode_audio,
+                        "audio_bitrate": config.audio_bitrate,
+                        "left_right_bitrate": config.left_right_bitrate,
+                        "mv_hevc_quality": config.mv_hevc_quality,
+                        "upscale_quality": config.upscale_quality,
+                        "fov": config.fov,
+                        "frame_rate": config.frame_rate,
+                        "resolution": config.resolution,
+                        "skip_subtitles": config.skip_subtitles,
+                        "crop_black_bars": config.crop_black_bars,
+                        "swap_eyes": config.swap_eyes,
+                        "fx_upscale": config.fx_upscale,
+                        "language_code": config.language_code,
+                        "remove_extra_languages": config.remove_extra_languages,
+                        "start_stage": config.start_stage.value,
+                        "keep_files": config.keep_files,
+                        "overwrite": config.overwrite,
+                        "remove_original": config.remove_original,
+                        "continue_on_error": config.continue_on_error,
+                        "software_encoder": config.software_encoder,
+                        "output_commands": config.output_commands,
+                        "keep_awake": config.keep_awake,
+                        "activity": activity,
+                    }
+                )
+                return final_path
+
+            with (
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.process.process_each", side_effect=fake_process_each),
+            ):
+                convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(observed["source_path"], source_path)
+            self.assertEqual(observed["output_root_path"], destination_path)
+            self.assertFalse(observed["transcode_audio"])
+            self.assertEqual(observed["audio_bitrate"], 512)
+            self.assertEqual(observed["left_right_bitrate"], 42)
+            self.assertEqual(observed["mv_hevc_quality"], 88)
+            self.assertEqual(observed["upscale_quality"], 66)
+            self.assertEqual(observed["fov"], 110)
+            self.assertEqual(observed["frame_rate"], "24000/1001")
+            self.assertEqual(observed["resolution"], "1920x1080")
+            self.assertTrue(observed["skip_subtitles"])
+            self.assertTrue(observed["crop_black_bars"])
+            self.assertTrue(observed["swap_eyes"])
+            self.assertTrue(observed["fx_upscale"])
+            self.assertEqual(observed["language_code"], "jpn")
+            self.assertTrue(observed["remove_extra_languages"])
+            self.assertEqual(observed["start_stage"], 7)
+            self.assertTrue(observed["keep_files"])
+            self.assertTrue(observed["overwrite"])
+            self.assertTrue(observed["remove_original"])
+            self.assertTrue(observed["continue_on_error"])
+            self.assertTrue(observed["software_encoder"])
+            self.assertTrue(observed["output_commands"])
+            self.assertTrue(observed["keep_awake"])
+            self.assertIs(observed["activity"], activity)
+
+    def test_conversion_maps_cancellation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.mkv"
+            source_path.write_bytes(b"source")
+            destination_path = temporary_path / "output"
+            job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+            owner = WorkerProcessOwner()
+
+            def cancel(_cancellation_event: object, activity: object | None = None) -> Path:
+                owner.request_cancel()
+                from bd_to_avp.modules.process import ProcessingCancelled
+
+                raise ProcessingCancelled("stop")
+
+            with (
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.process.process_each", side_effect=cancel),
+                self.assertRaises(WorkerCancelled),
+            ):
+                convert_source(job, owner, activity)
+
+    def test_conversion_maps_engine_failure_without_losing_error_type(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.mkv"
+            source_path.write_bytes(b"source")
+            destination_path = temporary_path / "output"
+            job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+            previous_source_path = config.source_path
+            previous_output_root_path = config.output_root_path
+            previous_tmpdir = os.environ.get("TMPDIR")
+
+            with (
+                patch.object(
+                    config,
+                    "configure_tool_environment",
+                    side_effect=lambda: os.environ.__setitem__("TMPDIR", "worker-failure-tmp"),
+                ),
+                patch("bd_to_avp.modules.process.process_each", side_effect=RuntimeError("bad source")),
+                self.assertRaises(WorkerOperationError) as context,
+            ):
+                convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(context.exception.code, "conversion_failed")
+            self.assertEqual(context.exception.details, "bad source")
+            self.assertEqual(config.source_path, previous_source_path)
+            self.assertEqual(config.output_root_path, previous_output_root_path)
+            self.assertEqual(os.environ.get("TMPDIR"), previous_tmpdir)
 
 
 class WorkerProcessOwnerTests(unittest.TestCase):

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -83,6 +83,15 @@ class DependencyPreflightTests(unittest.TestCase):
 
         self.assertNotIn(preflight.config.MAKEMKVCON_PATH, required_paths)
 
+    def test_mkv_sources_do_not_require_makemkv(self) -> None:
+        with (
+            patch.object(preflight.config, "source_path", Path("movie.mkv")),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job()
+
+        self.assertNotIn(preflight.config.MAKEMKVCON_PATH, required_paths)
+
     def test_disc_sources_require_makemkv(self) -> None:
         with (
             patch.object(preflight.config, "source_path", None),

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -248,6 +248,23 @@ class ProcessPreflightTests(unittest.TestCase):
             self.assertTrue(output_folder.exists())
             self.assertEqual((output_root / "Movie_AVP.mov").read_bytes(), b"final")
 
+    def test_output_move_returns_final_output_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            output_folder = output_root / "Movie"
+            output_folder.mkdir()
+            muxed_path = output_folder / "Movie_AVP.mov"
+            muxed_path.write_bytes(b"final")
+
+            with (
+                patch.object(process.config, "output_root_path", output_root),
+                patch.object(process.config, "keep_files", True),
+            ):
+                final_path = move_file_to_output_root_folder(muxed_path)
+
+            self.assertEqual(final_path, output_root / "Movie_AVP.mov")
+            self.assertEqual(final_path.read_bytes(), b"final")
+
     def test_create_mkv_start_preserves_symlink_source_inside_output_folder(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)


### PR DESCRIPTION
## Summary

- add a strict immutable `convert_source` worker request for MKV, MTS, and M2TS files
- map native conversion settings into the existing Python engine with scoped config/environment restoration
- emit structured conversion stages, heartbeats, failures, decisions, cancellation, and final output results
- wire Start Processing, stop/quit behavior, output reveal/sound, and conversion-aware status/recovery UI
- keep disc, ISO, Blu-ray folder, batch folder, and sample conversion explicitly unavailable
- add shared Swift/Python v1 contract fixtures and package-facing documentation

## Validation

- `uv run python -m unittest discover -s tests -t .` — 368 passed
- `uv run python scripts/native_app.py test` — 57 passed
- `uv run ruff format --check ...` — passed for changed Python files
- `uv run ruff check --no-fix ...` — passed for changed Python files
- `uv run mypy ...` — passed for changed Python source files
- `uv run python scripts/native_app.py package` — ad-hoc package, signature validation, and packaged-worker smoke passed
- packaged `convert_source` protocol probe reached structured stages and returned the expected `ffmpeg_failed` terminal event for an intentionally invalid media fixture
- independent backend, native UX, and release-risk reviews completed; final review found no remaining blockers

## Boundaries

This is the first real native conversion slice. It intentionally supports only previously inspected single-file MKV/MTS/M2TS sources and full-movie output. The existing production app remains required for physical discs, images, Blu-ray folders, batch folders, and interactive recovery that needs a second worker request.

Refs #198
