### PR TITLE
Wire native recovery and macOS 26 preview RC support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
         run: brew install xcodegen
 
       - name: Native shell tests
-        env:
-          BD_TO_AVP_NATIVE_DEPLOYMENT_TARGET_OVERRIDE: "26.0"
         run: uv run python scripts/native_app.py test
 
       - name: Import smoke

--- a/.github/workflows/native-ui-preview.yml
+++ b/.github/workflows/native-ui-preview.yml
@@ -153,7 +153,7 @@ jobs:
           command -v xcodegen >/dev/null
           test "$(xcodegen --version)" = "Version: $XCODEGEN_VERSION"
           if [ -n "${BD_TO_AVP_NATIVE_DEPLOYMENT_TARGET_OVERRIDE:-}" ]; then
-            echo "Release builds must not override the macOS 27 deployment target." >&2
+            echo "Release builds must not override the macOS 26 deployment target." >&2
             exit 1
           fi
 
@@ -333,11 +333,55 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  compatibility:
+    name: Verify notarized package on macOS 26
+    needs:
+      - package
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout released commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Download verified preview package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: native-preview-package
+          path: release-package
+
+      - name: Run the packaged worker on macOS 26
+        env:
+          EXPECTED_DMG_NAME: ${{ needs.package.outputs.dmg_name }}
+          EXPECTED_DMG_SHA256: ${{ needs.package.outputs.dmg_sha256 }}
+        run: |
+          set -euo pipefail
+          test "$(sw_vers -productVersion | cut -d. -f1)" = "26"
+          DMG_PATH="release-package/$EXPECTED_DMG_NAME"
+          test "$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')" = "$EXPECTED_DMG_SHA256"
+          python -m scripts.native_preview_release verify-dmg \
+            --dmg "$DMG_PATH" \
+            --verify-signatures \
+            --verify-distribution \
+            --smoke-app \
+            --smoke-tools \
+            --smoke-worker
+
   publish:
     name: Publish immutable opt-in prerelease
     needs:
       - prepare
       - package
+      - compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import ffmpeg
-from babelfish import Language
+from babelfish import Error as BabelfishError, Language
 
 from bd_to_avp.modules.config import (
     Stage,
@@ -134,9 +134,9 @@ def normalize_track_language(language_code: object) -> tuple[str, str]:
     for resolver in (Language.fromietf, Language.fromalpha3b, Language.fromalpha3t, Language.fromalpha2):
         try:
             language = resolver(language_code)
-        except (AttributeError, ValueError):
+            return language.alpha3, language.name
+        except (AttributeError, BabelfishError, ValueError):
             continue
-        return language.alpha3, language.name
 
     return "und", "Unknown"
 

--- a/bd_to_avp/resources/notices/mp4box-gpac-macos-arm64.txt
+++ b/bd_to_avp/resources/notices/mp4box-gpac-macos-arm64.txt
@@ -7,13 +7,18 @@ Vendored binary source:
 - Project: GPAC / MP4Box
 - Version: 26.02.0
 - Source tag: https://github.com/gpac/gpac/tree/v26.02.0
+- Source commit: 118e60a905878e56dc4f9c5b309143c5f447c702
 - Platform: macOS arm64 static executable
-- Executable SHA256: eb63ed3f3c73eadc61f9158961114a614c208cd5929f1abb7d13da3a679cfedf
+- Minimum macOS version: 14.0
+- Deterministic install prefix: `/opt/bd-to-avp/gpac`
+- Build toolchain: Xcode 27.0 (27A5194q), Apple clang 21.0.0
+- Executable SHA256: 61ddca2713e5de02798820e9e295edc959d09a8b15a30dcacc3d9c14df627a6a
 
-The vendored build is a static MP4Box executable built from GPAC source with
-Homebrew hidden from the build environment and external codec, image, network,
-and SSL libraries disabled. The resulting executable links only to macOS system
-libraries (`/usr/lib/libz.1.dylib` and `/usr/lib/libSystem.B.dylib`).
+The vendored build is a static MP4Box executable targeting macOS 14.0, built
+from GPAC source with Homebrew hidden from the build environment and external
+codec, image, network, and SSL libraries disabled. The resulting executable
+links only to macOS system libraries (`/usr/lib/libz.1.dylib` and
+`/usr/lib/libSystem.B.dylib`).
 
 MP4Box / GPAC is distributed under LGPL-2.1-or-later. BD_to_AVP invokes MP4Box
 as a separate command-line executable. Downstream redistributors must preserve
@@ -30,6 +35,7 @@ GPAC source and license information:
 - GNU LGPL v2.1 text: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
 
 The build script is `scripts/build_mp4box_macos.py`. It reads
-`vendor/mp4box-macos-arm64.toml`, checks out the pinned GPAC tag, builds MP4Box,
-verifies arm64/system-only linkage, and installs the executable into
-`bd_to_avp/bin`.
+`vendor/mp4box-macos-arm64.toml`, verifies the pinned GPAC commit and tag from a
+clean checkout, builds MP4Box, verifies arm64/system-only linkage, and installs the executable into
+`bd_to_avp/bin`. It also verifies the pinned minimum macOS version before
+accepting the binary.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -80,8 +80,9 @@ document it as an external dependency with preflight behavior.
   version-first title and tag derived from the committed, monotonically
   increasing native build number. Version `0.3.0` build `1` uses title
   `v0.3.0 (Build 1) — Native UI Preview` and tag `native-ui-preview-1`. The lane
-  uses a dedicated macOS 27/Xcode 27 release runner and an exact two-asset
-  allowlist: the notarized DMG and `SHA256SUMS`.
+  uses a dedicated macOS 27/Xcode 27 release runner to build a macOS 26-targeted
+  app, then verifies the notarized DMG on a macOS 26 runner before publication.
+  Its exact two-asset allowlist is the notarized DMG and `SHA256SUMS`.
 - PKG artifact policy is tracked in #118. Until that issue decides otherwise,
   PKG output is not the normal-user release path.
 - Homebrew distribution for CLI users is tracked in #119.

--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -46,7 +46,7 @@ It uses ad-hoc signing by default. Set `BD_TO_AVP_NATIVE_SIGN_IDENTITY` or pass
 
 The package command always produces the side-by-side preview identity
 `com.shinycomputers.bd-to-avp.native-preview` with marketing version `0.3.0`
-and preview-local build number `1`. It cannot overwrite the production app.
+and preview-local build number `2`. It cannot overwrite the production app.
 
 The auxiliary Python launcher is signed with the same direct-distribution
 entitlements already required by the Briefcase launcher: unsigned executable
@@ -63,7 +63,8 @@ Intel Mac cannot launch a shell whose processing runtime is incompatible.
 This slice proves that the native executable and embedded Python launcher can
 coexist in one directly signed app and that the packaged worker can execute the
 real FFprobe-backed source inspection path without a repo checkout or system
-Python.
+Python. Worker decisions for a partial MakeMKV result or unusable subtitle
+output are surfaced in SwiftUI and launch fresh immutable recovery jobs.
 
 Release assembly removes the development checkout path from `Info.plist` and
 marks the bundled worker as required. A packaged app with a missing worker fails
@@ -88,37 +89,40 @@ DMG, staples and Gatekeeper-validates the result, repeats the packaged-worker
 smoke from the mounted DMG, attests the artifact, and publishes only the DMG and
 `SHA256SUMS` as a GitHub prerelease.
 
-The native shell targets macOS 27. Review and release builds use the Xcode 27 SDK
-without a compatibility deployment path for older macOS releases.
+The native shell supports Apple Silicon Macs running macOS 26 or later. Review
+and release builds may use the Xcode 27 SDK, but the committed deployment target
+and packaged `LSMinimumSystemVersion` remain macOS 26.
 
-GitHub-hosted runners do not yet provide Xcode 27. Required CI therefore pins
-the `macos-26` runner and overrides the deployment target to macOS 26 only for
-the native test invocation. This is a compile/test
-compatibility gate, not a supported deployment target: local review packages and
-all eventual release artifacts continue to build with Xcode 27 for macOS 27.
+Required CI runs the native test host on the `macos-26` runner using the same
+committed macOS 26 deployment target as release packaging. The release workflow
+also downloads the final notarized DMG onto a separate macOS 26 runner, verifies
+its signatures and minimum-version metadata, launches the Swift app through a
+bounded startup smoke, probes every bundled conversion tool, and runs the
+packaged worker before publication.
 
 The preview release job therefore requires an ephemeral Apple Silicon
 self-hosted runner labeled `bd-to-avp-release`, running macOS 27 with Xcode 27
-and XcodeGen 2.45.4 already installed. The protected-main workflow never applies the
-CI deployment-target override. The runner is release infrastructure, not a
-general pull-request runner, and should be registered only for the bounded
-dispatch then removed after the job exits.
+and XcodeGen 2.45.4 already installed. The protected-main workflow never applies
+the deployment-target override; it uses the committed macOS 26 target. The
+runner is release infrastructure, not a general pull-request runner, and should
+be registered only for the bounded dispatch then removed after the job exits.
 
 ## Release Placement
 
 The native shell does not yet replace the current `0.2.x` Briefcase/Sparkle
 release line. Native Start Processing supports inspected Blu-ray folders, ISO,
-physical disc, MKV, MTS, and M2TS sources; batch, interactive recovery, and the
-native updater path still need release-level completion before promotion through
-the normal Release Candidates appcast.
+physical disc, MKV, MTS, and M2TS sources, including the worker's MakeMKV and
+subtitle recovery choices. Batch and the native updater path still need
+release-level completion before promotion through the normal Release Candidates
+appcast.
 
 The preview uses a separate product name and bundle identifier, installs beside
-the production app, targets Apple Silicon macOS 27, and is published only as a
-GitHub prerelease. It does not mutate Sparkle Pages, either appcast channel,
-GitHub latest, or PyPI. Release identity is derived from the committed native
-version and monotonically increasing build number. Version `0.3.0` build `1`
-uses tag `native-ui-preview-1` and title
-`v0.3.0 (Build 1) — Native UI Preview`. Repeated runs may resume only a matching
+the production app, targets Apple Silicon macOS 26 or later, and is published
+only as a GitHub prerelease. It does not mutate Sparkle Pages, either appcast
+channel, GitHub latest, or PyPI. Release identity is derived from the committed native
+version and monotonically increasing build number. Version `0.3.0` build `2`
+uses tag `native-ui-preview-2` and title
+`v0.3.0 (Build 2) — Native UI Preview`. Repeated runs may resume only a matching
 draft with byte-identical assets, and fail closed after publication. Published
 tags and assets remain immutable even if the human-readable title or notes need
 a metadata-only correction.

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -4,14 +4,18 @@ or update it.
 
 ## What To Try
 
-- Launch the new SwiftUI workspace on an Apple Silicon Mac running macOS 27.
-- Choose a physical disc, ISO disc image, Blu-ray folder, MKV, source folder, or
-  MTS/M2TS transport stream.
+- Launch the new SwiftUI workspace on an Apple Silicon Mac running macOS 26 or
+  later.
+- Choose a physical disc, ISO disc image, Blu-ray folder, MKV, or MTS/M2TS
+  transport stream.
 - Inspect physical-disc, Blu-ray-folder, ISO, MKV, MTS, and M2TS source metadata
   through the bundled engine.
 - Convert an inspected physical disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source to a
   completed MV-HEVC `.mov` through the bundled engine, with native progress,
   cancellation, and results.
+- Exercise the native recovery card if MakeMKV leaves a usable intermediate MKV
+  or subtitle extraction cannot continue. Recovery creates a new one-off job
+  without changing the selected profile or visible conversion defaults.
 - Review the Video, Audio & Subtitles, and Files & Recovery controls.
 - Create, duplicate, edit, import, export, and delete named encoding profiles.
 - Open Settings with `Command-,`, resize the window, and scroll through the
@@ -22,8 +26,8 @@ or update it.
 ## Important Limits
 
 - **Start Processing supports one physical disc, Blu-ray folder, ISO, MKV, MTS,
-  or M2TS source at a time.** Keep the production app installed for source-folder
-  batches and recovery decisions that require a second interactive step.
+  or M2TS source at a time.** Source-folder batch conversion is hidden in this
+  preview and remains available only in the production app.
 - Native conversion currently creates the full movie. Short sample outputs are
   not yet available.
 - This preview has no automatic updater. Future preview builds must be
@@ -31,8 +35,10 @@ or update it.
 - Live playback of a file while it is still being generated is not supported.
   Finalized preview playback is planned separately.
 - MakeMKV remains an external dependency for physical discs, Blu-ray folders,
-  and disc images.
-- The preview supports Apple Silicon and macOS 27 only.
+  and disc images. The source workspace links to the official download page when
+  MakeMKV is missing.
+- The preview supports Apple Silicon and macOS 26 or later. macOS 25 and earlier
+  are not supported by this release candidate.
 
 Please report interface feedback in issue #202, including the source workflow,
 window size, appearance, and any controls or terminology that were unclear.

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -118,9 +118,22 @@ Supported event types are `worker.ready`, `job.started`, `stage.started`,
 `job.failed`, and `job.cancelled`.
 
 MakeMKV errors that may leave a usable intermediate MKV terminate with
-`mkv_creation_decision_required`. A retry is a new immutable job with
-`continue_on_error=true` and the requested resume stage. The worker never treats
-a partial MKV as safe without that explicit decision.
+`mkv_creation_decision_required`. The app presents only the choices supplied by
+the worker. Choosing `retry_continue_on_error` starts a new immutable job with
+`job.start_stage=2` and `job.continue_on_error=true`; choosing `cancel` starts no
+job. The worker never treats a partial MKV as safe without that explicit
+decision.
+
+Subtitle extraction failures that can continue without subtitles terminate with
+`subtitle_decision_required`. Choosing `retry_without_subtitles` starts a new
+immutable job with `job.start_stage=3` and `encoding.skip_subtitles=true`. Stage
+3 still runs so stale subtitle files are removed before left/right-eye output is
+created. Choosing `cancel` starts no job.
+
+The native app retains the exact validated draft from the failed conversion and
+applies these changes only to the retry job. Profile settings and the editable
+conversion defaults are not mutated. Unsupported decision identifiers or
+choices are not presented as retry actions.
 
 ## Cancellation And Ownership
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -90,7 +90,9 @@ The native UI feedback release lane uses
 `.github/workflows/native-ui-preview.yml`, not the production Briefcase release
 workflow. Dispatch it only from the current protected `main` commit after CI is
 green and an ephemeral Apple Silicon runner labeled `bd-to-avp-release` is ready
-with macOS 27, Xcode 27, and XcodeGen 2.45.4.
+with macOS 27, Xcode 27, and XcodeGen 2.45.4. The builder uses the committed
+macOS 26 deployment target; publication is additionally gated by verification
+and packaged-worker execution on a separate macOS 26 runner.
 
 The workflow uses the existing reviewed `macos-signing` environment to sign and
 notarize the side-by-side Preview bundle, creates and revalidates a DMG, and

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -9,7 +9,9 @@ and dependency policy.
 
 ## Test Machine
 
-- Apple Silicon macOS VM or spare Apple Silicon Mac.
+- Apple Silicon Mac or VM running macOS 26 for the minimum-version pass. A
+  second pass on the newest supported macOS is useful but does not replace the
+  macOS 26 gate.
 - Fresh user account.
 - No Homebrew install.
 - No repo checkout.
@@ -44,6 +46,11 @@ test ! -e /usr/local/Homebrew || \
   echo "Intel Homebrew is present; use a cleaner VM"
 spctl --assess --type open --verbose=4 ~/Downloads/*.dmg
 ```
+
+Before installation, confirm the app inside the DMG reports
+`LSMinimumSystemVersion` as `26.0`. Launching the native host, probing the bundled
+conversion tools, and running the packaged-worker smoke on macOS 26 are release
+gates, not best-effort compatibility checks.
 
 The DMG check uses `--type open` because it assesses the downloaded disk image.
 The app smoke uses `--type execute` because it assesses the installed app
@@ -98,6 +105,7 @@ With MakeMKV absent:
    request admin privileges.
 4. Start an ISO or Blu-ray-folder conversion far enough to trigger preflight.
 5. Confirm the message asks for MakeMKV in plain user-facing language.
+6. Confirm `Download MakeMKV…` opens the official MakeMKV download page.
 
 With MakeMKV installed:
 
@@ -126,6 +134,15 @@ candidate. A VM without an attached optical drive is not sufficient.
    cleared, then reinsert it and confirm it reappears automatically.
 6. Confirm “Remove original after success” is unavailable for the physical disc
    and that the selected output folder is outside the mounted disc volume.
+7. If MakeMKV reports that it left a potentially usable intermediate MKV,
+   confirm the app shows `Continue From Created MKV` and `Cancel` instead of a
+   generic failure. Continue only with a known usable MKV and confirm a fresh
+   job resumes at Extract MVC and Audio.
+8. If subtitle extraction reports unusable output, confirm the app shows
+   `Continue Without Subtitles` and `Cancel`. Continuing must start a fresh job
+   without changing the visible profile or Include subtitles setting.
+9. On either recovery card, confirm `Cancel` starts no worker and unlocks the
+   conversion settings.
 
 If the drive drops offline during heavy seeking, repeat once with a powered hub
 before classifying the failure as an app defect. Preserve the activity log either
@@ -134,12 +151,17 @@ way so device, permission, AACS, and media-read failures can be distinguished.
 ## Pass Criteria
 
 - No Homebrew or admin setup is required for GUI launch.
+- The notarized DMG installs, launches, probes every bundled conversion tool,
+  and completes its packaged-worker smoke on Apple Silicon macOS 26.
 - The app's bundled tools are used where expected.
 - Missing MakeMKV produces a clear recovery path.
 - Installing MakeMKV clears the MakeMKV preflight blocker.
 - A physical-disc RC passes inspection, cancellation/eject, automatic
   insertion/ejection refresh, and at least one recorded real-disc conversion
   attempt on supported hardware.
+- A recoverable MakeMKV or subtitle failure presents explicit actions and never
+  collapses into a generic dead end. The selected recovery starts a new job;
+  cancelling starts none.
 - Any remaining missing bundled tool is recorded as a release blocker or linked
   to a follow-up issue. A reinstall-app message for a tool that is not part of
   the app bundle is a blocker, because reinstalling the current app will not add

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -20,7 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    static func isStartupSmoke(arguments: [String]) -> Bool {
+    nonisolated static func isStartupSmoke(arguments: [String]) -> Bool {
         arguments.contains(startupSmokeArgument)
     }
 

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -2,12 +2,27 @@ import AppKit
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    static let startupSmokeArgument = "--startup-smoke"
+
     weak var viewModel: ConversionViewModel?
     private weak var managedWindow: NSWindow?
     private var originalWindowDelegate: NSWindowDelegate?
     private var allowManagedWindowClose = false
     private var isStoppingForWindowClose = false
     private var isStoppingForTermination = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard Self.isStartupSmoke(arguments: ProcessInfo.processInfo.arguments) else {
+            return
+        }
+        DispatchQueue.main.async {
+            NSApp.terminate(nil)
+        }
+    }
+
+    static func isStartupSmoke(arguments: [String]) -> Bool {
+        arguments.contains(startupSmokeArgument)
+    }
 
     func attach(window: NSWindow, viewModel: ConversionViewModel) {
         self.viewModel = viewModel

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -2,7 +2,7 @@ import AppKit
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    static let startupSmokeArgument = "--startup-smoke"
+    nonisolated static let startupSmokeArgument = "--startup-smoke"
 
     weak var viewModel: ConversionViewModel?
     private weak var managedWindow: NSWindow?

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -13,6 +13,7 @@ final class ConversionViewModel: ObservableObject {
     private var client: (any WorkerProcessRunning)?
     private var runTask: Task<Void, Never>?
     private var pendingTerminalEvent: WorkerEvent?
+    private var lastConversionDraft: ConversionDraft?
 
     init(clientFactory: @escaping ClientFactory = {
         WorkerProcessClient(configuration: try WorkerLaunchConfiguration.automatic())
@@ -29,17 +30,20 @@ final class ConversionViewModel: ObservableObject {
     }
 
     var canSelectSource: Bool {
-        !hasActiveWorker
+        !hasActiveWorker && state.phase != .decisionRequired
     }
 
     var canRetry: Bool {
-        !hasActiveWorker && (state.phase == .cancelled || state.failureRetryable)
+        !hasActiveWorker
+            && state.recoveryDecision == nil
+            && (state.phase == .cancelled || state.failureRetryable)
     }
 
     func selectSource(_ sourceURL: URL) {
         guard !hasActiveWorker else {
             return
         }
+        lastConversionDraft = nil
         guard let source = ConversionSource.infer(from: sourceURL) else {
             self.source = nil
             state.selectSource(sourceURL.standardizedFileURL)
@@ -56,6 +60,7 @@ final class ConversionViewModel: ObservableObject {
         guard !hasActiveWorker else {
             return
         }
+        lastConversionDraft = nil
         self.source = source
         state.clear()
         diagnosticLog = ""
@@ -144,6 +149,7 @@ final class ConversionViewModel: ObservableObject {
         let job = WorkerJobSpec(draft: draft)
         do {
             try state.begin(jobID: job.jobID, operationKind: .conversion)
+            lastConversionDraft = draft
             pendingTerminalEvent = nil
             diagnosticLog = ""
             let client = try clientFactory()
@@ -187,11 +193,38 @@ final class ConversionViewModel: ObservableObject {
         diagnosticLog = ""
     }
 
+    @discardableResult
+    func resolveRecoveryChoice(_ choice: WorkerRecoveryChoice) -> Bool {
+        guard !hasActiveWorker,
+              let decision = state.recoveryDecision,
+              decision.supportedChoices.contains(choice)
+        else {
+            return false
+        }
+        if choice == .cancel {
+            state.cancelRecoveryDecision()
+            return true
+        }
+        guard let lastConversionDraft,
+              let retryDraft = lastConversionDraft.retrying(decision: decision, choice: choice)
+        else {
+            state.failTransport(
+                message: "This recovery option is not available for the current conversion.",
+                retryable: false
+            )
+            return false
+        }
+        state.prepareForRetry()
+        startConversion(draft: retryDraft)
+        return state.phase.isRunning
+    }
+
     func clearSource() {
         guard !hasActiveWorker else {
             return
         }
         source = nil
+        lastConversionDraft = nil
         state.clear()
         diagnosticLog = ""
     }

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -145,6 +145,7 @@ struct ConversionSource: Equatable {
 
 enum DiscSourceDetector {
     private static let makeMKVPath = "/Applications/MakeMKV.app/Contents/MacOS/makemkvcon"
+    static let makeMKVDownloadURL = URL(string: "https://www.makemkv.com/download/")
 
     static var makeMKVAvailable: Bool {
         FileManager.default.isExecutableFile(atPath: makeMKVPath)

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -149,6 +149,37 @@ struct ConversionDraft: Equatable {
         destinationURL.appendingPathComponent("\(outputStem)_AVP.mov")
     }
 
+    func retrying(
+        decision: WorkerDecision,
+        choice: WorkerRecoveryChoice
+    ) -> ConversionDraft? {
+        guard decision.choices.contains(choice.rawValue) else {
+            return nil
+        }
+
+        var retryOptions = options
+        switch (decision.identifier, choice) {
+        case ("mkv_creation_decision_required", .retryContinueOnError):
+            retryOptions.job.startStage = .extractMVCAndAudio
+            retryOptions.job.continueOnError = true
+        case ("subtitle_decision_required", .retryWithoutSubtitles):
+            retryOptions.job.startStage = .extractSubtitles
+            retryOptions.encoding.includeSubtitles = false
+        default:
+            return nil
+        }
+
+        return ConversionDraft(
+            source: source,
+            sourceDetails: sourceDetails,
+            profile: profile,
+            destinationURL: destinationURL,
+            outputLength: outputLength,
+            samplePosition: samplePosition,
+            options: retryOptions
+        )
+    }
+
     private var outputStem: String {
         let inspectedName = sourceDetails?.name.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !inspectedName.isEmpty {

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -65,6 +65,54 @@ struct WorkerDecision: Decodable, Equatable {
     }
 }
 
+enum WorkerRecoveryChoice: String, Identifiable, Equatable {
+    case retryContinueOnError = "retry_continue_on_error"
+    case retryWithoutSubtitles = "retry_without_subtitles"
+    case cancel
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .retryContinueOnError:
+            "Continue From Created MKV"
+        case .retryWithoutSubtitles:
+            "Continue Without Subtitles"
+        case .cancel:
+            "Cancel"
+        }
+    }
+
+    var accessibilityHint: String {
+        switch self {
+        case .retryContinueOnError:
+            "Uses the intermediate MKV and resumes at MVC and audio extraction."
+        case .retryWithoutSubtitles:
+            "Skips subtitle extraction and resumes the remaining conversion stages."
+        case .cancel:
+            "Leaves the conversion stopped without starting another job."
+        }
+    }
+}
+
+extension WorkerDecision {
+    var supportedChoices: [WorkerRecoveryChoice] {
+        choices.compactMap { rawChoice in
+            guard let choice = WorkerRecoveryChoice(rawValue: rawChoice) else {
+                return nil
+            }
+            switch (identifier, choice) {
+            case ("mkv_creation_decision_required", .retryContinueOnError),
+                 ("subtitle_decision_required", .retryWithoutSubtitles),
+                 (_, .cancel):
+                return choice
+            default:
+                return nil
+            }
+        }
+    }
+}
+
 struct WorkerEventPayload: Decodable, Equatable {
     let workerVersion: String?
     let processGroupID: Int32?

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -6,6 +6,7 @@ enum WorkerPhase: String, Equatable {
     case inspecting
     case processing
     case stopping
+    case decisionRequired
     case completed
     case cancelled
     case failed
@@ -15,7 +16,7 @@ enum WorkerPhase: String, Equatable {
     }
 
     var isTerminal: Bool {
-        self == .completed || self == .cancelled || self == .failed
+        self == .decisionRequired || self == .completed || self == .cancelled || self == .failed
     }
 }
 
@@ -64,7 +65,9 @@ struct WorkerLifecycleState: Equatable {
     private(set) var conversionResult: ConversionResult?
     private(set) var failureMessage: String?
     private(set) var failureDetails: String?
+    private(set) var failureCode: String?
     private(set) var failureRetryable = false
+    private(set) var recoveryDecision: WorkerDecision?
 
     mutating func selectSource(_ sourceURL: URL) {
         self.sourceURL = sourceURL
@@ -152,16 +155,22 @@ struct WorkerLifecycleState: Equatable {
             }
             failureMessage = failure.message
             failureDetails = failure.details
+            failureCode = failure.code
             failureRetryable = failure.retryable
             phase = .failed
         case .jobCancelled:
             activityMessage = event.payload.message ?? (operationKind == .inspection ? "Analysis stopped." : "Conversion stopped.")
             phase = .cancelled
         case .jobDecisionRequired:
-            failureMessage = event.payload.decision?.prompt ?? event.payload.message ?? "This source needs a choice before it can continue."
-            failureDetails = event.payload.decision?.details ?? "Adjust the conversion settings and try again."
+            guard let decision = event.payload.decision else {
+                throw WorkerLifecycleError.missingPayload(event: event.type)
+            }
+            recoveryDecision = decision
+            failureMessage = decision.prompt
+            failureDetails = decision.details ?? "Choose how this conversion should continue."
+            failureCode = decision.identifier
             failureRetryable = true
-            phase = .failed
+            phase = .decisionRequired
         }
     }
 
@@ -176,7 +185,9 @@ struct WorkerLifecycleState: Equatable {
     mutating func failTransport(message: String, details: String? = nil, retryable: Bool = true) {
         failureMessage = message
         failureDetails = details
+        failureCode = nil
         failureRetryable = retryable
+        recoveryDecision = nil
         phase = .failed
     }
 
@@ -190,8 +201,19 @@ struct WorkerLifecycleState: Equatable {
             phase = .empty
             return
         }
+        let inspectionResult = operationKind == .conversion ? result : nil
         phase = .ready
         resetJobState()
+        result = inspectionResult
+    }
+
+    mutating func cancelRecoveryDecision() {
+        guard phase == .decisionRequired else {
+            return
+        }
+        recoveryDecision = nil
+        failureRetryable = false
+        phase = .failed
     }
 
     mutating func clear() {
@@ -209,6 +231,8 @@ struct WorkerLifecycleState: Equatable {
         conversionResult = nil
         failureMessage = nil
         failureDetails = nil
+        failureCode = nil
         failureRetryable = false
+        recoveryDecision = nil
     }
 }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -64,11 +64,13 @@ struct ContentView: View {
                     openDiscImage: { chooseFile(.discImage) },
                     openBluRayFolder: { chooseFolder(.bluRayFolder) },
                     openMKV: { chooseFile(.matroska) },
-                    openSourceFolder: { chooseFolder(.sourceFolder) },
                     importTransportStream: { chooseFile(.transportStream) },
                     changeSource: chooseExistingSource,
                     chooseDestination: chooseDestination,
-                    retryAnalysis: viewModel.restartInspection
+                    retryAnalysis: viewModel.restartInspection,
+                    resolveRecoveryChoice: { choice in
+                        _ = viewModel.resolveRecoveryChoice(choice)
+                    }
                 )
                 .frame(minWidth: 350, idealWidth: 390, maxWidth: 450)
 
@@ -79,7 +81,7 @@ struct ContentView: View {
                     profiles: profileStore.profiles,
                     selectedProfile: selectedProfile,
                     profileModified: profileModified,
-                    isLocked: viewModel.hasActiveWorker,
+                    isLocked: viewModel.hasActiveWorker || viewModel.state.phase == .decisionRequired,
                     sourceKind: viewModel.source?.kind,
                     saveSelectedProfile: saveSelectedProfile,
                     saveAsNewProfile: beginSaveAsNewProfile,
@@ -239,7 +241,6 @@ struct ContentView: View {
             Button("Open Disc Image…") { chooseFile(.discImage) }
             Button("Open Blu-ray Folder…") { chooseFolder(.bluRayFolder) }
             Button("Open 3D MKV…") { chooseFile(.matroska) }
-            Button("Open Source Folder…") { chooseFolder(.sourceFolder) }
 
             Divider()
             Button("Import MTS or M2TS…") { chooseFile(.transportStream) }
@@ -253,7 +254,7 @@ struct ContentView: View {
         } label: {
             Label(viewModel.source == nil ? "Choose Source" : "Change Source", systemImage: "opticaldiscdrive")
         }
-        .help("Choose a physical disc, disc image, Blu-ray folder, MKV, source folder, or transport stream")
+        .help("Choose a physical disc, disc image, Blu-ray folder, MKV, or transport stream")
         .disabled(!viewModel.canSelectSource)
     }
 
@@ -350,6 +351,9 @@ struct ContentView: View {
             return viewModel.state.stageMessage
                 ?? (viewModel.state.operationKind == .inspection ? "Reading source details" : "Converting video")
         }
+        if viewModel.state.phase == .decisionRequired {
+            return "Choose how to continue"
+        }
         if viewModel.state.phase == .failed {
             return "Source needs attention"
         }
@@ -366,7 +370,7 @@ struct ContentView: View {
             return "Disc workflow ready"
         }
         if source.kind == .sourceFolder {
-            return "Source folder ready for batch processing"
+            return "Batch folder conversion is not available"
         }
         return "Conversion settings ready"
     }
@@ -392,6 +396,9 @@ struct ContentView: View {
         if viewModel.hasActiveWorker {
             return .blue
         }
+        if viewModel.state.phase == .decisionRequired {
+            return .orange
+        }
         if viewModel.state.phase == .failed {
             return .red
         }
@@ -402,11 +409,15 @@ struct ContentView: View {
         capabilities.conversionAvailable
             && viewModel.source?.kind.supportsConversion == true
             && viewModel.state.result != nil
+            && viewModel.state.phase != .decisionRequired
     }
 
     private var conversionUnavailableReason: String {
         guard capabilities.conversionAvailable else {
             return capabilities.conversionUnavailableReason
+        }
+        if viewModel.state.phase == .decisionRequired {
+            return "Choose a recovery option before starting another conversion."
         }
         switch viewModel.source?.kind {
         case .sourceFolder:
@@ -497,10 +508,14 @@ struct ContentView: View {
     }
 
     private func chooseExistingSource() {
-        guard viewModel.canSelectSource, let sourceURL = SourcePicker.chooseExistingSource() else {
+        guard viewModel.canSelectSource,
+              let sourceURL = SourcePicker.chooseExistingSource(),
+              let source = ConversionSource.infer(from: sourceURL),
+              source.kind.supportsMetadataInspection
+        else {
             return
         }
-        viewModel.selectSource(sourceURL)
+        selectSource(source)
     }
 
     private func chooseFile(_ kind: ConversionSourceKind) {
@@ -524,7 +539,11 @@ struct ContentView: View {
     }
 
     private func acceptDrop(_ urls: [URL], _ location: CGPoint) -> Bool {
-        guard viewModel.canSelectSource, let url = urls.first, let source = ConversionSource.infer(from: url) else {
+        guard viewModel.canSelectSource,
+              let url = urls.first,
+              let source = ConversionSource.infer(from: url),
+              source.kind.supportsMetadataInspection
+        else {
             return false
         }
         selectSource(source)

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -18,11 +18,11 @@ struct SourceWorkspaceView: View {
     let openDiscImage: () -> Void
     let openBluRayFolder: () -> Void
     let openMKV: () -> Void
-    let openSourceFolder: () -> Void
     let importTransportStream: () -> Void
     let changeSource: () -> Void
     let chooseDestination: () -> Void
     let retryAnalysis: () -> Void
+    let resolveRecoveryChoice: (WorkerRecoveryChoice) -> Void
 
     var body: some View {
         ScrollView {
@@ -72,6 +72,9 @@ struct SourceWorkspaceView: View {
                     .font(.callout)
                     .foregroundStyle(makeMKVAvailable ? Color.green : Color.orange)
                     Spacer()
+                    if !makeMKVAvailable, let downloadURL = DiscSourceDetector.makeMKVDownloadURL {
+                        Link("Download MakeMKV…", destination: downloadURL)
+                    }
                     Button("Refresh Drives", action: refreshDiscs)
                 }
 
@@ -111,15 +114,12 @@ struct SourceWorkspaceView: View {
                 Text("Other Sources")
                     .font(.headline)
 
-                Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 8) {
-                    GridRow {
+                VStack(spacing: 8) {
+                    HStack(spacing: 8) {
                         sourceButton("Open Disc Image…", systemImage: "opticaldiscdrive", action: openDiscImage)
                         sourceButton("Open Blu-ray Folder…", systemImage: "folder.badge.gearshape", action: openBluRayFolder)
                     }
-                    GridRow {
-                        sourceButton("Open 3D MKV…", systemImage: "film.stack", action: openMKV)
-                        sourceButton("Open Source Folder…", systemImage: "folder.stack", action: openSourceFolder)
-                    }
+                    sourceButton("Open 3D MKV…", systemImage: "film.stack", action: openMKV)
                 }
 
                 Button("Import MTS or M2TS transport stream…", action: importTransportStream)
@@ -165,6 +165,7 @@ struct SourceWorkspaceView: View {
 
                     Spacer()
                     Button("Change…", action: changeSource)
+                        .disabled(state.phase.isRunning || state.phase == .decisionRequired)
                 }
 
                 if source.kind.isSecondaryImport {
@@ -192,6 +193,9 @@ struct SourceWorkspaceView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
+                } else if state.phase == .decisionRequired, let decision = state.recoveryDecision {
+                    Divider()
+                    recoveryDecisionSection(decision)
                 } else if state.phase == .failed {
                     Divider()
                     Label(
@@ -210,6 +214,11 @@ struct SourceWorkspaceView: View {
                     }
                     if state.operationKind == .inspection, state.failureRetryable {
                         Button("Analyze Again", action: retryAnalysis)
+                    }
+                    if state.failureCode == "makemkv_missing",
+                       let downloadURL = DiscSourceDetector.makeMKVDownloadURL
+                    {
+                        Link("Download MakeMKV…", destination: downloadURL)
                     }
                 } else if let result = state.result {
                     Divider()
@@ -266,6 +275,7 @@ struct SourceWorkspaceView: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Button("Choose…", action: chooseDestination)
+                            .disabled(outputControlsLocked)
                     }
                 }
 
@@ -278,6 +288,7 @@ struct SourceWorkspaceView: View {
                         }
                         .labelsHidden()
                         .frame(width: 170)
+                        .disabled(outputControlsLocked)
                     } else {
                         Text("Full Movie")
                             .foregroundStyle(.secondary)
@@ -293,6 +304,7 @@ struct SourceWorkspaceView: View {
                         }
                         .labelsHidden()
                         .frame(width: 130)
+                        .disabled(outputControlsLocked)
                     }
                 }
 
@@ -386,6 +398,47 @@ struct SourceWorkspaceView: View {
         return options.encoding.keepExtraLanguages
             ? "\(options.encoding.language.name) preferred; keep others"
             : "\(options.encoding.language.name) only"
+    }
+
+    private var outputControlsLocked: Bool {
+        state.phase.isRunning || state.phase == .decisionRequired
+    }
+
+    private func recoveryDecisionSection(_ decision: WorkerDecision) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(decision.prompt, systemImage: "arrow.clockwise.circle.fill")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.orange)
+            if let details = decision.details, !details.isEmpty {
+                Text(details)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            HStack(spacing: 8) {
+                ForEach(decision.supportedChoices) { choice in
+                    recoveryButton(choice)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func recoveryButton(_ choice: WorkerRecoveryChoice) -> some View {
+        switch choice {
+        case .cancel:
+            Button(choice.title, role: .cancel) {
+                resolveRecoveryChoice(choice)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityHint(choice.accessibilityHint)
+        case .retryContinueOnError, .retryWithoutSubtitles:
+            Button(choice.title) {
+                resolveRecoveryChoice(choice)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityHint(choice.accessibilityHint)
+        }
     }
 
     private func sourceButton(_ title: String, systemImage: String, action: @escaping () -> Void) -> some View {

--- a/macos/BluRayToVisionProTests/AppDelegateTests.swift
+++ b/macos/BluRayToVisionProTests/AppDelegateTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+final class AppDelegateTests: XCTestCase {
+    func testStartupSmokeArgumentIsExplicit() {
+        XCTAssertTrue(AppDelegate.isStartupSmoke(arguments: ["app", AppDelegate.startupSmokeArgument]))
+        XCTAssertFalse(AppDelegate.isStartupSmoke(arguments: ["app"]))
+    }
+}

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -320,6 +320,171 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testMakeMKVDecisionStartsFreshStageTwoRecoveryJob() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let firstConversion = expectation(description: "first conversion received")
+        let recoveryConversion = expectation(description: "recovery conversion received")
+        var conversionJobs: [WorkerJobSpec] = []
+        let decision = WorkerDecision(
+            identifier: "mkv_creation_decision_required",
+            prompt: "MakeMKV reported errors.",
+            choices: ["retry_continue_on_error", "cancel"],
+            details: "Continue only if the created MKV is usable."
+        )
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { job in
+                conversionJobs.append(job)
+                if conversionJobs.count == 1 {
+                    firstConversion.fulfill()
+                } else {
+                    recoveryConversion.fulfill()
+                }
+            },
+            recoveryDecision: decision
+        )
+        let viewModel = ConversionViewModel { worker }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+            let draft = ConversionDraft(
+                source: try XCTUnwrap(viewModel.source),
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+
+            viewModel.startConversion(draft: draft)
+            await fulfillment(of: [firstConversion], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertEqual(viewModel.state.phase, .decisionRequired)
+            XCTAssertEqual(viewModel.state.recoveryDecision, decision)
+            XCTAssertTrue(viewModel.resolveRecoveryChoice(.retryContinueOnError))
+            await fulfillment(of: [recoveryConversion], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertEqual(conversionJobs.count, 2)
+            XCTAssertNotEqual(conversionJobs[0].jobID, conversionJobs[1].jobID)
+            XCTAssertEqual(conversionJobs[1].job?.startStage, ConversionStage.extractMVCAndAudio.rawValue)
+            XCTAssertTrue(conversionJobs[1].job?.continueOnError == true)
+            XCTAssertFalse(conversionJobs[1].job?.keepFiles == true)
+            XCTAssertEqual(draft.options.job.startStage, .createMKV)
+            XCTAssertFalse(draft.options.job.continueOnError)
+            XCTAssertEqual(viewModel.state.phase, .completed)
+        }
+    }
+
+    @MainActor
+    func testSubtitleDecisionStartsFreshStageThreeRecoveryWithoutSubtitles() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let firstConversion = expectation(description: "first conversion received")
+        let recoveryConversion = expectation(description: "recovery conversion received")
+        var conversionJobs: [WorkerJobSpec] = []
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["retry_without_subtitles", "cancel"],
+            details: "Continue without subtitles."
+        )
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { job in
+                conversionJobs.append(job)
+                if conversionJobs.count == 1 {
+                    firstConversion.fulfill()
+                } else {
+                    recoveryConversion.fulfill()
+                }
+            },
+            recoveryDecision: decision
+        )
+        let viewModel = ConversionViewModel { worker }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+            let draft = ConversionDraft(
+                source: try XCTUnwrap(viewModel.source),
+                sourceDetails: viewModel.state.result,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                outputLength: .fullMovie,
+                samplePosition: .beginning,
+                options: ConversionOptions()
+            )
+
+            viewModel.startConversion(draft: draft)
+            await fulfillment(of: [firstConversion], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertTrue(viewModel.resolveRecoveryChoice(.retryWithoutSubtitles))
+            await fulfillment(of: [recoveryConversion], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertEqual(conversionJobs[1].job?.startStage, ConversionStage.extractSubtitles.rawValue)
+            XCTAssertTrue(conversionJobs[1].encoding?.skipSubtitles == true)
+            XCTAssertTrue(draft.options.encoding.includeSubtitles)
+            XCTAssertEqual(viewModel.state.phase, .completed)
+        }
+    }
+
+    @MainActor
+    func testCancellingRecoveryStartsNoAdditionalWorker() async throws {
+        let inspectionDone = expectation(description: "inspection done")
+        let conversionStarted = expectation(description: "conversion received")
+        var conversionCount = 0
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["retry_without_subtitles", "cancel"],
+            details: nil
+        )
+        let worker = TwoPhaseWorkerClient(
+            onInspectionComplete: { inspectionDone.fulfill() },
+            onConversionJobReceived: { _ in
+                conversionCount += 1
+                conversionStarted.fulfill()
+            },
+            recoveryDecision: decision
+        )
+        let viewModel = ConversionViewModel { worker }
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [inspectionDone], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+            viewModel.startConversion(
+                draft: ConversionDraft(
+                    source: try XCTUnwrap(viewModel.source),
+                    sourceDetails: viewModel.state.result,
+                    profile: BuiltInProfile.balanced.profile,
+                    destinationURL: URL(fileURLWithPath: "/Movies"),
+                    outputLength: .fullMovie,
+                    samplePosition: .beginning,
+                    options: ConversionOptions()
+                )
+            )
+            await fulfillment(of: [conversionStarted], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertFalse(viewModel.canSelectSource)
+            XCTAssertTrue(viewModel.resolveRecoveryChoice(.cancel))
+
+            XCTAssertEqual(conversionCount, 1)
+            XCTAssertEqual(viewModel.state.phase, .failed)
+            XCTAssertNil(viewModel.state.recoveryDecision)
+            XCTAssertTrue(viewModel.canSelectSource)
+        }
+    }
+
+    @MainActor
     func testStartConversionStartsWorkerWithConvertSourceJobSpec() async throws {
         let inspectionDone = expectation(description: "inspection done")
         let conversionStarted = expectation(description: "conversion started")
@@ -475,6 +640,7 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
     private var callCount = 0
     private var conversionCancellationContinuation: CheckedContinuation<Void, Never>?
     private var conversionCancellationRequested = false
+    private var pendingRecoveryDecision: WorkerDecision?
 
     var onInspectionComplete: (() -> Void)?
     var onConversionJobReceived: ((WorkerJobSpec) -> Void)?
@@ -483,18 +649,25 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
     init(
         onInspectionComplete: (() -> Void)? = nil,
         onConversionJobReceived: ((WorkerJobSpec) -> Void)? = nil,
-        waitsForConversionCancellation: Bool = false
+        waitsForConversionCancellation: Bool = false,
+        recoveryDecision: WorkerDecision? = nil
     ) {
         self.onInspectionComplete = onInspectionComplete
         self.onConversionJobReceived = onConversionJobReceived
         self.waitsForConversionCancellation = waitsForConversionCancellation
+        pendingRecoveryDecision = recoveryDecision
     }
 
     func run(job: WorkerJobSpec, onEvent: @escaping (WorkerEvent) async throws -> Void) async throws -> WorkerRunResult {
         let isConversion: Bool
+        let recoveryDecision: WorkerDecision?
         lock.lock()
         callCount += 1
         isConversion = callCount > 1
+        recoveryDecision = isConversion ? pendingRecoveryDecision : nil
+        if isConversion {
+            pendingRecoveryDecision = nil
+        }
         lock.unlock()
 
         let ready = WorkerEvent(
@@ -508,6 +681,17 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
         if isConversion {
             onConversionJobReceived?(job)
             try await onEvent(ready)
+            if let recoveryDecision {
+                let decisionRequired = WorkerEvent(
+                    protocolVersion: WorkerJobSpec.protocolVersion,
+                    type: .jobDecisionRequired,
+                    jobID: job.jobID,
+                    sequence: 1,
+                    payload: WorkerEventPayload(decision: recoveryDecision)
+                )
+                try await onEvent(decisionRequired)
+                return WorkerRunResult(terminalEvent: decisionRequired, exitStatus: 3, diagnostics: "")
+            }
             if waitsForConversionCancellation {
                 await waitForConversionCancellation()
                 let cancelled = WorkerEvent(

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -261,6 +261,69 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertTrue(spec.job?.softwareEncoder == true)
     }
 
+    func testMakeMKVRecoveryBuildsFreshStageTwoDraft() throws {
+        let draft = makeDraft(kind: .discImage, extension: "iso")
+        let decision = WorkerDecision(
+            identifier: "mkv_creation_decision_required",
+            prompt: "MakeMKV reported errors.",
+            choices: ["retry_continue_on_error", "cancel"],
+            details: nil
+        )
+
+        let retry = try XCTUnwrap(
+            draft.retrying(decision: decision, choice: .retryContinueOnError)
+        )
+
+        XCTAssertEqual(draft.options.job.startStage, .createMKV)
+        XCTAssertFalse(draft.options.job.continueOnError)
+        XCTAssertEqual(retry.options.job.startStage, .extractMVCAndAudio)
+        XCTAssertTrue(retry.options.job.continueOnError)
+        XCTAssertEqual(retry.source, draft.source)
+        XCTAssertEqual(retry.destinationURL, draft.destinationURL)
+    }
+
+    func testSubtitleRecoveryBuildsFreshStageThreeDraftWithoutSubtitles() throws {
+        let draft = makeDraft(kind: .discImage, extension: "iso")
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["retry_without_subtitles", "cancel"],
+            details: nil
+        )
+
+        let retry = try XCTUnwrap(
+            draft.retrying(decision: decision, choice: .retryWithoutSubtitles)
+        )
+
+        XCTAssertTrue(draft.options.encoding.includeSubtitles)
+        XCTAssertEqual(retry.options.job.startStage, .extractSubtitles)
+        XCTAssertFalse(retry.options.encoding.includeSubtitles)
+        XCTAssertFalse(retry.options.job.continueOnError)
+    }
+
+    func testRecoveryDraftRejectsChoiceNotOfferedByDecision() {
+        let draft = makeDraft(kind: .discImage, extension: "iso")
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["cancel"],
+            details: nil
+        )
+
+        XCTAssertNil(draft.retrying(decision: decision, choice: .retryWithoutSubtitles))
+    }
+
+    func testDecisionOnlyExposesRecoveryChoicesForMatchingIdentifier() {
+        let decision = WorkerDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Subtitle extraction needs attention.",
+            choices: ["retry_continue_on_error", "retry_without_subtitles", "cancel", "future_choice"],
+            details: nil
+        )
+
+        XCTAssertEqual(decision.supportedChoices, [.retryWithoutSubtitles, .cancel])
+    }
+
     func testInspectionJobSpecOmitsConversionSettings() throws {
         let spec = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/src/m.mkv"))
         XCTAssertEqual(spec.operation, "inspect_source")

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -64,6 +64,7 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(state.phase, .failed)
         XCTAssertEqual(state.failureMessage, "Could not inspect source.")
         XCTAssertEqual(state.failureDetails, "bad stream")
+        XCTAssertEqual(state.failureCode, "probe_failed")
         XCTAssertFalse(state.failureRetryable)
     }
 
@@ -191,10 +192,43 @@ final class WorkerLifecycleTests: XCTestCase {
 
         try state.receive(event(.jobDecisionRequired, sequence: 0, payload: .init(decision: decision)))
 
-        XCTAssertEqual(state.phase, .failed)
+        XCTAssertEqual(state.phase, .decisionRequired)
         XCTAssertEqual(state.failureMessage, "Subtitle extraction needs attention.")
         XCTAssertEqual(state.failureDetails, "Disable subtitle extraction to retry.")
+        XCTAssertEqual(state.failureCode, "subtitle_decision_required")
         XCTAssertTrue(state.failureRetryable)
+        XCTAssertEqual(state.recoveryDecision, decision)
+        XCTAssertTrue(state.phase.isTerminal)
+    }
+
+    func testCancellingRecoveryLeavesActionableFailureWithoutDecision() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        let decision = WorkerDecision(
+            identifier: "mkv_creation_decision_required",
+            prompt: "MakeMKV needs attention.",
+            choices: ["retry_continue_on_error", "cancel"],
+            details: "Continue only when the MKV is usable."
+        )
+        try state.receive(event(.jobDecisionRequired, sequence: 0, payload: .init(decision: decision)))
+
+        state.cancelRecoveryDecision()
+
+        XCTAssertEqual(state.phase, .failed)
+        XCTAssertNil(state.recoveryDecision)
+        XCTAssertFalse(state.failureRetryable)
+        XCTAssertEqual(state.failureMessage, "MakeMKV needs attention.")
+    }
+
+    func testDecisionEventRequiresDecisionPayload() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        XCTAssertThrowsError(try state.receive(event(.jobDecisionRequired, sequence: 0))) { error in
+            XCTAssertEqual(error as? WorkerLifecycleError, .missingPayload(event: .jobDecisionRequired))
+        }
     }
 
     func testDecodesAndAppliesSharedPythonConversionCompletionFixture() throws {

--- a/macos/README.md
+++ b/macos/README.md
@@ -28,5 +28,6 @@ runtime and conversion engine with:
 uv run python scripts/native_app.py package
 ```
 
-The native application targets macOS 27 and uses the current platform controls,
-materials, and accessibility behavior as its native-shell baseline.
+The native application targets Apple Silicon macOS 26 or later while remaining
+buildable with the Xcode 27 SDK. Packaged release validation rejects a native
+binary, embedded engine, or bundled Mach-O that requires a newer system.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -4,7 +4,7 @@ options:
   createIntermediateGroups: true
   defaultConfig: Debug
   deploymentTarget:
-    macOS: "27.0"
+    macOS: "26.0"
 
 configs:
   Debug: debug
@@ -14,7 +14,7 @@ configs:
 settings:
   base:
     CLANG_ENABLE_MODULES: YES
-    MACOSX_DEPLOYMENT_TARGET: "27.0"
+    MACOSX_DEPLOYMENT_TARGET: "26.0"
     SWIFT_VERSION: "5.0"
 
 targets:
@@ -28,7 +28,7 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
+        CURRENT_PROJECT_VERSION: 2
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO

--- a/scripts/build_mp4box_macos.py
+++ b/scripts/build_mp4box_macos.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -42,10 +43,13 @@ class BuildManifest:
     version: str
     repo_url: str
     tag: str
+    source_commit: str
     license_mode: str
     binary: str
     binary_sha256: str
     build: str
+    install_prefix: str
+    minimum_macos: str
     configure_flags: list[str]
     validation: ValidationConfig
 
@@ -60,10 +64,13 @@ def load_manifest(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> BuildManifest:
         version=require_string(data, "version"),
         repo_url=require_string(data, "repo_url"),
         tag=require_string(data, "tag"),
+        source_commit=require_string(data, "source_commit"),
         license_mode=require_string(data, "license_mode"),
         binary=require_string(data, "binary"),
         binary_sha256=require_string(data, "binary_sha256"),
         build=require_string(data, "build"),
+        install_prefix=require_string(data, "install_prefix"),
+        minimum_macos=require_string(data, "minimum_macos"),
         configure_flags=require_string_list(data, "configure_flags"),
         validation=ValidationConfig(
             required_file_substring=require_string(validation, "required_file_substring"),
@@ -101,12 +108,14 @@ def run(command: list[str | Path], *, cwd: Path | None = None, env: dict[str, st
     return completed.stdout
 
 
-def build_env() -> dict[str, str]:
+def build_env(minimum_macos: str | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
     env["CC"] = "/usr/bin/clang"
     env["CXX"] = "/usr/bin/clang++"
     env["PKG_CONFIG"] = "/usr/bin/false"
+    if minimum_macos is not None:
+        env["MACOSX_DEPLOYMENT_TARGET"] = minimum_macos
     return env
 
 
@@ -124,21 +133,31 @@ def clone_or_update_source(source_dir: Path, manifest: BuildManifest, *, refresh
         shutil.rmtree(source_dir)
     if not source_dir.exists():
         run(["git", "clone", "--depth", "1", "--branch", manifest.tag, manifest.repo_url, source_dir])
-        return
 
+    origin_url = run(["git", "remote", "get-url", "origin"], cwd=source_dir).strip()
+    if origin_url != manifest.repo_url:
+        raise BuildFailure(f"MP4Box source origin mismatch: expected {manifest.repo_url}, found {origin_url}")
+    if run(["git", "status", "--porcelain"], cwd=source_dir).strip():
+        raise BuildFailure("MP4Box source checkout is dirty; rerun with --refresh.")
     try:
-        run(["git", "rev-parse", "--verify", f"{manifest.tag}^{{commit}}"], cwd=source_dir)
+        run(["git", "rev-parse", "--verify", f"{manifest.source_commit}^{{commit}}"], cwd=source_dir)
     except subprocess.CalledProcessError:
         run(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], cwd=source_dir)
-    run(["git", "checkout", manifest.tag], cwd=source_dir)
+    tag_commit = run(["git", "rev-parse", f"{manifest.tag}^{{commit}}"], cwd=source_dir).strip()
+    if tag_commit != manifest.source_commit:
+        raise BuildFailure(f"MP4Box tag {manifest.tag} resolves to {tag_commit}, expected {manifest.source_commit}.")
+    run(["git", "checkout", "--detach", manifest.source_commit], cwd=source_dir)
+    head_commit = run(["git", "rev-parse", "HEAD"], cwd=source_dir).strip()
+    if head_commit != manifest.source_commit:
+        raise BuildFailure(f"MP4Box source checkout is at {head_commit}, expected {manifest.source_commit}.")
 
 
-def build_mp4box(source_dir: Path, install_dir: Path, manifest: BuildManifest) -> Path:
-    env = build_env()
+def build_mp4box(source_dir: Path, manifest: BuildManifest) -> Path:
+    env = build_env(manifest.minimum_macos)
     if (source_dir / "Makefile").exists():
         run(["make", "distclean"], cwd=source_dir, env=env)
     run(
-        ["./configure", f"--prefix={install_dir}", *manifest.configure_flags],
+        ["./configure", f"--prefix={manifest.install_prefix}", *manifest.configure_flags],
         cwd=source_dir,
         env=env,
     )
@@ -151,7 +170,8 @@ def build_mp4box(source_dir: Path, install_dir: Path, manifest: BuildManifest) -
     return mp4box_path
 
 
-def verify_macos_binary(binary_path: Path, validation: ValidationConfig) -> None:
+def verify_macos_binary(binary_path: Path, manifest: BuildManifest) -> None:
+    validation = manifest.validation
     file_output = run(["file", binary_path])
     if validation.required_file_substring not in file_output:
         raise BuildFailure(f"MP4Box is not an arm64 Mach-O executable:\n{file_output}")
@@ -166,9 +186,17 @@ def verify_macos_binary(binary_path: Path, validation: ValidationConfig) -> None
     if unexpected_links:
         raise BuildFailure("MP4Box links to unexpected libraries:\n" + "\n".join(unexpected_links))
 
+    build_version = run(["vtool", "-show-build", binary_path])
+    if re.search(rf"^\s*minos\s+{re.escape(manifest.minimum_macos)}\s*$", build_version, re.MULTILINE) is None:
+        raise BuildFailure(f"MP4Box minimum macOS version is not {manifest.minimum_macos}:\n{build_version}")
+
     version_output = run([binary_path, "-version"], env=build_env())
     if validation.required_version_substring not in version_output:
         raise BuildFailure(f"MP4Box version probe did not look valid:\n{version_output}")
+    if f"--prefix={manifest.install_prefix}" not in version_output:
+        raise BuildFailure(f"MP4Box does not report the deterministic install prefix:\n{version_output}")
+    if str(REPO_ROOT) in version_output:
+        raise BuildFailure(f"MP4Box embeds the development checkout path:\n{version_output}")
 
 
 def verify_binary_checksum(binary_path: Path, expected_sha256: str) -> None:
@@ -194,13 +222,12 @@ def main() -> int:
     args = parser.parse_args()
 
     source_dir = args.build_root / "gpac-src"
-    install_dir = args.build_root / "install"
     try:
         verify_build_host()
         manifest = load_manifest(args.manifest)
         clone_or_update_source(source_dir, manifest, refresh=args.refresh)
-        mp4box_path = build_mp4box(source_dir, install_dir, manifest)
-        verify_macos_binary(mp4box_path, manifest.validation)
+        mp4box_path = build_mp4box(source_dir, manifest)
+        verify_macos_binary(mp4box_path, manifest)
         output_path = install_binary(mp4box_path, args.output_dir)
         verify_binary_checksum(output_path, manifest.binary_sha256)
         print(f"Built MP4Box {manifest.tag}: {output_path} ({manifest.binary_sha256})")

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -22,8 +22,8 @@ NATIVE_PROJECT_NAME = "BluRayToVisionPro"
 NATIVE_PRODUCT_NAME = "3D Blu-ray to Vision Pro Native Preview"
 NATIVE_BUNDLE_IDENTIFIER = "com.shinycomputers.bd-to-avp.native-preview"
 NATIVE_SHORT_VERSION = "0.3.0"
-NATIVE_BUILD_VERSION = "1"
-NATIVE_MINIMUM_SYSTEM_VERSION = "27.0"
+NATIVE_BUILD_VERSION = "2"
+NATIVE_MINIMUM_SYSTEM_VERSION = "26.0"
 NATIVE_EXECUTABLE_NAME = NATIVE_PRODUCT_NAME
 PROJECT_PATH = MACOS_ROOT / f"{NATIVE_PROJECT_NAME}.xcodeproj"
 SCHEME = NATIVE_PROJECT_NAME
@@ -215,6 +215,7 @@ def verify_layout(app_path: Path) -> None:
     for executable in (native_executable, worker_executable, ffprobe_executable):
         if executable_architectures(executable) != {"arm64"}:
             raise RuntimeError(f"Packaged executable must be arm64-only: {executable}")
+    verify_mach_o_minimum_system_versions(app_path, native_executable)
     verify_native_binary_paths(native_executable)
     verify_package_paths(app_path)
 
@@ -277,6 +278,51 @@ def executable_architectures(path: Path) -> set[str]:
         text=True,
     )
     return set(completed.stdout.split())
+
+
+def minimum_macos_versions(path: Path) -> set[str]:
+    completed = subprocess.run(
+        ["vtool", "-show-build", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    versions = set(re.findall(r"^\s*minos\s+(\d+(?:\.\d+){1,2})\s*$", completed.stdout, re.MULTILINE))
+    if not versions:
+        raise RuntimeError(f"Packaged Mach-O does not declare a minimum macOS version: {path}")
+    return versions
+
+
+def verify_mach_o_minimum_system_versions(app_path: Path, native_executable: Path) -> None:
+    expected_version = normalized_version(NATIVE_MINIMUM_SYSTEM_VERSION)
+    native_versions = minimum_macos_versions(native_executable)
+    if {normalized_version(version) for version in native_versions} != {expected_version}:
+        found = ", ".join(sorted(native_versions))
+        raise RuntimeError(
+            f"Native executable must target macOS {NATIVE_MINIMUM_SYSTEM_VERSION}; found {found}: {native_executable}"
+        )
+
+    incompatible: list[str] = []
+    for path in sorted(app_path.rglob("*")):
+        if path == native_executable or path.suffix in {".a", ".o"} or not is_mach_o(path):
+            continue
+        versions = minimum_macos_versions(path)
+        newer_versions = sorted(version for version in versions if normalized_version(version) > expected_version)
+        if newer_versions:
+            incompatible.append(f"{path.relative_to(app_path)}: {', '.join(newer_versions)}")
+    if incompatible:
+        raise RuntimeError(
+            "Packaged Mach-O requires a newer macOS version than "
+            f"{NATIVE_MINIMUM_SYSTEM_VERSION}:\n" + "\n".join(incompatible)
+        )
+
+
+def normalized_version(version: str) -> tuple[int, int, int]:
+    if re.fullmatch(r"\d+(?:\.\d+){1,2}", version) is None:
+        raise ValueError(f"Invalid macOS version: {version!r}")
+    components = [int(component) for component in version.split(".")]
+    components.extend([0] * (3 - len(components)))
+    return components[0], components[1], components[2]
 
 
 def verify_native_binary_paths(native_executable: Path) -> None:

--- a/scripts/native_preview_release.py
+++ b/scripts/native_preview_release.py
@@ -26,6 +26,7 @@ from scripts.native_app import (
     verify_codesign,
     verify_layout,
 )
+from scripts.verify_app_tools import REQUIRED_TOOLS, verify_tool
 
 PREVIEW_VOLUME_NAME = NATIVE_PRODUCT_NAME
 INFO_PLIST_RELATIVE_PATH = Path("Contents/Info.plist")
@@ -135,6 +136,8 @@ def verify_preview_app(
     *,
     verify_signatures: bool = False,
     verify_distribution: bool = False,
+    smoke_app: bool = False,
+    smoke_tools: bool = False,
     smoke_worker: bool = False,
 ) -> NativePreviewMetadata:
     metadata = inspect_preview_info(app_path)
@@ -144,9 +147,52 @@ def verify_preview_app(
     if verify_distribution:
         run(["xcrun", "stapler", "validate", str(app_path)])
         run(["spctl", "--assess", "--type", "execute", "--verbose=4", str(app_path)])
+    if smoke_app:
+        smoke_native_app_startup(app_path)
+    if smoke_tools:
+        smoke_packaged_tools(app_path)
     if smoke_worker:
         smoke_packaged_worker(app_path)
     return metadata
+
+
+def smoke_native_app_startup(app_path: Path) -> None:
+    executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
+    with tempfile.TemporaryDirectory(prefix="native-preview-startup-") as temporary_directory:
+        environment = os.environ.copy()
+        environment["HOME"] = temporary_directory
+        environment["TMPDIR"] = temporary_directory
+        try:
+            completed = subprocess.run(
+                [str(executable), "--startup-smoke"],
+                cwd=temporary_directory,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise NativePreviewReleaseError("Native preview startup smoke did not exit within 20 seconds.") from error
+    if completed.returncode != 0:
+        details = (completed.stderr or completed.stdout).strip()
+        raise NativePreviewReleaseError(
+            f"Native preview startup smoke exited with status {completed.returncode}: {details}"
+        )
+
+
+def smoke_packaged_tools(app_path: Path) -> None:
+    tool_directory = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin"
+    try:
+        for tool_name, probe_args in REQUIRED_TOOLS.items():
+            verify_tool(tool_directory / tool_name, probe_args)
+    except (
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as error:
+        raise NativePreviewReleaseError(f"Native preview bundled-tool smoke failed: {error}") from error
 
 
 def create_preview_dmg(app_path: Path, output_path: Path) -> Path:
@@ -287,6 +333,8 @@ def verify_preview_dmg(
     *,
     verify_signatures: bool = False,
     verify_distribution: bool = False,
+    smoke_app: bool = False,
+    smoke_tools: bool = False,
     smoke_worker: bool = False,
 ) -> NativePreviewMetadata:
     if not dmg_path.is_file():
@@ -307,6 +355,8 @@ def verify_preview_dmg(
             app_paths[0],
             verify_signatures=verify_signatures,
             verify_distribution=verify_distribution,
+            smoke_app=smoke_app,
+            smoke_tools=smoke_tools,
             smoke_worker=smoke_worker,
         )
 
@@ -314,6 +364,8 @@ def verify_preview_dmg(
 def add_verification_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--verify-signatures", action="store_true")
     parser.add_argument("--verify-distribution", action="store_true")
+    parser.add_argument("--smoke-app", action="store_true")
+    parser.add_argument("--smoke-tools", action="store_true")
     parser.add_argument("--smoke-worker", action="store_true")
 
 
@@ -358,6 +410,8 @@ def main(argv: list[str] | None = None) -> None:
             args.app,
             verify_signatures=args.verify_signatures,
             verify_distribution=args.verify_distribution,
+            smoke_app=args.smoke_app,
+            smoke_tools=args.smoke_tools,
             smoke_worker=args.smoke_worker,
         )
         print(json.dumps(asdict(metadata), sort_keys=True))
@@ -377,6 +431,8 @@ def main(argv: list[str] | None = None) -> None:
             args.dmg,
             verify_signatures=args.verify_signatures,
             verify_distribution=args.verify_distribution,
+            smoke_app=args.smoke_app,
+            smoke_tools=args.smoke_tools,
             smoke_worker=args.smoke_worker,
         )
         print(json.dumps(asdict(metadata), sort_keys=True))

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -14,6 +14,7 @@ CORE_TOOLS = {
 }
 GUI_RUNTIME_TOOLS = {
     "edge264_test": ["--help"],
+    "fx-upscale": ["--help"],
     "spatial-media-kit-tool": ["--help"],
 }
 REQUIRED_TOOLS = CORE_TOOLS | GUI_RUNTIME_TOOLS
@@ -26,6 +27,7 @@ def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        timeout=30,
     )
 
 

--- a/tests/test_mp4box_builder.py
+++ b/tests/test_mp4box_builder.py
@@ -18,10 +18,13 @@ class MP4BoxBuilderTests(unittest.TestCase):
                         'version = "26.02.0"',
                         'repo_url = "https://example.invalid/gpac.git"',
                         'tag = "v26.02.0"',
+                        'source_commit = "118e60a905878e56dc4f9c5b309143c5f447c702"',
                         'license_mode = "LGPL-2.1-or-later"',
                         'binary = "MP4Box"',
                         f'binary_sha256 = "{"1" * 64}"',
                         'build = "static test build"',
+                        'install_prefix = "/opt/bd-to-avp/gpac"',
+                        'minimum_macos = "14.0"',
                         'configure_flags = ["--static-bin", "--use-ffmpeg=no"]',
                         "",
                         "[validation]",
@@ -36,19 +39,23 @@ class MP4BoxBuilderTests(unittest.TestCase):
             manifest = build_mp4box_macos.load_manifest(manifest_path)
 
         self.assertEqual(manifest.tag, "v26.02.0")
+        self.assertEqual(manifest.source_commit, "118e60a905878e56dc4f9c5b309143c5f447c702")
         self.assertEqual(manifest.binary, "MP4Box")
         self.assertEqual(manifest.binary_sha256, "1" * 64)
+        self.assertEqual(manifest.install_prefix, "/opt/bd-to-avp/gpac")
+        self.assertEqual(manifest.minimum_macos, "14.0")
         self.assertIn("--static-bin", manifest.configure_flags)
         self.assertEqual(manifest.validation.forbidden_link_prefixes, ("/opt/homebrew", "/usr/local"))
         self.assertIn("/usr/lib/libSystem.B.dylib", manifest.validation.expected_system_links)
 
     def test_build_env_hides_homebrew_tools(self) -> None:
-        env = build_mp4box_macos.build_env()
+        env = build_mp4box_macos.build_env("14.0")
 
         self.assertEqual(env["PATH"], "/usr/bin:/bin:/usr/sbin:/sbin")
         self.assertEqual(env["CC"], "/usr/bin/clang")
         self.assertEqual(env["CXX"], "/usr/bin/clang++")
         self.assertEqual(env["PKG_CONFIG"], "/usr/bin/false")
+        self.assertEqual(env["MACOSX_DEPLOYMENT_TARGET"], "14.0")
 
     def test_verify_build_host_rejects_non_arm64_macos(self) -> None:
         with (
@@ -64,11 +71,12 @@ class MP4BoxBuilderTests(unittest.TestCase):
                 return "MP4Box: Mach-O 64-bit executable arm64"
             if command[0] == "otool":
                 return "MP4Box:\n\t/opt/homebrew/lib/libgpac.dylib\n"
-            return "MP4Box - GPAC version 26.02"
+            return "MP4Box - GPAC version 26.02\nGPAC Configuration: --prefix=/opt/bd-to-avp/gpac"
 
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
             with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "/opt/homebrew"):
-                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
+                manifest = build_mp4box_macos.load_manifest()
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), manifest)
 
     def test_verify_macos_binary_accepts_system_only_linkage(self) -> None:
         def fake_run(command: list[str | Path], **kwargs) -> str:
@@ -76,10 +84,13 @@ class MP4BoxBuilderTests(unittest.TestCase):
                 return "MP4Box: Mach-O 64-bit executable arm64"
             if command[0] == "otool":
                 return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libSystem.B.dylib\n"
-            return "MP4Box - GPAC version 26.02"
+            if command[0] == "vtool":
+                return "platform MACOS\nminos 14.0\n"
+            return "MP4Box - GPAC version 26.02\nGPAC Configuration: --prefix=/opt/bd-to-avp/gpac"
 
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
-            build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
+            manifest = build_mp4box_macos.load_manifest()
+            build_mp4box_macos.verify_macos_binary(Path("MP4Box"), manifest)
 
     def test_verify_macos_binary_rejects_unexpected_system_linkage(self) -> None:
         def fake_run(command: list[str | Path], **kwargs) -> str:
@@ -87,28 +98,65 @@ class MP4BoxBuilderTests(unittest.TestCase):
                 return "MP4Box: Mach-O 64-bit executable arm64"
             if command[0] == "otool":
                 return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libobjc.A.dylib\n"
-            return "MP4Box - GPAC version 26.02"
+            return "MP4Box - GPAC version 26.02\nGPAC Configuration: --prefix=/opt/bd-to-avp/gpac"
 
         with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
             with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "unexpected"):
-                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), build_mp4box_macos.load_manifest().validation)
+                manifest = build_mp4box_macos.load_manifest()
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), manifest)
+
+    def test_verify_macos_binary_rejects_newer_minimum_system_version(self) -> None:
+        def fake_run(command: list[str | Path], **kwargs) -> str:
+            if command[0] == "file":
+                return "MP4Box: Mach-O 64-bit executable arm64"
+            if command[0] == "otool":
+                return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libSystem.B.dylib\n"
+            if command[0] == "vtool":
+                return "platform MACOS\nminos 27.0\n"
+            return "MP4Box - GPAC version 26.02\nGPAC Configuration: --prefix=/opt/bd-to-avp/gpac"
+
+        with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+            manifest = build_mp4box_macos.load_manifest()
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "minimum macOS version"):
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), manifest)
+
+    def test_verify_macos_binary_rejects_checkout_prefix(self) -> None:
+        def fake_run(command: list[str | Path], **kwargs) -> str:
+            if command[0] == "file":
+                return "MP4Box: Mach-O 64-bit executable arm64"
+            if command[0] == "otool":
+                return "MP4Box:\n\t/usr/lib/libz.1.dylib\n\t/usr/lib/libSystem.B.dylib\n"
+            if command[0] == "vtool":
+                return "platform MACOS\nminos 14.0\n"
+            return f"MP4Box - GPAC version 26.02\nGPAC Configuration: --prefix={build_mp4box_macos.REPO_ROOT}"
+
+        with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
+            manifest = build_mp4box_macos.load_manifest()
+            with self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "deterministic install prefix"):
+                build_mp4box_macos.verify_macos_binary(Path("MP4Box"), manifest)
 
     def test_clone_or_update_source_uses_cached_tag_without_fetch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             source_dir = Path(temp_dir) / "gpac-src"
             source_dir.mkdir()
             commands: list[list[str | Path]] = []
+            manifest = build_mp4box_macos.load_manifest()
 
             def fake_run(command: list[str | Path], **kwargs) -> str:
                 commands.append(command)
-                return "cached-commit"
+                if command[:4] == ["git", "remote", "get-url", "origin"]:
+                    return manifest.repo_url
+                if command[:3] == ["git", "status", "--porcelain"]:
+                    return ""
+                if command[:2] == ["git", "rev-parse"]:
+                    return manifest.source_commit
+                return ""
 
-            manifest = build_mp4box_macos.load_manifest()
             with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
                 build_mp4box_macos.clone_or_update_source(source_dir, manifest, refresh=False)
 
-        self.assertIn(["git", "rev-parse", "--verify", f"{manifest.tag}^{{commit}}"], commands)
-        self.assertIn(["git", "checkout", manifest.tag], commands)
+        self.assertIn(["git", "rev-parse", "--verify", f"{manifest.source_commit}^{{commit}}"], commands)
+        self.assertIn(["git", "checkout", "--detach", manifest.source_commit], commands)
         self.assertNotIn(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], commands)
 
     def test_clone_or_update_source_fetches_missing_cached_tag(self) -> None:
@@ -116,19 +164,48 @@ class MP4BoxBuilderTests(unittest.TestCase):
             source_dir = Path(temp_dir) / "gpac-src"
             source_dir.mkdir()
             commands: list[list[str | Path]] = []
+            manifest = build_mp4box_macos.load_manifest()
 
             def fake_run(command: list[str | Path], **kwargs) -> str:
                 commands.append(command)
+                if command[:4] == ["git", "remote", "get-url", "origin"]:
+                    return manifest.repo_url
+                if command[:3] == ["git", "status", "--porcelain"]:
+                    return ""
                 if command[:3] == ["git", "rev-parse", "--verify"]:
                     raise subprocess.CalledProcessError(returncode=128, cmd=command)
+                if command[:2] == ["git", "rev-parse"]:
+                    return manifest.source_commit
                 return ""
 
-            manifest = build_mp4box_macos.load_manifest()
             with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
                 build_mp4box_macos.clone_or_update_source(source_dir, manifest, refresh=False)
 
         self.assertIn(["git", "fetch", "--depth", "1", "origin", "tag", manifest.tag], commands)
-        self.assertIn(["git", "checkout", manifest.tag], commands)
+        self.assertIn(["git", "checkout", "--detach", manifest.source_commit], commands)
+
+    def test_clone_or_update_source_rejects_mismatched_tag_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = Path(temp_dir) / "gpac-src"
+            source_dir.mkdir()
+            manifest = build_mp4box_macos.load_manifest()
+
+            def fake_run(command: list[str | Path], **kwargs) -> str:
+                if command[:4] == ["git", "remote", "get-url", "origin"]:
+                    return manifest.repo_url
+                if command[:3] == ["git", "status", "--porcelain"]:
+                    return ""
+                if command[:3] == ["git", "rev-parse", "--verify"]:
+                    return manifest.source_commit
+                if command[:3] == ["git", "rev-parse", f"{manifest.tag}^{{commit}}"]:
+                    return "0" * 40
+                return ""
+
+            with (
+                patch.object(build_mp4box_macos, "run", side_effect=fake_run),
+                self.assertRaisesRegex(build_mp4box_macos.BuildFailure, "resolves to"),
+            ):
+                build_mp4box_macos.clone_or_update_source(source_dir, manifest, refresh=False)
 
     def test_build_mp4box_skips_distclean_without_makefile(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -143,9 +220,10 @@ class MP4BoxBuilderTests(unittest.TestCase):
                 return ""
 
             with patch.object(build_mp4box_macos, "run", side_effect=fake_run):
-                build_mp4box_macos.build_mp4box(source_dir, source_dir / "install", build_mp4box_macos.load_manifest())
+                build_mp4box_macos.build_mp4box(source_dir, build_mp4box_macos.load_manifest())
 
         self.assertNotIn(["make", "distclean"], commands)
+        self.assertTrue(any(command[:2] == ["./configure", "--prefix=/opt/bd-to-avp/gpac"] for command in commands))
         self.assertIn(["make", f"-j{build_mp4box_macos.os.cpu_count() or 1}", "lib"], commands)
 
     def test_install_binary_sets_executable_bit(self) -> None:

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -24,11 +24,13 @@ from scripts.native_app import (
     REPO_ROOT,
     SCHEME,
     native_build_settings,
+    minimum_macos_versions,
     parse_args,
     sign_package,
     smoke_packaged_worker,
     validate_smoke_events,
     verify_native_binary_paths,
+    verify_mach_o_minimum_system_versions,
     verify_package_paths,
     verify_product_identity,
     verify_product_source_copy,
@@ -46,8 +48,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp.native-preview")
         self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0")
-        self.assertEqual(NATIVE_BUILD_VERSION, "1")
-        self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "27.0")
+        self.assertEqual(NATIVE_BUILD_VERSION, "2")
+        self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:
         project_spec = (MACOS_ROOT / "project.yml").read_text(encoding="utf-8")
@@ -67,6 +69,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn("openWindow(id: AppWindowID.settings)", app_source)
         self.assertIn(".windowResizability(.contentMinSize)", app_source)
         self.assertEqual(target_settings["base"]["CURRENT_PROJECT_VERSION"], NATIVE_BUILD_VERSION)
+        self.assertEqual(project["options"]["deploymentTarget"]["macOS"], NATIVE_MINIMUM_SYSTEM_VERSION)
+        self.assertEqual(project["settings"]["base"]["MACOSX_DEPLOYMENT_TARGET"], NATIVE_MINIMUM_SYSTEM_VERSION)
         self.assertEqual(preview_settings["MARKETING_VERSION"], NATIVE_SHORT_VERSION)
         self.assertEqual(preview_settings["PRODUCT_BUNDLE_IDENTIFIER"], NATIVE_BUNDLE_IDENTIFIER)
         self.assertEqual(preview_settings["PRODUCT_NAME"], NATIVE_PRODUCT_NAME)
@@ -86,6 +90,8 @@ class NativeAppPackagingTests(unittest.TestCase):
 
         self.assertIn("Convert a 3D Blu-ray Disc", source_view)
         self.assertIn("Import MTS or M2TS transport stream", source_view)
+        self.assertIn(".disabled(outputControlsLocked)", source_view)
+        self.assertIn("state.phase.isRunning || state.phase == .decisionRequired", source_view)
         self.assertLess(
             source_view.index("Convert a 3D Blu-ray Disc"),
             source_view.index("Import MTS or M2TS transport stream"),
@@ -142,6 +148,63 @@ class NativeAppPackagingTests(unittest.TestCase):
                 "Debug",
                 {"BD_TO_AVP_NATIVE_DEPLOYMENT_TARGET_OVERRIDE": "latest"},
             )
+
+    def test_reads_minimum_versions_from_mach_o_build_commands(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="""
+Load command 2
+      cmd LC_BUILD_VERSION
+ platform MACOS
+    minos 11.0
+Load command 3
+      cmd LC_BUILD_VERSION
+ platform MACOS
+    minos 26.0
+""",
+            stderr="",
+        )
+
+        with patch("scripts.native_app.subprocess.run", return_value=completed):
+            self.assertEqual(minimum_macos_versions(Path("/tmp/tool")), {"11.0", "26.0"})
+
+    def test_rejects_packaged_mach_o_requiring_newer_macos(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
+            newer_library = app_path / "Contents" / "Frameworks" / "Newer.dylib"
+            native_executable.parent.mkdir(parents=True)
+            newer_library.parent.mkdir(parents=True)
+            native_executable.write_bytes(b"\xcf\xfa\xed\xfe")
+            newer_library.write_bytes(b"\xcf\xfa\xed\xfe")
+
+            def versions(path: Path) -> set[str]:
+                return {"27.0"} if path == newer_library else {NATIVE_MINIMUM_SYSTEM_VERSION}
+
+            with (
+                patch("scripts.native_app.minimum_macos_versions", side_effect=versions),
+                self.assertRaisesRegex(RuntimeError, "requires a newer macOS version"),
+            ):
+                verify_mach_o_minimum_system_versions(app_path, native_executable)
+
+    def test_ignores_static_archives_when_validating_packaged_mach_o(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
+            static_archive = app_path / "Contents" / "Frameworks" / "libstub.a"
+            native_executable.parent.mkdir(parents=True)
+            static_archive.parent.mkdir(parents=True)
+            native_executable.write_bytes(b"\xcf\xfa\xed\xfe")
+            static_archive.write_bytes(b"\xca\xfe\xba\xbe")
+
+            with patch(
+                "scripts.native_app.minimum_macos_versions",
+                return_value={NATIVE_MINIMUM_SYSTEM_VERSION},
+            ) as versions:
+                verify_mach_o_minimum_system_versions(app_path, native_executable)
+
+            versions.assert_called_once_with(native_executable)
 
     def test_package_accepts_an_explicit_signing_keychain(self) -> None:
         args = parse_args(

--- a/tests/test_native_preview_release.py
+++ b/tests/test_native_preview_release.py
@@ -26,6 +26,9 @@ from scripts.native_preview_release import (
     main,
     mounted_dmg,
     notarize_and_staple,
+    parse_args,
+    smoke_native_app_startup,
+    smoke_packaged_tools,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -92,6 +95,44 @@ class NativePreviewIdentityTests(unittest.TestCase):
             create_preview_release_metadata(short_version="0.3")
         with self.assertRaisesRegex(NativePreviewReleaseError, "positive integer"):
             create_preview_release_metadata(build_version="0")
+
+    def test_verify_dmg_accepts_native_and_tool_smoke_flags(self) -> None:
+        args = parse_args(
+            [
+                "verify-dmg",
+                "--dmg",
+                "/tmp/preview.dmg",
+                "--smoke-app",
+                "--smoke-tools",
+                "--smoke-worker",
+            ]
+        )
+
+        self.assertTrue(args.smoke_app)
+        self.assertTrue(args.smoke_tools)
+        self.assertTrue(args.smoke_worker)
+
+    def test_native_startup_smoke_uses_explicit_exit_argument(self) -> None:
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
+            executable.parent.mkdir(parents=True)
+            executable.touch()
+            with patch("scripts.native_preview_release.subprocess.run", return_value=completed) as run_mock:
+                smoke_native_app_startup(app_path)
+
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command, [str(executable), "--startup-smoke"])
+        self.assertEqual(run_mock.call_args.kwargs["timeout"], 20)
+
+    def test_packaged_tool_smoke_probes_release_tool_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            with patch("scripts.native_preview_release.verify_tool") as verify_tool_mock:
+                smoke_packaged_tools(app_path)
+
+        self.assertGreaterEqual(verify_tool_mock.call_count, 6)
 
     def test_accepts_exact_preview_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -212,6 +253,7 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         workflow = load_workflow()
         prepare = workflow["jobs"]["prepare"]
         package = workflow["jobs"]["package"]
+        compatibility = workflow["jobs"]["compatibility"]
 
         self.assertEqual(set(workflow["on"]), {"workflow_dispatch"})
         self.assertEqual(workflow["concurrency"]["group"], "release")
@@ -236,6 +278,14 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertIn("python -m scripts.native_preview_release metadata", str(prepare))
         self.assertIn("needs.prepare.outputs.app_name", str(package))
         self.assertIn("needs.prepare.outputs.dmg_name", str(package))
+        self.assertEqual(compatibility["runs-on"], "macos-26")
+        self.assertEqual(compatibility["needs"], ["package"])
+        self.assertIn("actions/setup-python", str(compatibility))
+        self.assertIn("verify-dmg", str(compatibility))
+        self.assertIn("--smoke-app", str(compatibility))
+        self.assertIn("--smoke-tools", str(compatibility))
+        self.assertIn("--smoke-worker", str(compatibility))
+        self.assertIn("sw_vers", str(compatibility))
 
     def test_workflow_isolated_from_production_channels(self) -> None:
         workflow = load_workflow()
@@ -264,6 +314,7 @@ class NativePreviewWorkflowTests(unittest.TestCase):
     def test_workflow_attests_and_revalidates_exact_assets(self) -> None:
         workflow = load_workflow()
         package = workflow["jobs"]["package"]
+        compatibility = workflow["jobs"]["compatibility"]
         publish = workflow["jobs"]["publish"]
         config = json.loads((REPO_ROOT / ".github" / "github.json").read_text(encoding="utf-8"))
 
@@ -272,6 +323,8 @@ class NativePreviewWorkflowTests(unittest.TestCase):
         self.assertEqual(package["permissions"]["id-token"], "write")
         self.assertIn("actions/attest@", str(package))
         self.assertEqual(publish["permissions"]["contents"], "write")
+        self.assertEqual(set(publish["needs"]), {"prepare", "package", "compatibility"})
+        self.assertIn("native-preview-package", str(compatibility))
         self.assertIn("gh attestation verify", str(publish))
         self.assertIn("native-ui-preview.yml", str(publish))
         self.assertIn("SHA256SUMS", str(publish))

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from bd_to_avp.modules.config import config
 from bd_to_avp.modules.disc import DiscInfo, MKVCreationError
+from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.worker.__main__ import run_worker
 from bd_to_avp.worker.operations import WorkerDecisionRequired, WorkerOperationError, convert_source, inspect_source
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
@@ -822,6 +823,27 @@ class SourceConversionTests(unittest.TestCase):
             self.assertEqual(context.exception.code, "mkv_creation_decision_required")
             self.assertEqual(context.exception.choices, ("retry_continue_on_error", "cancel"))
             self.assertIn("Extract MVC and Audio", context.exception.details or "")
+
+    def test_subtitle_failure_requests_skip_subtitles_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.iso"
+            source_path.write_bytes(b"disc")
+            destination_path = temporary_path / "output"
+            job = JobSpec.from_json_line(conversion_request_line(source_path, destination_path))
+            emitter = WorkerEventEmitter(io.StringIO(), job.job_id)
+            activity = WorkerActivityReporter(emitter)
+
+            with (
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.process.process_each", side_effect=SRTCreationError("OCR error")),
+                self.assertRaises(WorkerDecisionRequired) as context,
+            ):
+                convert_source(job, WorkerProcessOwner(), activity)
+
+            self.assertEqual(context.exception.code, "subtitle_decision_required")
+            self.assertEqual(context.exception.choices, ("retry_without_subtitles", "cancel"))
+            self.assertIn("Turn off Include subtitles", context.exception.details or "")
 
     def test_conversion_restores_global_config_and_tool_environment(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -23,6 +23,7 @@ class VerifyAppToolsTests(unittest.TestCase):
                 "ffmpeg",
                 "ffprobe",
                 "edge264_test",
+                "fx-upscale",
                 "MP4Box",
                 "spatial-media-kit-tool",
             },

--- a/vendor/mp4box-macos-arm64.toml
+++ b/vendor/mp4box-macos-arm64.toml
@@ -1,10 +1,13 @@
 version = "26.02.0"
 repo_url = "https://github.com/gpac/gpac.git"
 tag = "v26.02.0"
+source_commit = "118e60a905878e56dc4f9c5b309143c5f447c702"
 license_mode = "LGPL-2.1-or-later"
 binary = "MP4Box"
-binary_sha256 = "eb63ed3f3c73eadc61f9158961114a614c208cd5929f1abb7d13da3a679cfedf"
-build = "static arm64 macOS MP4Box built from GPAC source with Homebrew hidden and external libraries disabled"
+binary_sha256 = "61ddca2713e5de02798820e9e295edc959d09a8b15a30dcacc3d9c14df627a6a"
+build = "static arm64 macOS MP4Box targeting macOS 14.0 with Homebrew hidden and external libraries disabled"
+install_prefix = "/opt/bd-to-avp/gpac"
+minimum_macos = "14.0"
 
 configure_flags = [
     "--static-bin",


### PR DESCRIPTION
## Summary

- surface MakeMKV and subtitle `job.decision_required` outcomes as native recovery actions and launch fresh immutable retry jobs
- preserve the failed conversion draft, lock source/output/profile edits until retry or cancel, add MakeMKV download guidance, and hide unsupported source-folder batch UI
- make macOS 26 the real native deployment target, bump the side-by-side preview to Build 2, and gate publication on the notarized app, bundled tools, and worker running on a macOS 26 runner
- audit every packaged Mach-O minimum version and rebuild the pinned MP4Box binary at a macOS 14 minimum with deterministic prefix/source provenance
- harden audio-language normalization against Babelfish reverse-language errors

## Validation

- `uv run python -m unittest discover -s tests -t .` — 409 tests passed
- `uv run ruff format --check ...` and `uv run ruff check --no-fix ...` — passed for changed Python files
- `uv run mypy bd_to_avp scripts/build_mp4box_macos.py scripts/native_app.py scripts/native_preview_release.py scripts/verify_app_tools.py` — passed
- `actionlint .github/workflows/ci.yml .github/workflows/native-ui-preview.yml` — passed
- `uv run python scripts/build_mp4box_macos.py` — deterministic pinned build/checksum passed
- release-profile bundled-tool probes passed, including MP4Box and `fx-upscale`
- 584 packaged runtime Mach-O files scanned; none requires newer than macOS 26
- Xcode 27 build with deployment target 26 succeeded; all Swift sources parse cleanly
- JetBrains changed-files inspection — green, zero findings

## Release scope

This advances #198 and prepares #202 Native UI Preview Build 2 (`native-ui-preview-2`). Physical-disc/AACS/drive-power behavior remains the signed-RC hardware test; source-folder batch and the production native updater remain separate follow-ups.