### PR TITLE
Add honest determinate progress to native jobs

### DIFF
--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -14,6 +14,8 @@ from bd_to_avp.modules.util import formatted_time_elapsed
 
 
 SpinnerUpdate = Callable[[str], object]
+LineHandler = Callable[[str], object]
+PROCESS_TERMINATION_TIMEOUT_SECONDS = 5.0
 
 
 def get_spinner_update_func() -> SpinnerUpdate | None:
@@ -87,7 +89,13 @@ def normalize_command_elements(command: list[Any]) -> list[str | Path | bytes]:
     return [str(item) if not isinstance(item, (str, bytes, Path)) else item for item in command if item is not None]
 
 
-def run_command(commands: list[Any], command_name: str = "", env: dict[str, str] | None = None) -> str:
+def run_command(
+    commands: list[Any],
+    command_name: str = "",
+    env: dict[str, str] | None = None,
+    *,
+    line_handler: LineHandler | None = None,
+) -> str:
     commands = normalize_command_elements(commands)
     if not command_name:
         command_name = str(commands[0])
@@ -116,6 +124,8 @@ def run_command(commands: list[Any], command_name: str = "", env: dict[str, str]
             if not line:
                 break
             output_lines.append(line)
+            if line_handler:
+                line_handler(line.rstrip("\r\n"))
 
         process.wait()
         if process.returncode != 0:
@@ -125,13 +135,31 @@ def run_command(commands: list[Any], command_name: str = "", env: dict[str, str]
     except KeyboardInterrupt:
         print("\nCommand interrupted.")
         if process:
-            process.terminate()
+            terminate_and_wait(process)
+        raise
+    except BaseException:
+        if process:
+            terminate_and_wait(process)
         raise
 
     finally:
         spinner.stop(spinner_update_func)
         spinner_thread.join()
     return "".join(output_lines)
+
+
+def terminate_and_wait(
+    process: subprocess.Popen,
+    timeout: float = PROCESS_TERMINATION_TIMEOUT_SECONDS,
+) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
 
 
 def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, **kwargs) -> None:

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -2,6 +2,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 import ffmpeg
 
@@ -32,6 +33,21 @@ class TitleInfo:
     has_mvc: bool = False
     resolution: str | None = None
     frame_rate: str | None = None
+
+
+ProgressCallback = Callable[[float, float], object]
+MAKEMKV_PROGRESS_PATTERN = re.compile(r"^PRGV:(\d+),(\d+),(\d+)$")
+
+
+def parse_makemkv_progress(line: str) -> tuple[int, int] | None:
+    match = MAKEMKV_PROGRESS_PATTERN.match(line.strip())
+    if match is None:
+        return None
+    total_progress = int(match.group(2))
+    maximum_progress = int(match.group(3))
+    if maximum_progress <= 0:
+        return None
+    return min(max(total_progress, 0), maximum_progress), maximum_progress
 
 
 def parse_makemkv_output(output: str) -> tuple[str, list[TitleInfo]]:
@@ -123,21 +139,36 @@ def get_disc_and_mvc_video_info() -> DiscInfo:
     return disc_info
 
 
-def rip_disc_to_mkv(output_folder: Path, disc_info: DiscInfo, language_code: str) -> None:
+def rip_disc_to_mkv(
+    output_folder: Path,
+    disc_info: DiscInfo,
+    language_code: str,
+    progress_callback: ProgressCallback | None = None,
+) -> None:
     custom_profile_path = output_folder / "custom_profile.mmcp.xml"
     create_custom_makemkv_profile(custom_profile_path, language_code)
 
     source = get_makemkv_source()
     command = [
         config.MAKEMKVCON_PATH,
+        "--robot",
         f"--profile={custom_profile_path}",
+        "--progress=-same",
         "--noscan" if makemkv_source_supports_noscan(source) else None,
         "mkv",
         source,
         disc_info.main_title_number,
         output_folder,
     ]
-    mkv_output = run_command(command, "Rip disc to MKV file.")
+
+    def report_progress(line: str) -> None:
+        if progress_callback is None:
+            return
+        progress = parse_makemkv_progress(line)
+        if progress is not None:
+            progress_callback(*progress)
+
+    mkv_output = run_command(command, "Rip disc to MKV file.", line_handler=report_progress)
     if config.continue_on_error or all(error not in mkv_output for error in config.MKV_ERROR_CODES):
         return
     filtered_output = filter_lines_from_output(mkv_output, config.MKV_ERROR_FILTERS)
@@ -182,7 +213,12 @@ def create_custom_makemkv_profile(custom_profile_path: Path, language_code: str)
     print(f"Custom MakeMKV profile created at {custom_profile_path}")
 
 
-def create_mkv_file(output_folder: Path, disc_info: DiscInfo, language_code: str) -> Path:
+def create_mkv_file(
+    output_folder: Path,
+    disc_info: DiscInfo,
+    language_code: str,
+    progress_callback: ProgressCallback | None = None,
+) -> Path:
     if config.source_path and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]:
         if not config.source_path.is_file():
             raise FileNotFoundError(f"Source file not found: {config.source_path}")
@@ -197,7 +233,7 @@ def create_mkv_file(output_folder: Path, disc_info: DiscInfo, language_code: str
             return mkv_file
 
     if config.start_stage.value <= Stage.CREATE_MKV.value:
-        rip_disc_to_mkv(output_folder, disc_info, language_code)
+        rip_disc_to_mkv(output_folder, disc_info, language_code, progress_callback)
 
     if mkv_file := find_largest_file_with_extensions(output_folder, [".mkv"]):
         return mkv_file

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -43,7 +43,13 @@ class BatchProcessingError(Exception):
 
 
 class ActivityReporter(Protocol):
+    def set_stage_plan(self, stages: tuple[str, ...]) -> None:
+        raise NotImplementedError
+
     def stage_started(self, stage: str, message: str) -> None:
+        raise NotImplementedError
+
+    def stage_progress(self, completed_units: float, total_units: float) -> None:
         raise NotImplementedError
 
     def log(self, message: str, *, stage: str | None = None, **fields: object) -> None:
@@ -67,6 +73,40 @@ def find_batch_sources(source_folder_path: Path) -> tuple[Path, ...]:
             key=lambda source: source.as_posix().casefold(),
         )
     )
+
+
+def conversion_stage_plan() -> tuple[str, ...]:
+    stages = [
+        "configure",
+        "preflight",
+        "inspect_source",
+    ]
+    if config.start_stage.value <= Stage.CREATE_MKV.value:
+        stages.append("create_mkv")
+    if config.preview_range is not None:
+        stages.append("prepare_preview_range")
+    stages.extend(
+        [
+            "probe_color",
+            "detect_crop",
+        ]
+    )
+    if config.start_stage.value <= Stage.EXTRACT_MVC_AND_AUDIO.value:
+        stages.append("extract_mvc_and_audio")
+    if not config.skip_subtitles and config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
+        stages.append("extract_subtitles")
+    if config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+        stages.append("create_left_right_files")
+    if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+        stages.append("combine_to_mv_hevc")
+    if config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
+        stages.append("upscale_video")
+    if config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
+        stages.append("transcode_audio")
+    if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
+        stages.append("create_final_file")
+    stages.append("move_files")
+    return tuple(stages)
 
 
 def process(
@@ -151,16 +191,21 @@ def process_each(cancellation_event: Event | None = None, activity: ActivityRepo
 
     print(f"Using temporary folder: {os.environ['TMPDIR']}")
     if activity:
-        activity.log("Temporary workspace ready", stage="preflight", path=os.environ["TMPDIR"])
+        activity.log("Temporary workspace ready", stage="inspect_source", path=os.environ["TMPDIR"])
 
     completed_path = config.output_root_path / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
 
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.start_stage.value <= Stage.CREATE_MKV.value:
         activity.stage_started("create_mkv", "Preparing source video")
-    mkv_output_path = create_mkv_file(output_folder, disc_info, config.language_code)
+    mkv_output_path = create_mkv_file(
+        output_folder,
+        disc_info,
+        config.language_code,
+        progress_callback=activity.stage_progress if activity else None,
+    )
     if config.preview_range is not None:
         raise_if_cancelled(cancellation_event)
         if activity:
@@ -183,34 +228,34 @@ def process_each(cancellation_event: Event | None = None, activity: ActivityRepo
     )
     crop_params = detect_crop_parameters(mkv_output_path, start_seconds=crop_start_seconds)
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.start_stage.value <= Stage.EXTRACT_MVC_AND_AUDIO.value:
         activity.stage_started("extract_mvc_and_audio", "Extracting MVC video and audio")
     audio_output_path, video_output_path = create_mvc_and_audio(disc_info.name, mkv_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and not config.skip_subtitles and config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
         activity.stage_started("extract_subtitles", "Extracting subtitles")
     create_srt_from_mkv(mkv_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
         activity.stage_started("create_left_right_files", "Creating left and right eye video")
     left_output_path, right_output_path = create_left_right_files(
         disc_info, output_folder, video_output_path, crop_params
     )
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
         activity.stage_started("combine_to_mv_hevc", "Combining stereo video into MV-HEVC")
     mv_hevc_path = create_mv_hevc_file(left_output_path, right_output_path, output_folder, disc_info)
     raise_if_cancelled(cancellation_event)
-    if activity and config.fx_upscale:
+    if activity and config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
         activity.stage_started("upscale_video", "Upscaling video")
     mv_hevc_path = create_upscaled_file(mv_hevc_path)
 
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
         activity.stage_started("transcode_audio", "Preparing audio")
     audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder)
     raise_if_cancelled(cancellation_event)
-    if activity:
+    if activity and config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         activity.stage_started("create_final_file", "Muxing final spatial video")
     muxed_output_path = create_muxed_file(
         audio_output_path,

--- a/bd_to_avp/worker/__main__.py
+++ b/bd_to_avp/worker/__main__.py
@@ -148,10 +148,7 @@ def _emit_heartbeats(
         if owner.cancellation_event.is_set() or emitter.terminal_emitted:
             return
         try:
-            emitter.emit(
-                WorkerEventType.HEARTBEAT,
-                activity.heartbeat_payload(int(time.monotonic() - started_at)),
-            )
+            activity.emit_heartbeat(int(time.monotonic() - started_at))
         except RuntimeError:
             return
 

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -16,7 +16,7 @@ from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.disc import get_disc_and_mvc_video_info, MKVCreationError
 from bd_to_avp.modules.file import path_is_relative_to
 from bd_to_avp.modules.preview import PreviewRange, resolve_preview_range
-from bd_to_avp.modules.process import ProcessingCancelled, start_process
+from bd_to_avp.modules.process import ProcessingCancelled, conversion_stage_plan, start_process
 from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
 from bd_to_avp.worker.protocol import (
@@ -235,6 +235,7 @@ def _convert_source(
     owner.check_cancelled()
     with configured_conversion(job, source_path, preview_range=preview_range):
         try:
+            activity.set_stage_plan(conversion_stage_plan())
             activity.stage_started("configure", "Preparing conversion settings")
             config.configure_tool_environment()
             activity.log("Tool environment configured", stage="configure")

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+import math
 import threading
 
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Mapping, TextIO
+from typing import Any, Mapping, Sequence, TextIO
 from uuid import UUID
 
 PROTOCOL_VERSION = 3
@@ -526,36 +527,88 @@ class WorkerActivityReporter:
     def __init__(self, emitter: "WorkerEventEmitter") -> None:
         self._emitter = emitter
         self._current_stage: str | None = None
+        self._stage_plan: tuple[str, ...] = ()
+        self._stage_index: int | None = None
+        self._stage_fraction: float | None = None
         self._lock = threading.Lock()
 
-    @property
-    def current_stage(self) -> str | None:
+    def set_stage_plan(self, stages: Sequence[str]) -> None:
+        stage_plan = tuple(stage for stage in stages if stage)
         with self._lock:
-            return self._current_stage
+            self._stage_plan = stage_plan
+            self._stage_index = None
+            self._stage_fraction = None
 
     def stage_started(self, stage: str, message: str) -> None:
         with self._lock:
             self._current_stage = stage
-        self._emitter.emit(WorkerEventType.STAGE_STARTED, {"stage": stage, "message": message})
+            self._stage_fraction = None
+            next_stage_index = 0 if self._stage_index is None else self._stage_index + 1
+            if next_stage_index < len(self._stage_plan) and self._stage_plan[next_stage_index] == stage:
+                self._stage_index = next_stage_index
+            else:
+                self._stage_plan = ()
+                self._stage_index = None
+            progress = self._progress_payload_locked()
+            payload: dict[str, Any] = {"stage": stage, "message": message}
+            if progress is not None:
+                payload["progress"] = progress
+            self._emitter.emit(WorkerEventType.STAGE_STARTED, payload)
+
+    def stage_progress(self, completed_units: float, total_units: float) -> None:
+        if not math.isfinite(completed_units) or not math.isfinite(total_units) or total_units <= 0:
+            return
+        fraction = min(1.0, max(0.0, completed_units / total_units))
+        with self._lock:
+            if self._stage_index is not None:
+                self._stage_fraction = fraction
 
     def log(self, message: str, *, stage: str | None = None, **fields: Any) -> None:
-        payload: dict[str, Any] = {"message": message, **fields}
-        payload["stage"] = stage or self.current_stage
-        self._emitter.emit(WorkerEventType.LOG, payload)
+        with self._lock:
+            payload: dict[str, Any] = {"message": message, **fields}
+            payload["stage"] = stage or self._current_stage
+            self._emitter.emit(WorkerEventType.LOG, payload)
 
     def warning(self, message: str, *, stage: str | None = None, **fields: Any) -> None:
-        payload: dict[str, Any] = {"message": message, **fields}
-        payload["stage"] = stage or self.current_stage
-        self._emitter.emit(WorkerEventType.WARNING, payload)
+        with self._lock:
+            payload: dict[str, Any] = {"message": message, **fields}
+            payload["stage"] = stage or self._current_stage
+            self._emitter.emit(WorkerEventType.WARNING, payload)
 
     def artifact_ready(self, artifact: Mapping[str, Any]) -> None:
         self._emitter.emit(WorkerEventType.ARTIFACT_READY, {"artifact": dict(artifact)})
 
     def heartbeat_payload(self, elapsed_seconds: int) -> dict[str, Any]:
-        return {
-            "stage": self.current_stage,
+        with self._lock:
+            return self._heartbeat_payload_locked(elapsed_seconds)
+
+    def emit_heartbeat(self, elapsed_seconds: int) -> None:
+        with self._lock:
+            self._emitter.emit(
+                WorkerEventType.HEARTBEAT,
+                self._heartbeat_payload_locked(elapsed_seconds),
+            )
+
+    def _heartbeat_payload_locked(self, elapsed_seconds: int) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "stage": self._current_stage,
             "elapsed_seconds": max(0, elapsed_seconds),
         }
+        progress = self._progress_payload_locked()
+        if progress is not None:
+            payload["progress"] = progress
+        return payload
+
+    def _progress_payload_locked(self) -> dict[str, Any] | None:
+        if self._stage_index is None or not self._stage_plan:
+            return None
+        progress: dict[str, Any] = {
+            "current_stage": self._stage_index + 1,
+            "total_stages": len(self._stage_plan),
+        }
+        if self._stage_fraction is not None:
+            progress["stage_fraction"] = self._stage_fraction
+        return progress
 
 
 class WorkerEventEmitter:

--- a/docs/native-ui-preview.md
+++ b/docs/native-ui-preview.md
@@ -13,6 +13,9 @@ does not replace or update it.
 - Convert an inspected physical disc, Blu-ray folder, ISO, MKV, MTS, or M2TS source to a
   completed MV-HEVC `.mov` through the bundled engine, with native progress,
   cancellation, and results.
+- During conversion and preview generation, confirm the app reports the current
+  workflow stage and total stage count. MakeMKV source preparation also shows a
+  determinate percentage from MakeMKV's own progress feed.
 - Exercise the native recovery card if MakeMKV leaves a usable intermediate MKV
   or subtitle extraction cannot continue. Recovery creates a new one-off job
   without changing the selected profile or visible conversion defaults.
@@ -30,6 +33,10 @@ does not replace or update it.
   preview and remains available only in the production app.
 - Native conversion currently creates the full movie. Short sample outputs are
   not yet available.
+- Stages without a trustworthy tool-reported denominator remain indeterminate.
+  The activity heartbeat and elapsed time continue to show that those stages are
+  running; the app does not infer an ETA from elapsed time or treat each stage as
+  equal-duration work.
 - This beta has no automatic updater. Future prerelease builds must be
   downloaded manually.
 - Live playback of a file while it is still being generated is not supported.

--- a/docs/native-worker-protocol-v3.md
+++ b/docs/native-worker-protocol-v3.md
@@ -93,6 +93,30 @@ The app accepts artifacts only inside the preview job's owned cache directory.
 That directory remains leased while AVPlayer uses the file, is removed when the
 preview is discarded, and is pruned after 24 hours if abandoned.
 
+## Progress Hints
+
+Conversion and preview jobs may add an optional `payload.progress` object to
+`stage.started` and `heartbeat` events:
+
+```json
+{
+  "current_stage": 4,
+  "total_stages": 13,
+  "stage_fraction": 0.42
+}
+```
+
+`current_stage` and `total_stages` describe the exact stages the current job
+will execute after applying its restart stage and optional features. The
+optional `stage_fraction` is a zero-to-one fraction reported by the tool running
+the current stage; it is not overall conversion completion or an ETA. Workers
+omit `stage_fraction` when the tool has no trustworthy denominator, while the
+heartbeat and elapsed time continue to indicate activity.
+
+The progress object is an additive optional v3 field. Existing v3 decoders may
+ignore it, and newer decoders must preserve the indeterminate fallback when it
+is absent or invalid.
+
 ## Compatibility
 
 Mixed v1, v2, and v3 processes fail before media inspection or destination

--- a/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
@@ -29,6 +29,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var artifactLease: PreviewArtifactLease?
     @Published private(set) var reviewedDraft: PreviewDraft?
     @Published private(set) var elapsedSeconds = 0
+    @Published private(set) var progress: WorkerProgress?
 
     private let clientFactory: ClientFactory
     private let cache: PreviewCache
@@ -85,6 +86,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         reviewedDraft = nil
         pendingTerminalEvent = nil
         elapsedSeconds = 0
+        progress = nil
 
         let jobID = UUID()
         do {
@@ -127,6 +129,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         }
         phase = .stopping
         stageMessage = "Stopping Preview"
+        progress = nil
         client?.cancel()
     }
 
@@ -176,6 +179,9 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
             pendingTerminalEvent = event
             return
         }
+        guard phase != .stopping else {
+            return
+        }
 
         switch event.type {
         case .workerReady, .jobStarted:
@@ -183,6 +189,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
             stageMessage = "Preparing Preview"
         case .stageStarted:
             let stage = event.payload.stage ?? ""
+            progress = event.payload.progress?.normalized
             if Self.encodingStages.contains(stage) {
                 phase = .encoding
                 stageMessage = event.payload.message ?? "Encoding Preview"
@@ -193,6 +200,9 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         case .heartbeat:
             elapsedSeconds = event.payload.elapsedSeconds ?? elapsedSeconds
             activityMessage = event.payload.message
+            if let incomingProgress = event.payload.progress {
+                progress = incomingProgress.normalized
+            }
         case .log, .warning:
             if let message = event.payload.message {
                 activityMessage = message
@@ -226,6 +236,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         phase = .ready
         stageMessage = "Ready to Play"
         activityMessage = nil
+        progress = nil
     }
 
     private func finish(_ result: WorkerRunResult) {
@@ -305,6 +316,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         activeDraft = nil
         activeDirectoryURL = nil
         pendingTerminalEvent = nil
+        progress = nil
 
         let actions = actionsWaitingForIdle
         actionsWaitingForIdle.removeAll()

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -94,6 +94,62 @@ struct WorkerDecision: Decodable, Equatable {
     }
 }
 
+struct WorkerProgress: Decodable, Equatable {
+    let currentStage: Int
+    let totalStages: Int
+    let stageFraction: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case currentStage = "current_stage"
+        case totalStages = "total_stages"
+        case stageFraction = "stage_fraction"
+    }
+
+    var normalized: WorkerProgress? {
+        guard totalStages > 0, currentStage > 0, currentStage <= totalStages else {
+            return nil
+        }
+        let normalizedFraction = stageFraction.map { min(1, max(0, $0)) }
+        return WorkerProgress(
+            currentStage: currentStage,
+            totalStages: totalStages,
+            stageFraction: normalizedFraction
+        )
+    }
+
+    var stagePositionText: String {
+        "Stage \(currentStage) of \(totalStages)"
+    }
+
+    var percentageText: String? {
+        guard let stageFraction else {
+            return nil
+        }
+        return "\(Int((stageFraction * 100).rounded()))%"
+    }
+
+    var detailText: String {
+        guard let percentageText else {
+            return stagePositionText
+        }
+        return "\(percentageText) of current stage · \(stagePositionText)"
+    }
+
+    var compactText: String {
+        guard let percentageText else {
+            return "Stage \(currentStage)/\(totalStages)"
+        }
+        return "Stage \(currentStage)/\(totalStages) · \(percentageText) of stage"
+    }
+
+    var accessibilityValue: String {
+        guard let percentageText else {
+            return stagePositionText
+        }
+        return "\(stagePositionText), \(percentageText) of current stage"
+    }
+}
+
 enum WorkerRecoveryChoice: String, Identifiable, Equatable {
     case retryContinueOnError = "retry_continue_on_error"
     case retryWithoutSubtitles = "retry_without_subtitles"
@@ -149,6 +205,7 @@ struct WorkerEventPayload: Decodable, Equatable {
     let stage: String?
     let message: String?
     let elapsedSeconds: Int?
+    let progress: WorkerProgress?
     let level: String?
     let result: SourceInspection?
     let conversionResult: ConversionResult?
@@ -164,6 +221,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         stage: String? = nil,
         message: String? = nil,
         elapsedSeconds: Int? = nil,
+        progress: WorkerProgress? = nil,
         level: String? = nil,
         result: SourceInspection? = nil,
         conversionResult: ConversionResult? = nil,
@@ -178,6 +236,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         self.stage = stage
         self.message = message
         self.elapsedSeconds = elapsedSeconds
+        self.progress = progress
         self.level = level
         self.result = result
         self.conversionResult = conversionResult
@@ -194,6 +253,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         case stage
         case message
         case elapsedSeconds = "elapsed_seconds"
+        case progress
         case level
         case result
         case conversionResult = "conversion_result"

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -76,6 +76,7 @@ struct WorkerLifecycleState: Equatable {
     private(set) var activityMessage: String?
     private(set) var warningMessage: String?
     private(set) var elapsedSeconds = 0
+    private(set) var progress: WorkerProgress?
     private(set) var result: SourceInspection?
     private(set) var conversionResult: ConversionResult?
     private(set) var failureMessage: String?
@@ -126,6 +127,10 @@ struct WorkerLifecycleState: Equatable {
         }
         lastSequence = event.sequence
 
+        if phase == .stopping, !event.type.isTerminal {
+            return
+        }
+
         switch event.type {
         case .workerReady:
             if phase != .stopping {
@@ -138,16 +143,16 @@ struct WorkerLifecycleState: Equatable {
             }
             stageMessage = operationKind == .inspection ? "Reading video details" : "Starting conversion"
         case .stageStarted:
-            if phase != .stopping {
-                phase = .processing
-            }
+            phase = .processing
             stageMessage = event.payload.message ?? event.payload.stage ?? "Processing"
+            progress = event.payload.progress?.normalized
         case .heartbeat:
-            if phase != .stopping {
-                phase = .processing
-            }
+            phase = .processing
             elapsedSeconds = event.payload.elapsedSeconds ?? elapsedSeconds
             activityMessage = event.payload.message
+            if let incomingProgress = event.payload.progress {
+                progress = incomingProgress.normalized
+            }
         case .log:
             activityMessage = event.payload.message
         case .warning:
@@ -169,6 +174,7 @@ struct WorkerLifecycleState: Equatable {
                 conversionResult = convResult
                 stageMessage = "Conversion complete"
             }
+            progress = nil
             phase = .completed
         case .jobFailed:
             guard let failure = event.payload.error else {
@@ -178,9 +184,11 @@ struct WorkerLifecycleState: Equatable {
             failureDetails = failure.details
             failureCode = failure.code
             failureRetryable = failure.retryable
+            progress = nil
             phase = .failed
         case .jobCancelled:
             activityMessage = event.payload.message ?? (operationKind == .inspection ? "Analysis stopped." : "Conversion stopped.")
+            progress = nil
             phase = .cancelled
         case .jobDecisionRequired:
             guard let decision = event.payload.decision else {
@@ -191,6 +199,7 @@ struct WorkerLifecycleState: Equatable {
             failureDetails = decision.details ?? "Choose how this conversion should continue."
             failureCode = decision.identifier
             failureRetryable = true
+            progress = nil
             phase = .decisionRequired
         }
     }
@@ -201,6 +210,7 @@ struct WorkerLifecycleState: Equatable {
         }
         phase = .stopping
         stageMessage = "Stopping safely"
+        progress = nil
     }
 
     mutating func failTransport(message: String, details: String? = nil, retryable: Bool = true) {
@@ -209,11 +219,13 @@ struct WorkerLifecycleState: Equatable {
         failureCode = nil
         failureRetryable = retryable
         recoveryDecision = nil
+        progress = nil
         phase = .failed
     }
 
     mutating func completeStop() {
         activityMessage = operationKind == .inspection ? "Inspection stopped." : "Conversion stopped."
+        progress = nil
         phase = .cancelled
     }
 
@@ -248,6 +260,7 @@ struct WorkerLifecycleState: Equatable {
         activityMessage = nil
         warningMessage = nil
         elapsedSeconds = 0
+        progress = nil
         result = nil
         conversionResult = nil
         failureMessage = nil

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -296,10 +296,15 @@ struct ContentView: View {
             .accessibilityLabel(statusAccessibilityLabel)
 
             if viewModel.hasActiveWorker {
-                ProgressView()
-                    .controlSize(.small)
+                WorkerProgressGauge(progress: viewModel.state.progress, width: 64)
                     .padding(.leading, 4)
-                    .accessibilityHidden(true)
+
+                if let progress = viewModel.state.progress {
+                    Text(progress.compactText)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
 
                 if let elapsedText = viewModel.state.elapsedText {
                     Label("Elapsed \(elapsedText)", systemImage: "clock")
@@ -413,6 +418,9 @@ struct ContentView: View {
         }
         if let elapsedText = viewModel.state.elapsedText, viewModel.hasActiveWorker {
             components.append("Elapsed time \(elapsedText)")
+        }
+        if let progress = viewModel.state.progress, viewModel.hasActiveWorker {
+            components.append(progress.accessibilityValue)
         }
         return components.joined(separator: ". ")
     }

--- a/macos/BluRayToVisionPro/Views/PreviewSheet.swift
+++ b/macos/BluRayToVisionPro/Views/PreviewSheet.swift
@@ -148,13 +148,17 @@ struct PreviewSheet: View {
                         }
                         Spacer()
                         if viewModel.hasActiveWorker {
+                            WorkerProgressGauge(progress: viewModel.progress, width: 76)
+                            if let progress = viewModel.progress {
+                                Text(progress.compactText)
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
                             if let elapsedText = viewModel.elapsedText {
                                 Label("Elapsed \(elapsedText)", systemImage: "clock")
                                     .font(.caption.monospacedDigit())
                                     .foregroundStyle(.secondary)
                             }
-                            ProgressView()
-                                .controlSize(.small)
                         }
                     }
                     .accessibilityElement(children: .ignore)
@@ -261,6 +265,9 @@ struct PreviewSheet: View {
         }
         if let elapsedText = viewModel.elapsedText, viewModel.hasActiveWorker {
             components.append("Elapsed time \(elapsedText)")
+        }
+        if let progress = viewModel.progress, viewModel.hasActiveWorker {
+            components.append(progress.accessibilityValue)
         }
         return components.joined(separator: ". ")
     }

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -177,8 +177,7 @@ struct SourceWorkspaceView: View {
                 if state.phase.isRunning {
                     Divider()
                     HStack(spacing: 10) {
-                        ProgressView()
-                            .controlSize(.small)
+                        WorkerProgressGauge(progress: state.progress, width: 84)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(state.operationKind == .inspection ? "Reading source details…" : "Converting video…")
                                 .fontWeight(.medium)
@@ -188,6 +187,11 @@ struct SourceWorkspaceView: View {
                             )
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                            if let progress = state.progress {
+                                Text(progress.detailText)
+                                    .font(.caption2.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 } else if state.phase == .decisionRequired, let decision = state.recoveryDecision {

--- a/macos/BluRayToVisionPro/Views/WorkerProgressGauge.swift
+++ b/macos/BluRayToVisionPro/Views/WorkerProgressGauge.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct WorkerProgressGauge: View {
+    let progress: WorkerProgress?
+    var width: CGFloat = 72
+
+    var body: some View {
+        Group {
+            if let stageFraction = progress?.stageFraction {
+                ProgressView(value: stageFraction, total: 1)
+                    .progressViewStyle(.linear)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .frame(width: width)
+        .accessibilityHidden(true)
+    }
+}

--- a/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
@@ -42,10 +42,12 @@ final class PreviewViewModelTests: XCTestCase {
     func testCancelledPreviewRemovesPartialWorkspace() async throws {
         try await withTemporaryPreviewEnvironment { sourceURL, cache in
             let started = expectation(description: "preview started")
+            let delayedEvents = expectation(description: "delayed cancellation events delivered")
             let cancelled = expectation(description: "preview cancelled")
             let worker = PreviewWorkerClient(
                 waitsForCancellation: true,
                 onStarted: { started.fulfill() },
+                onCancellationEventsDelivered: { delayedEvents.fulfill() },
                 onCompleted: { cancelled.fulfill() }
             )
             let viewModel = PreviewViewModel(clientFactory: { worker }, cache: cache)
@@ -54,12 +56,20 @@ final class PreviewViewModelTests: XCTestCase {
             viewModel.startPreview(previewDraft)
             await fulfillment(of: [started], timeout: 2)
             let destinationURL = try XCTUnwrap(worker.receivedJob?.destination.map { URL(fileURLWithPath: $0.path) })
+            XCTAssertEqual(viewModel.progress, WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: 0.5))
 
             viewModel.stopActiveWorker()
+
+            await fulfillment(of: [delayedEvents], timeout: 2)
+            XCTAssertEqual(viewModel.phase, .stopping)
+            XCTAssertEqual(viewModel.stageMessage, "Stopping Preview")
+            XCTAssertNil(viewModel.progress)
+            worker.resumeAfterDelayedCancellationEvents()
 
             await fulfillment(of: [cancelled], timeout: 2)
             while viewModel.hasActiveWorker { await Task.yield() }
             XCTAssertEqual(viewModel.phase, .idle)
+            XCTAssertNil(viewModel.progress)
             XCTAssertFalse(FileManager.default.fileExists(atPath: destinationURL.path))
             XCTAssertNil(viewModel.artifactLease)
         }
@@ -178,19 +188,24 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     private let lock = NSLock()
     private let waitsForCancellation: Bool
     private let onStarted: (() -> Void)?
+    private let onCancellationEventsDelivered: (() -> Void)?
     private let onCompleted: (() -> Void)?
     private var cancellationContinuation: CheckedContinuation<Void, Never>?
     private var cancellationRequested = false
+    private var delayedEventsContinuation: CheckedContinuation<Void, Never>?
+    private var delayedEventsResumeRequested = false
 
     private(set) var receivedJob: WorkerJobSpec?
 
     init(
         waitsForCancellation: Bool = false,
         onStarted: (() -> Void)? = nil,
+        onCancellationEventsDelivered: (() -> Void)? = nil,
         onCompleted: (() -> Void)? = nil
     ) {
         self.waitsForCancellation = waitsForCancellation
         self.onStarted = onStarted
+        self.onCancellationEventsDelivered = onCancellationEventsDelivered
         self.onCompleted = onCompleted
     }
 
@@ -213,7 +228,11 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             type: .stageStarted,
             jobID: job.jobID,
             sequence: 1,
-            payload: WorkerEventPayload(stage: "create_left_right_files", message: "Encoding Preview")
+            payload: WorkerEventPayload(
+                stage: "create_left_right_files",
+                message: "Encoding Preview",
+                progress: WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: nil)
+            )
         )
         try await onEvent(stage)
 
@@ -222,7 +241,11 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             type: .heartbeat,
             jobID: job.jobID,
             sequence: 2,
-            payload: WorkerEventPayload(message: "Encoding both eyes", elapsedSeconds: 65)
+            payload: WorkerEventPayload(
+                message: "Encoding both eyes",
+                elapsedSeconds: 65,
+                progress: WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: 0.5)
+            )
         )
         try await onEvent(heartbeat)
         onStarted?()
@@ -234,11 +257,38 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
 
         if waitsForCancellation {
             await waitForCancellation()
+            let delayedStage = WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .stageStarted,
+                jobID: job.jobID,
+                sequence: 3,
+                payload: WorkerEventPayload(
+                    stage: "combine_to_mv_hevc",
+                    message: "Combining stereo video into MV-HEVC",
+                    progress: WorkerProgress(currentStage: 10, totalStages: 13, stageFraction: nil)
+                )
+            )
+            try await onEvent(delayedStage)
+            let delayedHeartbeat = WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .heartbeat,
+                jobID: job.jobID,
+                sequence: 4,
+                payload: WorkerEventPayload(
+                    elapsedSeconds: 66,
+                    progress: WorkerProgress(currentStage: 10, totalStages: 13, stageFraction: 0.2)
+                )
+            )
+            try await onEvent(delayedHeartbeat)
+            if onCancellationEventsDelivered != nil {
+                onCancellationEventsDelivered?()
+                await waitForDelayedCancellationEventsResume()
+            }
             let cancelled = WorkerEvent(
                 protocolVersion: WorkerJobSpec.protocolVersion,
                 type: .jobCancelled,
                 jobID: job.jobID,
-                sequence: 3,
+                sequence: 5,
                 payload: WorkerEventPayload(message: "Preview stopped.")
             )
             try await onEvent(cancelled)
@@ -290,6 +340,18 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
         continuation?.resume()
     }
 
+    func resumeAfterDelayedCancellationEvents() {
+        let continuation: CheckedContinuation<Void, Never>?
+        lock.lock()
+        continuation = delayedEventsContinuation
+        delayedEventsContinuation = nil
+        if continuation == nil {
+            delayedEventsResumeRequested = true
+        }
+        lock.unlock()
+        continuation?.resume()
+    }
+
     private func waitForCancellation() async {
         await withCheckedContinuation { continuation in
             lock.lock()
@@ -300,6 +362,20 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             }
             cancellationContinuation = continuation
             lock.unlock()
+        }
+    }
+
+    private func waitForDelayedCancellationEventsResume() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if delayedEventsResumeRequested {
+                delayedEventsResumeRequested = false
+                lock.unlock()
+                continuation.resume()
+            } else {
+                delayedEventsContinuation = continuation
+                lock.unlock()
+            }
         }
     }
 }

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -46,6 +46,90 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(ElapsedTimeText.format(seconds: 3_661), "1:01:01")
     }
 
+    func testStageProgressUpdatesAndResetsWithLifecycle() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        let stageProgress = WorkerProgress(currentStage: 4, totalStages: 13, stageFraction: nil)
+        try state.receive(
+            event(
+                .stageStarted,
+                sequence: 0,
+                payload: .init(stage: "create_mkv", message: "Preparing source video", progress: stageProgress)
+            )
+        )
+        let heartbeatProgress = WorkerProgress(currentStage: 4, totalStages: 13, stageFraction: 0.42)
+        try state.receive(
+            event(
+                .heartbeat,
+                sequence: 1,
+                payload: .init(elapsedSeconds: 30, progress: heartbeatProgress)
+            )
+        )
+
+        XCTAssertEqual(state.progress, heartbeatProgress)
+        XCTAssertEqual(state.progress?.detailText, "42% of current stage · Stage 4 of 13")
+        XCTAssertEqual(state.progress?.compactText, "Stage 4/13 · 42% of stage")
+
+        state.requestStop()
+
+        XCTAssertNil(state.progress)
+
+        try state.receive(
+            event(
+                .stageStarted,
+                sequence: 2,
+                payload: .init(
+                    stage: "extract_mvc_and_audio",
+                    message: "Extracting MVC video and audio",
+                    progress: WorkerProgress(currentStage: 5, totalStages: 13, stageFraction: 0.1)
+                )
+            )
+        )
+        try state.receive(
+            event(
+                .heartbeat,
+                sequence: 3,
+                payload: .init(
+                    elapsedSeconds: 31,
+                    progress: WorkerProgress(currentStage: 5, totalStages: 13, stageFraction: 0.2)
+                )
+            )
+        )
+
+        XCTAssertEqual(state.phase, .stopping)
+        XCTAssertEqual(state.stageMessage, "Stopping safely")
+        XCTAssertNil(state.progress)
+    }
+
+    func testSharedPythonProgressFixtureDecodes() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/native_worker_stage_started_progress_v3.json")
+
+        let event = try JSONDecoder().decode(WorkerEvent.self, from: Data(contentsOf: fixtureURL))
+
+        XCTAssertEqual(event.payload.progress, WorkerProgress(currentStage: 1, totalStages: 2, stageFraction: nil))
+    }
+
+    func testInvalidProgressFallsBackToIndeterminate() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        try state.receive(
+            event(
+                .stageStarted,
+                sequence: 0,
+                payload: .init(progress: WorkerProgress(currentStage: 0, totalStages: 13, stageFraction: 0.5))
+            )
+        )
+
+        XCTAssertNil(state.progress)
+    }
+
     func testCancellationTransitionsThroughStoppingAndCancelled() throws {
         var state = WorkerLifecycleState()
         state.selectSource(sourceURL)

--- a/tests/fixtures/native_worker_stage_started_progress_v3.json
+++ b/tests/fixtures/native_worker_stage_started_progress_v3.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 3,
+  "type": "stage.started",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "configure",
+    "message": "Preparing conversion settings",
+    "progress": {
+      "current_stage": 1,
+      "total_stages": 2
+    }
+  }
+}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,97 @@
+import io
+import unittest
+
+from unittest.mock import Mock, call, patch
+
+from bd_to_avp.modules import command
+
+
+class RunCommandTests(unittest.TestCase):
+    def test_line_handler_receives_streamed_output(self) -> None:
+        process = Mock()
+        process.stdout = io.StringIO("first\nsecond\r\n")
+        process.returncode = 0
+        lines: list[str] = []
+
+        with (
+            patch.object(command.subprocess, "Popen", return_value=process),
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+        ):
+            output = command.run_command(["tool"], line_handler=lines.append)
+
+        self.assertEqual(lines, ["first", "second"])
+        self.assertEqual(output, "first\nsecond\r\n")
+        process.wait.assert_called_once_with()
+
+    def test_line_handler_failure_terminates_running_process(self) -> None:
+        process = Mock()
+        process.stdout = io.StringIO("progress\n")
+        process.poll.return_value = None
+
+        def fail(_line: str) -> None:
+            raise RuntimeError("bad progress parser")
+
+        with (
+            patch.object(command.subprocess, "Popen", return_value=process),
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+            self.assertRaisesRegex(RuntimeError, "bad progress parser"),
+        ):
+            command.run_command(["tool"], line_handler=fail)
+
+        process.terminate.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS)
+
+    def test_line_handler_failure_kills_process_after_termination_timeout(self) -> None:
+        process = Mock()
+        process.stdout = io.StringIO("progress\n")
+        process.poll.return_value = None
+        process.wait.side_effect = [
+            command.subprocess.TimeoutExpired(cmd="tool", timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS),
+            None,
+        ]
+
+        def fail(_line: str) -> None:
+            raise RuntimeError("bad progress parser")
+
+        with (
+            patch.object(command.subprocess, "Popen", return_value=process),
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+            self.assertRaisesRegex(RuntimeError, "bad progress parser"),
+        ):
+            command.run_command(["tool"], line_handler=fail)
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        self.assertEqual(
+            process.wait.call_args_list,
+            [
+                call(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS),
+                call(),
+            ],
+        )
+
+    def test_keyboard_interrupt_terminates_running_process(self) -> None:
+        process = Mock()
+        process.stdout = io.StringIO("progress\n")
+        process.poll.return_value = None
+
+        def interrupt(_line: str) -> None:
+            raise KeyboardInterrupt
+
+        with (
+            patch.object(command.subprocess, "Popen", return_value=process),
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            command.run_command(["tool"], line_handler=interrupt)
+
+        process.terminate.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -8,6 +8,48 @@ from bd_to_avp.modules.config import Stage
 
 
 class DiscStageArtifactTests(unittest.TestCase):
+    def test_makemkv_progress_uses_total_and_clamps_to_maximum(self) -> None:
+        self.assertEqual(disc.parse_makemkv_progress("PRGV:5,25,100"), (25, 100))
+        self.assertEqual(disc.parse_makemkv_progress("PRGV:5,125,100"), (100, 100))
+        self.assertIsNone(disc.parse_makemkv_progress("PRGV:5,25,0"))
+        self.assertIsNone(disc.parse_makemkv_progress("MSG:1005,0,1,Finished"))
+
+    def test_rip_requests_progress_and_reports_robot_updates(self) -> None:
+        progress_updates: list[tuple[float, float]] = []
+
+        def run_command(
+            command: list[object],
+            _name: str,
+            *,
+            line_handler: object,
+        ) -> str:
+            assert callable(line_handler)
+            line_handler("PRGV:5,25,100")
+            line_handler("MSG:1005,0,1,Finished")
+            line_handler("PRGV:5,100,100")
+            self.assertIn("--robot", command)
+            self.assertIn("--progress=-same", command)
+            return ""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir)
+            with (
+                patch.object(disc.config, "source_path", Path("/Movies/Feature.iso")),
+                patch.object(disc.config, "source_str", None),
+                patch.object(disc.config, "IMAGE_EXTENSIONS", [".iso"]),
+                patch.object(disc.config, "MAKEMKVCON_PATH", Path("/Applications/MakeMKV/makemkvcon")),
+                patch.object(disc, "create_custom_makemkv_profile"),
+                patch.object(disc, "run_command", side_effect=run_command),
+            ):
+                disc.rip_disc_to_mkv(
+                    output_folder,
+                    disc.DiscInfo(name="Feature", main_title_number=0),
+                    "eng",
+                    lambda completed, total: progress_updates.append((completed, total)),
+                )
+
+        self.assertEqual(progress_updates, [(25, 100), (100, 100)])
+
     def test_disc_info_uses_iso_source_prefix_for_image(self) -> None:
         makemkv_output = "\n".join(
             [

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -354,6 +354,54 @@ class WorkerEventEmitterTests(unittest.TestCase):
         self.assertEqual(events[-1]["type"], "job.failed")
 
 
+class WorkerActivityReporterTests(unittest.TestCase):
+    def test_stage_plan_emits_shared_progress_fixture(self) -> None:
+        output = io.StringIO()
+        job_id = "11111111-1111-4111-8111-111111111111"
+        activity = WorkerActivityReporter(WorkerEventEmitter(output, job_id))
+        activity.set_stage_plan(("configure", "create_mkv"))
+
+        activity.stage_started("configure", "Preparing conversion settings")
+
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v3.json"
+        expected = json.loads(fixture_path.read_text())
+        self.assertEqual(decoded_events(output), [expected])
+
+    def test_heartbeat_carries_current_stage_fraction(self) -> None:
+        output = io.StringIO()
+        activity = WorkerActivityReporter(WorkerEventEmitter(output, str(uuid4())))
+        activity.set_stage_plan(("configure", "create_mkv"))
+        activity.stage_started("configure", "Preparing conversion settings")
+        activity.stage_progress(25, 100)
+
+        payload = activity.heartbeat_payload(12)
+
+        self.assertEqual(payload["elapsed_seconds"], 12)
+        self.assertEqual(
+            payload["progress"],
+            {"current_stage": 1, "total_stages": 2, "stage_fraction": 0.25},
+        )
+
+        activity.emit_heartbeat(13)
+        events = decoded_events(output)
+        self.assertEqual([event["type"] for event in events], ["stage.started", "heartbeat"])
+        self.assertEqual(events[-1]["payload"]["progress"], payload["progress"])
+
+    def test_new_stage_resets_fraction_and_plan_mismatch_disables_progress(self) -> None:
+        output = io.StringIO()
+        activity = WorkerActivityReporter(WorkerEventEmitter(output, str(uuid4())))
+        activity.set_stage_plan(("configure", "create_mkv"))
+        activity.stage_started("configure", "Preparing conversion settings")
+        activity.stage_progress(120, 100)
+        activity.stage_started("create_mkv", "Preparing source video")
+        activity.stage_started("unexpected", "Unexpected stage")
+
+        events = decoded_events(output)
+        self.assertEqual(events[1]["payload"]["progress"], {"current_stage": 2, "total_stages": 2})
+        self.assertNotIn("progress", events[2]["payload"])
+        self.assertNotIn("progress", activity.heartbeat_payload(13))
+
+
 class WorkerRuntimeTests(unittest.TestCase):
     def test_success_emits_structured_terminal_event_and_redirects_prints(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -16,6 +16,77 @@ from bd_to_avp.modules.file import (
 
 
 class ProcessPreflightTests(unittest.TestCase):
+    def test_conversion_stage_plan_tracks_optional_work(self) -> None:
+        with (
+            patch.object(process.config, "preview_range", None),
+            patch.object(process.config, "skip_subtitles", False),
+            patch.object(process.config, "fx_upscale", False),
+            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            default_plan = process.conversion_stage_plan()
+
+        self.assertEqual(
+            default_plan,
+            (
+                "configure",
+                "preflight",
+                "inspect_source",
+                "create_mkv",
+                "probe_color",
+                "detect_crop",
+                "extract_mvc_and_audio",
+                "extract_subtitles",
+                "create_left_right_files",
+                "combine_to_mv_hevc",
+                "transcode_audio",
+                "create_final_file",
+                "move_files",
+            ),
+        )
+
+        with (
+            patch.object(process.config, "preview_range", Mock()),
+            patch.object(process.config, "skip_subtitles", True),
+            patch.object(process.config, "fx_upscale", True),
+            patch.object(process.config, "transcode_audio", False),
+            patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            optional_plan = process.conversion_stage_plan()
+
+        self.assertIn("prepare_preview_range", optional_plan)
+        self.assertIn("upscale_video", optional_plan)
+        self.assertNotIn("extract_subtitles", optional_plan)
+        self.assertNotIn("transcode_audio", optional_plan)
+
+    def test_conversion_stage_plan_excludes_completed_recovery_stages(self) -> None:
+        with (
+            patch.object(process.config, "preview_range", None),
+            patch.object(process.config, "skip_subtitles", False),
+            patch.object(process.config, "fx_upscale", False),
+            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
+        ):
+            mkv_recovery_plan = process.conversion_stage_plan()
+
+        self.assertNotIn("create_mkv", mkv_recovery_plan)
+        self.assertIn("extract_mvc_and_audio", mkv_recovery_plan)
+        self.assertIn("extract_subtitles", mkv_recovery_plan)
+
+        with (
+            patch.object(process.config, "preview_range", None),
+            patch.object(process.config, "skip_subtitles", True),
+            patch.object(process.config, "fx_upscale", False),
+            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "start_stage", Stage.EXTRACT_SUBTITLES),
+        ):
+            subtitle_recovery_plan = process.conversion_stage_plan()
+
+        self.assertNotIn("create_mkv", subtitle_recovery_plan)
+        self.assertNotIn("extract_mvc_and_audio", subtitle_recovery_plan)
+        self.assertNotIn("extract_subtitles", subtitle_recovery_plan)
+        self.assertIn("create_left_right_files", subtitle_recovery_plan)
+
     def test_batch_processing_aborts_on_dependency_preflight_error(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             source_folder = Path(temp_dir)


### PR DESCRIPTION
## Summary

- extend worker protocol v3 stage and heartbeat payloads with optional, backward-compatible progress hints
- report exact per-job stage position, including recovery jobs that resume after completed stages
- stream MakeMKV robot `PRGV` output into a determinate current-stage percentage while leaving unsupported stages indeterminate
- present stage-scoped progress consistently in full conversions and preview jobs without inventing an ETA
- keep cancellation state stable when delayed worker events arrive and harden child-process cleanup if a progress callback fails

## Validation

- `uv run python -m unittest discover -s tests -t .` — 443 passed
- `uv run python scripts/native_app.py test` — 103 passed
- `uv run ruff format --check ...` — passed
- `uv run ruff check ...` — passed
- `uv run mypy bd_to_avp` — passed
- `uv build` — passed
- `uv run python scripts/native_app.py package` — passed, including app/worker signature validation
- independent multi-model reviews plus a final current-diff review found no remaining blockers
- PyCharm changed-files inspection was inconclusive because the helper returned stale results after its permitted retry; cached findings were withheld and no actionable IDE findings were reported

Refs #6
Refs #180
Refs #191