### PR TITLE
Add physical Blu-ray disc conversion to native app

### DIFF
--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -128,7 +128,7 @@ def process(
 
 def process_each(cancellation_event: Event | None = None, activity: ActivityReporter | None = None) -> Path:
     raise_if_cancelled(cancellation_event)
-    print(f"\nProcessing {config.source_path}")
+    print(f"\nProcessing {config.source_path or config.source_str}")
     if activity:
         activity.stage_started("preflight", "Checking required conversion tools")
     preflight.verify_runtime_ready()

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 
 from contextlib import contextmanager
@@ -95,7 +96,12 @@ def run_operation(
 def inspect_source(source: JobSource, owner: WorkerProcessOwner) -> dict[str, object]:
     source_path = validate_source(source)
     if (
-        source.kind in {WorkerSourceKind.DISC_IMAGE, WorkerSourceKind.BLU_RAY_FOLDER}
+        source.kind
+        in {
+            WorkerSourceKind.DISC_IMAGE,
+            WorkerSourceKind.BLU_RAY_FOLDER,
+            WorkerSourceKind.PHYSICAL_DISC,
+        }
         and not config.MAKEMKVCON_PATH.is_file()
     ):
         raise WorkerOperationError(
@@ -119,9 +125,15 @@ def inspect_source(source: JobSource, owner: WorkerProcessOwner) -> dict[str, ob
         if owner.cancellation_event.is_set():
             raise WorkerCancelled("The source inspection was cancelled.") from error
         details = error.output if isinstance(error.output, str) else None
+        message = (
+            "MakeMKV could not read the selected Blu-ray disc. Confirm it is inserted, "
+            "wait for the drive to finish spinning up, and try again."
+            if source.kind is WorkerSourceKind.PHYSICAL_DISC
+            else "MakeMKV could not inspect the selected Blu-ray source."
+        )
         raise WorkerOperationError(
             "disc_inspection_failed",
-            "MakeMKV could not inspect the selected Blu-ray source.",
+            message,
             details,
             retryable=True,
         ) from error
@@ -250,7 +262,7 @@ def configured_source(source: JobSource, source_path: Path) -> Iterator[None]:
     previous_source_str = config.source_str
     previous_source_folder_path = config.source_folder_path
     try:
-        config.source_path = source_path
+        config.source_path = None if source.kind is WorkerSourceKind.PHYSICAL_DISC else source_path
         config.source_str = makemkv_source(source.kind, source_path)
         config.source_folder_path = None
         yield
@@ -269,7 +281,7 @@ def configured_conversion(job: JobSpec, source_path: Path) -> Iterator[None]:
     environment_snapshot = {key: os.environ.get(key) for key in TOOL_ENVIRONMENT_KEYS}
     try:
         config.source_str = makemkv_source(job.source.kind, source_path)
-        config.source_path = source_path
+        config.source_path = None if job.source.kind is WorkerSourceKind.PHYSICAL_DISC else source_path
         config.source_folder_path = None
         config.output_root_path = job.destination.path
         config.overwrite = job.job.overwrite
@@ -284,7 +296,7 @@ def configured_conversion(job: JobSpec, source_path: Path) -> Iterator[None]:
         config.resolution = job.encoding.resolution
         config.keep_files = job.job.keep_files
         config.start_stage = Stage.get_stage(job.job.start_stage)
-        config.remove_original = job.job.remove_original
+        config.remove_original = False if job.source.kind is WorkerSourceKind.PHYSICAL_DISC else job.job.remove_original
         config.swap_eyes = job.encoding.swap_eyes
         config.skip_subtitles = job.encoding.skip_subtitles
         config.crop_black_bars = job.encoding.crop_black_bars
@@ -308,6 +320,20 @@ def configured_conversion(job: JobSpec, source_path: Path) -> Iterator[None]:
 
 def validate_source(source: JobSource) -> Path:
     source_path = source.path
+    if source.kind is WorkerSourceKind.PHYSICAL_DISC:
+        if not physical_disc_device_path_is_valid(source_path):
+            raise WorkerOperationError(
+                "source_kind_mismatch",
+                "Physical-disc sources must use a macOS device path such as /dev/disk4.",
+            )
+        if not physical_disc_device_is_available(source_path):
+            raise WorkerOperationError(
+                "disc_unavailable",
+                "The selected Blu-ray disc is no longer available. Reinsert it and try again.",
+                retryable=True,
+            )
+        return source_path
+
     if not source_path.exists():
         raise WorkerOperationError("source_not_found", "The selected source no longer exists.")
 
@@ -336,6 +362,27 @@ def validate_source(source: JobSource) -> Path:
     return blu_ray_root
 
 
+def physical_disc_device_path_is_valid(source_path: Path) -> bool:
+    device_name = source_path.name
+    if source_path.parent != Path("/dev"):
+        return False
+    if device_name.startswith("rdisk"):
+        identifier = device_name.removeprefix("rdisk")
+    elif device_name.startswith("disk"):
+        identifier = device_name.removeprefix("disk")
+    else:
+        return False
+    return identifier.isdecimal()
+
+
+def physical_disc_device_is_available(source_path: Path) -> bool:
+    try:
+        mode = source_path.stat().st_mode
+    except OSError:
+        return False
+    return stat.S_ISBLK(mode) or stat.S_ISCHR(mode)
+
+
 def normalize_blu_ray_root(source_path: Path) -> Path | None:
     if not source_path.is_dir():
         return None
@@ -349,6 +396,8 @@ def normalize_blu_ray_root(source_path: Path) -> Path | None:
 
 
 def makemkv_source(source_kind: WorkerSourceKind, source_path: Path) -> str | None:
+    if source_kind is WorkerSourceKind.PHYSICAL_DISC:
+        return f"dev:{source_path}"
     if source_kind is WorkerSourceKind.DISC_IMAGE:
         return f"iso:{source_path}"
     if source_kind is WorkerSourceKind.BLU_RAY_FOLDER:

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -34,6 +34,7 @@ class WorkerSourceKind(StrEnum):
     DIRECT_FILE = "direct_file"
     DISC_IMAGE = "disc_image"
     BLU_RAY_FOLDER = "blu_ray_folder"
+    PHYSICAL_DISC = "physical_disc"
 
 
 class WorkerEventType(StrEnum):
@@ -217,6 +218,12 @@ class JobSpec:
             )
             encoding = cls._parse_encoding(raw.get("encoding"), job_id)
             job_options = cls._parse_job_options(raw.get("job"), job_id)
+            if source_kind is WorkerSourceKind.PHYSICAL_DISC and job_options.remove_original:
+                raise WorkerProtocolError(
+                    "invalid_job_options",
+                    "job.remove_original must be false for physical discs.",
+                    job_id=job_id,
+                )
 
         return cls(
             protocol_version=protocol_version,

--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -108,7 +108,7 @@ dispatch then removed after the job exits.
 
 The native shell does not yet replace the current `0.2.x` Briefcase/Sparkle
 release line. Native Start Processing supports inspected Blu-ray folders, ISO,
-MKV, MTS, and M2TS sources; physical disc, batch, interactive recovery, and the
+physical disc, MKV, MTS, and M2TS sources; batch, interactive recovery, and the
 native updater path still need release-level completion before promotion through
 the normal Release Candidates appcast.
 

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -7,9 +7,9 @@ or update it.
 - Launch the new SwiftUI workspace on an Apple Silicon Mac running macOS 27.
 - Choose a physical disc, ISO disc image, Blu-ray folder, MKV, source folder, or
   MTS/M2TS transport stream.
-- Inspect Blu-ray folder, ISO, MKV, MTS, and M2TS source metadata through the
-  bundled engine.
-- Convert an inspected Blu-ray folder, ISO, MKV, MTS, or M2TS source to a
+- Inspect physical-disc, Blu-ray-folder, ISO, MKV, MTS, and M2TS source metadata
+  through the bundled engine.
+- Convert an inspected physical disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source to a
   completed MV-HEVC `.mov` through the bundled engine, with native progress,
   cancellation, and results.
 - Review the Video, Audio & Subtitles, and Files & Recovery controls.
@@ -21,10 +21,9 @@ or update it.
 
 ## Important Limits
 
-- **Start Processing supports one Blu-ray folder, ISO, MKV, MTS, or M2TS source
-  at a time.** Keep the production app installed for physical discs,
-  source-folder batches, and recovery decisions that require a second
-  interactive step.
+- **Start Processing supports one physical disc, Blu-ray folder, ISO, MKV, MTS,
+  or M2TS source at a time.** Keep the production app installed for source-folder
+  batches and recovery decisions that require a second interactive step.
 - Native conversion currently creates the full movie. Short sample outputs are
   not yet available.
 - This preview has no automatic updater. Future preview builds must be

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -2,8 +2,8 @@
 
 The native macOS app communicates with its bundled Python engine over a bounded
 JSON Lines (JSONL) protocol. Version 2 makes the source kind explicit and adds
-single Blu-ray folder inspection and conversion. Physical-disc and batch-folder
-conversion remain outside this contract.
+single Blu-ray folder and physical-disc inspection and conversion. Batch-folder
+conversion remains outside this contract.
 
 ## Transport
 
@@ -22,12 +22,20 @@ Every request contains exactly one absolute source path and one source kind:
 | `direct_file` | Existing `.mkv`, `.mts`, or `.m2ts` file. |
 | `disc_image` | Existing `.iso` file. |
 | `blu_ray_folder` | Folder containing `BDMV`, or the `BDMV` folder itself. |
+| `physical_disc` | Available macOS whole-disc device such as `/dev/disk4`. |
 
 The worker validates that kind and path agree before launching tools. A selected
 `BDMV` folder is normalized to its parent disc root. Blu-ray folders are passed
 to MakeMKV as `file:<absolute path>`; ISO files are passed as
 `iso:<absolute path>`. A conversion destination may not be inside a Blu-ray
 source folder.
+
+The native app resolves a selected mounted Blu-ray volume to its stable BSD
+device with Disk Arbitration. The worker validates the `/dev/diskN` or
+`/dev/rdiskN` shape and availability, then passes it to MakeMKV as
+`dev:<device path>`. Physical devices are never stored as an owned source path,
+and conversion requests must set `job.remove_original` to `false`, so cleanup
+cannot modify or remove the device node.
 
 ## Inspection Request
 
@@ -47,6 +55,8 @@ source folder.
 Inspection completion places `name`, `resolution`, `frame_rate`, `interlaced`,
 and optional `size_bytes` under `payload.result`. Directory size is intentionally
 not reported because filesystem directory metadata is not the media size.
+Physical discs also omit `size_bytes` because the selected device is not an
+owned input file.
 
 ## Conversion Request
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -108,12 +108,38 @@ With MakeMKV installed:
    conversion smoke and record the first failing stage, logs, runtime, and
    whether output files are created.
 
+### Physical-Disc RC Smoke
+
+Complete this section on real hardware before promoting a physical-disc release
+candidate. A VM without an attached optical drive is not sufficient.
+
+1. Connect a USB Blu-ray drive, preferably through a powered hub, install
+   MakeMKV, and insert a known 3D Blu-ray disc.
+2. Confirm the app detects the disc without relaunching. Select it and confirm
+   metadata inspection completes through MakeMKV.
+3. Start conversion, wait until MakeMKV is actively reading the disc, then press
+   Stop. Confirm processing exits and Finder can eject the disc without a reboot.
+4. Reinsert the disc and complete a conversion, or record the first failing
+   stage, the activity log, drive model, connection type, and whether the drive
+   disconnected or spun down.
+5. Eject the selected disc while the app is idle. Confirm the stale selection is
+   cleared, then reinsert it and confirm it reappears automatically.
+6. Confirm “Remove original after success” is unavailable for the physical disc
+   and that the selected output folder is outside the mounted disc volume.
+
+If the drive drops offline during heavy seeking, repeat once with a powered hub
+before classifying the failure as an app defect. Preserve the activity log either
+way so device, permission, AACS, and media-read failures can be distinguished.
+
 ## Pass Criteria
 
 - No Homebrew or admin setup is required for GUI launch.
 - The app's bundled tools are used where expected.
 - Missing MakeMKV produces a clear recovery path.
 - Installing MakeMKV clears the MakeMKV preflight blocker.
+- A physical-disc RC passes inspection, cancellation/eject, automatic
+  insertion/ejection refresh, and at least one recorded real-disc conversion
+  attempt on supported hardware.
 - Any remaining missing bundled tool is recorded as a release blocker or linked
   to a follow-up issue. A reinstall-app message for a tool that is not part of
   the app bundle is a blocker, because reinstalling the current app will not add

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -119,7 +119,16 @@ final class ConversionViewModel: ObservableObject {
               FileManager.default.fileExists(atPath: draft.source.url.path)
         else {
             state.failTransport(
-                message: "Conversion requires an existing Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
+                message: "Conversion requires an inserted Blu-ray disc or existing Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
+                retryable: false
+            )
+            return
+        }
+        if draft.source.kind == .physicalDisc,
+           Self.isInsideSourceVolume(draft.destinationURL, sourceURL: draft.source.url)
+        {
+            state.failTransport(
+                message: "Choose a destination outside the Blu-ray disc.",
                 retryable: false
             )
             return
@@ -187,6 +196,20 @@ final class ConversionViewModel: ObservableObject {
         diagnosticLog = ""
     }
 
+    func sourceVolumeDidUnmount(_ volumeURL: URL) {
+        guard let source,
+              source.kind == .physicalDisc,
+              source.url == volumeURL.standardizedFileURL
+        else {
+            return
+        }
+        if hasActiveWorker {
+            stopActiveWorker()
+        } else {
+            clearSource()
+        }
+    }
+
     func stopForQuit() async {
         guard let task = runTask else {
             return
@@ -212,7 +235,7 @@ final class ConversionViewModel: ObservableObject {
         }
         guard source.kind.supportsMetadataInspection else {
             state.failTransport(
-                message: "Choose a Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
+                message: "Choose a Blu-ray disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source.",
                 retryable: false
             )
             return
@@ -222,6 +245,13 @@ final class ConversionViewModel: ObservableObject {
             return
         }
         startInspection()
+    }
+
+    private static func isInsideSourceVolume(_ destinationURL: URL, sourceURL: URL) -> Bool {
+        let destinationPath = destinationURL.standardizedFileURL.path
+        let sourcePath = sourceURL.standardizedFileURL.path
+        let sourcePrefix = sourcePath.hasSuffix("/") ? sourcePath : "\(sourcePath)/"
+        return destinationPath == sourcePath || destinationPath.hasPrefix(sourcePrefix)
     }
 
     private func receive(_ event: WorkerEvent) throws {

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -1,3 +1,4 @@
+import DiskArbitration
 import Foundation
 
 enum ConversionSourceKind: String, CaseIterable, Identifiable {
@@ -45,11 +46,15 @@ enum ConversionSourceKind: String, CaseIterable, Identifiable {
     }
 
     var supportsMetadataInspection: Bool {
-        self == .discImage || self == .bluRayFolder || self == .matroska || self == .transportStream
+        self == .physicalDisc
+            || self == .discImage
+            || self == .bluRayFolder
+            || self == .matroska
+            || self == .transportStream
     }
 
     var supportsConversion: Bool {
-        self == .discImage || self == .bluRayFolder || self == .matroska || self == .transportStream
+        supportsMetadataInspection
     }
 
     var isDiscWorkflow: Bool {
@@ -78,14 +83,21 @@ struct ConversionSource: Equatable {
     let kind: ConversionSourceKind
     let url: URL
     let displayName: String
+    let workerSourcePath: String
 
-    init(kind: ConversionSourceKind, url: URL, displayName: String? = nil) {
+    init(
+        kind: ConversionSourceKind,
+        url: URL,
+        displayName: String? = nil,
+        workerSourcePath: String? = nil
+    ) {
         let normalizedURL = kind == .bluRayFolder
             ? DiscSourceDetector.bluRayRoot(for: url) ?? url.standardizedFileURL
             : url.standardizedFileURL
         self.kind = kind
         self.url = normalizedURL
         self.displayName = displayName ?? Self.defaultDisplayName(for: normalizedURL)
+        self.workerSourcePath = workerSourcePath ?? normalizedURL.path
     }
 
     var proposedOutputStem: String {
@@ -147,19 +159,39 @@ enum DiscSourceDetector {
         return insertedDiscs(in: volumes, fileManager: fileManager)
     }
 
-    static func insertedDiscs(in volumes: [URL], fileManager: FileManager = .default) -> [ConversionSource] {
+    static func insertedDiscs(
+        in volumes: [URL],
+        fileManager: FileManager = .default,
+        devicePathResolver: (URL) -> String? = physicalDevicePath(for:)
+    ) -> [ConversionSource] {
         volumes.compactMap { volumeURL in
-            guard isBluRayFolder(volumeURL, fileManager: fileManager) else {
+            guard isBluRayFolder(volumeURL, fileManager: fileManager),
+                  let devicePath = devicePathResolver(volumeURL)
+            else {
                 return nil
             }
             let values = try? volumeURL.resourceValues(forKeys: [.volumeNameKey])
             return ConversionSource(
                 kind: .physicalDisc,
                 url: volumeURL,
-                displayName: values?.volumeName ?? volumeURL.lastPathComponent
+                displayName: values?.volumeName ?? volumeURL.lastPathComponent,
+                workerSourcePath: devicePath
             )
         }
         .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    private static func physicalDevicePath(for volumeURL: URL) -> String? {
+        guard let session = DASessionCreate(kCFAllocatorDefault),
+              let disk = DADiskCreateFromVolumePath(kCFAllocatorDefault, session, volumeURL as CFURL)
+        else {
+            return nil
+        }
+        let wholeDisk = DADiskCopyWholeDisk(disk) ?? disk
+        guard let deviceName = DADiskGetBSDName(wholeDisk) else {
+            return nil
+        }
+        return "/dev/\(String(cString: deviceName))"
     }
 
     static func isBluRayFolder(_ url: URL, fileManager: FileManager = .default) -> Bool {

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -128,7 +128,7 @@ struct AppCapabilities: Equatable {
     )
 
     var conversionUnavailableReason: String {
-        "Conversion requires a Blu-ray folder, ISO, MKV, MTS, or M2TS source."
+        "Conversion requires a Blu-ray disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source."
     }
 
     var automaticUpdatesUnavailableReason: String {

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -8,6 +8,7 @@ struct WorkerJobSpec: Encodable, Equatable {
             case directFile = "direct_file"
             case discImage = "disc_image"
             case bluRayFolder = "blu_ray_folder"
+            case physicalDisc = "physical_disc"
         }
 
         let kind: Kind
@@ -15,16 +16,18 @@ struct WorkerJobSpec: Encodable, Equatable {
 
         init(source: ConversionSource) {
             switch source.kind {
+            case .physicalDisc:
+                kind = .physicalDisc
             case .discImage:
                 kind = .discImage
             case .bluRayFolder:
                 kind = .bluRayFolder
             case .matroska, .transportStream:
                 kind = .directFile
-            case .physicalDisc, .sourceFolder:
+            case .sourceFolder:
                 preconditionFailure("Unsupported worker source kind: \(source.kind)")
             }
-            path = source.url.path
+            path = source.workerSourcePath
         }
 
         init(fileURL: URL) {
@@ -164,7 +167,7 @@ struct WorkerJobSpec: Encodable, Equatable {
             startStage: jobOptions.startStage.rawValue,
             keepFiles: jobOptions.keepStageFiles,
             overwrite: jobOptions.overwriteExisting,
-            removeOriginal: jobOptions.removeOriginalAfterSuccess,
+            removeOriginal: draft.source.kind == .physicalDisc ? false : jobOptions.removeOriginalAfterSuccess,
             continueOnError: jobOptions.continueOnError,
             softwareEncoder: jobOptions.softwareEncoder,
             outputCommands: jobOptions.outputCommands,

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -80,6 +80,7 @@ struct ContentView: View {
                     selectedProfile: selectedProfile,
                     profileModified: profileModified,
                     isLocked: viewModel.hasActiveWorker,
+                    sourceKind: viewModel.source?.kind,
                     saveSelectedProfile: saveSelectedProfile,
                     saveAsNewProfile: beginSaveAsNewProfile,
                     resetProfile: resetProfile
@@ -121,6 +122,18 @@ struct ContentView: View {
             }
         }
         .onAppear(perform: refreshDiscs)
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
+            refreshDiscs()
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didUnmountNotification)) {
+            notification in
+            handleVolumeUnmount(notification)
+        }
+        .onChange(of: viewModel.hasActiveWorker) { _, isActive in
+            if !isActive {
+                refreshDiscs()
+            }
+        }
         .onChange(of: selectedProfileID) { _, _ in
             if preserveEncodingOnNextProfileChange {
                 preserveEncodingOnNextProfileChange = false
@@ -349,9 +362,6 @@ struct ContentView: View {
         if viewModel.state.result != nil {
             return "Source analyzed and conversion settings ready"
         }
-        if source.kind == .physicalDisc {
-            return "Physical disc conversion is not available yet"
-        }
         if source.kind.isDiscWorkflow {
             return "Disc workflow ready"
         }
@@ -399,13 +409,13 @@ struct ContentView: View {
             return capabilities.conversionUnavailableReason
         }
         switch viewModel.source?.kind {
-        case .physicalDisc:
-            return "Physical discs are not yet supported for native conversion."
         case .sourceFolder:
             return "Batch folder conversion is not yet available."
-        case .discImage, .bluRayFolder, .matroska, .transportStream where viewModel.state.result == nil:
-            return "Source analysis must complete before conversion can start."
-        case .none, .discImage, .bluRayFolder, .matroska, .transportStream:
+        case .physicalDisc, .discImage, .bluRayFolder, .matroska, .transportStream:
+            return viewModel.state.result == nil
+                ? "Source analysis must complete before conversion can start."
+                : capabilities.conversionUnavailableReason
+        case .none:
             return capabilities.conversionUnavailableReason
         }
     }
@@ -457,12 +467,31 @@ struct ContentView: View {
     }
 
     private func refreshDiscs() {
-        insertedDiscs = DiscSourceDetector.insertedDiscs()
+        let refreshedDiscs = DiscSourceDetector.insertedDiscs()
+        insertedDiscs = refreshedDiscs
+        guard !viewModel.hasActiveWorker,
+              let selectedSource = viewModel.source,
+              selectedSource.kind == .physicalDisc,
+              !refreshedDiscs.contains(where: { $0.workerSourcePath == selectedSource.workerSourcePath })
+        else {
+            return
+        }
+        viewModel.clearSource()
+    }
+
+    private func handleVolumeUnmount(_ notification: Notification) {
+        if let volumeURL = notification.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL {
+            viewModel.sourceVolumeDidUnmount(volumeURL)
+        }
+        refreshDiscs()
     }
 
     private func selectSource(_ source: ConversionSource) {
         guard viewModel.canSelectSource else {
             return
+        }
+        if source.kind == .physicalDisc {
+            options.job.removeOriginalAfterSuccess = false
         }
         viewModel.selectSource(source)
     }

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -11,6 +11,7 @@ struct ConversionSetupView: View {
     let selectedProfile: EncodingProfile
     let profileModified: Bool
     let isLocked: Bool
+    let sourceKind: ConversionSourceKind?
     let saveSelectedProfile: () -> Void
     let saveAsNewProfile: () -> Void
     let resetProfile: () -> Void
@@ -122,11 +123,16 @@ struct ConversionSetupView: View {
                 Toggle(isOn: $options.job.removeOriginalAfterSuccess) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Remove original after success")
-                        Text("Destructive — the source is removed only after the finished movie is verified.")
+                        Text(
+                            sourceKind == .physicalDisc
+                                ? "Not available for physical discs. The disc is never modified."
+                                : "Destructive — the source is removed only after the finished movie is verified."
+                        )
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
                 }
+                .disabled(sourceKind == .physicalDisc)
             }
 
             Section("Run Behavior") {

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -177,23 +177,146 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testStartConversionForUnsupportedSourceKindDoesNotStartWorker() {
-        let viewModel = ConversionViewModel()
-        let discSource = ConversionSource(kind: .physicalDisc, url: URL(fileURLWithPath: "/Volumes/Disc"))
+    func testPhysicalDiscSelectionStartsInspectionAndConversion() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { spec in
+                XCTAssertEqual(spec.source.kind, .physicalDisc)
+                XCTAssertEqual(spec.source.path, "/dev/disk9")
+                XCTAssertFalse(spec.job?.removeOriginal == true)
+                conversionStarted.fulfill()
+            }
+        )
+        let viewModel = ConversionViewModel { worker }
+        let volumeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: volumeURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: volumeURL) }
+        let discSource = ConversionSource(
+            kind: .physicalDisc,
+            url: volumeURL,
+            workerSourcePath: "/dev/disk9"
+        )
+
         viewModel.selectSource(discSource)
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
 
         let draft = ConversionDraft(
             source: discSource,
-            sourceDetails: nil,
+            sourceDetails: viewModel.state.result,
             profile: BuiltInProfile.balanced.profile,
-            destinationURL: URL(fileURLWithPath: "/Movies"),
+            destinationURL: FileManager.default.temporaryDirectory,
             outputLength: .fullMovie,
             samplePosition: .beginning,
             options: ConversionOptions()
         )
         viewModel.startConversion(draft: draft)
 
+        await fulfillment(of: [conversionStarted], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+        XCTAssertEqual(viewModel.state.phase, .completed)
+    }
+
+    @MainActor
+    func testPhysicalDiscConversionRejectsDestinationOnDisc() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let viewModel = ConversionViewModel {
+            TwoPhaseWorkerClient(onInspectionComplete: { inspectionDone.fulfill() })
+        }
+        let volumeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: volumeURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: volumeURL) }
+        let discSource = ConversionSource(
+            kind: .physicalDisc,
+            url: volumeURL,
+            workerSourcePath: "/dev/disk9"
+        )
+
+        viewModel.selectSource(discSource)
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+        viewModel.startConversion(
+            draft: ConversionDraft(
+                source: discSource,
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: volumeURL.appendingPathComponent("Output", isDirectory: true),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+        )
+
         XCTAssertFalse(viewModel.hasActiveWorker)
+        XCTAssertEqual(viewModel.state.failureMessage, "Choose a destination outside the Blu-ray disc.")
+    }
+
+    @MainActor
+    func testUnmountedPhysicalDiscClearsIdleSelection() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let viewModel = ConversionViewModel {
+            TwoPhaseWorkerClient(onInspectionComplete: { inspectionDone.fulfill() })
+        }
+        let volumeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: volumeURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: volumeURL) }
+
+        viewModel.selectSource(
+            ConversionSource(kind: .physicalDisc, url: volumeURL, workerSourcePath: "/dev/disk9")
+        )
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+
+        viewModel.sourceVolumeDidUnmount(volumeURL)
+
+        XCTAssertNil(viewModel.source)
+        XCTAssertEqual(viewModel.state.phase, .empty)
+    }
+
+    @MainActor
+    func testUnmountedPhysicalDiscStopsActiveConversion() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { _ in conversionStarted.fulfill() },
+            waitsForConversionCancellation: true
+        )
+        let viewModel = ConversionViewModel { worker }
+        let volumeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: volumeURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: volumeURL) }
+        let source = ConversionSource(
+            kind: .physicalDisc,
+            url: volumeURL,
+            workerSourcePath: "/dev/disk9"
+        )
+
+        viewModel.selectSource(source)
+        await fulfillment(of: [inspectionDone], timeout: 2)
+        while viewModel.hasActiveWorker { await Task.yield() }
+        viewModel.startConversion(
+            draft: ConversionDraft(
+                source: source,
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: FileManager.default.temporaryDirectory,
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+        )
+        await fulfillment(of: [conversionStarted], timeout: 2)
+
+        viewModel.sourceVolumeDidUnmount(volumeURL)
+
+        XCTAssertEqual(viewModel.state.phase, .stopping)
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -75,12 +75,47 @@ final class ConversionWorkflowTests: XCTestCase {
         }
     }
 
+    func testInsertedDiscDetectionCarriesResolvedDevicePath() throws {
+        try withTemporaryDirectory { volumeURL in
+            try FileManager.default.createDirectory(
+                at: volumeURL.appendingPathComponent("BDMV", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+
+            let discs = DiscSourceDetector.insertedDiscs(
+                in: [volumeURL],
+                devicePathResolver: { _ in "/dev/disk9" }
+            )
+
+            XCTAssertEqual(discs.count, 1)
+            XCTAssertEqual(discs.first?.kind, .physicalDisc)
+            XCTAssertEqual(discs.first?.url, volumeURL)
+            XCTAssertEqual(discs.first?.workerSourcePath, "/dev/disk9")
+        }
+    }
+
+    func testInsertedDiscDetectionOmitsUnresolvedVolumes() throws {
+        try withTemporaryDirectory { volumeURL in
+            try FileManager.default.createDirectory(
+                at: volumeURL.appendingPathComponent("BDMV", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+
+            let discs = DiscSourceDetector.insertedDiscs(
+                in: [volumeURL],
+                devicePathResolver: { _ in nil }
+            )
+
+            XCTAssertTrue(discs.isEmpty)
+        }
+    }
+
     func testCurrentCapabilitiesStayHonest() {
         XCTAssertTrue(AppCapabilities.current.conversionAvailable)
         XCTAssertFalse(AppCapabilities.current.automaticUpdateChecksAvailable)
         XCTAssertEqual(
             AppCapabilities.current.conversionUnavailableReason,
-            "Conversion requires a Blu-ray folder, ISO, MKV, MTS, or M2TS source."
+            "Conversion requires a Blu-ray disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source."
         )
     }
 
@@ -94,8 +129,9 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertTrue(ConversionSourceKind.transportStream.supportsConversion)
     }
 
-    func testPhysicalDiscAndBatchFolderKindsDoNotSupportConversion() {
-        XCTAssertFalse(ConversionSourceKind.physicalDisc.supportsConversion)
+    func testPhysicalDiscSupportsConversionWhileBatchFolderDoesNot() {
+        XCTAssertTrue(ConversionSourceKind.physicalDisc.supportsMetadataInspection)
+        XCTAssertTrue(ConversionSourceKind.physicalDisc.supportsConversion)
         XCTAssertFalse(ConversionSourceKind.sourceFolder.supportsConversion)
     }
 
@@ -144,6 +180,39 @@ final class ConversionWorkflowTests: XCTestCase {
         )
 
         XCTAssertEqual(WorkerJobSpec(draft: draft).source.kind, .bluRayFolder)
+    }
+
+    func testPhysicalDiscJobSpecUsesResolvedDevicePathAndPreservesSourceVolume() {
+        let source = ConversionSource(
+            kind: .physicalDisc,
+            url: URL(fileURLWithPath: "/Volumes/Feature", isDirectory: true),
+            workerSourcePath: "/dev/disk9"
+        )
+        let spec = WorkerJobSpec(source: source)
+
+        XCTAssertEqual(spec.source.kind, .physicalDisc)
+        XCTAssertEqual(spec.source.path, "/dev/disk9")
+        XCTAssertEqual(source.url.path, "/Volumes/Feature")
+    }
+
+    func testPhysicalDiscJobSpecNeverRequestsSourceRemoval() {
+        var jobOptions = JobOptions()
+        jobOptions.removeOriginalAfterSuccess = true
+        let draft = ConversionDraft(
+            source: ConversionSource(
+                kind: .physicalDisc,
+                url: URL(fileURLWithPath: "/Volumes/Feature", isDirectory: true),
+                workerSourcePath: "/dev/disk9"
+            ),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions(job: jobOptions)
+        )
+
+        XCTAssertFalse(WorkerJobSpec(draft: draft).job?.removeOriginal == true)
     }
 
     func testConversionJobSpecEncodesVideoAndAudioSettings() {
@@ -250,6 +319,35 @@ final class ConversionWorkflowTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("tests/fixtures/native_worker_convert_v2.json")
+        let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
+
+        XCTAssertEqual(encoded, fixture)
+    }
+
+    func testPhysicalDiscJobSpecMatchesSharedPythonFixture() throws {
+        let draft = ConversionDraft(
+            source: ConversionSource(
+                kind: .physicalDisc,
+                url: URL(fileURLWithPath: "/Volumes/Feature", isDirectory: true),
+                workerSourcePath: "/dev/disk9"
+            ),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            outputLength: .fullMovie,
+            samplePosition: .beginning,
+            options: ConversionOptions()
+        )
+        let spec = WorkerJobSpec(
+            draft: draft,
+            jobID: try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        )
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/native_worker_convert_physical_disc_v2.json")
         let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)

--- a/tests/fixtures/native_worker_convert_physical_disc_v2.json
+++ b/tests/fixtures/native_worker_convert_physical_disc_v2.json
@@ -1,0 +1,41 @@
+{
+  "protocol_version": 2,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "physical_disc",
+    "path": "/dev/disk9"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "transcode_audio": false,
+    "audio_bitrate": 384,
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "skip_subtitles": false,
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "language_code": "eng",
+    "remove_extra_languages": false
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true,
+    "output_length": "full_movie"
+  }
+}

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -79,6 +79,34 @@ class DiscStageArtifactTests(unittest.TestCase):
         self.assertFalse(disc.makemkv_source_supports_noscan("dev:/dev/rdisk4"))
         self.assertTrue(disc.makemkv_source_supports_noscan("file:/Movies/Feature"))
 
+    def test_disc_info_passes_device_source_to_makemkv_without_noscan(self) -> None:
+        makemkv_output = "\n".join(
+            [
+                'CINFO:2,0,"Physical 3D"',
+                'TINFO:0,9,0,"0:45:00"',
+                'SINFO:0,1,6,0,"Mpeg4-MVC-3D"',
+            ]
+        )
+        with (
+            patch.object(disc.config, "source_path", None),
+            patch.object(disc.config, "source_str", "dev:/dev/disk9"),
+            patch.object(disc.config, "MAKEMKVCON_PATH", Path("/Applications/MakeMKV/makemkvcon")),
+            patch.object(disc, "run_command", return_value=makemkv_output) as run_command,
+        ):
+            result = disc.get_disc_and_mvc_video_info()
+
+        self.assertEqual(result.name, "Physical 3D")
+        self.assertEqual(
+            run_command.call_args.args[0],
+            [
+                Path("/Applications/MakeMKV/makemkvcon"),
+                "--robot",
+                None,
+                "info",
+                "dev:/dev/disk9",
+            ],
+        )
+
     def test_keep_files_copies_mkv_source_to_output_folder(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -114,6 +114,14 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.source.kind, WorkerSourceKind.DIRECT_FILE)
         self.assertEqual(job.source.path, source_path)
 
+    def test_parses_physical_disc_request(self) -> None:
+        source_path = Path("/dev/disk9")
+
+        job = JobSpec.from_json_line(request_line(source_path, source_kind=WorkerSourceKind.PHYSICAL_DISC.value))
+
+        self.assertEqual(job.source.kind, WorkerSourceKind.PHYSICAL_DISC)
+        self.assertEqual(job.source.path, source_path)
+
     def test_parses_strict_conversion_request(self) -> None:
         source_path = Path("/tmp/movie.mkv")
         destination_path = Path("/tmp/output")
@@ -137,6 +145,31 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.source.path, Path("/tmp/movie.mkv"))
         self.assertEqual(job.destination.path if job.destination else None, Path("/tmp/output"))
         self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
+
+    def test_parses_shared_swift_physical_disc_fixture(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v2.json"
+
+        job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(job.source.kind, WorkerSourceKind.PHYSICAL_DISC)
+        self.assertEqual(job.source.path, Path("/dev/disk9"))
+        self.assertFalse(job.job.remove_original if job.job else True)
+
+    def test_rejects_remove_original_for_physical_disc(self) -> None:
+        request = json.loads(
+            conversion_request_line(
+                Path("/dev/disk9"),
+                Path("/tmp/output"),
+                source_kind=WorkerSourceKind.PHYSICAL_DISC.value,
+            )
+        )
+        request["job"]["remove_original"] = True
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request))
+
+        self.assertEqual(context.exception.code, "invalid_job_options")
+        self.assertIn("physical discs", context.exception.message)
 
     def test_rejects_sample_conversion_request(self) -> None:
         request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
@@ -537,6 +570,75 @@ class SourceInspectionTests(unittest.TestCase):
             self.assertEqual(context.exception.code, "makemkv_missing")
             self.assertTrue(context.exception.retryable)
 
+    def test_inspects_physical_disc_through_device_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fake_makemkv = Path(temporary_directory) / "makemkvcon"
+            fake_makemkv.touch()
+            source_path = Path("/dev/disk9")
+            observed: dict[str, object] = {}
+
+            def inspect_disc() -> DiscInfo:
+                observed["source_path"] = config.source_path
+                observed["source_str"] = config.source_str
+                return DiscInfo(name="Physical 3D", resolution="1920x1080", frame_rate="24000/1001")
+
+            with (
+                patch.object(config, "MAKEMKVCON_PATH", fake_makemkv),
+                patch("bd_to_avp.worker.operations.physical_disc_device_is_available", return_value=True),
+                patch("bd_to_avp.worker.operations.get_disc_and_mvc_video_info", side_effect=inspect_disc),
+            ):
+                result = inspect_source(
+                    JobSource(kind=WorkerSourceKind.PHYSICAL_DISC, path=source_path),
+                    WorkerProcessOwner(),
+                )
+
+            self.assertEqual(result["name"], "Physical 3D")
+            self.assertNotIn("size_bytes", result)
+            self.assertIsNone(observed["source_path"])
+            self.assertEqual(observed["source_str"], "dev:/dev/disk9")
+
+    def test_reports_unavailable_physical_disc_as_retryable(self) -> None:
+        with (
+            patch("bd_to_avp.worker.operations.physical_disc_device_is_available", return_value=False),
+            self.assertRaises(WorkerOperationError) as context,
+        ):
+            inspect_source(
+                JobSource(kind=WorkerSourceKind.PHYSICAL_DISC, path=Path("/dev/disk9")),
+                WorkerProcessOwner(),
+            )
+
+        self.assertEqual(context.exception.code, "disc_unavailable")
+        self.assertTrue(context.exception.retryable)
+
+    def test_rejects_non_device_path_for_physical_disc(self) -> None:
+        with self.assertRaises(WorkerOperationError) as context:
+            inspect_source(
+                JobSource(kind=WorkerSourceKind.PHYSICAL_DISC, path=Path("/tmp/disk9")),
+                WorkerProcessOwner(),
+            )
+
+        self.assertEqual(context.exception.code, "source_kind_mismatch")
+
+    def test_accepts_raw_device_path_for_physical_disc(self) -> None:
+        source_path = Path("/dev/rdisk9")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fake_makemkv = Path(temporary_directory) / "makemkvcon"
+            fake_makemkv.touch()
+            with (
+                patch.object(config, "MAKEMKVCON_PATH", fake_makemkv),
+                patch("bd_to_avp.worker.operations.physical_disc_device_is_available", return_value=True),
+                patch(
+                    "bd_to_avp.worker.operations.get_disc_and_mvc_video_info",
+                    return_value=DiscInfo(name="Raw Device 3D"),
+                ),
+            ):
+                inspected = inspect_source(
+                    JobSource(kind=WorkerSourceKind.PHYSICAL_DISC, path=source_path),
+                    WorkerProcessOwner(),
+                )
+
+        self.assertEqual(inspected["name"], "Raw Device 3D")
+
     def test_inspects_bluray_folder_without_reporting_directory_size(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             source_path = Path(temporary_directory) / "Movie"
@@ -600,6 +702,43 @@ class SourceInspectionTests(unittest.TestCase):
 
 
 class SourceConversionTests(unittest.TestCase):
+    def test_physical_disc_conversion_uses_unowned_device_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = Path("/dev/disk9")
+            destination_path = temporary_path / "output"
+            final_path = destination_path / "movie_AVP.mov"
+            final_path.parent.mkdir()
+            final_path.write_bytes(b"final")
+            job = JobSpec.from_json_line(
+                conversion_request_line(
+                    source_path,
+                    destination_path,
+                    source_kind=WorkerSourceKind.PHYSICAL_DISC.value,
+                )
+            )
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+            observed: dict[str, object] = {}
+
+            def process_each(*_args: object, **_kwargs: object) -> Path:
+                observed["source_path"] = config.source_path
+                observed["source_str"] = config.source_str
+                observed["remove_original"] = config.remove_original
+                return final_path
+
+            with (
+                patch("bd_to_avp.worker.operations.physical_disc_device_is_available", return_value=True),
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.process.process_each", side_effect=process_each),
+            ):
+                result = convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(result["source_path"], source_path.as_posix())
+            self.assertIsNone(observed["source_path"])
+            self.assertEqual(observed["source_str"], "dev:/dev/disk9")
+            self.assertFalse(observed["remove_original"])
+
     def test_bluray_folder_conversion_passes_explicit_file_source_to_engine(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)


### PR DESCRIPTION
## Summary

- resolve mounted Blu-ray volumes to their macOS whole-disc device with Disk Arbitration and send an additive `physical_disc` source through worker protocol v2
- pass physical media to MakeMKV as `dev:/dev/disk…` while keeping the device outside owned-source cleanup and forcing `remove_original=false` at every boundary
- enable native inspection/conversion, automatic mount/eject refresh, destination safety, and worker cancellation when the selected disc is ejected
- add shared Swift/Python contract fixtures, direct MakeMKV command coverage, unmount/cancellation tests, and an RC real-hardware smoke checklist

## Validation

- `uv run python -m unittest discover -s tests -t .` — 399 passed
- `uv run python scripts/native_app.py test` — 70 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/release.py validate`
- import smoke and `uv build`
- native Debug and Preview builds
- packaged-worker smoke plus strict ad-hoc codesign verification
- JetBrains changed-files inspection — green, zero findings
- independent multi-model review completed; eject and MakeMKV command gaps found in the first pass were fixed and re-reviewed clean

## Hardware Validation

This change is deterministic without a drive, but final device permissions, AACS behavior, drive lock release, and USB power behavior require a real Blu-ray drive and representative 3D disc. `docs/release-smoke.md` now defines the required RC inspection, cancellation/eject, reinsertion, and conversion checks.

Part of #198 and #191.
