### PR TITLE
Add native Blu-ray folder conversion

### DIFF
--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -68,14 +68,15 @@ def parse_makemkv_output(output: str) -> tuple[str, list[TitleInfo]]:
 
 
 def get_disc_and_mvc_video_info() -> DiscInfo:
-    source = config.source_path.as_posix() if config.source_path else config.source_str
+    source_path = config.source_path
+    source = source_path.as_posix() if source_path else config.source_str
     if not source:
         raise ValueError("No source path provided.")
-    if Path(source).suffix.lower() in {*config.MTS_EXTENSIONS, ".mkv"}:
-        filename = Path(source).stem
+    if source_path and source_path.suffix.lower() in {*config.MTS_EXTENSIONS, ".mkv"}:
+        filename = source_path.stem
         disc_info = DiscInfo(name=filename)
 
-        streams = ffmpeg.probe(source, cmd=config.FFPROBE_PATH.as_posix()).get("streams", [])
+        streams = ffmpeg.probe(source_path.as_posix(), cmd=config.FFPROBE_PATH.as_posix()).get("streams", [])
         ffmpeg_probe_output = next((stream for stream in streams if stream.get("codec_type") == "video"), None)
         if ffmpeg_probe_output is None:
             raise ValueError("No video stream found in source metadata.")
@@ -87,13 +88,12 @@ def get_disc_and_mvc_video_info() -> DiscInfo:
             disc_info.is_interlaced = True
         return disc_info
 
-    if config.source_path and config.source_path.suffix.lower() in config.IMAGE_EXTENSIONS:
-        source = f"iso:{config.source_path}"
+    source = get_makemkv_source()
 
     command = [
         config.MAKEMKVCON_PATH,
         "--robot",
-        "--noscan" if "disc:" not in source else None,
+        "--noscan" if makemkv_source_supports_noscan(source) else None,
         "info",
         source,
     ]
@@ -121,18 +121,11 @@ def rip_disc_to_mkv(output_folder: Path, disc_info: DiscInfo, language_code: str
     custom_profile_path = output_folder / "custom_profile.mmcp.xml"
     create_custom_makemkv_profile(custom_profile_path, language_code)
 
-    if config.source_path and config.source_path.suffix.lower() in config.IMAGE_EXTENSIONS:
-        source = f"iso:{config.source_path}"
-    elif config.source_path:
-        source = config.source_path.as_posix()
-    elif config.source_str:
-        source = config.source_str
-    else:
-        raise ValueError("No source provided.")
+    source = get_makemkv_source()
     command = [
         config.MAKEMKVCON_PATH,
         f"--profile={custom_profile_path}",
-        "--noscan" if "disc:" not in source else None,
+        "--noscan" if makemkv_source_supports_noscan(source) else None,
         "mkv",
         source,
         disc_info.main_title_number,
@@ -144,6 +137,22 @@ def rip_disc_to_mkv(output_folder: Path, disc_info: DiscInfo, language_code: str
     filtered_output = filter_lines_from_output(mkv_output, config.MKV_ERROR_FILTERS)
 
     raise MKVCreationError(f"Error occurred while ripping disc to MKV.\n\n{filtered_output}")
+
+
+def get_makemkv_source() -> str:
+    if config.source_path and config.source_path.suffix.lower() in config.IMAGE_EXTENSIONS:
+        return f"iso:{config.source_path}"
+    if config.source_path and config.source_path.is_dir():
+        return f"file:{config.source_path}"
+    if config.source_path:
+        return config.source_path.as_posix()
+    if config.source_str:
+        return config.source_str
+    raise ValueError("No source provided.")
+
+
+def makemkv_source_supports_noscan(source: str) -> bool:
+    return not source.startswith(("disc:", "dev:"))
 
 
 def filter_lines_from_output(output: str, filter_strings: list[str]) -> str:

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -13,15 +13,20 @@ import ffmpeg
 from bd_to_avp import preflight
 from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.disc import get_disc_and_mvc_video_info, MKVCreationError
+from bd_to_avp.modules.file import path_is_relative_to
 from bd_to_avp.modules.process import ProcessingCancelled, start_process
 from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
-from bd_to_avp.worker.protocol import JobSpec, WorkerActivityReporter, WorkerOperation
+from bd_to_avp.worker.protocol import (
+    JobSource,
+    JobSpec,
+    WorkerActivityReporter,
+    WorkerOperation,
+    WorkerSourceKind,
+)
 
 DIRECT_VIDEO_EXTENSIONS = frozenset({".mkv", ".mts", ".m2ts"})
 DISC_IMAGE_EXTENSIONS = frozenset({".iso"})
-SUPPORTED_INSPECTION_EXTENSIONS = DIRECT_VIDEO_EXTENSIONS | DISC_IMAGE_EXTENSIONS
-SUPPORTED_CONVERSION_EXTENSIONS = SUPPORTED_INSPECTION_EXTENSIONS
 TOOL_ENVIRONMENT_KEYS = ("PATH", "FFMPEG_BINARY", "FFPROBE_BINARY", "TMPDIR")
 CONFIG_SNAPSHOT_FIELDS = (
     "source_str",
@@ -79,7 +84,7 @@ def run_operation(
     activity: WorkerActivityReporter | None = None,
 ) -> dict[str, object]:
     if job.operation is WorkerOperation.INSPECT_SOURCE:
-        return inspect_source(job.source.path, owner)
+        return inspect_source(job.source, owner)
     if job.operation is WorkerOperation.CONVERT_SOURCE:
         if activity is None:
             raise WorkerOperationError("internal_error", "Conversion requires an activity reporter.")
@@ -87,28 +92,23 @@ def run_operation(
     raise WorkerOperationError("unsupported_operation", f"Unsupported worker operation: {job.operation.value}.")
 
 
-def inspect_source(source_path: Path, owner: WorkerProcessOwner) -> dict[str, object]:
-    if not source_path.exists():
-        raise WorkerOperationError("source_not_found", "The selected source no longer exists.")
-    if not source_path.is_file():
-        raise WorkerOperationError("source_not_file", "The selected source is not a regular file.")
-    if source_path.suffix.lower() not in SUPPORTED_INSPECTION_EXTENSIONS:
-        raise WorkerOperationError(
-            "unsupported_source",
-            "Source inspection supports ISO, MKV, MTS, and M2TS files.",
-        )
-    if source_path.suffix.lower() in DISC_IMAGE_EXTENSIONS and not config.MAKEMKVCON_PATH.is_file():
+def inspect_source(source: JobSource, owner: WorkerProcessOwner) -> dict[str, object]:
+    source_path = validate_source(source)
+    if (
+        source.kind in {WorkerSourceKind.DISC_IMAGE, WorkerSourceKind.BLU_RAY_FOLDER}
+        and not config.MAKEMKVCON_PATH.is_file()
+    ):
         raise WorkerOperationError(
             "makemkv_missing",
-            "MakeMKV is required to inspect a Blu-ray ISO.",
+            "MakeMKV is required to inspect this Blu-ray source.",
             retryable=True,
         )
-    if source_path.suffix.lower() in DIRECT_VIDEO_EXTENSIONS and not config.FFPROBE_PATH.is_file():
+    if source.kind is WorkerSourceKind.DIRECT_FILE and not config.FFPROBE_PATH.is_file():
         raise WorkerOperationError("ffprobe_missing", "The FFprobe helper could not be found.")
 
     owner.check_cancelled()
     try:
-        with configured_source(source_path):
+        with configured_source(source, source_path):
             disc_info = get_disc_and_mvc_video_info()
     except ffmpeg.Error as error:
         if owner.cancellation_event.is_set():
@@ -121,7 +121,7 @@ def inspect_source(source_path: Path, owner: WorkerProcessOwner) -> dict[str, ob
         details = error.output if isinstance(error.output, str) else None
         raise WorkerOperationError(
             "disc_inspection_failed",
-            "MakeMKV could not inspect the selected Blu-ray ISO.",
+            "MakeMKV could not inspect the selected Blu-ray source.",
             details,
             retryable=True,
         ) from error
@@ -135,17 +135,19 @@ def inspect_source(source_path: Path, owner: WorkerProcessOwner) -> dict[str, ob
         ) from error
 
     owner.check_cancelled()
-    return {
+    result: dict[str, object] = {
         "name": disc_info.name,
         "resolution": disc_info.resolution,
         "frame_rate": disc_info.frame_rate,
         "interlaced": disc_info.is_interlaced,
-        "size_bytes": source_path.stat().st_size,
     }
+    if source_path.is_file():
+        result["size_bytes"] = source_path.stat().st_size
+    return result
 
 
 def convert_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActivityReporter) -> dict[str, object]:
-    source_path = job.source.path
+    source_path = validate_source(job.source)
     destination = job.destination
     encoding = job.encoding
     job_options = job.job
@@ -153,20 +155,16 @@ def convert_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActi
         raise WorkerOperationError(
             "invalid_request", "Conversion requests require destination, encoding, and job options."
         )
-    if not source_path.exists():
-        raise WorkerOperationError("source_not_found", "The selected source no longer exists.")
-    if not source_path.is_file():
-        raise WorkerOperationError("source_not_file", "The selected source is not a regular file.")
-    if source_path.suffix.lower() not in SUPPORTED_CONVERSION_EXTENSIONS:
-        raise WorkerOperationError(
-            "unsupported_source",
-            "Conversion currently supports ISO, MKV, MTS, and M2TS files.",
-        )
     if destination.path.exists() and not destination.path.is_dir():
         raise WorkerOperationError("destination_not_directory", "The destination path must be a folder.")
+    if job.source.kind is WorkerSourceKind.BLU_RAY_FOLDER and path_is_relative_to(destination.path, source_path):
+        raise WorkerOperationError(
+            "destination_inside_source",
+            "Choose a destination outside the Blu-ray source folder.",
+        )
 
     owner.check_cancelled()
-    with configured_conversion(job):
+    with configured_conversion(job, source_path):
         try:
             activity.stage_started("configure", "Preparing conversion settings")
             config.configure_tool_environment()
@@ -247,13 +245,13 @@ def convert_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActi
 
 
 @contextmanager
-def configured_source(source_path: Path) -> Iterator[None]:
+def configured_source(source: JobSource, source_path: Path) -> Iterator[None]:
     previous_source_path = config.source_path
     previous_source_str = config.source_str
     previous_source_folder_path = config.source_folder_path
     try:
         config.source_path = source_path
-        config.source_str = None
+        config.source_str = makemkv_source(source.kind, source_path)
         config.source_folder_path = None
         yield
     finally:
@@ -263,15 +261,15 @@ def configured_source(source_path: Path) -> Iterator[None]:
 
 
 @contextmanager
-def configured_conversion(job: JobSpec) -> Iterator[None]:
+def configured_conversion(job: JobSpec, source_path: Path) -> Iterator[None]:
     assert job.destination is not None
     assert job.encoding is not None
     assert job.job is not None
     config_snapshot = {field: getattr(config, field) for field in CONFIG_SNAPSHOT_FIELDS}
     environment_snapshot = {key: os.environ.get(key) for key in TOOL_ENVIRONMENT_KEYS}
     try:
-        config.source_str = None
-        config.source_path = job.source.path
+        config.source_str = makemkv_source(job.source.kind, source_path)
+        config.source_path = source_path
         config.source_folder_path = None
         config.output_root_path = job.destination.path
         config.overwrite = job.job.overwrite
@@ -306,3 +304,53 @@ def configured_conversion(job: JobSpec) -> Iterator[None]:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+
+def validate_source(source: JobSource) -> Path:
+    source_path = source.path
+    if not source_path.exists():
+        raise WorkerOperationError("source_not_found", "The selected source no longer exists.")
+
+    if source.kind is WorkerSourceKind.DIRECT_FILE:
+        if not source_path.is_file() or source_path.suffix.lower() not in DIRECT_VIDEO_EXTENSIONS:
+            raise WorkerOperationError(
+                "source_kind_mismatch",
+                "Direct-file sources must be MKV, MTS, or M2TS files.",
+            )
+        return source_path
+
+    if source.kind is WorkerSourceKind.DISC_IMAGE:
+        if not source_path.is_file() or source_path.suffix.lower() not in DISC_IMAGE_EXTENSIONS:
+            raise WorkerOperationError(
+                "source_kind_mismatch",
+                "Disc-image sources must be ISO files.",
+            )
+        return source_path
+
+    blu_ray_root = normalize_blu_ray_root(source_path)
+    if blu_ray_root is None:
+        raise WorkerOperationError(
+            "invalid_bluray_folder",
+            "Choose a Blu-ray folder containing a BDMV directory.",
+        )
+    return blu_ray_root
+
+
+def normalize_blu_ray_root(source_path: Path) -> Path | None:
+    if not source_path.is_dir():
+        return None
+    if source_path.name.casefold() == "bdmv":
+        return source_path.parent
+    try:
+        has_bdmv = any(child.is_dir() and child.name.casefold() == "bdmv" for child in source_path.iterdir())
+    except OSError:
+        return None
+    return source_path if has_bdmv else None
+
+
+def makemkv_source(source_kind: WorkerSourceKind, source_path: Path) -> str | None:
+    if source_kind is WorkerSourceKind.DISC_IMAGE:
+        return f"iso:{source_path}"
+    if source_kind is WorkerSourceKind.BLU_RAY_FOLDER:
+        return f"file:{source_path}"
+    return None

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Mapping, TextIO
 from uuid import UUID
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_EVENT_BYTES = 1024 * 1024
 MAX_DETAIL_BYTES = 64 * 1024
@@ -28,6 +28,12 @@ def bounded_detail(value: str) -> str:
 class WorkerOperation(StrEnum):
     INSPECT_SOURCE = "inspect_source"
     CONVERT_SOURCE = "convert_source"
+
+
+class WorkerSourceKind(StrEnum):
+    DIRECT_FILE = "direct_file"
+    DISC_IMAGE = "disc_image"
+    BLU_RAY_FOLDER = "blu_ray_folder"
 
 
 class WorkerEventType(StrEnum):
@@ -62,6 +68,7 @@ class WorkerProtocolError(ValueError):
 
 @dataclass(frozen=True)
 class JobSource:
+    kind: WorkerSourceKind
     path: Path
 
 
@@ -170,14 +177,36 @@ class JobSpec:
         cls._reject_unknown_keys(raw, operation_keys, "request", job_id)
 
         source = raw.get("source")
-        if not isinstance(source, Mapping) or not isinstance(source.get("path"), str):
+        if not isinstance(source, Mapping):
             raise WorkerProtocolError(
                 "invalid_source",
-                "The request must contain a source path.",
+                "The request must contain a source kind and path.",
                 job_id=job_id,
             )
-        cls._reject_unknown_keys(source, {"path"}, "source", job_id)
-        source_path = cls._parse_absolute_path(source["path"], "source", job_id)
+        cls._require_exact_keys(source, {"kind", "path"}, "source", job_id)
+        raw_source_kind = source.get("kind")
+        if not isinstance(raw_source_kind, str):
+            raise WorkerProtocolError(
+                "invalid_source",
+                "source.kind must be a string.",
+                job_id=job_id,
+            )
+        try:
+            source_kind = WorkerSourceKind(raw_source_kind)
+        except ValueError as error:
+            raise WorkerProtocolError(
+                "invalid_source",
+                f"Unsupported source kind: {raw_source_kind!r}.",
+                job_id=job_id,
+            ) from error
+        raw_source_path = source.get("path")
+        if not isinstance(raw_source_path, str):
+            raise WorkerProtocolError(
+                "invalid_source",
+                "source.path must be a string.",
+                job_id=job_id,
+            )
+        source_path = cls._parse_absolute_path(raw_source_path, "source", job_id)
 
         destination: JobDestination | None = None
         encoding: EncodingOptions | None = None
@@ -193,7 +222,7 @@ class JobSpec:
             protocol_version=protocol_version,
             job_id=job_id,
             operation=operation,
-            source=JobSource(path=source_path),
+            source=JobSource(kind=source_kind, path=source_path),
             destination=destination,
             encoding=encoding,
             job=job_options,

--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -107,10 +107,10 @@ dispatch then removed after the job exits.
 ## Release Placement
 
 The native shell does not yet replace the current `0.2.x` Briefcase/Sparkle
-release line. Native Start Processing supports inspected ISO, MKV, MTS, and
-M2TS sources; physical disc, Blu-ray folder, batch, interactive recovery, and
-the native updater path still need release-level completion before promotion
-through the normal Release Candidates appcast.
+release line. Native Start Processing supports inspected Blu-ray folders, ISO,
+MKV, MTS, and M2TS sources; physical disc, batch, interactive recovery, and the
+native updater path still need release-level completion before promotion through
+the normal Release Candidates appcast.
 
 The preview uses a separate product name and bundle identifier, installs beside
 the production app, targets Apple Silicon macOS 27, and is published only as a

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -7,9 +7,11 @@ or update it.
 - Launch the new SwiftUI workspace on an Apple Silicon Mac running macOS 27.
 - Choose a physical disc, ISO disc image, Blu-ray folder, MKV, source folder, or
   MTS/M2TS transport stream.
-- Inspect ISO, MKV, MTS, and M2TS source metadata through the bundled engine.
-- Convert an inspected ISO, MKV, MTS, or M2TS source to a completed MV-HEVC `.mov`
-  through the bundled engine, with native progress, cancellation, and results.
+- Inspect Blu-ray folder, ISO, MKV, MTS, and M2TS source metadata through the
+  bundled engine.
+- Convert an inspected Blu-ray folder, ISO, MKV, MTS, or M2TS source to a
+  completed MV-HEVC `.mov` through the bundled engine, with native progress,
+  cancellation, and results.
 - Review the Video, Audio & Subtitles, and Files & Recovery controls.
 - Create, duplicate, edit, import, export, and delete named encoding profiles.
 - Open Settings with `Command-,`, resize the window, and scroll through the
@@ -19,8 +21,8 @@ or update it.
 
 ## Important Limits
 
-- **Start Processing currently supports ISO, MKV, MTS, and M2TS files only.**
-  Keep the production app installed for physical discs, Blu-ray folders,
+- **Start Processing supports one Blu-ray folder, ISO, MKV, MTS, or M2TS source
+  at a time.** Keep the production app installed for physical discs,
   source-folder batches, and recovery decisions that require a second
   interactive step.
 - Native conversion currently creates the full movie. Short sample outputs are
@@ -29,7 +31,8 @@ or update it.
   downloaded manually.
 - Live playback of a file while it is still being generated is not supported.
   Finalized preview playback is planned separately.
-- MakeMKV remains an external dependency for physical discs and disc images.
+- MakeMKV remains an external dependency for physical discs, Blu-ray folders,
+  and disc images.
 - The preview supports Apple Silicon and macOS 27 only.
 
 Please report interface feedback in issue #202, including the source workflow,

--- a/docs/native-worker-protocol-v1.md
+++ b/docs/native-worker-protocol-v1.md
@@ -1,5 +1,8 @@
 # Native Worker Protocol v1
 
+> Historical contract. The native app and bundled worker now use
+> [Native Worker Protocol v2](native-worker-protocol-v2.md).
+
 The native macOS prototype communicates with the existing Python engine over a
 bounded JSON Lines (JSONL) protocol. The boundary is intentionally independent
 of SwiftUI and PySide so the processing engine can remain Python while the app

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -1,0 +1,127 @@
+# Native Worker Protocol v2
+
+The native macOS app communicates with its bundled Python engine over a bounded
+JSON Lines (JSONL) protocol. Version 2 makes the source kind explicit and adds
+single Blu-ray folder inspection and conversion. Physical-disc and batch-folder
+conversion remain outside this contract.
+
+## Transport
+
+- One worker process handles exactly one immutable job.
+- The app writes one UTF-8 JSON object followed by `\n`, then closes standard input.
+- The worker writes and flushes one UTF-8 JSON event per standard-output line.
+- Standard output is protocol-only; helper output and tracebacks use standard error.
+- Requests are limited to 64 KiB and individual events to 1 MiB.
+
+## Source Contract
+
+Every request contains exactly one absolute source path and one source kind:
+
+| Kind | Required path |
+| --- | --- |
+| `direct_file` | Existing `.mkv`, `.mts`, or `.m2ts` file. |
+| `disc_image` | Existing `.iso` file. |
+| `blu_ray_folder` | Folder containing `BDMV`, or the `BDMV` folder itself. |
+
+The worker validates that kind and path agree before launching tools. A selected
+`BDMV` folder is normalized to its parent disc root. Blu-ray folders are passed
+to MakeMKV as `file:<absolute path>`; ISO files are passed as
+`iso:<absolute path>`. A conversion destination may not be inside a Blu-ray
+source folder.
+
+## Inspection Request
+
+```json
+{
+  "protocol_version": 2,
+  "type": "job.start",
+  "job_id": "d870b63d-939e-4584-a2a4-cd441f628cbe",
+  "operation": "inspect_source",
+  "source": {
+    "kind": "blu_ray_folder",
+    "path": "/absolute/path/to/Disc"
+  }
+}
+```
+
+Inspection completion places `name`, `resolution`, `frame_rate`, `interlaced`,
+and optional `size_bytes` under `payload.result`. Directory size is intentionally
+not reported because filesystem directory metadata is not the media size.
+
+## Conversion Request
+
+```json
+{
+  "protocol_version": 2,
+  "type": "job.start",
+  "job_id": "d870b63d-939e-4584-a2a4-cd441f628cbe",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/absolute/path/to/movie.mkv"
+  },
+  "destination": {
+    "path": "/absolute/path/to/output-folder"
+  },
+  "encoding": {
+    "transcode_audio": true,
+    "audio_bitrate": 384,
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "skip_subtitles": false,
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "language_code": "eng",
+    "remove_extra_languages": false
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true,
+    "output_length": "full_movie"
+  }
+}
+```
+
+All conversion fields are required and unknown fields are rejected. Protocol v2
+accepts only `job.output_length = "full_movie"`. Completion places
+`source_path`, `destination_path`, `output_path`, and `size_bytes` under
+`payload.conversion_result` after the final `.mov` exists.
+
+## Events And Recovery
+
+Every event repeats `protocol_version`, `job_id`, and a gap-free `sequence`.
+`worker.ready` is sequence zero and reports the worker-owned process group.
+Supported event types are `worker.ready`, `job.started`, `stage.started`,
+`heartbeat`, `log`, `warning`, `job.decision_required`, `job.completed`,
+`job.failed`, and `job.cancelled`.
+
+MakeMKV errors that may leave a usable intermediate MKV terminate with
+`mkv_creation_decision_required`. A retry is a new immutable job with
+`continue_on_error=true` and the requested resume stage. The worker never treats
+a partial MKV as safe without that explicit decision.
+
+## Cancellation And Ownership
+
+The worker owns a dedicated process group and reports it in `worker.ready`. The
+native app verifies the protocol version, job UUID, launched PID, and live group
+before signaling. Cancellation sends `SIGTERM` to that group, waits two seconds,
+and uses `SIGKILL` only as a bounded fallback. `job.cancelled` is emitted only
+after descendant cleanup.
+
+## Compatibility
+
+The app and bundled worker ship atomically and both require protocol version 2.
+Mixed v1/v2 processes fail before media inspection or destination mutation.
+Changes to required fields or event meaning require another protocol version.

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -96,7 +96,7 @@ With MakeMKV absent:
 2. Confirm Gatekeeper does not block launch.
 3. Confirm the app does not ask to install Homebrew, run terminal commands, or
    request admin privileges.
-4. Start a disc-oriented conversion far enough to trigger preflight.
+4. Start an ISO or Blu-ray-folder conversion far enough to trigger preflight.
 5. Confirm the message asks for MakeMKV in plain user-facing language.
 
 With MakeMKV installed:
@@ -104,8 +104,9 @@ With MakeMKV installed:
 1. Install the current macOS MakeMKV app from the official MakeMKV website.
 2. Reopen BD_to_AVP.
 3. Confirm the MakeMKV preflight no longer blocks disc-oriented work.
-4. If test media is available, run a short conversion smoke and record the first
-   failing stage, logs, runtime, and whether output files are created.
+4. If test media is available, inspect both an ISO and a Blu-ray folder. Run a
+   conversion smoke and record the first failing stage, logs, runtime, and
+   whether output files are created.
 
 ## Pass Criteria
 

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -5,8 +5,6 @@ import SwiftUI
 final class ConversionViewModel: ObservableObject {
     typealias ClientFactory = () throws -> any WorkerProcessRunning
 
-    static let supportedExtensions = Set(["iso", "mkv", "mts", "m2ts"])
-
     @Published private(set) var source: ConversionSource?
     @Published private(set) var state = WorkerLifecycleState()
     @Published private(set) var diagnosticLog = ""
@@ -69,11 +67,11 @@ final class ConversionViewModel: ObservableObject {
     }
 
     func startInspection() {
-        guard !hasActiveWorker, let sourceURL = state.sourceURL else {
+        guard !hasActiveWorker, let source, state.sourceURL == source.url else {
             return
         }
 
-        let job = WorkerJobSpec(sourceURL: sourceURL)
+        let job = WorkerJobSpec(source: source)
         do {
             try state.begin(jobID: job.jobID)
             pendingTerminalEvent = nil
@@ -118,11 +116,10 @@ final class ConversionViewModel: ObservableObject {
             return
         }
         guard draft.source.kind.supportsConversion,
-              Self.supportedExtensions.contains(draft.source.url.pathExtension.lowercased()),
               FileManager.default.fileExists(atPath: draft.source.url.path)
         else {
             state.failTransport(
-                message: "Conversion requires an existing ISO, MKV, MTS, or M2TS source.",
+                message: "Conversion requires an existing Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
                 retryable: false
             )
             return
@@ -209,15 +206,18 @@ final class ConversionViewModel: ObservableObject {
     }
 
     private func validateSelectedSourceAndStart() {
-        guard let sourceURL = state.sourceURL else {
+        guard let source, state.sourceURL == source.url else {
             state.failTransport(message: "Choose a source before continuing.", retryable: false)
             return
         }
-        guard Self.supportedExtensions.contains(sourceURL.pathExtension.lowercased()) else {
-            state.failTransport(message: "Choose an ISO, MKV, MTS, or M2TS source file.", retryable: false)
+        guard source.kind.supportsMetadataInspection else {
+            state.failTransport(
+                message: "Choose a Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
+                retryable: false
+            )
             return
         }
-        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+        guard FileManager.default.fileExists(atPath: source.url.path) else {
             state.failTransport(message: "The selected source no longer exists.", retryable: false)
             return
         }

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -45,11 +45,11 @@ enum ConversionSourceKind: String, CaseIterable, Identifiable {
     }
 
     var supportsMetadataInspection: Bool {
-        self == .discImage || self == .matroska || self == .transportStream
+        self == .discImage || self == .bluRayFolder || self == .matroska || self == .transportStream
     }
 
     var supportsConversion: Bool {
-        self == .discImage || self == .matroska || self == .transportStream
+        self == .discImage || self == .bluRayFolder || self == .matroska || self == .transportStream
     }
 
     var isDiscWorkflow: Bool {
@@ -80,9 +80,12 @@ struct ConversionSource: Equatable {
     let displayName: String
 
     init(kind: ConversionSourceKind, url: URL, displayName: String? = nil) {
+        let normalizedURL = kind == .bluRayFolder
+            ? DiscSourceDetector.bluRayRoot(for: url) ?? url.standardizedFileURL
+            : url.standardizedFileURL
         self.kind = kind
-        self.url = url.standardizedFileURL
-        self.displayName = displayName ?? Self.defaultDisplayName(for: url)
+        self.url = normalizedURL
+        self.displayName = displayName ?? Self.defaultDisplayName(for: normalizedURL)
     }
 
     var proposedOutputStem: String {
@@ -160,10 +163,30 @@ enum DiscSourceDetector {
     }
 
     static func isBluRayFolder(_ url: URL, fileManager: FileManager = .default) -> Bool {
-        let candidates = [url, url.appendingPathComponent("BDMV", isDirectory: true)]
-        return candidates.contains { candidate in
-            candidate.lastPathComponent.caseInsensitiveCompare("BDMV") == .orderedSame
-                && fileManager.fileExists(atPath: candidate.path)
+        bluRayRoot(for: url, fileManager: fileManager) != nil
+    }
+
+    static func bluRayRoot(for url: URL, fileManager: FileManager = .default) -> URL? {
+        let normalizedURL = url.standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: normalizedURL.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return nil
         }
+        if normalizedURL.lastPathComponent.caseInsensitiveCompare("BDMV") == .orderedSame {
+            return normalizedURL.deletingLastPathComponent()
+        }
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: normalizedURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ),
+            children.contains(where: { childURL in
+                childURL.lastPathComponent.caseInsensitiveCompare("BDMV") == .orderedSame
+                    && (try? childURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            })
+        else {
+            return nil
+        }
+        return normalizedURL
     }
 }

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -128,7 +128,7 @@ struct AppCapabilities: Equatable {
     )
 
     var conversionUnavailableReason: String {
-        "Conversion requires an ISO, MKV, MTS, or M2TS source."
+        "Conversion requires a Blu-ray folder, ISO, MKV, MTS, or M2TS source."
     }
 
     var automaticUpdatesUnavailableReason: String {

--- a/macos/BluRayToVisionPro/Models/SourceInspection.swift
+++ b/macos/BluRayToVisionPro/Models/SourceInspection.swift
@@ -5,7 +5,7 @@ struct SourceInspection: Codable, Equatable {
     let resolution: String
     let frameRate: String
     let interlaced: Bool
-    let sizeBytes: Int64
+    let sizeBytes: Int64?
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -16,7 +16,10 @@ struct SourceInspection: Codable, Equatable {
     }
 
     var formattedSize: String {
-        ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        guard let sizeBytes else {
+            return "Not reported"
+        }
+        return ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
     }
 
     var scanDescription: String {

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -1,10 +1,40 @@
 import Foundation
 
 struct WorkerJobSpec: Encodable, Equatable {
-    static let protocolVersion = 1
+    static let protocolVersion = 2
 
     struct Source: Encodable, Equatable {
+        enum Kind: String, Encodable {
+            case directFile = "direct_file"
+            case discImage = "disc_image"
+            case bluRayFolder = "blu_ray_folder"
+        }
+
+        let kind: Kind
         let path: String
+
+        init(source: ConversionSource) {
+            switch source.kind {
+            case .discImage:
+                kind = .discImage
+            case .bluRayFolder:
+                kind = .bluRayFolder
+            case .matroska, .transportStream:
+                kind = .directFile
+            case .physicalDisc, .sourceFolder:
+                preconditionFailure("Unsupported worker source kind: \(source.kind)")
+            }
+            path = source.url.path
+        }
+
+        init(fileURL: URL) {
+            if fileURL.hasDirectoryPath || DiscSourceDetector.isBluRayFolder(fileURL) {
+                kind = .bluRayFolder
+            } else {
+                kind = fileURL.pathExtension.lowercased() == "iso" ? .discImage : .directFile
+            }
+            path = fileURL.path
+        }
     }
 
     struct Destination: Encodable, Equatable {
@@ -80,12 +110,23 @@ struct WorkerJobSpec: Encodable, Equatable {
     let encoding: Encoding?
     let job: Job?
 
+    init(source: ConversionSource, jobID: UUID = UUID()) {
+        protocolVersion = Self.protocolVersion
+        type = "job.start"
+        self.jobID = jobID
+        operation = "inspect_source"
+        self.source = Source(source: source)
+        destination = nil
+        encoding = nil
+        job = nil
+    }
+
     init(sourceURL: URL, jobID: UUID = UUID()) {
         protocolVersion = Self.protocolVersion
         type = "job.start"
         self.jobID = jobID
         operation = "inspect_source"
-        source = Source(path: sourceURL.path)
+        source = Source(fileURL: sourceURL)
         destination = nil
         encoding = nil
         job = nil
@@ -96,7 +137,7 @@ struct WorkerJobSpec: Encodable, Equatable {
         type = "job.start"
         self.jobID = jobID
         operation = "convert_source"
-        source = Source(path: draft.source.url.path)
+        source = Source(source: draft.source)
         destination = Destination(path: draft.destinationURL.path)
 
         let encodingOptions = draft.options.encoding

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -349,6 +349,9 @@ struct ContentView: View {
         if viewModel.state.result != nil {
             return "Source analyzed and conversion settings ready"
         }
+        if source.kind == .physicalDisc {
+            return "Physical disc conversion is not available yet"
+        }
         if source.kind.isDiscWorkflow {
             return "Disc workflow ready"
         }
@@ -396,13 +399,13 @@ struct ContentView: View {
             return capabilities.conversionUnavailableReason
         }
         switch viewModel.source?.kind {
-        case .physicalDisc, .bluRayFolder:
-            return "Physical discs and Blu-ray folders are not yet supported for native conversion."
+        case .physicalDisc:
+            return "Physical discs are not yet supported for native conversion."
         case .sourceFolder:
             return "Batch folder conversion is not yet available."
-        case .discImage, .matroska, .transportStream where viewModel.state.result == nil:
+        case .discImage, .bluRayFolder, .matroska, .transportStream where viewModel.state.result == nil:
             return "Source analysis must complete before conversion can start."
-        case .none, .discImage, .matroska, .transportStream:
+        case .none, .discImage, .bluRayFolder, .matroska, .transportStream:
             return capabilities.conversionUnavailableReason
         }
     }

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -136,6 +136,47 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testBluRayFolderSelectionStartsInspectionAndConversion() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { spec in
+                XCTAssertEqual(spec.source.kind, .bluRayFolder)
+                conversionStarted.fulfill()
+            }
+        )
+        let viewModel = ConversionViewModel { worker }
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let discURL = directoryURL.appendingPathComponent("Feature", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: discURL.appendingPathComponent("BDMV", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        viewModel.selectSource(discURL)
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+
+        let draft = ConversionDraft(
+            source: try XCTUnwrap(viewModel.source),
+            sourceDetails: viewModel.state.result,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: directoryURL.appendingPathComponent("Output", isDirectory: true),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+        viewModel.startConversion(draft: draft)
+
+        await fulfillment(of: [conversionStarted], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+        XCTAssertEqual(viewModel.state.phase, .completed)
+    }
+
+    @MainActor
     func testStartConversionForUnsupportedSourceKindDoesNotStartWorker() {
         let viewModel = ConversionViewModel()
         let discSource = ConversionSource(kind: .physicalDisc, url: URL(fileURLWithPath: "/Volumes/Disc"))

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -61,10 +61,17 @@ final class ConversionWorkflowTests: XCTestCase {
         try withTemporaryDirectory { directoryURL in
             let discURL = directoryURL.appendingPathComponent("Feature Disc", isDirectory: true)
             let bdmvURL = discURL.appendingPathComponent("BDMV", isDirectory: true)
+            let lowercaseDiscURL = directoryURL.appendingPathComponent("Lowercase Disc", isDirectory: true)
             try FileManager.default.createDirectory(at: bdmvURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(
+                at: lowercaseDiscURL.appendingPathComponent("bdmv", isDirectory: true),
+                withIntermediateDirectories: true
+            )
 
             XCTAssertTrue(DiscSourceDetector.isBluRayFolder(discURL))
+            XCTAssertTrue(DiscSourceDetector.isBluRayFolder(lowercaseDiscURL))
             XCTAssertEqual(ConversionSource.infer(from: discURL)?.kind, .bluRayFolder)
+            XCTAssertEqual(ConversionSource.infer(from: bdmvURL)?.url, discURL)
         }
     }
 
@@ -73,21 +80,22 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertFalse(AppCapabilities.current.automaticUpdateChecksAvailable)
         XCTAssertEqual(
             AppCapabilities.current.conversionUnavailableReason,
-            "Conversion requires an ISO, MKV, MTS, or M2TS source."
+            "Conversion requires a Blu-ray folder, ISO, MKV, MTS, or M2TS source."
         )
     }
 
-    func testISOAndExistingFileKindsSupportConversion() {
+    func testFolderISOAndExistingFileKindsSupportConversion() {
         XCTAssertTrue(ConversionSourceKind.discImage.supportsMetadataInspection)
         XCTAssertTrue(ConversionSourceKind.discImage.supportsConversion)
         XCTAssertEqual(ConversionSourceKind.discImage.allowedExtensions, ["iso"])
+        XCTAssertTrue(ConversionSourceKind.bluRayFolder.supportsMetadataInspection)
+        XCTAssertTrue(ConversionSourceKind.bluRayFolder.supportsConversion)
         XCTAssertTrue(ConversionSourceKind.matroska.supportsConversion)
         XCTAssertTrue(ConversionSourceKind.transportStream.supportsConversion)
     }
 
-    func testPhysicalDiscAndFolderKindsDoNotSupportConversion() {
+    func testPhysicalDiscAndBatchFolderKindsDoNotSupportConversion() {
         XCTAssertFalse(ConversionSourceKind.physicalDisc.supportsConversion)
-        XCTAssertFalse(ConversionSourceKind.bluRayFolder.supportsConversion)
         XCTAssertFalse(ConversionSourceKind.sourceFolder.supportsConversion)
     }
 
@@ -119,8 +127,23 @@ final class ConversionWorkflowTests: XCTestCase {
             options: ConversionOptions()
         )
         let spec = WorkerJobSpec(draft: draft)
+        XCTAssertEqual(spec.source.kind, .directFile)
         XCTAssertEqual(spec.source.path, "/src/movie.mkv")
         XCTAssertEqual(spec.destination?.path, "/Movies")
+    }
+
+    func testBluRayFolderJobSpecUsesExplicitFolderKind() {
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .bluRayFolder, url: URL(fileURLWithPath: "/src/Disc")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+
+        XCTAssertEqual(WorkerJobSpec(draft: draft).source.kind, .bluRayFolder)
     }
 
     func testConversionJobSpecEncodesVideoAndAudioSettings() {
@@ -182,14 +205,23 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertNil(json?["job"], "inspection spec must not include job options")
     }
 
+    func testInspectionJobSpecClassifiesDirectoryURLAsBluRayFolder() {
+        let sourceURL = URL(fileURLWithPath: "/src/Disc", isDirectory: true)
+
+        XCTAssertEqual(WorkerJobSpec(sourceURL: sourceURL).source.kind, .bluRayFolder)
+    }
+
     func testConversionJobSpecWireFormatMatchesWorkerContract() throws {
         let spec = WorkerJobSpec(draft: makeDraft(kind: .matroska, extension: "mkv"))
         let data = try JSONEncoder().encode(spec)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
         let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
         let job = try XCTUnwrap(json["job"] as? [String: Any])
+        let source = try XCTUnwrap(json["source"] as? [String: Any])
 
         XCTAssertEqual(json["operation"] as? String, "convert_source")
+        XCTAssertEqual(json["protocol_version"] as? Int, 2)
+        XCTAssertEqual(source["kind"] as? String, "direct_file")
         XCTAssertEqual((json["destination"] as? [String: Any])?["path"] as? String, "/Movies")
         XCTAssertEqual(encoding["mv_hevc_quality"] as? Int, 75)
         XCTAssertEqual(encoding["language_code"] as? String, "eng")
@@ -217,7 +249,7 @@ final class ConversionWorkflowTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_convert_v1.json")
+            .appendingPathComponent("tests/fixtures/native_worker_convert_v2.json")
         let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -202,7 +202,7 @@ final class WorkerLifecycleTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_conversion_completed_v1.json")
+            .appendingPathComponent("tests/fixtures/native_worker_conversion_completed_v2.json")
         let completed = try JSONDecoder().decode(WorkerEvent.self, from: Data(contentsOf: fixtureURL))
         let fixtureJobID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         var state = WorkerLifecycleState()

--- a/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
@@ -7,8 +7,8 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testDecodesEventsFromWorkerProcess() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 1, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
-        print(json.dumps({"protocol_version": 1, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
         var events: [WorkerEvent] = []
@@ -52,7 +52,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testRejectsTerminalEventBeforeWorkerReady() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 1, "type": "job.completed", "job_id": job_id, "sequence": 0, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "job.completed", "job_id": job_id, "sequence": 0, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
 
@@ -68,7 +68,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testRejectsWorkerReadyWithoutOwnedProcessGroup() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 1, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
 
@@ -85,7 +85,7 @@ final class WorkerProcessClientTests: XCTestCase {
     func testCancellationReapsWorkerAfterTerminalEvent() async throws {
         let client = fixtureClient(body: """
         \(readyEvent())
-        print(json.dumps({"protocol_version": 1, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
         time.sleep(30)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
@@ -122,7 +122,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     private func readyEvent() -> String {
         """
-        print(json.dumps({"protocol_version": 1, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
         """
     }
 

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -34,6 +34,7 @@ BRIEFCASE_APP = REPO_ROOT / "build" / "bd-to-avp" / "macos" / "app" / "3D Blu-ra
 PACKAGE_ROOT = MACOS_ROOT / "build" / "package"
 PACKAGED_APP = PACKAGE_ROOT / NATIVE_APP_NAME
 WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
+WORKER_PROTOCOL_VERSION = 2
 WORKER_ENTITLEMENTS = MACOS_ROOT / "BluRayToVisionPro" / "Worker.entitlements"
 DEPLOYMENT_TARGET_OVERRIDE_ENV = "BD_TO_AVP_NATIVE_DEPLOYMENT_TARGET_OVERRIDE"
 USER_INTERFACE_SOURCE_FILES = sorted(
@@ -384,11 +385,11 @@ def smoke_packaged_worker(app_path: Path) -> None:
         )
         job_id = str(uuid4())
         request = {
-            "protocol_version": 1,
+            "protocol_version": WORKER_PROTOCOL_VERSION,
             "type": "job.start",
             "job_id": job_id,
             "operation": "inspect_source",
-            "source": {"path": str(source_path)},
+            "source": {"kind": "direct_file", "path": str(source_path)},
         }
         completed = subprocess.run(
             [str(worker_path)],
@@ -428,8 +429,8 @@ def validate_smoke_events(events: list[object], job_id: str) -> None:
     typed_events = [cast(Mapping[str, Any], event) for event in events]
     if [event.get("sequence") for event in typed_events] != list(range(len(typed_events))):
         raise ValueError("Worker smoke event sequence was not contiguous.")
-    if any(event.get("protocol_version") != 1 for event in typed_events):
-        raise ValueError("Worker smoke protocol version did not match v1.")
+    if any(event.get("protocol_version") != WORKER_PROTOCOL_VERSION for event in typed_events):
+        raise ValueError(f"Worker smoke protocol version did not match v{WORKER_PROTOCOL_VERSION}.")
     if any(event.get("job_id") != job_id for event in typed_events):
         raise ValueError("Worker smoke returned an event for another job.")
     event_types = [event.get("type") for event in typed_events]

--- a/tests/fixtures/native_worker_conversion_completed_v2.json
+++ b/tests/fixtures/native_worker_conversion_completed_v2.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 2,
+  "type": "job.completed",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 2,
+  "payload": {
+    "conversion_result": {
+      "source_path": "/tmp/movie.mkv",
+      "destination_path": "/tmp/output",
+      "output_path": "/tmp/output/movie_AVP.mov",
+      "size_bytes": 1024
+    }
+  }
+}

--- a/tests/fixtures/native_worker_convert_v2.json
+++ b/tests/fixtures/native_worker_convert_v2.json
@@ -1,0 +1,41 @@
+{
+  "protocol_version": 2,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "transcode_audio": false,
+    "audio_bitrate": 384,
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "skip_subtitles": false,
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "language_code": "eng",
+    "remove_extra_languages": false
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true,
+    "output_length": "full_movie"
+  }
+}

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -20,7 +20,7 @@ class DiscStageArtifactTests(unittest.TestCase):
         )
         with (
             patch.object(disc.config, "source_path", Path("/Movies/Feature.iso")),
-            patch.object(disc.config, "source_str", None),
+            patch.object(disc.config, "source_str", "disc:0"),
             patch.object(disc.config, "IMAGE_EXTENSIONS", [".iso"]),
             patch.object(disc.config, "MAKEMKVCON_PATH", Path("/Applications/MakeMKV/makemkvcon")),
             patch.object(disc, "run_command", return_value=makemkv_output) as run_command,
@@ -30,6 +30,54 @@ class DiscStageArtifactTests(unittest.TestCase):
         self.assertEqual(result.name, "Feature 3D")
         self.assertEqual(result.main_title_number, 0)
         self.assertIn("iso:/Movies/Feature.iso", run_command.call_args.args[0])
+
+    def test_selected_bluray_folder_overrides_stale_disc_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "Feature"
+            source_path.mkdir()
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "source_str", "disc:0"),
+            ):
+                source = disc.get_makemkv_source()
+
+            self.assertEqual(source, f"file:{source_path}")
+
+    def test_disc_info_uses_explicit_file_source_for_bluray_folder(self) -> None:
+        makemkv_output = "\n".join(
+            [
+                'CINFO:2,0,"Feature 3D"',
+                'TINFO:0,9,0,"0:45:00"',
+                'SINFO:0,1,6,0,"Mpeg4-MVC-3D"',
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "Feature"
+            source_path.mkdir()
+            with (
+                patch.object(disc.config, "source_path", source_path),
+                patch.object(disc.config, "source_str", f"file:{source_path}"),
+                patch.object(disc.config, "MAKEMKVCON_PATH", Path("/Applications/MakeMKV/makemkvcon")),
+                patch.object(disc, "run_command", return_value=makemkv_output) as run_command,
+            ):
+                result = disc.get_disc_and_mvc_video_info()
+
+            self.assertEqual(result.name, "Feature 3D")
+            self.assertEqual(
+                run_command.call_args.args[0],
+                [
+                    Path("/Applications/MakeMKV/makemkvcon"),
+                    "--robot",
+                    "--noscan",
+                    "info",
+                    f"file:{source_path}",
+                ],
+            )
+
+    def test_device_sources_do_not_disable_drive_scanning(self) -> None:
+        self.assertFalse(disc.makemkv_source_supports_noscan("disc:0"))
+        self.assertFalse(disc.makemkv_source_supports_noscan("dev:/dev/rdisk4"))
+        self.assertTrue(disc.makemkv_source_supports_noscan("file:/Movies/Feature"))
 
     def test_keep_files_copies_mkv_source_to_output_folder(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -18,6 +18,7 @@ from scripts.native_app import (
     NATIVE_PACKAGE_CONFIGURATION,
     NATIVE_PRODUCT_NAME,
     NATIVE_SHORT_VERSION,
+    WORKER_PROTOCOL_VERSION,
     MACOS_ROOT,
     PROJECT_PATH,
     REPO_ROOT,
@@ -277,28 +278,28 @@ class NativeAppPackagingTests(unittest.TestCase):
         job_id = "97456c4a-f3c5-44e4-a548-0bd833ead4bb"
         events: list[object] = [
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": "worker.ready",
                 "job_id": job_id,
                 "sequence": 0,
                 "payload": {"process_group_id": 123},
             },
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": "job.started",
                 "job_id": job_id,
                 "sequence": 1,
                 "payload": {},
             },
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": "stage.started",
                 "job_id": job_id,
                 "sequence": 2,
                 "payload": {},
             },
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": "job.completed",
                 "job_id": job_id,
                 "sequence": 3,
@@ -319,7 +320,7 @@ class NativeAppPackagingTests(unittest.TestCase):
         job_id = "97456c4a-f3c5-44e4-a548-0bd833ead4bb"
         events = [
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": event_type,
                 "job_id": job_id,
                 "sequence": sequence,
@@ -367,7 +368,7 @@ class NativeAppPackagingTests(unittest.TestCase):
     def test_rejects_wrong_job_or_result(self) -> None:
         events: list[object] = [
             {
-                "protocol_version": 1,
+                "protocol_version": WORKER_PROTOCOL_VERSION,
                 "type": event_type,
                 "job_id": "wrong-job",
                 "sequence": sequence,

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -19,6 +19,7 @@ from bd_to_avp.worker.__main__ import run_worker
 from bd_to_avp.worker.operations import WorkerDecisionRequired, WorkerOperationError, convert_source, inspect_source
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
 from bd_to_avp.worker.protocol import (
+    JobSource,
     MAX_EVENT_BYTES,
     MAX_REQUEST_BYTES,
     MAX_DETAIL_BYTES,
@@ -28,28 +29,43 @@ from bd_to_avp.worker.protocol import (
     WorkerEventEmitter,
     WorkerEventType,
     WorkerProtocolError,
+    WorkerSourceKind,
 )
 
 
-def request_line(source_path: Path, **overrides: object) -> str:
+def source_kind_for_path(source_path: Path) -> str:
+    if source_path.suffix.lower() == ".iso":
+        return WorkerSourceKind.DISC_IMAGE.value
+    if source_path.is_dir():
+        return WorkerSourceKind.BLU_RAY_FOLDER.value
+    return WorkerSourceKind.DIRECT_FILE.value
+
+
+def request_line(source_path: Path, *, source_kind: str | None = None, **overrides: object) -> str:
     request: dict[str, object] = {
         "protocol_version": PROTOCOL_VERSION,
         "type": "job.start",
         "job_id": str(uuid4()),
         "operation": "inspect_source",
-        "source": {"path": str(source_path)},
+        "source": {"kind": source_kind or source_kind_for_path(source_path), "path": str(source_path)},
     }
     request.update(overrides)
     return json.dumps(request) + "\n"
 
 
-def conversion_request_line(source_path: Path, destination_path: Path, **overrides: object) -> str:
+def conversion_request_line(
+    source_path: Path,
+    destination_path: Path,
+    *,
+    source_kind: str | None = None,
+    **overrides: object,
+) -> str:
     request: dict[str, object] = {
         "protocol_version": PROTOCOL_VERSION,
         "type": "job.start",
         "job_id": str(uuid4()),
         "operation": "convert_source",
-        "source": {"path": str(source_path)},
+        "source": {"kind": source_kind or source_kind_for_path(source_path), "path": str(source_path)},
         "destination": {"path": str(destination_path)},
         "encoding": {
             "transcode_audio": True,
@@ -95,6 +111,7 @@ class JobSpecTests(unittest.TestCase):
 
         self.assertEqual(job.protocol_version, PROTOCOL_VERSION)
         self.assertEqual(job.operation.value, "inspect_source")
+        self.assertEqual(job.source.kind, WorkerSourceKind.DIRECT_FILE)
         self.assertEqual(job.source.path, source_path)
 
     def test_parses_strict_conversion_request(self) -> None:
@@ -111,11 +128,12 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.job.output_length if job.job else None, "full_movie")
 
     def test_parses_shared_swift_conversion_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v1.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v2.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(job.operation.value, "convert_source")
+        self.assertEqual(job.source.kind, WorkerSourceKind.DIRECT_FILE)
         self.assertEqual(job.source.path, Path("/tmp/movie.mkv"))
         self.assertEqual(job.destination.path if job.destination else None, Path("/tmp/output"))
         self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
@@ -186,6 +204,21 @@ class JobSpecTests(unittest.TestCase):
             JobSpec.from_json_line(request_line(Path("movie.m2ts")))
 
         self.assertEqual(context.exception.code, "source_not_absolute")
+
+    def test_rejects_missing_source_kind(self) -> None:
+        request = json.loads(request_line(Path("/tmp/movie.m2ts")))
+        del request["source"]["kind"]
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_source")
+
+    def test_rejects_unknown_source_kind(self) -> None:
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(request_line(Path("/tmp/movie.m2ts"), source_kind="optical_disc"))
+
+        self.assertEqual(context.exception.code, "invalid_source")
 
     def test_rejects_oversized_request(self) -> None:
         oversized = "{" + (" " * MAX_REQUEST_BYTES) + "}"
@@ -331,7 +364,7 @@ class WorkerRuntimeTests(unittest.TestCase):
                 }
             },
         )
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v1.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v2.json"
         fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(decoded_events(output)[-1], fixture)
@@ -434,7 +467,10 @@ class SourceInspectionTests(unittest.TestCase):
                 fake_ffprobe.chmod(fake_ffprobe.stat().st_mode | stat.S_IXUSR)
 
                 with patch.object(config, "FFPROBE_PATH", fake_ffprobe):
-                    result = inspect_source(source_path, WorkerProcessOwner())
+                    result = inspect_source(
+                        JobSource(kind=WorkerSourceKind.DIRECT_FILE, path=source_path),
+                        WorkerProcessOwner(),
+                    )
 
                 self.assertEqual(result["name"], "movie")
                 self.assertEqual(result["resolution"], "1920x1080")
@@ -447,8 +483,13 @@ class SourceInspectionTests(unittest.TestCase):
             source_path = Path(temporary_directory) / "movie.mp4"
             source_path.touch()
 
-            with self.assertRaisesRegex(WorkerOperationError, "supports ISO, MKV, MTS, and M2TS"):
-                inspect_source(source_path, WorkerProcessOwner())
+            with self.assertRaises(WorkerOperationError) as context:
+                inspect_source(
+                    JobSource(kind=WorkerSourceKind.DIRECT_FILE, path=source_path),
+                    WorkerProcessOwner(),
+                )
+
+            self.assertEqual(context.exception.code, "source_kind_mismatch")
 
     def test_inspects_iso_with_makemkv_disc_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -469,7 +510,10 @@ class SourceInspectionTests(unittest.TestCase):
                     ),
                 ),
             ):
-                result = inspect_source(source_path, WorkerProcessOwner())
+                result = inspect_source(
+                    JobSource(kind=WorkerSourceKind.DISC_IMAGE, path=source_path),
+                    WorkerProcessOwner(),
+                )
 
             self.assertEqual(result["name"], "Feature 3D")
             self.assertEqual(result["resolution"], "1920x1080")
@@ -485,27 +529,117 @@ class SourceInspectionTests(unittest.TestCase):
                 patch.object(config, "MAKEMKVCON_PATH", Path(temporary_directory) / "missing-makemkvcon"),
                 self.assertRaises(WorkerOperationError) as context,
             ):
-                inspect_source(source_path, WorkerProcessOwner())
+                inspect_source(
+                    JobSource(kind=WorkerSourceKind.DISC_IMAGE, path=source_path),
+                    WorkerProcessOwner(),
+                )
 
             self.assertEqual(context.exception.code, "makemkv_missing")
             self.assertTrue(context.exception.retryable)
 
+    def test_inspects_bluray_folder_without_reporting_directory_size(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "Movie"
+            (source_path / "BDMV").mkdir(parents=True)
+            fake_makemkv = Path(temporary_directory) / "makemkvcon"
+            fake_makemkv.touch()
+
+            with (
+                patch.object(config, "MAKEMKVCON_PATH", fake_makemkv),
+                patch(
+                    "bd_to_avp.worker.operations.get_disc_and_mvc_video_info",
+                    return_value=DiscInfo(name="Folder 3D", resolution="1920x1080", frame_rate="24/1"),
+                ),
+            ):
+                result = inspect_source(
+                    JobSource(kind=WorkerSourceKind.BLU_RAY_FOLDER, path=source_path),
+                    WorkerProcessOwner(),
+                )
+
+            self.assertEqual(result["name"], "Folder 3D")
+            self.assertNotIn("size_bytes", result)
+
+    def test_normalizes_selected_bdmv_folder_to_disc_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "Movie"
+            bdmv_path = source_path / "BDMV"
+            bdmv_path.mkdir(parents=True)
+            fake_makemkv = Path(temporary_directory) / "makemkvcon"
+            fake_makemkv.touch()
+            observed: dict[str, object] = {}
+
+            def inspect_disc() -> DiscInfo:
+                observed["source_path"] = config.source_path
+                observed["source_str"] = config.source_str
+                return DiscInfo(name="Folder 3D")
+
+            with (
+                patch.object(config, "MAKEMKVCON_PATH", fake_makemkv),
+                patch("bd_to_avp.worker.operations.get_disc_and_mvc_video_info", side_effect=inspect_disc),
+            ):
+                inspect_source(
+                    JobSource(kind=WorkerSourceKind.BLU_RAY_FOLDER, path=bdmv_path),
+                    WorkerProcessOwner(),
+                )
+
+            self.assertEqual(observed["source_path"], source_path)
+            self.assertEqual(observed["source_str"], f"file:{source_path}")
+
+    def test_rejects_folder_without_bdmv_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "Not a Disc"
+            source_path.mkdir()
+
+            with self.assertRaises(WorkerOperationError) as context:
+                inspect_source(
+                    JobSource(kind=WorkerSourceKind.BLU_RAY_FOLDER, path=source_path),
+                    WorkerProcessOwner(),
+                )
+
+            self.assertEqual(context.exception.code, "invalid_bluray_folder")
+
 
 class SourceConversionTests(unittest.TestCase):
-    def test_rejects_folder_source(self) -> None:
+    def test_bluray_folder_conversion_passes_explicit_file_source_to_engine(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
-            source_path = temporary_path / "BDMV"
-            source_path.mkdir()
+            source_path = temporary_path / "Movie"
+            (source_path / "BDMV").mkdir(parents=True)
             destination_path = temporary_path / "output"
+            final_path = destination_path / "movie_AVP.mov"
+            final_path.parent.mkdir()
+            final_path.write_bytes(b"final")
             job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
             emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
             activity = WorkerActivityReporter(emitter)
+            observed: dict[str, object] = {}
+
+            def process_each(*_args: object, **_kwargs: object) -> Path:
+                observed["source_path"] = config.source_path
+                observed["source_str"] = config.source_str
+                return final_path
+
+            with (
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.process.process_each", side_effect=process_each),
+            ):
+                result = convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(result["output_path"], final_path.as_posix())
+            self.assertEqual(observed["source_path"], source_path)
+            self.assertEqual(observed["source_str"], f"file:{source_path}")
+
+    def test_bluray_folder_destination_must_be_outside_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "Movie"
+            (source_path / "BDMV").mkdir(parents=True)
+            job = JobSpec.from_json_line(conversion_request_line(source_path, source_path / "output"))
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
 
             with self.assertRaises(WorkerOperationError) as context:
-                convert_source(job, WorkerProcessOwner(), activity)
+                convert_source(job, WorkerProcessOwner(), WorkerActivityReporter(emitter))
 
-            self.assertEqual(context.exception.code, "source_not_file")
+            self.assertEqual(context.exception.code, "destination_inside_source")
 
     def test_iso_conversion_passes_source_to_existing_engine(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- upgrade the bundled worker contract to protocol v2 with explicit `direct_file`, `disc_image`, and `blu_ray_folder` source kinds
- normalize selected `BDMV` directories, map Blu-ray folders to MakeMKV `file:<path>`, and reject destinations inside source folders
- enable Blu-ray folder inspection/conversion in the native UI while keeping physical-disc and batch workflows explicitly unavailable
- update shared Swift/Python fixtures, packaging smoke, release docs, and source-safety regression coverage

## Review follow-up
- fixed a reviewer-found shared-engine regression where stale `disc:0` state could override a newly selected ISO/folder and leave cleanup pointed at the wrong source
- clarified native capability copy and made Swift/Python BDMV detection agree on case-insensitive folder names

## Validation
- `uv run python -m unittest discover -s tests -t .` — 390 passed
- full native XCTest bundle via `xcrun xctest` — 62 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv build`
- Preview build, ad-hoc package signing, bundled protocol-v2 worker smoke, and strict codesign verification passed
- non-destructive MakeMKV probe opened the mounted tester ISO as `file:<folder>` and began MVC title discovery

## Scope
Physical-disc mapping remains a separate follow-up because it requires stable device identity, eject/hot-swap behavior, and real optical-drive validation. Interactive recovery continuation and source-folder batching remain subsequent #198 slices.

Refs #198