### PR TITLE
Integrate Sparkle into the native macOS updater

### DIFF
--- a/docs/native-shell-packaging.md
+++ b/docs/native-shell-packaging.md
@@ -90,6 +90,18 @@ DMG, staples and Gatekeeper-validates the result, repeats the packaged-worker
 smoke from the mounted DMG, attests the artifact, and publishes only the DMG and
 `SHA256SUMS` as a GitHub prerelease.
 
+The native Xcode project exact-pins Sparkle 2.9.4 through Swift Package Manager
+so the future direct Release target compiles against the same updater version as
+the production Briefcase app. Debug and Preview use the ordinary `Info.plist`,
+which contains no distribution channel, appcast URL, or public key. Their shared
+update controller therefore stays in manual-download mode and never initializes
+Sparkle. The single app target still embeds the dormant framework in Preview;
+the package signer already treats its nested framework, app, and XPC bundles as
+inside-out signing targets. `Info-Release.plist` contains the policy-checked
+direct metadata, but that unsigned Release build is compile evidence only until
+the native RC packaging and installed-app update smoke are completed under
+#192 and #197.
+
 The native shell supports Apple Silicon Macs running macOS 26 or later. Review
 and release builds may use the Xcode 27 SDK, but the committed deployment target
 and packaged `LSMinimumSystemVersion` remain macOS 26.

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -34,6 +34,23 @@ synchronous PyGithub About-dialog checker, and exposes Sparkle's standard
 `Check for Updates…` action. Source/development builds retain only a manual
 GitHub Releases link and never initialize Sparkle.
 
+The native SwiftUI project now exact-pins the same Sparkle 2.9.4 package. A
+single observable update controller owns Sparkle's automatic-check preference,
+the shared `BDToAVPUpdateChannel` Stable/`rc` selection, check availability,
+Settings controls, and Help commands. It starts Sparkle only when the bundle has
+the complete direct-distribution policy: `direct` channel, HTTPS feed, public
+key, automatic installation disabled, extraction verification enabled, and no
+forced `SUEnableAutomaticChecks` value. Missing or invalid metadata fails closed
+to the GitHub Releases fallback. Sparkle relaunch is postponed while the native
+conversion worker is active and resumes after the worker becomes idle.
+
+Native Debug and Preview builds omit all update metadata and do not initialize
+Sparkle, although the current single-target SPM build embeds the dormant signed
+framework. The native Release plist matches the Briefcase updater policy, but
+its current version/build identity is not eligible for production publication.
+Signed installed-app upgrades, Stable/RC feed behavior, permission prompting,
+and rendered release notes remain release-cycle validation for #192 and #197.
+
 Briefcase writes the direct-distribution metadata and repository build counter,
 and the repo-owned signing extension adds nested `.xpc` bundles to Briefcase's
 inside-out signing pass. The manual main-only release workflow validates the

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -7,11 +7,18 @@ enum AppWindowID {
 @main
 struct BluRayToVisionProApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @StateObject private var viewModel = ConversionViewModel()
+    @StateObject private var viewModel: ConversionViewModel
+    @StateObject private var updater: UpdateController
     @StateObject private var settings = AppSettings()
     @StateObject private var profileStore = ProfileStore()
 
     private let capabilities = AppCapabilities.current
+
+    init() {
+        let viewModel = ConversionViewModel()
+        _viewModel = StateObject(wrappedValue: viewModel)
+        _updater = StateObject(wrappedValue: UpdateController(installPostponer: viewModel))
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -28,7 +35,7 @@ struct BluRayToVisionProApp: App {
                     }
                 )
                 .onAppear {
-                    settings.normalize(for: capabilities)
+                    updater.startIfNeeded()
                     settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
                     appDelegate.viewModel = viewModel
                 }
@@ -38,6 +45,7 @@ struct BluRayToVisionProApp: App {
         .windowToolbarStyle(.unified)
         .commands {
             SettingsWindowCommands()
+            UpdateCommands(updater: updater)
 
             CommandGroup(replacing: .newItem) {
                 Button("Add Source…") {
@@ -52,7 +60,7 @@ struct BluRayToVisionProApp: App {
             SettingsView(
                 settings: settings,
                 profileStore: profileStore,
-                capabilities: capabilities
+                updater: updater
             )
         }
         .defaultSize(width: 900, height: 680)
@@ -68,6 +76,29 @@ struct BluRayToVisionProApp: App {
             return
         }
         viewModel.selectSource(sourceURL)
+    }
+}
+
+private struct UpdateCommands: Commands {
+    @ObservedObject var updater: UpdateController
+
+    var body: some Commands {
+        CommandGroup(after: .help) {
+            Divider()
+
+            Button(updater.updateActionTitle) {
+                updater.performUpdateAction()
+            }
+            .disabled(!updater.canPerformUpdateAction)
+
+            if updater.supportsChannels {
+                Picker("Update Channel", selection: $updater.updateChannel) {
+                    ForEach(UpdateChannelPreference.allCases) { channel in
+                        Text(channel.name).tag(channel)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/macos/BluRayToVisionPro/Feature/AppSettings.swift
+++ b/macos/BluRayToVisionPro/Feature/AppSettings.swift
@@ -1,21 +1,5 @@
 import Foundation
 
-enum UpdateChannelPreference: String, CaseIterable, Identifiable {
-    case stable
-    case releaseCandidate
-
-    var id: String { rawValue }
-
-    var name: String {
-        switch self {
-        case .stable:
-            "Stable"
-        case .releaseCandidate:
-            "Release Candidates"
-        }
-    }
-}
-
 @MainActor
 final class AppSettings: ObservableObject {
     private enum Key {
@@ -24,8 +8,6 @@ final class AppSettings: ObservableObject {
         static let revealOutput = "native.revealOutput"
         static let playSound = "native.playSound"
         static let keepAwake = "native.keepAwake"
-        static let automaticUpdates = "native.automaticUpdates"
-        static let updateChannel = "native.updateChannel"
         static let showTechnicalDetails = "native.showTechnicalDetails"
         static let keepIntermediateFiles = "native.keepIntermediateFiles"
         static let useSoftwareEncoder = "native.useSoftwareEncoder"
@@ -54,14 +36,6 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(keepAwake, forKey: Key.keepAwake) }
     }
 
-    @Published var automaticallyChecksForUpdates: Bool {
-        didSet { defaults.set(automaticallyChecksForUpdates, forKey: Key.automaticUpdates) }
-    }
-
-    @Published var updateChannel: UpdateChannelPreference {
-        didSet { defaults.set(updateChannel.rawValue, forKey: Key.updateChannel) }
-    }
-
     @Published var showTechnicalDetails: Bool {
         didSet { defaults.set(showTechnicalDetails, forKey: Key.showTechnicalDetails) }
     }
@@ -88,10 +62,6 @@ final class AppSettings: ObservableObject {
         revealOutput = defaults.object(forKey: Key.revealOutput) as? Bool ?? true
         playSound = defaults.object(forKey: Key.playSound) as? Bool ?? true
         keepAwake = defaults.object(forKey: Key.keepAwake) as? Bool ?? true
-        automaticallyChecksForUpdates = defaults.object(forKey: Key.automaticUpdates) as? Bool ?? true
-        updateChannel = UpdateChannelPreference(
-            rawValue: defaults.string(forKey: Key.updateChannel) ?? UpdateChannelPreference.stable.rawValue
-        ) ?? .stable
         showTechnicalDetails = defaults.object(forKey: Key.showTechnicalDetails) as? Bool ?? false
         keepIntermediateFiles = defaults.object(forKey: Key.keepIntermediateFiles) as? Bool ?? false
         useSoftwareEncoder = defaults.object(forKey: Key.useSoftwareEncoder) as? Bool ?? false
@@ -101,12 +71,6 @@ final class AppSettings: ObservableObject {
         showTechnicalDetails = false
         keepIntermediateFiles = false
         useSoftwareEncoder = false
-    }
-
-    func normalize(for capabilities: AppCapabilities) {
-        if !capabilities.automaticUpdateChecksAvailable {
-            automaticallyChecksForUpdates = false
-        }
     }
 
     func resetDestination() {

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 @MainActor
-final class ConversionViewModel: ObservableObject {
+final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     typealias ClientFactory = () throws -> any WorkerProcessRunning
 
     @Published private(set) var source: ConversionSource?
@@ -14,6 +14,7 @@ final class ConversionViewModel: ObservableObject {
     private var runTask: Task<Void, Never>?
     private var pendingTerminalEvent: WorkerEvent?
     private var lastConversionDraft: ConversionDraft?
+    private var actionsWaitingForIdle: [() -> Void] = []
 
     init(clientFactory: @escaping ClientFactory = {
         WorkerProcessClient(configuration: try WorkerLaunchConfiguration.automatic())
@@ -100,8 +101,7 @@ final class ConversionViewModel: ObservableObject {
             }
         } catch {
             state.failTransport(message: error.localizedDescription)
-            client = nil
-            runTask = nil
+            clearActiveWorker()
         }
     }
 
@@ -172,8 +172,7 @@ final class ConversionViewModel: ObservableObject {
             }
         } catch {
             state.failTransport(message: error.localizedDescription)
-            client = nil
-            runTask = nil
+            clearActiveWorker()
         }
     }
 
@@ -252,6 +251,14 @@ final class ConversionViewModel: ObservableObject {
         await task.value
     }
 
+    func postponeInstallUntilIdle(_ installHandler: @escaping () -> Void) -> Bool {
+        guard hasActiveWorker else {
+            return false
+        }
+        actionsWaitingForIdle.append(installHandler)
+        return true
+    }
+
     func restartInspection() {
         guard canRetry else {
             return
@@ -324,8 +331,7 @@ final class ConversionViewModel: ObservableObject {
             )
         }
         pendingTerminalEvent = nil
-        client = nil
-        runTask = nil
+        clearActiveWorker()
     }
 
     private func fail(_ error: Error) {
@@ -340,8 +346,17 @@ final class ConversionViewModel: ObservableObject {
             )
         }
         pendingTerminalEvent = nil
+        clearActiveWorker()
+    }
+
+    private func clearActiveWorker() {
         client = nil
         runTask = nil
+        let actions = actionsWaitingForIdle
+        actionsWaitingForIdle.removeAll()
+        for action in actions {
+            action()
+        }
     }
 
     private func appendDiagnostic(_ message: String) {

--- a/macos/BluRayToVisionPro/Feature/SparkleUpdateBackend.swift
+++ b/macos/BluRayToVisionPro/Feature/SparkleUpdateBackend.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Sparkle
+
+@MainActor
+final class SparkleUpdateBackend: NSObject, UpdateBackend, SPUUpdaterDelegate {
+    var stateDidChange: (() -> Void)?
+    var updateChannel: UpdateChannelPreference {
+        didSet {
+            guard updateChannel != oldValue else {
+                return
+            }
+            controller.updater.resetUpdateCycleAfterShortDelay()
+        }
+    }
+
+    var automaticallyChecksForUpdates: Bool {
+        get { controller.updater.automaticallyChecksForUpdates }
+        set { controller.updater.automaticallyChecksForUpdates = newValue }
+    }
+
+    var canCheckForUpdates: Bool {
+        controller.updater.canCheckForUpdates
+    }
+
+    private var controller: SPUStandardUpdaterController!
+    private weak var installPostponer: (any UpdateInstallPostponing)?
+    private var observations: [NSKeyValueObservation] = []
+
+    init(
+        updateChannel: UpdateChannelPreference,
+        installPostponer: (any UpdateInstallPostponing)?
+    ) {
+        self.updateChannel = updateChannel
+        self.installPostponer = installPostponer
+        super.init()
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
+        observations = [
+            controller.updater.observe(\.automaticallyChecksForUpdates, options: [.new]) { [weak self] _, _ in
+                Task { @MainActor in
+                    self?.stateDidChange?()
+                }
+            },
+            controller.updater.observe(\.canCheckForUpdates, options: [.new]) { [weak self] _, _ in
+                Task { @MainActor in
+                    self?.stateDidChange?()
+                }
+            },
+        ]
+    }
+
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        updateChannel.sparkleChannels
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        shouldPostponeRelaunchForUpdate item: SUAppcastItem,
+        untilInvokingBlock installHandler: @escaping () -> Void
+    ) -> Bool {
+        installPostponer?.postponeInstallUntilIdle(installHandler) ?? false
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/UpdateController.swift
+++ b/macos/BluRayToVisionPro/Feature/UpdateController.swift
@@ -1,0 +1,307 @@
+import AppKit
+import Foundation
+
+enum UpdateChannelPreference: String, CaseIterable, Identifiable {
+    case stable
+    case releaseCandidate = "rc"
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .stable:
+            "Stable"
+        case .releaseCandidate:
+            "Release Candidates"
+        }
+    }
+
+    var sparkleChannels: Set<String> {
+        switch self {
+        case .stable:
+            []
+        case .releaseCandidate:
+            ["rc"]
+        }
+    }
+
+    static func storedValue(_ rawValue: String?) -> UpdateChannelPreference {
+        if rawValue == "releaseCandidate" {
+            return .releaseCandidate
+        }
+        return UpdateChannelPreference(rawValue: rawValue ?? "") ?? .stable
+    }
+}
+
+enum UpdateMode: Equatable {
+    case sparkle
+    case manual
+    case appStore
+    case disabled
+}
+
+struct UpdateEnvironment: Equatable {
+    let distributionChannel: String?
+    let feedURL: String?
+    let publicKey: String?
+    let allowsAutomaticUpdates: Bool?
+    let verifiesBeforeExtraction: Bool?
+    let automaticChecksSettingPresent: Bool
+    let startupSuppressed: Bool
+
+    init(
+        distributionChannel: String?,
+        feedURL: String?,
+        publicKey: String?,
+        allowsAutomaticUpdates: Bool?,
+        verifiesBeforeExtraction: Bool?,
+        automaticChecksSettingPresent: Bool,
+        startupSuppressed: Bool = false
+    ) {
+        self.distributionChannel = distributionChannel
+        self.feedURL = feedURL
+        self.publicKey = publicKey
+        self.allowsAutomaticUpdates = allowsAutomaticUpdates
+        self.verifiesBeforeExtraction = verifiesBeforeExtraction
+        self.automaticChecksSettingPresent = automaticChecksSettingPresent
+        self.startupSuppressed = startupSuppressed
+    }
+
+    init(
+        bundle: Bundle = .main,
+        arguments: [String] = ProcessInfo.processInfo.arguments,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        func stringValue(_ key: String) -> String? {
+            guard let value = bundle.object(forInfoDictionaryKey: key) else {
+                return nil
+            }
+            let text = String(describing: value).trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? nil : text
+        }
+
+        func boolValue(_ key: String) -> Bool? {
+            guard let value = bundle.object(forInfoDictionaryKey: key) else {
+                return nil
+            }
+            if let value = value as? Bool {
+                return value
+            }
+            if let value = value as? NSNumber {
+                return value.boolValue
+            }
+            return nil
+        }
+
+        distributionChannel = stringValue("BDToAVPDistributionChannel")
+        feedURL = stringValue("SUFeedURL")
+        publicKey = stringValue("SUPublicEDKey")
+        allowsAutomaticUpdates = boolValue("SUAllowsAutomaticUpdates")
+        verifiesBeforeExtraction = boolValue("SUVerifyUpdateBeforeExtraction")
+        automaticChecksSettingPresent = bundle.object(forInfoDictionaryKey: "SUEnableAutomaticChecks") != nil
+        startupSuppressed = AppDelegate.isStartupSmoke(arguments: arguments)
+            || processEnvironment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
+    var mode: UpdateMode {
+        if startupSuppressed {
+            return .disabled
+        }
+        if distributionChannel == "app-store" {
+            return .appStore
+        }
+        guard distributionChannel == "direct",
+              let feedURL,
+              let url = URL(string: feedURL),
+              url.scheme == "https",
+              url.host != nil,
+              let publicKey,
+              !publicKey.isEmpty,
+              allowsAutomaticUpdates == false,
+              verifiesBeforeExtraction == true,
+              !automaticChecksSettingPresent
+        else {
+            return .manual
+        }
+        return .sparkle
+    }
+}
+
+@MainActor
+protocol UpdateInstallPostponing: AnyObject {
+    func postponeInstallUntilIdle(_ installHandler: @escaping () -> Void) -> Bool
+}
+
+@MainActor
+protocol UpdateBackend: AnyObject {
+    var stateDidChange: (() -> Void)? { get set }
+    var automaticallyChecksForUpdates: Bool { get set }
+    var canCheckForUpdates: Bool { get }
+    var updateChannel: UpdateChannelPreference { get set }
+
+    func checkForUpdates()
+}
+
+@MainActor
+final class UpdateController: ObservableObject {
+    static let channelDefaultsKey = "BDToAVPUpdateChannel"
+    static let legacyChannelDefaultsKey = "native.updateChannel"
+    static let releasesURL = URL(string: "https://github.com/cbusillo/BD_to_AVP/releases")!
+
+    typealias BackendFactory = @MainActor (
+        UpdateChannelPreference,
+        (any UpdateInstallPostponing)?
+    ) throws -> any UpdateBackend
+
+    @Published private(set) var mode: UpdateMode
+    @Published var automaticallyChecksForUpdates: Bool {
+        didSet {
+            guard !isSynchronizingBackend,
+                  automaticallyChecksForUpdates != oldValue else {
+                return
+            }
+            backend?.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+        }
+    }
+
+    @Published var updateChannel: UpdateChannelPreference {
+        didSet {
+            guard updateChannel != oldValue else {
+                return
+            }
+            defaults.set(updateChannel.rawValue, forKey: Self.channelDefaultsKey)
+            if !isSynchronizingBackend {
+                backend?.updateChannel = updateChannel
+            }
+        }
+    }
+
+    @Published private(set) var canCheckForUpdates = false
+    private(set) var initializationError: Error?
+
+    private let defaults: UserDefaults
+    private let backendFactory: BackendFactory
+    private let openURL: (URL) -> Bool
+    private weak var installPostponer: (any UpdateInstallPostponing)?
+    private var backend: (any UpdateBackend)?
+    private var didStart = false
+    private var isSynchronizingBackend = false
+
+    init(
+        environment: UpdateEnvironment = UpdateEnvironment(),
+        defaults: UserDefaults = .standard,
+        installPostponer: (any UpdateInstallPostponing)? = nil,
+        openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) },
+        backendFactory: @escaping BackendFactory = { channel, postponer in
+            SparkleUpdateBackend(updateChannel: channel, installPostponer: postponer)
+        }
+    ) {
+        self.defaults = defaults
+        self.installPostponer = installPostponer
+        self.openURL = openURL
+        self.backendFactory = backendFactory
+        mode = environment.mode
+        automaticallyChecksForUpdates = false
+        updateChannel = Self.readChannel(from: defaults)
+        migrateLegacyChannelIfNeeded(defaults: defaults, channel: updateChannel)
+    }
+
+    var supportsAutomaticChecks: Bool {
+        mode == .sparkle && backend != nil
+    }
+
+    var supportsChannels: Bool {
+        supportsAutomaticChecks
+    }
+
+    var canPerformUpdateAction: Bool {
+        switch mode {
+        case .sparkle:
+            canCheckForUpdates
+        case .manual:
+            true
+        case .appStore, .disabled:
+            false
+        }
+    }
+
+    var updateActionTitle: String {
+        mode == .sparkle ? "Check for Updates…" : "View Available Releases…"
+    }
+
+    var unavailableReason: String {
+        switch mode {
+        case .sparkle:
+            ""
+        case .manual:
+            "Automatic update checks aren’t available in this build. Releases remain available for manual download."
+        case .appStore:
+            "Updates for this build are managed by the App Store."
+        case .disabled:
+            "Update checks are disabled for this launch."
+        }
+    }
+
+    func startIfNeeded() {
+        guard !didStart else {
+            return
+        }
+        didStart = true
+        guard mode == .sparkle else {
+            return
+        }
+
+        do {
+            let backend = try backendFactory(updateChannel, installPostponer)
+            self.backend = backend
+            backend.stateDidChange = { [weak self] in
+                self?.refreshFromBackend()
+            }
+            refreshFromBackend()
+        } catch {
+            initializationError = error
+            mode = .manual
+            backend = nil
+        }
+    }
+
+    func performUpdateAction() {
+        switch mode {
+        case .sparkle:
+            guard canCheckForUpdates else {
+                return
+            }
+            backend?.checkForUpdates()
+        case .manual:
+            _ = openURL(Self.releasesURL)
+        case .appStore, .disabled:
+            return
+        }
+    }
+
+    private func refreshFromBackend() {
+        guard let backend else {
+            return
+        }
+        isSynchronizingBackend = true
+        automaticallyChecksForUpdates = backend.automaticallyChecksForUpdates
+        canCheckForUpdates = backend.canCheckForUpdates
+        isSynchronizingBackend = false
+    }
+
+    private static func readChannel(from defaults: UserDefaults) -> UpdateChannelPreference {
+        if let currentValue = defaults.string(forKey: channelDefaultsKey) {
+            return .storedValue(currentValue)
+        }
+        return .storedValue(defaults.string(forKey: legacyChannelDefaultsKey))
+    }
+
+    private func migrateLegacyChannelIfNeeded(defaults: UserDefaults, channel: UpdateChannelPreference) {
+        guard defaults.string(forKey: Self.channelDefaultsKey) == nil,
+              defaults.string(forKey: Self.legacyChannelDefaultsKey) != nil else {
+            return
+        }
+        defaults.set(channel.rawValue, forKey: Self.channelDefaultsKey)
+        defaults.removeObject(forKey: Self.legacyChannelDefaultsKey)
+    }
+}

--- a/macos/BluRayToVisionPro/Info-Release.plist
+++ b/macos/BluRayToVisionPro/Info-Release.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BDToAVPDistributionChannel</key>
+	<string>direct</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleIconFile</key>
+	<string>app_icon</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.video</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>MainModule</key>
+	<string>bd_to_avp.worker</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
+	<key>SUFeedURL</key>
+	<string>https://cbusillo.github.io/BD_to_AVP/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU=</string>
+	<key>SUVerifyUpdateBeforeExtraction</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -120,20 +120,15 @@ enum SamplePosition: String, CaseIterable, Identifiable {
 
 struct AppCapabilities: Equatable {
     let conversionAvailable: Bool
-    let automaticUpdateChecksAvailable: Bool
 
     static let current = AppCapabilities(
-        conversionAvailable: true,
-        automaticUpdateChecksAvailable: false
+        conversionAvailable: true
     )
 
     var conversionUnavailableReason: String {
         "Conversion requires a Blu-ray disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source."
     }
 
-    var automaticUpdatesUnavailableReason: String {
-        "Automatic update checks aren’t available in this version."
-    }
 }
 
 struct ConversionDraft: Equatable {

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var profileStore: ProfileStore
-    let capabilities: AppCapabilities
+    @ObservedObject var updater: UpdateController
 
     var body: some View {
         TabView {
@@ -13,7 +13,7 @@ struct SettingsView: View {
             ProfilesSettingsPane(settings: settings, profileStore: profileStore)
                 .tabItem { Label("Profiles", systemImage: "slider.horizontal.3") }
 
-            UpdatesSettingsPane(settings: settings, capabilities: capabilities)
+            UpdatesSettingsPane(updater: updater)
                 .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
 
             AdvancedSettingsPane(settings: settings)
@@ -618,10 +618,7 @@ private struct ProfileEditorSheet: View {
 }
 
 private struct UpdatesSettingsPane: View {
-    @ObservedObject var settings: AppSettings
-    let capabilities: AppCapabilities
-
-    private let releasesURL = URL(string: "https://github.com/cbusillo/BD_to_AVP/releases")!
+    @ObservedObject var updater: UpdateController
 
     var body: some View {
         Form {
@@ -631,25 +628,32 @@ private struct UpdatesSettingsPane: View {
             )
 
             Section("Update Preferences") {
-                Toggle("Automatically check for updates", isOn: $settings.automaticallyChecksForUpdates)
-                    .disabled(!capabilities.automaticUpdateChecksAvailable)
+                Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
+                    .disabled(!updater.supportsAutomaticChecks)
 
-                Picker("Update channel", selection: $settings.updateChannel) {
+                Picker("Update channel", selection: $updater.updateChannel) {
                     ForEach(UpdateChannelPreference.allCases) { channel in
                         Text(channel.name).tag(channel)
                     }
                 }
-                .disabled(!capabilities.automaticUpdateChecksAvailable)
+                .disabled(!updater.supportsChannels)
 
-                if !capabilities.automaticUpdateChecksAvailable {
-                    Label(capabilities.automaticUpdatesUnavailableReason, systemImage: "info.circle")
+                if !updater.supportsAutomaticChecks {
+                    Label(updater.unavailableReason, systemImage: "info.circle")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
             }
 
             Section {
-                Link("View Available Releases…", destination: releasesURL)
+                Button(updater.updateActionTitle) {
+                    updater.performUpdateAction()
+                }
+                .disabled(!updater.canPerformUpdateAction)
+
+                if updater.mode == .sparkle {
+                    Link("View All Releases…", destination: UpdateController.releasesURL)
+                }
             }
         }
         .formStyle(.grouped)

--- a/macos/BluRayToVisionProTests/AppSettingsTests.swift
+++ b/macos/BluRayToVisionProTests/AppSettingsTests.swift
@@ -13,14 +13,12 @@ final class AppSettingsTests: XCTestCase {
         let settings = AppSettings(defaults: defaults, homeDirectoryURL: homeURL)
         settings.selectedProfileID = BuiltInProfile.fourKUpscale.id
         settings.destinationURL = URL(fileURLWithPath: "/Volumes/Media", isDirectory: true)
-        settings.updateChannel = .releaseCandidate
         settings.showTechnicalDetails = true
 
         let restored = AppSettings(defaults: defaults, homeDirectoryURL: homeURL)
 
         XCTAssertEqual(restored.selectedProfileID, BuiltInProfile.fourKUpscale.id)
         XCTAssertEqual(restored.destinationURL.path, "/Volumes/Media")
-        XCTAssertEqual(restored.updateChannel, .releaseCandidate)
         XCTAssertTrue(restored.showTechnicalDetails)
     }
 
@@ -38,22 +36,4 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.destinationURL.path, "/Users/example/Movies")
     }
 
-    @MainActor
-    func testUnavailableAutomaticUpdatesNormalizeToOff() {
-        let suiteName = "AppSettingsTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(true, forKey: "native.automaticUpdates")
-        let settings = AppSettings(defaults: defaults)
-
-        settings.normalize(
-            for: AppCapabilities(
-                conversionAvailable: false,
-                automaticUpdateChecksAvailable: false
-            )
-        )
-
-        XCTAssertFalse(settings.automaticallyChecksForUpdates)
-        XCTAssertFalse(defaults.bool(forKey: "native.automaticUpdates"))
-    }
 }

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -5,6 +5,44 @@ import XCTest
 
 final class ConversionViewModelTests: XCTestCase {
     @MainActor
+    func testUpdateInstallRelaunchWaitsForActiveWorker() async throws {
+        let terminalDelivered = expectation(description: "terminal delivered")
+        let worker = ControlledWorkerClient(terminalDelivered: terminalDelivered)
+        let viewModel = ConversionViewModel { worker }
+        var installCount = 0
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [terminalDelivered], timeout: 2)
+
+            XCTAssertTrue(
+                viewModel.postponeInstallUntilIdle {
+                    installCount += 1
+                }
+            )
+            XCTAssertEqual(installCount, 0)
+
+            await viewModel.stopForQuit()
+
+            XCTAssertEqual(installCount, 1)
+            XCTAssertFalse(viewModel.hasActiveWorker)
+        }
+    }
+
+    @MainActor
+    func testUpdateInstallRelaunchDoesNotPostponeWhileIdle() {
+        let viewModel = ConversionViewModel()
+        var installCount = 0
+
+        XCTAssertFalse(
+            viewModel.postponeInstallUntilIdle {
+                installCount += 1
+            }
+        )
+        XCTAssertEqual(installCount, 0)
+    }
+
+    @MainActor
     func testTerminalCompletionWinsIfStopIsRequestedBeforeProcessExit() async throws {
         let terminalDelivered = expectation(description: "terminal delivered")
         let worker = ControlledWorkerClient(terminalDelivered: terminalDelivered)

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -112,7 +112,6 @@ final class ConversionWorkflowTests: XCTestCase {
 
     func testCurrentCapabilitiesStayHonest() {
         XCTAssertTrue(AppCapabilities.current.conversionAvailable)
-        XCTAssertFalse(AppCapabilities.current.automaticUpdateChecksAvailable)
         XCTAssertEqual(
             AppCapabilities.current.conversionUnavailableReason,
             "Conversion requires a Blu-ray disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source."

--- a/macos/BluRayToVisionProTests/UpdateControllerTests.swift
+++ b/macos/BluRayToVisionProTests/UpdateControllerTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class UpdateControllerTests: XCTestCase {
+    @MainActor
+    func testDebugBundleRemainsInManualUpdateMode() {
+        XCTAssertEqual(UpdateEnvironment().mode, .manual)
+    }
+
+    @MainActor
+    func testDirectEnvironmentRequiresCompleteFailClosedMetadata() {
+        XCTAssertEqual(directEnvironment().mode, .sparkle)
+        XCTAssertEqual(directEnvironment(feedURL: "http://example.com/appcast.xml").mode, .manual)
+        XCTAssertEqual(directEnvironment(publicKey: nil).mode, .manual)
+        XCTAssertEqual(directEnvironment(allowsAutomaticUpdates: true).mode, .manual)
+        XCTAssertEqual(directEnvironment(verifiesBeforeExtraction: false).mode, .manual)
+        XCTAssertEqual(directEnvironment(automaticChecksSettingPresent: true).mode, .manual)
+        XCTAssertEqual(directEnvironment(distributionChannel: "app-store").mode, .appStore)
+        XCTAssertEqual(directEnvironment(startupSuppressed: true).mode, .disabled)
+    }
+
+    @MainActor
+    func testControllerSynchronizesSparklePreferencesAndChannel() {
+        let suiteName = "UpdateControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let backend = FakeUpdateBackend(automaticallyChecksForUpdates: false, canCheckForUpdates: true)
+        let controller = UpdateController(
+            environment: directEnvironment(),
+            defaults: defaults,
+            backendFactory: { _, _ in backend }
+        )
+
+        controller.startIfNeeded()
+
+        XCTAssertTrue(controller.supportsAutomaticChecks)
+        XCTAssertTrue(controller.canPerformUpdateAction)
+        XCTAssertFalse(controller.automaticallyChecksForUpdates)
+        XCTAssertEqual(controller.updateChannel, .stable)
+
+        controller.automaticallyChecksForUpdates = true
+        controller.updateChannel = .releaseCandidate
+        controller.performUpdateAction()
+
+        XCTAssertTrue(backend.automaticallyChecksForUpdates)
+        XCTAssertEqual(backend.updateChannel, .releaseCandidate)
+        XCTAssertEqual(backend.channelChangeCount, 1)
+        XCTAssertEqual(defaults.string(forKey: UpdateController.channelDefaultsKey), "rc")
+        XCTAssertEqual(backend.checkCount, 1)
+    }
+
+    @MainActor
+    func testControllerRefreshesWhenSparkleStateChanges() {
+        let backend = FakeUpdateBackend(automaticallyChecksForUpdates: false, canCheckForUpdates: true)
+        let controller = UpdateController(
+            environment: directEnvironment(),
+            defaults: isolatedDefaults(),
+            backendFactory: { _, _ in backend }
+        )
+        controller.startIfNeeded()
+
+        backend.automaticallyChecksForUpdates = true
+        backend.canCheckForUpdates = false
+        backend.stateDidChange?()
+
+        XCTAssertTrue(controller.automaticallyChecksForUpdates)
+        XCTAssertFalse(controller.canCheckForUpdates)
+        XCTAssertFalse(controller.canPerformUpdateAction)
+    }
+
+    @MainActor
+    func testManualModeUsesReleasePageWithoutCreatingSparkle() {
+        var openedURL: URL?
+        var factoryCalled = false
+        let controller = UpdateController(
+            environment: directEnvironment(publicKey: nil),
+            defaults: isolatedDefaults(),
+            openURL: { url in
+                openedURL = url
+                return true
+            },
+            backendFactory: { _, _ in
+                factoryCalled = true
+                return FakeUpdateBackend()
+            }
+        )
+
+        controller.startIfNeeded()
+        controller.performUpdateAction()
+
+        XCTAssertEqual(controller.mode, .manual)
+        XCTAssertFalse(controller.supportsAutomaticChecks)
+        XCTAssertTrue(controller.canPerformUpdateAction)
+        XCTAssertFalse(factoryCalled)
+        XCTAssertEqual(openedURL, UpdateController.releasesURL)
+    }
+
+    @MainActor
+    func testLegacyReleaseCandidatePreferenceMigratesToProductionKey() {
+        let suiteName = "UpdateControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("releaseCandidate", forKey: UpdateController.legacyChannelDefaultsKey)
+
+        let controller = UpdateController(
+            environment: directEnvironment(publicKey: nil),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(controller.updateChannel, .releaseCandidate)
+        XCTAssertEqual(defaults.string(forKey: UpdateController.channelDefaultsKey), "rc")
+        XCTAssertNil(defaults.string(forKey: UpdateController.legacyChannelDefaultsKey))
+    }
+
+    @MainActor
+    func testInvalidStoredChannelFallsBackToStable() {
+        let suiteName = "UpdateControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("nightly", forKey: UpdateController.channelDefaultsKey)
+
+        let controller = UpdateController(
+            environment: directEnvironment(publicKey: nil),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(controller.updateChannel, .stable)
+    }
+
+    @MainActor
+    func testSparkleInitializationFailureFallsBackToManualUpdates() {
+        let controller = UpdateController(
+            environment: directEnvironment(),
+            defaults: isolatedDefaults(),
+            backendFactory: { _, _ in throw TestError.initializationFailed }
+        )
+
+        controller.startIfNeeded()
+
+        XCTAssertEqual(controller.mode, .manual)
+        XCTAssertNotNil(controller.initializationError)
+        XCTAssertTrue(controller.canPerformUpdateAction)
+    }
+
+    @MainActor
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "UpdateControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+
+    private func directEnvironment(
+        distributionChannel: String? = "direct",
+        feedURL: String? = "https://example.com/appcast.xml",
+        publicKey: String? = "public-key",
+        allowsAutomaticUpdates: Bool? = false,
+        verifiesBeforeExtraction: Bool? = true,
+        automaticChecksSettingPresent: Bool = false,
+        startupSuppressed: Bool = false
+    ) -> UpdateEnvironment {
+        UpdateEnvironment(
+            distributionChannel: distributionChannel,
+            feedURL: feedURL,
+            publicKey: publicKey,
+            allowsAutomaticUpdates: allowsAutomaticUpdates,
+            verifiesBeforeExtraction: verifiesBeforeExtraction,
+            automaticChecksSettingPresent: automaticChecksSettingPresent,
+            startupSuppressed: startupSuppressed
+        )
+    }
+}
+
+@MainActor
+private final class FakeUpdateBackend: UpdateBackend {
+    var stateDidChange: (() -> Void)?
+    var automaticallyChecksForUpdates: Bool
+    var canCheckForUpdates: Bool
+    var updateChannel = UpdateChannelPreference.stable {
+        didSet {
+            if updateChannel != oldValue {
+                channelChangeCount += 1
+            }
+        }
+    }
+    private(set) var checkCount = 0
+    private(set) var channelChangeCount = 0
+
+    init(
+        automaticallyChecksForUpdates: Bool = false,
+        canCheckForUpdates: Bool = true
+    ) {
+        self.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+        self.canCheckForUpdates = canCheckForUpdates
+    }
+
+    func checkForUpdates() {
+        checkCount += 1
+    }
+}
+
+private enum TestError: Error {
+    case initializationFailed
+}

--- a/macos/README.md
+++ b/macos/README.md
@@ -21,12 +21,22 @@ uv run python scripts/native_app.py test
 uv run python scripts/native_app.py build
 ```
 
+The project exact-pins Sparkle 2.9.4 through Swift Package Manager. Debug and
+Preview builds omit direct-distribution update metadata, never start Sparkle,
+and retain the manual GitHub Releases fallback. The Release configuration uses
+`Info-Release.plist` for the policy-checked direct appcast metadata.
+
 Create an ad-hoc signed review build containing the Briefcase-managed Python
 runtime and conversion engine with:
 
 ```sh
 uv run python scripts/native_app.py package
 ```
+
+Ad-hoc packages omit Hardened Runtime because ad-hoc signatures have no Team ID
+for dyld library validation; Developer ID packages retain Hardened Runtime. The
+package gate launches the signed native host with `--startup-smoke`, smokes the
+embedded conversion worker, and then performs strict deep signature validation.
 
 The native application targets Apple Silicon macOS 26 or later while remaining
 buildable with the Xcode 27 SDK. Packaged release validation rejects a native

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -11,6 +11,11 @@ configs:
   Preview: release
   Release: release
 
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    exactVersion: 2.9.4
+
 settings:
   base:
     CLANG_ENABLE_MODULES: YES
@@ -25,6 +30,8 @@ targets:
       - path: BluRayToVisionPro
       - path: ../bd_to_avp/resources/app_icon.icns
         buildPhase: resources
+    dependencies:
+      - package: Sparkle
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
@@ -60,6 +67,7 @@ targets:
           DEAD_CODE_STRIPPING: YES
           DEPLOYMENT_POSTPROCESSING: YES
           ENABLE_CODE_COVERAGE: NO
+          INFOPLIST_FILE: BluRayToVisionPro/Info-Release.plist
           ONLY_ACTIVE_ARCH: NO
           OTHER_SWIFT_FLAGS: $(inherited) -file-prefix-map $(SRCROOT)/BluRayToVisionPro=/Sources -debug-prefix-map $(SRCROOT)/BluRayToVisionPro=/Sources -coverage-prefix-map $(SRCROOT)/BluRayToVisionPro=/Sources
           SWIFT_SERIALIZE_DEBUGGING_OPTIONS: NO

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -371,7 +371,9 @@ def is_mach_o(path: Path) -> bool:
 
 
 def sign_package(app_path: Path, identity: str, keychain: str | None = None) -> None:
-    sign_options = ["codesign", "--force", "--sign", identity, "--options", "runtime"]
+    sign_options = ["codesign", "--force", "--sign", identity]
+    if identity != "-":
+        sign_options.extend(["--options", "runtime"])
     if keychain:
         sign_options.extend(["--keychain", keychain])
     sign_options.append("--timestamp=none" if identity == "-" else "--timestamp")
@@ -402,6 +404,12 @@ def sign_package(app_path: Path, identity: str, keychain: str | None = None) -> 
 
 def verify_codesign(app_path: Path) -> None:
     run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])
+
+
+def smoke_packaged_native_app(app_path: Path) -> None:
+    app_path = app_path.resolve()
+    native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
+    run([str(native_executable), "--startup-smoke"], cwd=app_path)
 
 
 def smoke_packaged_worker(app_path: Path) -> None:
@@ -503,6 +511,7 @@ def package(identity: str, keychain: str | None = None) -> None:
     xcodebuild("build", NATIVE_PACKAGE_CONFIGURATION)
     app_path = assemble_package()
     sign_package(app_path, identity, keychain)
+    smoke_packaged_native_app(app_path)
     smoke_packaged_worker(app_path)
     verify_codesign(app_path)
     print(app_path)

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -3,6 +3,7 @@ import json
 import plistlib
 import subprocess
 import tempfile
+import tomllib
 import unittest
 
 from contextlib import chdir
@@ -27,6 +28,7 @@ from scripts.native_app import (
     minimum_macos_versions,
     parse_args,
     sign_package,
+    smoke_packaged_native_app,
     smoke_packaged_worker,
     validate_smoke_events,
     verify_native_binary_paths,
@@ -56,6 +58,13 @@ class NativeAppPackagingTests(unittest.TestCase):
         project = yaml.load(project_spec, Loader=yaml.BaseLoader)
         target_settings = project["targets"]["BluRayToVisionPro"]["settings"]
         preview_settings = target_settings["configs"]["Preview"]
+        release_settings = target_settings["configs"]["Release"]
+        sparkle_manifest = tomllib.loads((REPO_ROOT / "vendor" / "sparkle-macos.toml").read_text(encoding="utf-8"))
+        briefcase_info = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["briefcase"][
+            "app"
+        ]["bd-to-avp"]["macOS"]["info"]
+        preview_info = plistlib.loads((MACOS_ROOT / "BluRayToVisionPro" / "Info.plist").read_bytes())
+        release_info = plistlib.loads((MACOS_ROOT / "BluRayToVisionPro" / "Info-Release.plist").read_bytes())
         app_source = (MACOS_ROOT / "BluRayToVisionPro" / "App" / "BluRayToVisionProApp.swift").read_text(
             encoding="utf-8"
         )
@@ -65,7 +74,12 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn("SettingsView(", app_source)
         self.assertIn("profileStore: profileStore", app_source)
         self.assertIn("capabilities: capabilities", app_source)
+        self.assertIn("updater: updater", app_source)
+        self.assertIn("UpdateCommands(updater: updater)", app_source)
+        self.assertIn("UpdateController(installPostponer: viewModel)", app_source)
         self.assertIn("CommandGroup(replacing: .appSettings)", app_source)
+        self.assertIn("CommandGroup(after: .help)", app_source)
+        self.assertIn('Picker("Update Channel"', app_source)
         self.assertIn("openWindow(id: AppWindowID.settings)", app_source)
         self.assertIn(".windowResizability(.contentMinSize)", app_source)
         self.assertEqual(target_settings["base"]["CURRENT_PROJECT_VERSION"], NATIVE_BUILD_VERSION)
@@ -75,6 +89,21 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(preview_settings["PRODUCT_BUNDLE_IDENTIFIER"], NATIVE_BUNDLE_IDENTIFIER)
         self.assertEqual(preview_settings["PRODUCT_NAME"], NATIVE_PRODUCT_NAME)
         self.assertIn("Preview: release", project_spec)
+        self.assertEqual(project["packages"]["Sparkle"]["exactVersion"], sparkle_manifest["version"])
+        self.assertIn({"package": "Sparkle"}, project["targets"]["BluRayToVisionPro"]["dependencies"])
+        update_keys = {
+            "BDToAVPDistributionChannel",
+            "SUAllowsAutomaticUpdates",
+            "SUFeedURL",
+            "SUPublicEDKey",
+            "SUVerifyUpdateBeforeExtraction",
+        }
+        for key in update_keys:
+            self.assertNotIn(key, preview_info)
+            self.assertEqual(release_info[key], briefcase_info[key])
+        self.assertEqual(preview_info, {key: value for key, value in release_info.items() if key not in update_keys})
+        self.assertEqual(release_settings["INFOPLIST_FILE"], "BluRayToVisionPro/Info-Release.plist")
+        self.assertNotIn("SUEnableAutomaticChecks", release_info)
 
     def test_native_ui_keeps_discs_primary_and_original_job_controls_visible(self) -> None:
         source_view = (MACOS_ROOT / "BluRayToVisionPro" / "Views" / "SourceWorkspaceView.swift").read_text(
@@ -240,6 +269,27 @@ Load command 3
         for command in signing_commands:
             self.assertIn("--keychain", command)
             self.assertIn("/tmp/release.keychain-db", command)
+            self.assertIn("--options", command)
+            self.assertIn("runtime", command)
+            self.assertIn("--timestamp", command)
+
+    def test_ad_hoc_package_signing_omits_hardened_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            (app_path / "Contents" / "MacOS").mkdir(parents=True)
+            with patch("scripts.native_app.run") as run_mock:
+                sign_package(app_path, "-")
+
+        signing_commands = [
+            call.args[0]
+            for call in run_mock.call_args_list
+            if call.args[0][0] == "codesign" and "--sign" in call.args[0]
+        ]
+        self.assertGreaterEqual(len(signing_commands), 2)
+        for command in signing_commands:
+            self.assertNotIn("--options", command)
+            self.assertNotIn("runtime", command)
+            self.assertIn("--timestamp=none", command)
 
     def test_product_copy_has_no_internal_labels(self) -> None:
         verify_product_source_copy()
@@ -427,6 +477,24 @@ Load command 3
                 [str(resolved_app_path / "Contents" / "MacOS" / "BluRayToVisionProEngine")],
             )
             self.assertEqual(run_mock.call_args.kwargs["cwd"], resolved_app_path)
+
+    def test_native_startup_smoke_uses_the_signed_packaged_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            relative_app_path = Path("package") / NATIVE_APP_NAME
+            absolute_app_path = temporary_path / relative_app_path
+            absolute_app_path.mkdir(parents=True)
+            resolved_app_path = absolute_app_path.resolve()
+            with chdir(temporary_path), patch("scripts.native_app.run") as run_mock:
+                smoke_packaged_native_app(relative_app_path)
+
+        run_mock.assert_called_once_with(
+            [
+                str(resolved_app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME),
+                "--startup-smoke",
+            ],
+            cwd=resolved_app_path,
+        )
 
     def test_rejects_wrong_job_or_result(self) -> None:
         events: list[object] = [


### PR DESCRIPTION
## Summary
- exact-pin Sparkle 2.9.4 through XcodeGen/SPM and add fail-closed direct-distribution metadata for Release builds
- add a testable native update controller that drives Settings and Help, persists Stable/RC selection, mirrors Sparkle automatic checks, and falls back to manual releases in Preview/Debug
- postpone update relaunch while conversion work is active, and strengthen packaging with Sparkle-safe ad-hoc signing plus a post-sign native startup smoke

## Validation
- `uv run python -m unittest discover -s tests` — 417 passed
- `uv run python scripts/native_app.py test` — 90 passed
- `uv run python scripts/native_app.py package` — assembled app, native startup smoke, worker smoke, and strict deep codesign verification passed
- JetBrains changed-files inspection — GREEN, 0 findings
- Gemini final review — no functional blockers

## Deferred
- production Developer ID installed-app upgrade, live Stable/RC appcast behavior, permission prompting, and rendered release notes remain signed release-cycle validation with #197

Refs #192