### PR TITLE
Fix native ISO review follow-ups

### DIFF
--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -19,6 +19,7 @@ def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int,
 
 def create_transcoded_audio_file(original_audio_path: Path, output_folder: Path) -> Path:
     transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.m4a"
+    legacy_transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.mov"
     direct_audio_transcode = is_direct_audio_transcode_enabled()
 
     if config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
@@ -36,6 +37,11 @@ def create_transcoded_audio_file(original_audio_path: Path, output_folder: Path)
 
     if config.transcode_audio and transcoded_audio_path.exists():
         return transcoded_audio_path
+    if config.transcode_audio and legacy_transcoded_audio_path.exists():
+        raise FileNotFoundError(
+            "Legacy AAC audio artifact found. Restart from Transcode Audio to regenerate a compatible M4A file: "
+            f"{legacy_transcoded_audio_path}"
+        )
     if direct_audio_transcode and config.transcode_audio:
         raise FileNotFoundError(f"Direct AAC audio artifact not found: {transcoded_audio_path}")
     return original_audio_path

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -65,6 +65,9 @@ named restartable file.
 - Output: `<folder>_audio_AAC.m4a` when enabled. The MPEG-4 audio container
   preserves AAC decoder configuration when MP4Box imports the tracks into the
   final spatial movie.
+- Older builds wrote `<folder>_audio_AAC.mov`. A resume directory containing
+  only that legacy artifact must restart from `TRANSCODE_AUDIO` so the app can
+  regenerate a compatible M4A instead of attempting an unsafe final mux.
 - Restart/debug value: medium. This is the final mux input and useful for audio
   debugging.
 

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -64,10 +64,10 @@ struct BluRayToVisionProApp: App {
         guard viewModel.canSelectSource else {
             return
         }
-        guard let source = SourcePicker.chooseExistingSource() else {
+        guard let sourceURL = SourcePicker.chooseExistingSource() else {
             return
         }
-        viewModel.selectSource(source)
+        viewModel.selectSource(sourceURL)
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -128,7 +128,7 @@ struct AppCapabilities: Equatable {
     )
 
     var conversionUnavailableReason: String {
-        "Conversion requires an MKV, MTS, or M2TS source."
+        "Conversion requires an ISO, MKV, MTS, or M2TS source."
     }
 
     var automaticUpdatesUnavailableReason: String {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -465,10 +465,10 @@ struct ContentView: View {
     }
 
     private func chooseExistingSource() {
-        guard viewModel.canSelectSource, let source = SourcePicker.chooseExistingSource() else {
+        guard viewModel.canSelectSource, let sourceURL = SourcePicker.chooseExistingSource() else {
             return
         }
-        selectSource(source)
+        viewModel.selectSource(sourceURL)
     }
 
     private func chooseFile(_ kind: ConversionSourceKind) {

--- a/macos/BluRayToVisionPro/Views/SourcePicker.swift
+++ b/macos/BluRayToVisionPro/Views/SourcePicker.swift
@@ -3,7 +3,7 @@ import UniformTypeIdentifiers
 
 enum SourcePicker {
     @MainActor
-    static func chooseExistingSource() -> ConversionSource? {
+    static func chooseExistingSource() -> URL? {
         let panel = NSOpenPanel()
         panel.title = "Open a 3D Blu-ray Source"
         panel.prompt = "Open Source"
@@ -15,7 +15,7 @@ enum SourcePicker {
         guard panel.runModal() == .OK, let url = panel.url else {
             return nil
         }
-        return ConversionSource.infer(from: url)
+        return url.standardizedFileURL
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -41,6 +41,38 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testUnsupportedSelectionClearsPreviouslyInspectedSource() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let validSourceURL = directoryURL.appendingPathComponent("Feature.mkv")
+        let unsupportedSourceURL = directoryURL.appendingPathComponent("Feature.img")
+        _ = FileManager.default.createFile(atPath: validSourceURL.path, contents: Data("video".utf8))
+        _ = FileManager.default.createFile(atPath: unsupportedSourceURL.path, contents: Data("disc".utf8))
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let inspectionDone = expectation(description: "inspection done")
+        let viewModel = ConversionViewModel {
+            TwoPhaseWorkerClient(onInspectionComplete: { inspectionDone.fulfill() })
+        }
+
+        viewModel.selectSource(validSourceURL)
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+        XCTAssertNotNil(viewModel.state.result)
+
+        viewModel.selectSource(unsupportedSourceURL)
+
+        XCTAssertNil(viewModel.source)
+        XCTAssertNil(viewModel.state.result)
+        XCTAssertEqual(viewModel.state.phase, .failed)
+        XCTAssertEqual(
+            viewModel.state.failureMessage,
+            "Choose a 3D Blu-ray disc, ISO, Blu-ray folder, MKV, MTS, or M2TS source."
+        )
+    }
+
+    @MainActor
     func testDiscImageSelectionStartsInspection() async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -71,6 +71,10 @@ final class ConversionWorkflowTests: XCTestCase {
     func testCurrentCapabilitiesStayHonest() {
         XCTAssertTrue(AppCapabilities.current.conversionAvailable)
         XCTAssertFalse(AppCapabilities.current.automaticUpdateChecksAvailable)
+        XCTAssertEqual(
+            AppCapabilities.current.conversionUnavailableReason,
+            "Conversion requires an ISO, MKV, MTS, or M2TS source."
+        )
     }
 
     func testISOAndExistingFileKindsSupportConversion() {

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -153,6 +153,28 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             ):
                 audio.create_transcoded_audio_file(source_path, output_folder)
 
+    def test_final_mux_resume_rejects_legacy_aac_mov_with_recovery_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            legacy_aac_path = output_folder / "Movie_audio_AAC.mov"
+            legacy_aac_path.write_bytes(b"legacy-aac")
+
+            with (
+                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(audio.config, "audio_bitrate", 384),
+                self.assertRaisesRegex(FileNotFoundError, "Restart from Transcode Audio"),
+            ):
+                audio.create_transcoded_audio_file(source_path, output_folder)
+
+            self.assertTrue(legacy_aac_path.exists())
+
     def test_transcode_disabled_returns_original_audio(self) -> None:
         original_audio_path = Path("Movie_audio_PCM.mov")
         with (


### PR DESCRIPTION
## Why

Independent review of #212 completed after that PR was merged by another active session. This follow-up addresses the concrete findings without reopening the larger source-support slice.

## What Changed

- route generic picker URLs through `ConversionViewModel` so unsupported selections clear any previously armed source and show the existing error state
- update the remaining capability fallback copy to include ISO
- detect legacy `_audio_AAC.mov` restart artifacts and require regeneration from Transcode Audio instead of allowing an unsafe or opaque final-mux attempt
- document the legacy restart behavior and add focused Python/Swift regressions

## Validation

- `uv run python -m unittest discover -s tests -t .` — 381 passed
- `uv run python scripts/native_app.py test` — 59 passed
- targeted Ruff check/format passed
- `uv run mypy bd_to_avp` passed
- `uv build` passed
- `uv run python scripts/native_app.py package` passed, including packaged-worker smoke and signature validation
- JetBrains changed-files inspection: GREEN
- independent follow-up review: clean

Follow-up to #212. Refs #198.