### PR TITLE
Add visionOS spatial playback probe

### DIFF
--- a/docs/visionos-spatial-playback-probe.md
+++ b/docs/visionos-spatial-playback-probe.md
@@ -1,0 +1,63 @@
+# visionOS Spatial Playback Probe
+
+`SpatialPlaybackProbe` is an isolated visionOS companion target for validating finalized BD to AVP preview and output movies with native Apple playback APIs. It contains no Python runtime, ripping tools, or conversion engine.
+
+## What It Proves
+
+- `VTIsStereoMVHEVCDecodeSupported()` on the target device.
+- `AVPlayerItem.status == .readyToPlay` for the transferred movie.
+- `VideoPlayerComponent.currentRenderingStatus == .ready`.
+- Requested stereo viewing, `.spatial` presentation, and portal rendering versus the actual RealityKit modes.
+- Beginning, middle, and end seeks while preserving the reported spatial mode.
+- Available audio and subtitle choices.
+
+The simulator is useful for builds and flat playback behavior, but it is not acceptance evidence for stereoscopic presentation. A physical Apple Vision Pro is required.
+
+## Build
+
+Create a six-second finalized MV-HEVC fixture with English audio and subtitles:
+
+```bash
+scripts/create_spatial_playback_fixture.sh
+```
+
+Generate the project and build for the simulator:
+
+```bash
+uv run python scripts/native_app.py generate
+xcodebuild build \
+  -project macos/BluRayToVisionPro.xcodeproj \
+  -scheme SpatialPlaybackProbe \
+  -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+  -derivedDataPath macos/build/SpatialPlaybackProbeDerivedData \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+For a physical device, supply a development team and the connected device identifier:
+
+```bash
+xcodebuild build \
+  -project macos/BluRayToVisionPro.xcodeproj \
+  -scheme SpatialPlaybackProbe \
+  -destination 'platform=visionOS,id=<device-id>' \
+  -derivedDataPath macos/build/SpatialPlaybackProbeDerivedData \
+  -allowProvisioningUpdates \
+  DEVELOPMENT_TEAM=<team-id>
+```
+
+The `SpatialPlaybackProbeUITests` target performs the user-initiated **Open Spatial View** action required by visionOS and verifies the reported stereo, spatial, portal presentation on a physical headset. Simulator runs skip this acceptance test. The headset must allow Xcode to enter UI automation mode; a timeout while enabling automation is an environment blocker, not spatial-playback evidence.
+
+## Open a Finalized Movie
+
+Launch the app on Apple Vision Pro and choose **Open Preview…**. The file importer accepts a movie from Files, copies it into the app container, and keeps playback independent from the source file's security-scoped lifetime. The default volumetric window renders through `VideoPlayerComponent`; **Open Spatial View** requests a mixed immersive-space portal for focused review.
+
+For automated development-device evidence, install the built app, copy a finalized movie into its data container as `Documents/Probe.mov`, and launch with `BD_TO_AVP_PROBE_AUTORUN=1`. The visible **Open Spatial View** action—or the physical-device UI test—must enter the immersive portal before the automated seek sequence begins and `.spatial` can be accepted.
+
+Structured events are printed with the `BD_TO_AVP_PLAYBACK_PROBE` prefix. The terminal event is `automated_probe_complete`; acceptance requires `result=pass`, `rendering_status=ready`, a stereo/spatial actual presentation, and all three seeks to finish.
+
+## Interpretation
+
+- `.spatial` is acceptance for stereoscopic presentation.
+- `.screen` is a useful diagnostic fallback but does not satisfy the spatial-mode criterion.
+- Missing audio or subtitle choices are fixture limitations, not decode failures. Use a representative final mux before closing the media-selection criteria.
+- Live playback of the MOV while the conversion pipeline is still writing it remains out of scope. This target consumes immutable finalized artifacts only.

--- a/macos/README.md
+++ b/macos/README.md
@@ -51,3 +51,6 @@ binary, embedded engine, or bundled Mach-O that requires a newer system.
 
 See [Native UI Acceptance](../docs/native-ui-acceptance.md) for the current
 profile, appearance, accessibility, window-size, and native screenshot evidence.
+
+See [visionOS Spatial Playback Probe](../docs/visionos-spatial-playback-probe.md)
+for the isolated RealityKit companion target and physical-headset validation flow.

--- a/macos/SpatialPlaybackProbe/Info.plist
+++ b/macos/SpatialPlaybackProbe/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>BD to AVP Spatial Playback</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Movie</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.movie</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationPreferredDefaultSceneSessionRole</key>
+		<string>UIWindowSceneSessionRoleVolumetricApplication</string>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UISceneSessionRoleImmersiveSpaceApplication</key>
+			<array>
+				<dict>
+					<key>UISceneInitialImmersionStyle</key>
+					<string>UIImmersionStyleMixed</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
@@ -1,0 +1,627 @@
+import AVFoundation
+import Combine
+import Foundation
+import RealityKit
+import VideoToolbox
+
+enum ProbeFailureCategory: String, Codable {
+    case unsupportedDecode = "unsupported_decode"
+    case malformedMetadata = "malformed_metadata"
+    case missingFile = "missing_file"
+    case transferFailure = "transfer_failure"
+    case playbackFailure = "playback_failure"
+}
+
+struct ProbeFailure: Identifiable, Equatable {
+    let id = UUID()
+    let category: ProbeFailureCategory
+    let title: String
+    let message: String
+}
+
+struct ProbeMediaOption: Identifiable, Equatable {
+    let id: String
+    let name: String
+}
+
+enum ProbeSeekPosition: String, CaseIterable {
+    case beginning
+    case middle
+    case end
+}
+
+private struct ProbeLogEvent: Encodable {
+    let sequence: Int
+    let timestamp: String
+    let name: String
+    let values: [String: String]
+}
+
+@MainActor
+final class PlaybackProbeModel: ObservableObject {
+    static let defaultTransferredAssetName = "Probe.mov"
+
+    let player = AVPlayer()
+    let playerEntity = Entity()
+
+    @Published private(set) var assetName = "No preview selected"
+    @Published private(set) var hasLoadedAsset = false
+    @Published private(set) var isLoading = false
+    @Published private(set) var isPlaying = false
+    @Published private(set) var playerItemStatusText = "Not loaded"
+    @Published private(set) var renderingStatusText = "Not loaded"
+    @Published private(set) var immersiveSpaceStatusText = "Not open"
+    @Published private(set) var immersiveSpaceIsOpen = false
+    @Published private(set) var actualPresentationText = "Not available"
+    @Published private(set) var isActuallySpatial = false
+    @Published private(set) var currentSeconds = 0.0
+    @Published private(set) var durationSeconds = 0.0
+    @Published private(set) var failure: ProbeFailure?
+    @Published private(set) var audioOptions: [ProbeMediaOption] = []
+    @Published private(set) var subtitleOptions: [ProbeMediaOption] = []
+    @Published var selectedAudioID = ""
+    @Published var selectedSubtitleID = "off"
+
+    let stereoDecodeSupported = VTIsStereoMVHEVCDecodeSupported()
+
+    private var itemStatusObservation: NSKeyValueObservation?
+    private var timeObserver: Any?
+    private var statusTask: Task<Void, Never>?
+    private var automatedProbeTask: Task<Void, Never>?
+    private var playerComponentInstalled = false
+    private var logSequence = 0
+    private var audioGroup: AVMediaSelectionGroup?
+    private var subtitleGroup: AVMediaSelectionGroup?
+    private var audioSelectionByID: [String: AVMediaSelectionOption] = [:]
+    private var subtitleSelectionByID: [String: AVMediaSelectionOption] = [:]
+    private var automatedProbeStarted = false
+
+    private var environment: [String: String] {
+        ProcessInfo.processInfo.environment
+    }
+
+    private var shouldRunAutomatedProbe: Bool {
+        environment["BD_TO_AVP_PROBE_AUTORUN"] == "1"
+    }
+
+    var decodeSupportText: String {
+        stereoDecodeSupported ? "Supported" : "Unavailable"
+    }
+
+    var canControlPlayback: Bool {
+        player.currentItem?.status == .readyToPlay
+    }
+
+    var canSeek: Bool {
+        canControlPlayback && durationSeconds.isFinite && durationSeconds > 0
+    }
+
+    var timeSummary: String {
+        "\(formatTime(currentSeconds)) / \(formatTime(durationSeconds))"
+    }
+
+    deinit {
+        statusTask?.cancel()
+        automatedProbeTask?.cancel()
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+    }
+
+    func bootstrap() async {
+        emit(
+            "capability",
+            values: [
+                "stereo_mv_hevc_decode": String(stereoDecodeSupported),
+                "visionos_version": ProcessInfo.processInfo.operatingSystemVersionString,
+            ]
+        )
+
+        if !stereoDecodeSupported {
+            emit(
+                "warning",
+                values: [
+                    "category": ProbeFailureCategory.unsupportedDecode.rawValue,
+                    "message": "This device does not currently report stereo MV-HEVC decode support.",
+                ]
+            )
+        }
+
+        if let automaticAssetURL = automaticAssetURL() {
+            await loadAsset(at: automaticAssetURL)
+        } else if shouldRunAutomatedProbe {
+            setFailure(
+                category: .missingFile,
+                title: "Transferred preview is missing",
+                message: "Copy a finalized movie to Documents/\(Self.defaultTransferredAssetName) or set BD_TO_AVP_PROBE_ASSET."
+            )
+        }
+    }
+
+    func installPlayerComponent() {
+        guard !playerComponentInstalled else {
+            return
+        }
+
+        var component = VideoPlayerComponent(avPlayer: player)
+        component.desiredViewingMode = .stereo
+        component.desiredSpatialVideoMode = .spatial
+        component.desiredImmersiveViewingMode = .portal
+        playerEntity.components.set(component)
+        playerEntity.position = .zero
+        playerEntity.scale = SIMD3<Float>(repeating: 0.20)
+        playerComponentInstalled = true
+        startStatusPolling()
+
+        emit(
+            "component_installed",
+            values: [
+                "desired_viewing_mode": "stereo",
+                "desired_spatial_video_mode": "spatial",
+                "desired_immersive_viewing_mode": "portal",
+            ]
+        )
+    }
+
+    func importAsset(from sourceURL: URL) {
+        isLoading = true
+        failure = nil
+        let didAccess = sourceURL.startAccessingSecurityScopedResource()
+
+        Task {
+            defer {
+                if didAccess {
+                    sourceURL.stopAccessingSecurityScopedResource()
+                }
+            }
+            do {
+                let localURL = try await Self.copyImportedAsset(sourceURL)
+                await loadAsset(at: localURL)
+            } catch {
+                setFailure(
+                    category: .transferFailure,
+                    title: "Preview import failed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    func reportImportFailure(_ error: Error) {
+        setFailure(
+            category: .transferFailure,
+            title: "Preview selection failed",
+            message: error.localizedDescription
+        )
+    }
+
+    func recordImmersiveSpaceStatus(_ status: String, isOpen: Bool) {
+        immersiveSpaceStatusText = status
+        immersiveSpaceIsOpen = isOpen
+        emit(
+            "immersive_space",
+            values: [
+                "status": status.lowercased().replacingOccurrences(of: " ", with: "_"),
+                "is_open": String(isOpen),
+            ]
+        )
+        scheduleAutomatedProbeIfNeeded()
+    }
+
+    func togglePlayback() {
+        guard canControlPlayback else {
+            return
+        }
+
+        if isPlaying {
+            player.pause()
+        } else {
+            player.play()
+        }
+    }
+
+    func seek(to position: ProbeSeekPosition) {
+        guard canSeek else {
+            return
+        }
+
+        Task {
+            let target = seekTarget(for: position)
+            let finished = await seek(to: target)
+            emit(
+                "seek",
+                values: [
+                    "position": position.rawValue,
+                    "target_seconds": formatNumber(target),
+                    "finished": String(finished),
+                    "actual_spatial_video_mode": isActuallySpatial ? "spatial" : "screen",
+                ]
+            )
+        }
+    }
+
+    func selectAudio(_ identifier: String) {
+        guard
+            let currentItem = player.currentItem,
+            let audioGroup,
+            let option = audioSelectionByID[identifier]
+        else {
+            return
+        }
+
+        currentItem.select(option, in: audioGroup)
+        emit("audio_selected", values: ["name": option.displayName])
+    }
+
+    func selectSubtitle(_ identifier: String) {
+        guard let currentItem = player.currentItem, let subtitleGroup else {
+            return
+        }
+
+        let option = subtitleSelectionByID[identifier]
+        currentItem.select(option, in: subtitleGroup)
+        emit("subtitle_selected", values: ["name": option?.displayName ?? "Off"])
+    }
+
+    private func loadAsset(at url: URL) async {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            setFailure(
+                category: .missingFile,
+                title: "Preview is missing",
+                message: "The selected movie is no longer available at \(url.lastPathComponent)."
+            )
+            return
+        }
+
+        failure = nil
+        isLoading = true
+        hasLoadedAsset = true
+        assetName = url.lastPathComponent
+        playerItemStatusText = "Loading"
+        renderingStatusText = "Loading"
+        actualPresentationText = "Waiting for RealityKit"
+        isActuallySpatial = false
+        automatedProbeStarted = false
+
+        let asset = AVURLAsset(url: url)
+        let item = AVPlayerItem(asset: asset)
+        observe(item)
+        player.replaceCurrentItem(with: item)
+
+        do {
+            let duration = try await asset.load(.duration)
+            durationSeconds = duration.seconds.isFinite ? max(0, duration.seconds) : 0
+            try await loadMediaSelections(for: asset, item: item)
+            emit(
+                "asset_loaded",
+                values: [
+                    "file": url.lastPathComponent,
+                    "duration_seconds": formatNumber(durationSeconds),
+                    "audio_options": String(audioOptions.count),
+                    "subtitle_options": String(max(0, subtitleOptions.count - 1)),
+                ]
+            )
+        } catch {
+            setFailure(
+                category: .malformedMetadata,
+                title: "Movie metadata is unreadable",
+                message: error.localizedDescription
+            )
+            return
+        }
+
+        player.play()
+    }
+
+    private func observe(_ item: AVPlayerItem) {
+        itemStatusObservation = item.observe(\.status, options: [.initial, .new]) { [weak self] observedItem, _ in
+            Task { @MainActor in
+                self?.handleItemStatus(observedItem)
+            }
+        }
+
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+        timeObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 0.25, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] time in
+            Task { @MainActor in
+                guard let self else {
+                    return
+                }
+                self.currentSeconds = max(0, time.seconds.isFinite ? time.seconds : 0)
+                self.isPlaying = self.player.rate != 0
+            }
+        }
+    }
+
+    private func handleItemStatus(_ item: AVPlayerItem) {
+        switch item.status {
+        case .unknown:
+            playerItemStatusText = "Loading"
+        case .readyToPlay:
+            playerItemStatusText = "Ready to play"
+            isLoading = false
+            emit("player_item", values: ["status": "ready_to_play"])
+            scheduleAutomatedProbeIfNeeded()
+        case .failed:
+            setFailure(
+                category: .playbackFailure,
+                title: "AVPlayer could not load the movie",
+                message: item.error?.localizedDescription ?? "The player item failed without an error description."
+            )
+        @unknown default:
+            playerItemStatusText = "Unknown"
+        }
+    }
+
+    private func startStatusPolling() {
+        statusTask?.cancel()
+        statusTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                self?.refreshComponentStatus()
+            }
+        }
+    }
+
+    private func refreshComponentStatus() {
+        guard hasLoadedAsset, let component = playerEntity.components[VideoPlayerComponent.self] else {
+            return
+        }
+
+        let newRenderingStatus = component.currentRenderingStatus == .ready ? "Ready" : "Loading"
+        let newSpatialMode = component.spatialVideoMode == .spatial ? "Spatial" : "Screen fallback"
+        let viewingMode: String
+        switch component.viewingMode {
+        case .stereo:
+            viewingMode = "Stereo"
+        case .mono:
+            viewingMode = "Mono"
+        case nil:
+            viewingMode = "Unknown"
+        @unknown default:
+            viewingMode = "Unknown"
+        }
+
+        let immersiveMode: String
+        switch component.immersiveViewingMode {
+        case .portal:
+            immersiveMode = "Portal"
+        case .full:
+            immersiveMode = "Full"
+        case .progressive:
+            immersiveMode = "Progressive"
+        case nil:
+            immersiveMode = "None"
+        @unknown default:
+            immersiveMode = "Unknown"
+        }
+
+        let newPresentation = "\(viewingMode) · \(newSpatialMode) · \(immersiveMode)"
+        let didChange = newRenderingStatus != renderingStatusText || newPresentation != actualPresentationText
+
+        renderingStatusText = newRenderingStatus
+        actualPresentationText = newPresentation
+        isActuallySpatial = component.spatialVideoMode == .spatial
+            && component.viewingMode == .stereo
+            && component.immersiveViewingMode == .portal
+
+        if didChange {
+            emit(
+                "component_status",
+                values: [
+                    "rendering_status": newRenderingStatus.lowercased(),
+                    "viewing_mode": viewingMode.lowercased(),
+                    "spatial_video_mode": component.spatialVideoMode == .spatial ? "spatial" : "screen",
+                    "immersive_viewing_mode": immersiveMode.lowercased(),
+                ]
+            )
+        }
+
+        scheduleAutomatedProbeIfNeeded()
+    }
+
+    private func scheduleAutomatedProbeIfNeeded() {
+        guard
+            shouldRunAutomatedProbe,
+            !automatedProbeStarted,
+            immersiveSpaceIsOpen,
+            isActuallySpatial,
+            player.currentItem?.status == .readyToPlay,
+            renderingStatusText == "Ready",
+            canSeek
+        else {
+            return
+        }
+
+        automatedProbeStarted = true
+        automatedProbeTask = Task { [weak self] in
+            await self?.runAutomatedProbe()
+        }
+    }
+
+    private func runAutomatedProbe() async {
+        var seekResults: [String: Bool] = [:]
+
+        for position in ProbeSeekPosition.allCases {
+            let target = seekTarget(for: position)
+            let finished = await seek(to: target)
+            seekResults[position.rawValue] = finished
+            player.play()
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            emit(
+                "automated_seek",
+                values: [
+                    "position": position.rawValue,
+                    "target_seconds": formatNumber(target),
+                    "current_seconds": formatNumber(currentSeconds),
+                    "finished": String(finished),
+                    "spatial_video_mode": isActuallySpatial ? "spatial" : "screen",
+                ]
+            )
+        }
+
+        let seeksPassed = seekResults.values.allSatisfy { $0 }
+        let result = isActuallySpatial && seeksPassed ? "pass" : "fail"
+        emit(
+            "automated_probe_complete",
+            values: [
+                "result": result,
+                "rendering_status": renderingStatusText.lowercased(),
+                "actual_presentation": actualPresentationText.lowercased(),
+                "seeks_passed": String(seeksPassed),
+                "audio_options": String(audioOptions.count),
+                "subtitle_options": String(max(0, subtitleOptions.count - 1)),
+            ]
+        )
+    }
+
+    private func seekTarget(for position: ProbeSeekPosition) -> Double {
+        switch position {
+        case .beginning:
+            return 0
+        case .middle:
+            return durationSeconds / 2
+        case .end:
+            return max(0, durationSeconds - min(1, durationSeconds / 10))
+        }
+    }
+
+    private func seek(to seconds: Double) async -> Bool {
+        await withCheckedContinuation { continuation in
+            player.seek(
+                to: CMTime(seconds: seconds, preferredTimescale: 600),
+                toleranceBefore: .zero,
+                toleranceAfter: .zero
+            ) { finished in
+                continuation.resume(returning: finished)
+            }
+        }
+    }
+
+    private func loadMediaSelections(for asset: AVAsset, item: AVPlayerItem) async throws {
+        audioGroup = try await asset.loadMediaSelectionGroup(for: .audible)
+        subtitleGroup = try await asset.loadMediaSelectionGroup(for: .legible)
+
+        audioSelectionByID.removeAll()
+        subtitleSelectionByID.removeAll()
+
+        if let audioGroup {
+            audioOptions = audioGroup.options.enumerated().map { index, option in
+                let identifier = "audio-\(index)"
+                audioSelectionByID[identifier] = option
+                return ProbeMediaOption(id: identifier, name: option.displayName)
+            }
+            selectedAudioID = audioOptions.first(where: { option in
+                guard let selection = audioSelectionByID[option.id] else {
+                    return false
+                }
+                return item.currentMediaSelection.selectedMediaOption(in: audioGroup) === selection
+            })?.id ?? audioOptions.first?.id ?? ""
+        } else {
+            audioOptions = []
+            selectedAudioID = ""
+        }
+
+        if let subtitleGroup {
+            subtitleOptions = [ProbeMediaOption(id: "off", name: "Off")]
+            subtitleOptions += subtitleGroup.options.enumerated().map { index, option in
+                let identifier = "subtitle-\(index)"
+                subtitleSelectionByID[identifier] = option
+                return ProbeMediaOption(id: identifier, name: option.displayName)
+            }
+            selectedSubtitleID = subtitleOptions.first(where: { option in
+                guard let selection = subtitleSelectionByID[option.id] else {
+                    return false
+                }
+                return item.currentMediaSelection.selectedMediaOption(in: subtitleGroup) === selection
+            })?.id ?? "off"
+        } else {
+            subtitleOptions = []
+            selectedSubtitleID = "off"
+        }
+    }
+
+    private func automaticAssetURL() -> URL? {
+        let fileManager = FileManager.default
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let requestedPath = environment["BD_TO_AVP_PROBE_ASSET"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let requestedPath, !requestedPath.isEmpty {
+            let requestedURL = URL(fileURLWithPath: requestedPath)
+            let candidate = requestedURL.path.hasPrefix("/")
+                ? requestedURL
+                : documentsURL.appendingPathComponent(requestedPath)
+            return fileManager.fileExists(atPath: candidate.path) ? candidate : nil
+        }
+
+        let defaultURL = documentsURL.appendingPathComponent(Self.defaultTransferredAssetName)
+        return fileManager.fileExists(atPath: defaultURL.path) ? defaultURL : nil
+    }
+
+    private func setFailure(category: ProbeFailureCategory, title: String, message: String) {
+        isLoading = false
+        playerItemStatusText = "Failed"
+        failure = ProbeFailure(category: category, title: title, message: message)
+        emit(
+            "failure",
+            values: [
+                "category": category.rawValue,
+                "message": message,
+            ]
+        )
+    }
+
+    private func emit(_ name: String, values: [String: String]) {
+        logSequence += 1
+        let event = ProbeLogEvent(
+            sequence: logSequence,
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            name: name,
+            values: values
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(event), let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        print("BD_TO_AVP_PLAYBACK_PROBE \(json)")
+    }
+
+    private func formatTime(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds > 0 else {
+            return "0:00"
+        }
+        let wholeSeconds = Int(seconds.rounded(.down))
+        return String(format: "%d:%02d", wholeSeconds / 60, wholeSeconds % 60)
+    }
+
+    private func formatNumber(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private nonisolated static func copyImportedAsset(_ sourceURL: URL) async throws -> URL {
+        try await Task.detached(priority: .userInitiated) {
+            let fileManager = FileManager.default
+            let supportURL = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            let destinationDirectory = supportURL.appendingPathComponent("SpatialPlaybackProbe", isDirectory: true)
+            try fileManager.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+
+            let extensionName = sourceURL.pathExtension.isEmpty ? "mov" : sourceURL.pathExtension
+            let destinationURL = destinationDirectory.appendingPathComponent("CurrentPreview.\(extensionName)")
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.copyItem(at: sourceURL, to: destinationURL)
+            return destinationURL
+        }.value
+    }
+}

--- a/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
@@ -1,0 +1,265 @@
+import RealityKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PlaybackProbeView: View {
+    @Environment(\.dismissImmersiveSpace) private var dismissImmersiveSpace
+    @Environment(\.openImmersiveSpace) private var openImmersiveSpace
+
+    @ObservedObject var model: PlaybackProbeModel
+    @State private var isImporting = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            playerPane
+            Divider()
+            inspector
+                .frame(width: 330)
+        }
+        .fileImporter(
+            isPresented: $isImporting,
+            allowedContentTypes: [.movie],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case let .success(urls):
+                if let url = urls.first {
+                    model.importAsset(from: url)
+                }
+            case let .failure(error):
+                model.reportImportFailure(error)
+            }
+        }
+    }
+
+    private var playerPane: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                Color.black.opacity(0.72)
+                RealityView { content in
+                    model.installPlayerComponent()
+                    if model.playerEntity.parent == nil {
+                        content.add(model.playerEntity)
+                    }
+                } update: { content in
+                    if !model.immersiveSpaceIsOpen, model.playerEntity.parent == nil {
+                        content.add(model.playerEntity)
+                    }
+                }
+
+                if !model.hasLoadedAsset {
+                    ContentUnavailableView {
+                        Label("Open a Finalized Preview", systemImage: "visionpro")
+                    } description: {
+                        Text("Choose a completed MV-HEVC movie. Conversion tools are intentionally not included in this companion.")
+                    } actions: {
+                        Button("Open Preview…") {
+                            isImporting = true
+                        }
+                    }
+                } else if model.isLoading {
+                    ProgressView("Preparing spatial playback…")
+                        .padding(24)
+                        .glassBackgroundEffect()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.black.opacity(0.72))
+
+            Divider()
+
+            playbackControls
+                .padding(.horizontal, 24)
+                .padding(.vertical, 16)
+                .background(.regularMaterial)
+        }
+    }
+
+    private var playbackControls: some View {
+        HStack(spacing: 16) {
+            Button {
+                model.togglePlayback()
+            } label: {
+                Label(model.isPlaying ? "Pause" : "Play", systemImage: model.isPlaying ? "pause.fill" : "play.fill")
+            }
+            .disabled(!model.canControlPlayback)
+
+            Button("Beginning") {
+                model.seek(to: .beginning)
+            }
+            .disabled(!model.canSeek)
+
+            Button("Middle") {
+                model.seek(to: .middle)
+            }
+            .disabled(!model.canSeek)
+
+            Button("End") {
+                model.seek(to: .end)
+            }
+            .disabled(!model.canSeek)
+
+            Spacer()
+
+            Text(model.timeSummary)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Button("Open…") {
+                isImporting = true
+            }
+
+            Button(model.immersiveSpaceIsOpen ? "Close Spatial View" : "Open Spatial View") {
+                Task {
+                    await toggleSpatialView()
+                }
+            }
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private var inspector: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Spatial Playback Probe")
+                        .font(.title2.bold())
+                    Text(model.assetName)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                statusSection
+
+                if let failure = model.failure {
+                    failureSection(failure)
+                }
+
+                mediaSection
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Playback-only companion", systemImage: "checkmark.shield")
+                        .font(.headline)
+                    Text("The target imports finalized movies and reports native decode and rendering state. It does not embed Python, ripping, or conversion dependencies.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(24)
+        }
+        .background(.ultraThinMaterial)
+    }
+
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Validation")
+                .font(.headline)
+
+            statusRow(
+                title: "Stereo MV-HEVC decode",
+                value: model.decodeSupportText,
+                symbol: model.stereoDecodeSupported ? "checkmark.circle.fill" : "xmark.octagon.fill",
+                color: model.stereoDecodeSupported ? .green : .red
+            )
+            statusRow(title: "AVPlayer item", value: model.playerItemStatusText)
+            statusRow(title: "RealityKit rendering", value: model.renderingStatusText)
+            statusRow(title: "Immersive space", value: model.immersiveSpaceStatusText)
+            statusRow(title: "Requested presentation", value: "Stereo · Spatial · Portal")
+            statusRow(
+                title: "Actual presentation",
+                value: model.actualPresentationText,
+                symbol: model.isActuallySpatial ? "checkmark.circle.fill" : "circle.dashed",
+                color: model.isActuallySpatial ? .green : .orange
+            )
+            .accessibilityIdentifier("actual-presentation-status")
+        }
+    }
+
+    private var mediaSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Media")
+                .font(.headline)
+
+            Picker("Audio", selection: $model.selectedAudioID) {
+                ForEach(model.audioOptions) { option in
+                    Text(option.name).tag(option.id)
+                }
+            }
+            .disabled(model.audioOptions.isEmpty)
+
+            Picker("Subtitles", selection: $model.selectedSubtitleID) {
+                ForEach(model.subtitleOptions) { option in
+                    Text(option.name).tag(option.id)
+                }
+            }
+            .disabled(model.subtitleOptions.isEmpty)
+        }
+        .onChange(of: model.selectedAudioID) { _, identifier in
+            model.selectAudio(identifier)
+        }
+        .onChange(of: model.selectedSubtitleID) { _, identifier in
+            model.selectSubtitle(identifier)
+        }
+    }
+
+    private func failureSection(_ failure: ProbeFailure) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(failure.title, systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.red)
+            Text(failure.message)
+                .font(.caption)
+            Text("Category: \(failure.category.rawValue)")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .padding(14)
+        .background(.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func statusRow(
+        title: String,
+        value: String,
+        symbol: String = "circle.fill",
+        color: Color = .secondary
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: symbol)
+                .foregroundStyle(color)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.body)
+            }
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func toggleSpatialView() async {
+        if model.immersiveSpaceIsOpen {
+            await dismissImmersiveSpace()
+            model.recordImmersiveSpaceStatus("Closed", isOpen: false)
+        } else {
+            await openSpatialView()
+        }
+    }
+
+    private func openSpatialView() async {
+        model.recordImmersiveSpaceStatus("Opening", isOpen: false)
+        switch await openImmersiveSpace(id: SpatialPlaybackProbeApp.immersiveSpaceID) {
+        case .opened:
+            model.recordImmersiveSpaceStatus("Open", isOpen: true)
+        case .userCancelled:
+            model.recordImmersiveSpaceStatus("Cancelled", isOpen: false)
+        case .error:
+            model.recordImmersiveSpaceStatus("Could not open", isOpen: false)
+        @unknown default:
+            model.recordImmersiveSpaceStatus("Unknown", isOpen: false)
+        }
+    }
+}

--- a/macos/SpatialPlaybackProbe/SpatialPlaybackProbeApp.swift
+++ b/macos/SpatialPlaybackProbe/SpatialPlaybackProbeApp.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@main
+struct SpatialPlaybackProbeApp: App {
+    static let immersiveSpaceID = "spatial-playback"
+
+    @StateObject private var model = PlaybackProbeModel()
+    @State private var immersionStyle: ImmersionStyle = .mixed
+
+    var body: some Scene {
+        WindowGroup("Spatial Playback") {
+            PlaybackProbeView(model: model)
+                .task {
+                    await model.bootstrap()
+                }
+                .onOpenURL { url in
+                    model.importAsset(from: url)
+                }
+        }
+        .defaultSize(width: 1.1, height: 0.76, depth: 0.24, in: .meters)
+        .windowStyle(.volumetric)
+
+        ImmersiveSpace(id: Self.immersiveSpaceID) {
+            SpatialPlaybackRealityView(model: model)
+        }
+        .immersionStyle(selection: $immersionStyle, in: .mixed)
+    }
+}

--- a/macos/SpatialPlaybackProbe/SpatialPlaybackRealityView.swift
+++ b/macos/SpatialPlaybackProbe/SpatialPlaybackRealityView.swift
@@ -1,0 +1,14 @@
+import RealityKit
+import SwiftUI
+
+struct SpatialPlaybackRealityView: View {
+    @ObservedObject var model: PlaybackProbeModel
+
+    var body: some View {
+        RealityView { content in
+            model.installPlayerComponent()
+            model.playerEntity.removeFromParent()
+            content.add(model.playerEntity)
+        }
+    }
+}

--- a/macos/SpatialPlaybackProbeUITests/SpatialPlaybackProbeUITests.swift
+++ b/macos/SpatialPlaybackProbeUITests/SpatialPlaybackProbeUITests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class SpatialPlaybackProbeUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testPhysicalDeviceOpensSpatialPortal() throws {
+        #if targetEnvironment(simulator)
+        throw XCTSkip("Spatial portal acceptance requires a physical Apple Vision Pro.")
+        #else
+        let app = XCUIApplication()
+        app.launchEnvironment["BD_TO_AVP_PROBE_AUTORUN"] = "1"
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Probe.mov"].waitForExistence(timeout: 20))
+
+        let openSpatialView = app.buttons["Open Spatial View"]
+        XCTAssertTrue(openSpatialView.waitForExistence(timeout: 20))
+        openSpatialView.tap()
+
+        XCTAssertTrue(app.buttons["Close Spatial View"].waitForExistence(timeout: 20))
+
+        let presentationStatus = app.descendants(matching: .any)["actual-presentation-status"]
+        XCTAssertTrue(presentationStatus.waitForExistence(timeout: 20))
+
+        let spatialPredicate = NSPredicate(format: "label CONTAINS %@", "Stereo · Spatial · Portal")
+        expectation(for: spatialPredicate, evaluatedWith: presentationStatus)
+        waitForExpectations(timeout: 30)
+        #endif
+    }
+}

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -5,6 +5,7 @@ options:
   defaultConfig: Debug
   deploymentTarget:
     macOS: "26.0"
+    visionOS: "26.0"
 
 configs:
   Debug: debug
@@ -86,6 +87,47 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.tests
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/3D Blu-ray to Vision Pro Native Preview.app/Contents/MacOS/3D Blu-ray to Vision Pro Native Preview
 
+  SpatialPlaybackProbe:
+    type: application
+    platform: auto
+    supportedDestinations: [visionOS]
+    deploymentTarget:
+      visionOS: "26.0"
+    sources:
+      - path: SpatialPlaybackProbe
+    settings:
+      base:
+        CODE_SIGN_STYLE: Automatic
+        CURRENT_PROJECT_VERSION: 1
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: SpatialPlaybackProbe/Info.plist
+        MARKETING_VERSION: 0.1.0
+        PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.spatial-playback-probe
+        PRODUCT_MODULE_NAME: SpatialPlaybackProbe
+        PRODUCT_NAME: BD to AVP Spatial Playback
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: "7"
+        XROS_DEPLOYMENT_TARGET: "26.0"
+
+  SpatialPlaybackProbeUITests:
+    type: bundle.ui-testing
+    platform: auto
+    supportedDestinations: [visionOS]
+    deploymentTarget:
+      visionOS: "26.0"
+    sources:
+      - path: SpatialPlaybackProbeUITests
+    dependencies:
+      - target: SpatialPlaybackProbe
+    settings:
+      base:
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.spatial-playback-probe.ui-tests
+        TARGETED_DEVICE_FAMILY: "7"
+        TEST_TARGET_NAME: SpatialPlaybackProbe
+        XROS_DEPLOYMENT_TARGET: "26.0"
+
 schemes:
   BluRayToVisionPro:
     build:
@@ -96,3 +138,13 @@ schemes:
       gatherCoverageData: true
       targets:
         - BluRayToVisionProTests
+
+  SpatialPlaybackProbe:
+    build:
+      targets:
+        SpatialPlaybackProbe: all
+    run:
+      config: Debug
+    test:
+      targets:
+        - SpatialPlaybackProbeUITests

--- a/scripts/create_spatial_playback_fixture.sh
+++ b/scripts/create_spatial_playback_fixture.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+output_path="${1:-/tmp/bd-to-avp-spatial-fixture/Probe.mov}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+for command_name in ffmpeg ffprobe; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		printf 'Required command is unavailable: %s\n' "$command_name" >&2
+		exit 1
+	fi
+done
+
+spatial_tool="$repo_root/bd_to_avp/bin/spatial-media-kit-tool"
+mp4box="$repo_root/bd_to_avp/bin/MP4Box"
+for tool_path in "$spatial_tool" "$mp4box"; do
+	if [[ ! -x "$tool_path" ]]; then
+		printf 'Required bundled tool is unavailable: %s\n' "$tool_path" >&2
+		exit 1
+	fi
+done
+
+mkdir -p "$(dirname "$output_path")"
+
+ffmpeg -hide_banner -loglevel error -f lavfi -i 'testsrc2=size=656x360:rate=30' -t 6 -vf 'crop=640:360:0:0' -c:v hevc_videotoolbox -tag:v hvc1 -b:v 2M -an -y "$work_dir/left.mov"
+ffmpeg -hide_banner -loglevel error -f lavfi -i 'testsrc2=size=656x360:rate=30' -t 6 -vf 'crop=640:360:16:0' -c:v hevc_videotoolbox -tag:v hvc1 -b:v 2M -an -y "$work_dir/right.mov"
+
+"$spatial_tool" merge \
+	--left-file "$work_dir/left.mov" \
+	--right-file "$work_dir/right.mov" \
+	--quality 60 \
+	--left-is-primary \
+	--horizontal-field-of-view 90 \
+	--output-file "$work_dir/spatial.mov"
+
+ffmpeg -hide_banner -loglevel error -f lavfi -i 'sine=frequency=880:sample_rate=48000' -t 6 -c:a aac -b:a 192k -metadata:s:a:0 language=eng -y "$work_dir/audio.m4a"
+
+cat >"$work_dir/subtitles.srt" <<'EOF'
+1
+00:00:00,500 --> 00:00:02,500
+BD to AVP spatial playback probe
+
+2
+00:00:03,000 --> 00:00:05,500
+Beginning, middle, and end seek fixture
+EOF
+
+"$mp4box" -new \
+	-add "$work_dir/spatial.mov:forcesync" \
+	-add "$work_dir/audio.m4a#1:lang=eng:group=1:alternate_group=1" \
+	-add "$work_dir/subtitles.srt#1:hdlr=sbtl:lang=eng:group=2:name=English Subtitles:tx3g" \
+	"$output_path"
+
+ffprobe -v error -show_entries format=duration:stream=index,codec_name,codec_type:stream_tags=language -of json "$output_path"
+printf 'Created spatial playback fixture: %s\n' "$output_path"


### PR DESCRIPTION
## Summary

- add an isolated visionOS 26 `SpatialPlaybackProbe` target using `AVPlayer` and RealityKit `VideoPlayerComponent`
- request stereo, spatial, and portal modes while reporting the actual decode, rendering, viewing, spatial, and immersive states
- add finalized-movie import, audio/subtitle selection, playback controls, beginning/middle/end seeks, structured probe events, and explicit failure categories
- add a physical-only UI test for the user-gated immersive transition
- add a reproducible six-second MV-HEVC fixture generator with English audio and subtitles
- document simulator, physical-device, and immutable-artifact validation boundaries

## Validation

- `uv run python -m unittest discover -s tests`: 432 passed on the final run
  - the first full run hit the existing timing-sensitive heartbeat assertion; the focused test passed 3/3 immediately afterward
- `uv run python -m unittest tests.test_native_app`: 22 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run mypy bd_to_avp`: passed
- `uv build`: passed
- import and CLI smokes: passed
- `uv run python scripts/native_app.py build`: passed
- visionOS simulator `xcodebuild test`: passed with the physical-only UI test skipped as intended
- physical visionOS 27 build: signed successfully with Xcode 27 and installed on the connected M2 Apple Vision Pro
- physical fixture evidence: stereo MV-HEVC decode supported; `AVPlayerItem` ready; RealityKit rendering ready; stereo viewing active; audio and subtitle choices discovered; beginning/middle/end seeks completed
- fixture generator: produced a validated 6-second HEVC/AAC/tx3g final MOV
- `shellcheck`, `shfmt -d`, plist validation, and `git diff --check`: passed
- PyCharm changed-files inspection: green with zero findings
- independent Gemini final review: no blockers

## Remaining Acceptance Work

This PR advances #200 but does not close it. The unattended physical run remains in `.screen` fallback until visionOS receives the user-initiated **Open Spatial View** action. The physical UI-test runner reached the headset but timed out while enabling automation mode, so actual `spatialVideoMode == .spatial` and portal confirmation remain pending on an awake/unlocked headset with UI automation available or an on-headset tap.

Relates to #200.
