### PR TITLE
docs: correct macOS support wording

### DIFF
--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -37,8 +37,8 @@ does not replace or update it.
 - MakeMKV remains an external dependency for physical discs, Blu-ray folders,
   and disc images. The source workspace links to the official download page when
   MakeMKV is missing.
-- Beta 1 supports Apple Silicon and macOS 26 or later. macOS 25 and earlier are
-  not supported.
+- Beta 1 supports Apple Silicon and macOS 26 or later. Earlier macOS releases
+  are not supported.
 
 Please report interface feedback in issue #202, including the source workflow,
 window size, appearance, and any controls or terminology that were unclear.


### PR DESCRIPTION
## Summary
- remove the nonexistent `macOS 25` reference from the Beta 1 notes source
- preserve the actual Apple Silicon and macOS 26-or-later support floor
- keep the committed notes aligned with the metadata-only correction already applied to the immutable release

## Validation
- `git diff --check`
- confirmed `docs/native-ui-preview.md` contains no `macOS 25` reference
- independent review found no blocker

Relates to #202.