### PR TITLE
fix: stabilize worker terminal cancellation

### DIFF
--- a/macos/BluRayToVisionPro/Worker/WorkerProcessClient.swift
+++ b/macos/BluRayToVisionPro/Worker/WorkerProcessClient.swift
@@ -299,10 +299,10 @@ final class WorkerProcessClient: WorkerProcessRunning, @unchecked Sendable {
                     throw WorkerStreamError.duplicateWorkerReady
                 }
                 expectedSequence += 1
-                try await onEvent(event)
                 if event.type.isTerminal {
                     terminalEvent = event
                 }
+                try await onEvent(event)
             }
         }
         try framer.finish()

--- a/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
@@ -82,6 +82,24 @@ final class WorkerProcessClientTests: XCTestCase {
         }
     }
 
+    func testRejectsEventAfterTerminal() async throws {
+        let client = fixtureClient(body: """
+        \(readyEvent())
+        print(json.dumps({"protocol_version": 2, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10}}}), flush=True)
+        print(json.dumps({"protocol_version": 2, "type": "log", "job_id": job_id, "sequence": 2, "payload": {"level": "info", "message": "late event"}}), flush=True)
+        """)
+        let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
+
+        do {
+            _ = try await client.run(job: job) { _ in }
+            XCTFail("Expected an event after terminal to fail")
+        } catch let error as WorkerClientError {
+            guard case .protocolFailure = error else {
+                return XCTFail("Unexpected worker error: \(error)")
+            }
+        }
+    }
+
     func testCancellationReapsWorkerAfterTerminalEvent() async throws {
         let client = fixtureClient(body: """
         \(readyEvent())
@@ -90,15 +108,22 @@ final class WorkerProcessClientTests: XCTestCase {
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
         let terminalReceived = expectation(description: "terminal event received")
+        let terminalState = TerminalEventState()
         let task = Task {
             try await client.run(job: job) { event in
                 if event.type.isTerminal {
+                    await terminalState.record()
                     terminalReceived.fulfill()
                 }
             }
         }
 
-        await fulfillment(of: [terminalReceived], timeout: 3)
+        await fulfillment(of: [terminalReceived], timeout: 10)
+        guard await terminalState.wasReceived else {
+            client.cancel()
+            _ = await task.result
+            return
+        }
         client.cancel()
         let result = try await task.value
 
@@ -150,5 +175,13 @@ final class WorkerProcessClientTests: XCTestCase {
                 environment: ProcessInfo.processInfo.environment
             )
         )
+    }
+}
+
+private actor TerminalEventState {
+    private(set) var wasReceived = false
+
+    func record() {
+        wasReceived = true
     }
 }


### PR DESCRIPTION
## Summary
- record a validated terminal event before yielding to the external event callback
- preserve the primary XCTest timeout diagnostic while still cancelling and reaping the worker
- add direct fail-closed coverage for events emitted after a terminal event

## Why
CI run `29346862070` failed twice in `testCancellationReapsWorkerAfterTerminalEvent` with a secondary `missingTerminalEvent(exitStatus: 15)` after the three-second expectation expired, then passed on its third attempt. This change removes both the terminal-state ordering window and the misleading timeout cleanup path.

## Validation
- focused cancellation test: 50 consecutive repetitions passed
- complete `WorkerProcessClientTests`: 20 consecutive repetitions passed
- full native suite: 81 tests passed
- Python suite: 415 tests passed
- `git diff --check`
- JetBrains changed-files inspection: clean
- Gemini-family and GPT independent reviews: no blockers

No documentation update is needed because this changes internal worker lifecycle ordering and test diagnostics without changing the public protocol or user workflow.

Relates to #225.
