### PR TITLE
Add searchable subtitle language selection

### DIFF
--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -11,16 +11,21 @@ final class ProfileStore: ObservableObject {
     private let fileManager: FileManager
     private let fileURL: URL
     private let idGenerator: () -> UUID
+    private let dataWriter: (Data, URL) throws -> Void
     private var writesBlocked = false
 
     init(
         fileURL: URL? = nil,
         fileManager: FileManager = .default,
-        idGenerator: @escaping () -> UUID = UUID.init
+        idGenerator: @escaping () -> UUID = UUID.init,
+        dataWriter: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: .atomic)
+        }
     ) {
         self.fileManager = fileManager
         self.fileURL = fileURL ?? Self.defaultFileURL(fileManager: fileManager)
         self.idGenerator = idGenerator
+        self.dataWriter = dataWriter
         loadProfiles()
     }
 
@@ -137,29 +142,33 @@ final class ProfileStore: ObservableObject {
         }
         do {
             let data = try Data(contentsOf: fileURL)
-            let document = try JSONDecoder().decode(ProfileDocument.self, from: data)
-            guard document.version == ProfileDocument.currentVersion else {
-                throw ProfileStoreError.unsupportedVersion(document.version)
+            let decoder = JSONDecoder()
+            let version = try decoder.decode(ProfileDocumentVersion.self, from: data).version
+            let storedProfiles: [StoredProfile]
+            let needsMigration: Bool
+            switch version {
+            case 1:
+                let legacyDocument = try decoder.decode(LegacyProfileDocumentV1.self, from: data)
+                storedProfiles = try legacyDocument.profiles.map { try $0.migrated() }
+                needsMigration = true
+            case ProfileDocument.currentVersion:
+                storedProfiles = try decoder.decode(ProfileDocument.self, from: data).profiles
+                needsMigration = false
+            default:
+                throw ProfileStoreError.unsupportedVersion(version)
             }
-            var identifiers = Set<String>()
-            var names = Set<String>()
-            customProfiles = try document.profiles.map { storedProfile in
-                let identifier = "custom.\(storedProfile.id.uuidString.lowercased())"
-                let normalizedName = storedProfile.name.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !normalizedName.isEmpty,
-                      identifiers.insert(identifier).inserted,
-                      names.insert(normalizedName.lowercased()).inserted
-                else {
-                    throw ProfileStoreError.invalidDocument
+            let loadedProfiles = try restoreProfiles(storedProfiles)
+            if needsMigration {
+                do {
+                    try persist(loadedProfiles)
+                } catch {
+                    writesBlocked = true
+                    customProfiles = loadedProfiles
+                    loadErrorMessage = "Custom profiles were loaded but could not be upgraded. Profile changes are disabled to protect the original library."
+                    return
                 }
-                return EncodingProfile(
-                    id: identifier,
-                    name: normalizedName,
-                    options: storedProfile.options,
-                    kind: .custom,
-                    systemImage: "slider.horizontal.3"
-                )
             }
+            customProfiles = loadedProfiles
         } catch {
             if let recoveryURL = preserveUnreadableFile() {
                 loadErrorMessage = "Custom profiles could not be loaded. The original library was preserved as \(recoveryURL.lastPathComponent)."
@@ -168,6 +177,28 @@ final class ProfileStore: ObservableObject {
                 loadErrorMessage = "Custom profiles could not be loaded or preserved. Profile changes are disabled to protect the original library."
             }
             customProfiles = []
+        }
+    }
+
+    private func restoreProfiles(_ storedProfiles: [StoredProfile]) throws -> [EncodingProfile] {
+        var identifiers = Set<String>()
+        var names = Set<String>()
+        return try storedProfiles.map { storedProfile in
+            let identifier = "custom.\(storedProfile.id.uuidString.lowercased())"
+            let normalizedName = storedProfile.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedName.isEmpty,
+                  identifiers.insert(identifier).inserted,
+                  names.insert(normalizedName.lowercased()).inserted
+            else {
+                throw ProfileStoreError.invalidDocument
+            }
+            return EncodingProfile(
+                id: identifier,
+                name: normalizedName,
+                options: storedProfile.options,
+                kind: .custom,
+                systemImage: "slider.horizontal.3"
+            )
         }
     }
 
@@ -189,7 +220,7 @@ final class ProfileStore: ObservableObject {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(document)
-        try data.write(to: fileURL, options: .atomic)
+        try dataWriter(data, fileURL)
         loadErrorMessage = nil
     }
 
@@ -246,14 +277,79 @@ enum ProfileStoreError: LocalizedError, Equatable {
 }
 
 private struct ProfileDocument: Codable {
-    static let currentVersion = 1
+    static let currentVersion = 2
 
     let version: Int
     let profiles: [StoredProfile]
+}
+
+private struct ProfileDocumentVersion: Decodable {
+    let version: Int
 }
 
 private struct StoredProfile: Codable {
     let id: UUID
     let name: String
     let options: EncodingOptions
+}
+
+private struct LegacyProfileDocumentV1: Decodable {
+    let version: Int
+    let profiles: [LegacyStoredProfileV1]
+}
+
+private struct LegacyStoredProfileV1: Decodable {
+    let id: UUID
+    let name: String
+    let options: LegacyEncodingOptionsV1
+
+    func migrated() throws -> StoredProfile {
+        StoredProfile(id: id, name: name, options: try options.migrated())
+    }
+}
+
+private struct LegacyEncodingOptionsV1: Decodable {
+    let hevcQuality: Int
+    let leftRightBitrate: Int
+    let upscaleEnabled: Bool
+    let upscaleQuality: Int
+    let linkQuality: Bool
+    let fieldOfView: Int
+    let frameRateOverride: String
+    let resolutionOverride: String
+    let cropBlackBars: Bool
+    let swapEyes: Bool
+    let audioHandling: AudioHandling
+    let audioBitrate: Int
+    let language: String
+    let includeSubtitles: Bool
+    let keepExtraLanguages: Bool
+
+    func migrated() throws -> EncodingOptions {
+        guard let preferredLanguage = SubtitleLanguage(code: language) else {
+            throw ProfileStoreError.invalidDocument
+        }
+        let mode: SubtitleMode = if !includeSubtitles {
+            .off
+        } else if keepExtraLanguages {
+            .preferredPlusOthers
+        } else {
+            .preferredOnly
+        }
+        return EncodingOptions(
+            hevcQuality: hevcQuality,
+            leftRightBitrate: leftRightBitrate,
+            upscaleEnabled: upscaleEnabled,
+            upscaleQuality: upscaleQuality,
+            linkQuality: linkQuality,
+            fieldOfView: fieldOfView,
+            frameRateOverride: frameRateOverride,
+            resolutionOverride: resolutionOverride,
+            cropBlackBars: cropBlackBars,
+            swapEyes: swapEyes,
+            audioHandling: audioHandling,
+            audioBitrate: audioBitrate,
+            subtitles: SubtitlePolicy(mode: mode, preferredLanguage: preferredLanguage)
+        )
+    }
 }

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -35,34 +35,39 @@ enum AudioHandling: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum SubtitleLanguage: String, CaseIterable, Codable, Identifiable {
-    case english = "eng"
-    case spanish = "spa"
-    case french = "fre"
-    case german = "ger"
-    case chinese = "chi"
-    case japanese = "jpn"
-    case portuguese = "por"
-    case russian = "rus"
-    case italian = "ita"
-    case korean = "kor"
+enum SubtitleMode: String, CaseIterable, Codable, Identifiable {
+    case off
+    case preferredOnly = "preferred_only"
+    case preferredPlusOthers = "preferred_plus_others"
 
     var id: String { rawValue }
 
-    var name: String {
+    var title: String {
         switch self {
-        case .english: "English"
-        case .spanish: "Spanish"
-        case .french: "French"
-        case .german: "German"
-        case .chinese: "Chinese"
-        case .japanese: "Japanese"
-        case .portuguese: "Portuguese"
-        case .russian: "Russian"
-        case .italian: "Italian"
-        case .korean: "Korean"
+        case .off:
+            "Off"
+        case .preferredOnly:
+            "Preferred Only"
+        case .preferredPlusOthers:
+            "Preferred + Others"
         }
     }
+
+    var detail: String {
+        switch self {
+        case .off:
+            "No subtitle tracks will be extracted."
+        case .preferredOnly:
+            "Only the preferred language is retained when matching subtitles are available."
+        case .preferredPlusOthers:
+            "The preferred language is prioritized while other available subtitle tracks are retained."
+        }
+    }
+}
+
+struct SubtitlePolicy: Codable, Equatable {
+    var mode = SubtitleMode.preferredPlusOthers
+    var preferredLanguage = SubtitleLanguage.english
 }
 
 enum ConversionStage: Int, CaseIterable, Codable, Identifiable {
@@ -116,9 +121,7 @@ struct EncodingOptions: Codable, Equatable {
 
     var audioHandling = AudioHandling.preserve
     var audioBitrate = 384
-    var language = SubtitleLanguage.english
-    var includeSubtitles = true
-    var keepExtraLanguages = true
+    var subtitles = SubtitlePolicy()
 
     var compactSummary: String {
         let resolution = upscaleEnabled ? "2× upscale" : "source resolution"

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -202,7 +202,7 @@ struct ConversionDraft: Equatable {
             retryOptions.job.continueOnError = true
         case ("subtitle_decision_required", .retryWithoutSubtitles):
             retryOptions.job.startStage = .extractSubtitles
-            retryOptions.encoding.includeSubtitles = false
+            retryOptions.encoding.subtitles.mode = .off
         default:
             return nil
         }

--- a/macos/BluRayToVisionPro/Models/LanguageCatalog.swift
+++ b/macos/BluRayToVisionPro/Models/LanguageCatalog.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+enum LanguageCatalogError: LocalizedError {
+    case missingResource
+    case invalidResource
+    case unsupportedSchema(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingResource:
+            "The bundled language catalog is missing."
+        case .invalidResource:
+            "The bundled language catalog is invalid."
+        case let .unsupportedSchema(version):
+            "Language catalog schema version \(version) is not supported."
+        }
+    }
+}
+
+struct LanguageCatalog {
+    struct Language: Decodable, Hashable, Identifiable {
+        let code: String
+        let name: String
+        let alpha2: String?
+        let bibliographic: String
+
+        var id: String { code }
+        var displayName: String { "\(name) (\(code))" }
+
+        var aliasSummary: String {
+            [alpha2, bibliographic == code ? nil : bibliographic]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+        }
+    }
+
+    static let shared: LanguageCatalog = {
+        do {
+            return try LanguageCatalog(bundle: .main)
+        } catch {
+            preconditionFailure("Unable to load the language catalog: \(error.localizedDescription)")
+        }
+    }()
+
+    private static let commonCodes = [
+        "eng", "spa", "fra", "deu", "nld", "zho", "jpn", "por",
+        "rus", "ita", "kor", "ara", "pol", "swe", "hin",
+    ]
+    private static let specialCodes = Set(["mis", "mul", "und", "zxx"])
+
+    let languages: [Language]
+    let commonLanguages: [Language]
+    private let languagesByCode: [String: Language]
+    private let canonicalCodesByAlias: [String: String]
+
+    init(bundle: Bundle) throws {
+        guard let url = bundle.url(forResource: "iso639_languages", withExtension: "json") else {
+            throw LanguageCatalogError.missingResource
+        }
+        try self.init(data: Data(contentsOf: url))
+    }
+
+    init(data: Data) throws {
+        let document: Document
+        do {
+            document = try JSONDecoder().decode(Document.self, from: data)
+        } catch {
+            throw LanguageCatalogError.invalidResource
+        }
+        guard document.schemaVersion == 1 else {
+            throw LanguageCatalogError.unsupportedSchema(document.schemaVersion)
+        }
+        guard !document.languages.isEmpty else {
+            throw LanguageCatalogError.invalidResource
+        }
+
+        var codes = Set<String>()
+        var names = Set<String>()
+        var aliases: [String: String] = [:]
+        for language in document.languages {
+            guard Self.isASCIIAlphaCode(language.code, length: 3),
+                  Self.isASCIIAlphaCode(language.bibliographic, length: 3),
+                  language.alpha2.map({ Self.isASCIIAlphaCode($0, length: 2) }) ?? true,
+                  !language.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !Self.specialCodes.contains(language.code),
+                  codes.insert(language.code).inserted,
+                  names.insert(language.name.localizedLowercase).inserted
+            else {
+                throw LanguageCatalogError.invalidResource
+            }
+
+            for alias in Set([language.code, language.alpha2, language.bibliographic].compactMap { $0 }) {
+                if let existingCode = aliases[alias], existingCode != language.code {
+                    throw LanguageCatalogError.invalidResource
+                }
+                aliases[alias] = language.code
+            }
+        }
+
+        let sortedLanguages = document.languages.sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+        let indexedLanguages = Dictionary(uniqueKeysWithValues: sortedLanguages.map { ($0.code, $0) })
+        languages = sortedLanguages
+        languagesByCode = indexedLanguages
+        canonicalCodesByAlias = aliases
+        commonLanguages = Self.commonCodes.compactMap { code in
+            indexedLanguages[code]
+        }
+    }
+
+    func language(matching suppliedCode: String) -> Language? {
+        guard let primaryCode = Self.primaryLanguageCode(suppliedCode),
+              let canonicalCode = canonicalCodesByAlias[primaryCode]
+        else {
+            return nil
+        }
+        return languagesByCode[canonicalCode]
+    }
+
+    func language(canonicalCode: String) -> Language? {
+        languagesByCode[canonicalCode]
+    }
+
+    func search(_ query: String) -> [Language] {
+        let normalizedQuery = Self.normalizedSearchText(query)
+        guard !normalizedQuery.isEmpty else {
+            return languages
+        }
+
+        return languages
+            .compactMap { language -> (Language, Int)? in
+                let name = Self.normalizedSearchText(language.name)
+                let aliases = [language.code, language.alpha2, language.bibliographic]
+                    .compactMap { $0 }
+                    .map(Self.normalizedSearchText)
+                let rank: Int
+                if aliases.contains(normalizedQuery) {
+                    rank = 0
+                } else if name.hasPrefix(normalizedQuery) {
+                    rank = 1
+                } else if aliases.contains(where: { $0.hasPrefix(normalizedQuery) }) {
+                    rank = 2
+                } else if name.contains(normalizedQuery) {
+                    rank = 3
+                } else if aliases.contains(where: { $0.contains(normalizedQuery) }) {
+                    rank = 4
+                } else {
+                    return nil
+                }
+                return (language, rank)
+            }
+            .sorted { left, right in
+                if left.1 != right.1 {
+                    return left.1 < right.1
+                }
+                return left.0.name.localizedStandardCompare(right.0.name) == .orderedAscending
+            }
+            .map(\.0)
+    }
+
+    private static func isASCIIAlphaCode(_ value: String, length: Int) -> Bool {
+        value.count == length && value.unicodeScalars.allSatisfy { (97 ... 122).contains($0.value) }
+    }
+
+    private static func primaryLanguageCode(_ value: String) -> String? {
+        let normalized = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        let parts = normalized.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        guard (1 ... 3).contains(parts.count),
+              let primaryCode = parts.first,
+              (primaryCode.count == 2 || primaryCode.count == 3),
+              isASCIIAlphaCode(primaryCode, length: primaryCode.count)
+        else {
+            return nil
+        }
+        for suffix in parts.dropFirst() {
+            let validSuffix = isASCIIAlphaCode(suffix, length: 2)
+                || isASCIIAlphaCode(suffix, length: 4)
+                || (suffix.count == 3 && suffix.unicodeScalars.allSatisfy { (48 ... 57).contains($0.value) })
+            guard validSuffix else {
+                return nil
+            }
+        }
+        return primaryCode
+    }
+
+    private static func normalizedSearchText(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private struct Document: Decodable {
+        let schemaVersion: Int
+        let languages: [Language]
+
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion = "schema_version"
+            case languages
+        }
+    }
+}
+
+struct SubtitleLanguage: Codable, Equatable, Hashable, Identifiable {
+    let code: String
+
+    var id: String { code }
+    var name: String { catalogLanguage.name }
+    var alpha2: String? { catalogLanguage.alpha2 }
+    var bibliographic: String { catalogLanguage.bibliographic }
+    var displayName: String { catalogLanguage.displayName }
+
+    static let english = SubtitleLanguage(canonicalCode: "eng")
+    static let spanish = SubtitleLanguage(canonicalCode: "spa")
+    static let french = SubtitleLanguage(canonicalCode: "fra")
+    static let german = SubtitleLanguage(canonicalCode: "deu")
+    static let dutch = SubtitleLanguage(canonicalCode: "nld")
+    static let chinese = SubtitleLanguage(canonicalCode: "zho")
+    static let japanese = SubtitleLanguage(canonicalCode: "jpn")
+    static let portuguese = SubtitleLanguage(canonicalCode: "por")
+    static let russian = SubtitleLanguage(canonicalCode: "rus")
+    static let italian = SubtitleLanguage(canonicalCode: "ita")
+    static let korean = SubtitleLanguage(canonicalCode: "kor")
+
+    init?(code: String, catalog: LanguageCatalog = .shared) {
+        guard let language = catalog.language(matching: code) else {
+            return nil
+        }
+        self.code = language.code
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let suppliedCode = try container.decode(String.self)
+        guard let language = SubtitleLanguage(code: suppliedCode) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported subtitle language code: \(suppliedCode)."
+            )
+        }
+        self = language
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(code)
+    }
+
+    private init(canonicalCode: String) {
+        code = canonicalCode
+    }
+
+    private var catalogLanguage: LanguageCatalog.Language {
+        guard let language = LanguageCatalog.shared.language(canonicalCode: code) else {
+            preconditionFailure("Unsupported canonical subtitle language: \(code)")
+        }
+        return language
+    }
+}

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -55,13 +55,7 @@ struct WorkerJobSpec: Encodable, Equatable {
 
     struct Encoding: Encodable, Equatable {
         struct Subtitles: Encodable, Equatable {
-            enum Mode: String, Encodable {
-                case off
-                case preferredOnly = "preferred_only"
-                case preferredPlusOthers = "preferred_plus_others"
-            }
-
-            let mode: Mode
+            let mode: SubtitleMode
             let preferredLanguage: String?
 
             func encode(to encoder: Encoder) throws {
@@ -256,12 +250,12 @@ struct WorkerJobSpec: Encodable, Equatable {
     }
 
     private static func subtitleOptions(from options: EncodingOptions) -> Encoding.Subtitles {
-        guard options.includeSubtitles else {
+        guard options.subtitles.mode != .off else {
             return Encoding.Subtitles(mode: .off, preferredLanguage: nil)
         }
         return Encoding.Subtitles(
-            mode: options.keepExtraLanguages ? .preferredPlusOthers : .preferredOnly,
-            preferredLanguage: options.language.rawValue
+            mode: options.subtitles.mode,
+            preferredLanguage: options.subtitles.preferredLanguage.code
         )
     }
 

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -108,25 +108,22 @@ struct EncodingOptionsEditor: View {
                 }
 
                 Section("Subtitles and Languages") {
-                    Picker("Preferred language", selection: $options.language) {
-                        ForEach(SubtitleLanguage.allCases) { language in
-                            Text(language.name).tag(language)
+                    Picker("Subtitle handling", selection: $options.subtitles.mode) {
+                        ForEach(SubtitleMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
                         }
                     }
+                    .pickerStyle(.segmented)
 
-                    Toggle("Include subtitles", isOn: $options.includeSubtitles)
-                    Toggle("Keep extra languages", isOn: $options.keepExtraLanguages)
-                        .disabled(!options.includeSubtitles)
+                    if options.subtitles.mode != .off {
+                        LanguagePickerField(selection: $options.subtitles.preferredLanguage)
+                    }
 
-                    if options.includeSubtitles {
-                        Text(
-                            options.keepExtraLanguages
-                                ? "The preferred language is prioritized while other available tracks are retained."
-                                : "Only the preferred language is retained when the disc contains multiple tracks."
-                        )
+                    Text(
+                        "\(options.subtitles.mode.detail) Source audio tracks are preserved independently of subtitle choices."
+                    )
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    }
                 }
             }
         }

--- a/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
+++ b/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+struct LanguagePickerField: View {
+    @Binding var selection: SubtitleLanguage
+    @State private var isPresented = false
+
+    var body: some View {
+        LabeledContent("Preferred language") {
+            Button {
+                isPresented.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Text(selection.displayName)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel("Preferred language: \(selection.displayName)")
+            .accessibilityHint("Opens a searchable list of languages")
+            .popover(isPresented: $isPresented, arrowEdge: .trailing) {
+                LanguagePickerPopover(selection: $selection, isPresented: $isPresented)
+            }
+        }
+    }
+}
+
+private struct LanguagePickerPopover: View {
+    @Binding var selection: SubtitleLanguage
+    @Binding var isPresented: Bool
+    @State private var query = ""
+    @State private var highlightedCode: String?
+    @FocusState private var searchIsFocused: Bool
+    @FocusState private var resultsAreFocused: Bool
+
+    private let catalog = LanguageCatalog.shared
+
+    private var results: [LanguageCatalog.Language] {
+        catalog.search(query)
+    }
+
+    private var commonCodes: Set<String> {
+        Set(catalog.commonLanguages.map(\.code))
+    }
+
+    private var highlightedLanguage: LanguageCatalog.Language? {
+        highlightedCode.flatMap(catalog.language(canonicalCode:))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                TextField("Search by language or code", text: $query)
+                    .textFieldStyle(.plain)
+                    .focused($searchIsFocused)
+                    .accessibilityLabel("Search languages")
+                    .onSubmit {
+                        if let highlightedLanguage {
+                            select(highlightedLanguage)
+                        }
+                    }
+                    .onKeyPress(.downArrow) {
+                        highlightedCode = query.isEmpty ? selection.code : results.first?.code
+                        resultsAreFocused = highlightedCode != nil
+                        return highlightedCode == nil ? .ignored : .handled
+                    }
+                if !query.isEmpty {
+                    Button {
+                        query = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear language search")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            if !query.isEmpty, results.isEmpty {
+                ContentUnavailableView(
+                    "No Languages Found",
+                    systemImage: "magnifyingglass",
+                    description: Text("Try a language name or an ISO code such as Dutch, nl, nld, or dut.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(selection: $highlightedCode) {
+                    if query.isEmpty {
+                        Section("Common") {
+                            ForEach(catalog.commonLanguages) { language in
+                                languageRow(language)
+                            }
+                        }
+                        Section("All Languages") {
+                            ForEach(catalog.languages.filter { !commonCodes.contains($0.code) }) { language in
+                                languageRow(language)
+                            }
+                        }
+                    } else {
+                        ForEach(results) { language in
+                            languageRow(language)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .focused($resultsAreFocused)
+                .onKeyPress(.return) {
+                    guard let highlightedLanguage else {
+                        return .ignored
+                    }
+                    select(highlightedLanguage)
+                    return .handled
+                }
+            }
+        }
+        .frame(width: 340, height: 390)
+        .onAppear {
+            highlightedCode = selection.code
+            searchIsFocused = true
+        }
+        .onChange(of: query) { _, newQuery in
+            highlightedCode = newQuery.isEmpty ? selection.code : results.first?.code
+        }
+        .onExitCommand {
+            isPresented = false
+        }
+    }
+
+    private func languageRow(_ language: LanguageCatalog.Language) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(language.name)
+                    .foregroundStyle(.primary)
+                HStack(spacing: 6) {
+                    Text(language.code)
+                        .monospaced()
+                    if !language.aliasSummary.isEmpty {
+                        Text(language.aliasSummary)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 12)
+            if language.code == selection.code {
+                Image(systemName: "checkmark")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.tint)
+                    .accessibilityHidden(true)
+            }
+        }
+        .contentShape(Rectangle())
+        .tag(language.code)
+        .onTapGesture {
+            select(language)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(language.displayName)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            select(language)
+        }
+    }
+
+    private func select(_ language: LanguageCatalog.Language) {
+        guard let selectedLanguage = SubtitleLanguage(code: language.code, catalog: catalog) else {
+            assertionFailure("Language catalog returned an unselectable code: \(language.code)")
+            isPresented = false
+            return
+        }
+        selection = selectedLanguage
+        isPresented = false
+    }
+}

--- a/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
+++ b/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
@@ -168,6 +168,7 @@ private struct LanguagePickerPopover: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(language.displayName)
         .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(language.code == selection.code ? .isSelected : [])
         .accessibilityAction {
             select(language)
         }

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -432,9 +432,11 @@ private struct ProfileEncodingSummaryView: View {
                     ProfileSummarySection(
                         title: "Subtitles and Languages",
                         items: [
-                            ProfileSummaryItem(title: "Preferred language", value: options.language.name),
-                            ProfileSummaryItem(title: "Include subtitles", value: enabledText(options.includeSubtitles)),
-                            ProfileSummaryItem(title: "Keep extra languages", value: enabledText(options.keepExtraLanguages)),
+                            ProfileSummaryItem(title: "Subtitle handling", value: options.subtitles.mode.title),
+                            ProfileSummaryItem(
+                                title: "Preferred language",
+                                value: options.subtitles.preferredLanguage.displayName
+                            ),
                         ]
                     )
                 }

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -564,12 +564,13 @@ struct SourceWorkspaceView: View {
     }
 
     private var subtitleSummary: String {
-        guard options.encoding.includeSubtitles else {
+        guard options.encoding.subtitles.mode != .off else {
             return "Skipped"
         }
-        return options.encoding.keepExtraLanguages
-            ? "\(options.encoding.language.name) preferred; keep others"
-            : "\(options.encoding.language.name) only"
+        let languageName = options.encoding.subtitles.preferredLanguage.name
+        return options.encoding.subtitles.mode == .preferredPlusOthers
+            ? "\(languageName) preferred; keep others"
+            : "\(languageName) only"
     }
 
     private var outputControlsLocked: Bool {

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -544,7 +544,7 @@ final class ConversionViewModelTests: XCTestCase {
             XCTAssertEqual(conversionJobs[1].job?.startStage, ConversionStage.extractSubtitles.rawValue)
             XCTAssertEqual(conversionJobs[1].encoding?.subtitles.mode, .off)
             XCTAssertNil(conversionJobs[1].encoding?.subtitles.preferredLanguage)
-            XCTAssertTrue(draft.options.encoding.includeSubtitles)
+            XCTAssertEqual(draft.options.encoding.subtitles.mode, .preferredPlusOthers)
             XCTAssertEqual(viewModel.state.phase, .completed)
         }
     }

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -139,7 +139,9 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(BuiltInProfile.originalResolution.options.hevcQuality, 85)
         XCTAssertEqual(ConversionStage.combineToMVHEVC.rawValue, 5)
         XCTAssertEqual(ConversionStage.upscaleVideo.rawValue, 6)
-        XCTAssertEqual(SubtitleLanguage.french.rawValue, "fre")
+        XCTAssertEqual(SubtitleLanguage.french.code, "fra")
+        XCTAssertEqual(SubtitleLanguage.german.code, "deu")
+        XCTAssertEqual(SubtitleLanguage.chinese.code, "zho")
     }
 
     func testPCMHandlingIsDescribedTruthfullyWithoutChangingItsStoredValue() {
@@ -420,9 +422,7 @@ final class ConversionWorkflowTests: XCTestCase {
             swapEyes: true,
             audioHandling: .transcodeAAC,
             audioBitrate: 512,
-            language: .japanese,
-            includeSubtitles: false,
-            keepExtraLanguages: false
+            subtitles: SubtitlePolicy(mode: .off, preferredLanguage: .japanese)
         )
         let profile = EncodingProfile(
             id: "custom.11111111-1111-4111-8111-111111111111",
@@ -574,9 +574,9 @@ final class ConversionWorkflowTests: XCTestCase {
             draft.retrying(decision: decision, choice: .retryWithoutSubtitles)
         )
 
-        XCTAssertTrue(draft.options.encoding.includeSubtitles)
+        XCTAssertEqual(draft.options.encoding.subtitles.mode, .preferredPlusOthers)
         XCTAssertEqual(retry.options.job.startStage, .extractSubtitles)
-        XCTAssertFalse(retry.options.encoding.includeSubtitles)
+        XCTAssertEqual(retry.options.encoding.subtitles.mode, .off)
         XCTAssertFalse(retry.options.job.continueOnError)
     }
 
@@ -641,6 +641,70 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(job["start_stage"] as? Int, 1)
         XCTAssertNil(job["output_length"])
         XCTAssertNil(json["conversion_settings"])
+    }
+
+    func testConversionJobSpecUsesCanonicalDutchAndNullsLanguageWhenOff() throws {
+        var options = ConversionOptions()
+        options.encoding.subtitles = SubtitlePolicy(mode: .preferredOnly, preferredLanguage: .dutch)
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv"))
+        let draft = ConversionDraft(
+            source: source,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+
+        var data = try JSONEncoder().encode(WorkerJobSpec(draft: draft))
+        var json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        var subtitles = try XCTUnwrap(encoding["subtitles"] as? [String: Any])
+        XCTAssertEqual(subtitles["mode"] as? String, "preferred_only")
+        XCTAssertEqual(subtitles["preferred_language"] as? String, "nld")
+        XCTAssertEqual(Set(subtitles.keys), ["mode", "preferred_language"])
+        XCTAssertNil(encoding["skip_subtitles"])
+        XCTAssertNil(encoding["language_code"])
+        XCTAssertNil(encoding["remove_extra_languages"])
+
+        options.encoding.subtitles.mode = .off
+        let offDraft = ConversionDraft(
+            source: source,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+        data = try JSONEncoder().encode(WorkerJobSpec(draft: offDraft))
+        json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        subtitles = try XCTUnwrap(encoding["subtitles"] as? [String: Any])
+        XCTAssertEqual(subtitles["mode"] as? String, "off")
+        XCTAssertTrue(subtitles["preferred_language"] is NSNull)
+    }
+
+    func testSubtitlePolicyDoesNotChangeAudioEncodingFields() throws {
+        var options = ConversionOptions()
+        options.encoding.audioHandling = .transcodeAAC
+        options.encoding.audioBitrate = 640
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv"))
+
+        func workerEncoding(for options: ConversionOptions) throws -> WorkerJobSpec.Encoding {
+            let draft = ConversionDraft(
+                source: source,
+                sourceDetails: nil,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+                options: options
+            )
+            return try XCTUnwrap(WorkerJobSpec(draft: draft).encoding)
+        }
+
+        let originalEncoding = try workerEncoding(for: options)
+        options.encoding.subtitles = SubtitlePolicy(mode: .off, preferredLanguage: .dutch)
+        let changedEncoding = try workerEncoding(for: options)
+
+        XCTAssertEqual(changedEncoding.transcodeAudio, originalEncoding.transcodeAudio)
+        XCTAssertEqual(changedEncoding.audioBitrate, originalEncoding.audioBitrate)
     }
 
     func testConversionJobSpecMatchesSharedPythonFixture() throws {

--- a/macos/BluRayToVisionProTests/LanguageCatalogTests.swift
+++ b/macos/BluRayToVisionProTests/LanguageCatalogTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class LanguageCatalogTests: XCTestCase {
+    func testBundledCatalogContainsAllSelectableLanguages() {
+        let catalog = LanguageCatalog.shared
+
+        XCTAssertEqual(catalog.languages.count, 414)
+        XCTAssertEqual(catalog.language(matching: "eng")?.name, "English")
+        XCTAssertNil(catalog.language(matching: "und"))
+        XCTAssertTrue(catalog.commonLanguages.contains { $0.code == "nld" })
+    }
+
+    func testCatalogNormalizesLegacyAndIETFAliases() {
+        let catalog = LanguageCatalog.shared
+        let expected = [
+            "nl": "nld",
+            "dut": "nld",
+            "nld": "nld",
+            "ger": "deu",
+            "fre": "fra",
+            "chi": "zho",
+            "pt-BR": "por",
+            "zh_Hant": "zho",
+        ]
+
+        for (supplied, canonical) in expected {
+            XCTAssertEqual(catalog.language(matching: supplied)?.code, canonical, supplied)
+        }
+    }
+
+    func testSearchFindsDutchByNameAndEveryCode() {
+        let catalog = LanguageCatalog.shared
+
+        for query in ["Dutch", "nl", "nld", "dut"] {
+            XCTAssertEqual(catalog.search(query).first?.code, "nld", query)
+        }
+        XCTAssertTrue(catalog.search("not-a-language").isEmpty)
+    }
+
+    func testSubtitleLanguageCodableCanonicalizesLegacyAliases() throws {
+        let decoded = try JSONDecoder().decode(SubtitleLanguage.self, from: Data(#""dut""#.utf8))
+        let encoded = try JSONEncoder().encode(decoded)
+
+        XCTAssertEqual(decoded, .dutch)
+        XCTAssertEqual(String(decoding: encoded, as: UTF8.self), #""nld""#)
+    }
+
+    func testCatalogRejectsUnknownAndMalformedSelectableCodes() {
+        let catalog = LanguageCatalog.shared
+
+        for code in ["und", "xyz", "en-", "en-not", "zh__Hant"] {
+            XCTAssertNil(catalog.language(matching: code), code)
+        }
+    }
+
+    func testCatalogRejectsDuplicateCodes() {
+        let data = Data(
+            #"{"schema_version":1,"languages":[{"code":"eng","name":"English","alpha2":"en","bibliographic":"eng"},{"code":"eng","name":"Duplicate","alpha2":null,"bibliographic":"eng"}]}"#.utf8
+        )
+
+        XCTAssertThrowsError(try LanguageCatalog(data: data))
+    }
+}

--- a/macos/BluRayToVisionProTests/LanguageCatalogTests.swift
+++ b/macos/BluRayToVisionProTests/LanguageCatalogTests.swift
@@ -33,7 +33,7 @@ final class LanguageCatalogTests: XCTestCase {
     func testSearchFindsDutchByNameAndEveryCode() {
         let catalog = LanguageCatalog.shared
 
-        for query in ["Dutch", "nl", "nld", "dut"] {
+        for query in ["Dutch", "dutch", "nl", "nld", "dut"] {
             XCTAssertEqual(catalog.search(query).first?.code, "nld", query)
         }
         XCTAssertTrue(catalog.search("not-a-language").isEmpty)

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -159,6 +159,33 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testVersionOneProfileWithUnsupportedLanguageIsPreservedAsCorrupt() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let legacyData = try legacyDocument(
+            profiles: [
+                legacyProfile(
+                    id: "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    name: "Unsupported Language",
+                    language: "xyz",
+                    includeSubtitles: true,
+                    keepExtraLanguages: false
+                )
+            ]
+        )
+        try legacyData.write(to: fileURL)
+
+        let store = ProfileStore(fileURL: fileURL)
+
+        XCTAssertTrue(store.customProfiles.isEmpty)
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertEqual(try Data(contentsOf: fileURL.appendingPathExtension("corrupt")), legacyData)
+    }
+
+    @MainActor
     func testDuplicateUpdateAndDeleteLifecycle() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -35,9 +35,7 @@ final class ProfileStoreTests: XCTestCase {
             swapEyes: true,
             audioHandling: .transcodeAAC,
             audioBitrate: 512,
-            language: .japanese,
-            includeSubtitles: false,
-            keepExtraLanguages: false
+            subtitles: SubtitlePolicy(mode: .off, preferredLanguage: .japanese)
         )
         let store = ProfileStore(fileURL: fileURL, idGenerator: { identifier })
 
@@ -47,6 +45,117 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertEqual(profileID, "custom.\(identifier.uuidString.lowercased())")
         XCTAssertEqual(restoredStore.profile(withID: profileID).name, "Cinema")
         XCTAssertEqual(restoredStore.profile(withID: profileID).options, options)
+    }
+
+    @MainActor
+    func testVersionOneProfilesMigrateAtomicallyToCanonicalVersionTwoData() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let legacyData = try legacyDocument(
+            profiles: [
+                legacyProfile(
+                    id: "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    name: "Dutch Off",
+                    language: "dut",
+                    includeSubtitles: false,
+                    keepExtraLanguages: false
+                ),
+                legacyProfile(
+                    id: "6C02DFB0-2B6A-4F6D-9335-3703487FB9D7",
+                    name: "French Only",
+                    language: "fre",
+                    includeSubtitles: true,
+                    keepExtraLanguages: false
+                ),
+                legacyProfile(
+                    id: "9B58E388-CB38-46ED-ADE4-F690F6A40D81",
+                    name: "German Plus",
+                    language: "ger",
+                    includeSubtitles: true,
+                    keepExtraLanguages: true
+                ),
+                legacyProfile(
+                    id: "E27A632D-C9F0-424D-85B0-77E153AE1DA8",
+                    name: "Chinese Plus",
+                    language: "chi",
+                    includeSubtitles: true,
+                    keepExtraLanguages: true
+                ),
+            ]
+        )
+        try legacyData.write(to: fileURL)
+
+        let store = ProfileStore(fileURL: fileURL)
+
+        XCTAssertNil(store.loadErrorMessage)
+        XCTAssertEqual(store.customProfiles.map(\.options.subtitles.preferredLanguage.code), ["nld", "fra", "deu", "zho"])
+        XCTAssertEqual(
+            store.customProfiles.map(\.options.subtitles.mode),
+            [.off, .preferredOnly, .preferredPlusOthers, .preferredPlusOthers]
+        )
+        let migratedOptions = try XCTUnwrap(store.customProfiles.first?.options)
+        XCTAssertEqual(migratedOptions.hevcQuality, 91)
+        XCTAssertEqual(migratedOptions.leftRightBitrate, 35)
+        XCTAssertTrue(migratedOptions.upscaleEnabled)
+        XCTAssertEqual(migratedOptions.upscaleQuality, 87)
+        XCTAssertFalse(migratedOptions.linkQuality)
+        XCTAssertEqual(migratedOptions.fieldOfView, 100)
+        XCTAssertEqual(migratedOptions.frameRateOverride, "24000/1001")
+        XCTAssertEqual(migratedOptions.resolutionOverride, "3840x2160")
+        XCTAssertTrue(migratedOptions.cropBlackBars)
+        XCTAssertTrue(migratedOptions.swapEyes)
+        XCTAssertEqual(migratedOptions.audioHandling, .transcodeAAC)
+        XCTAssertEqual(migratedOptions.audioBitrate, 512)
+
+        let migratedJSON = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        )
+        XCTAssertEqual(migratedJSON["version"] as? Int, 2)
+        let profiles = try XCTUnwrap(migratedJSON["profiles"] as? [[String: Any]])
+        let options = try XCTUnwrap(profiles.first?["options"] as? [String: Any])
+        let subtitles = try XCTUnwrap(options["subtitles"] as? [String: Any])
+        XCTAssertEqual(subtitles["mode"] as? String, "off")
+        XCTAssertEqual(subtitles["preferredLanguage"] as? String, "nld")
+        XCTAssertNil(options["language"])
+        XCTAssertNil(options["includeSubtitles"])
+        XCTAssertNil(options["keepExtraLanguages"])
+
+        let reopenedStore = ProfileStore(fileURL: fileURL)
+        XCTAssertEqual(reopenedStore.customProfiles, store.customProfiles)
+    }
+
+    @MainActor
+    func testMigrationWriteFailureKeepsValidVersionOneLibraryAndLoadsReadOnly() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let legacyData = try legacyDocument(
+            profiles: [
+                legacyProfile(
+                    id: "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    name: "Protected",
+                    language: "ger",
+                    includeSubtitles: true,
+                    keepExtraLanguages: false
+                )
+            ]
+        )
+        try legacyData.write(to: fileURL)
+
+        let store = ProfileStore(
+            fileURL: fileURL,
+            dataWriter: { _, _ in throw TestWriteError.failed }
+        )
+
+        XCTAssertEqual(store.customProfiles.first?.options.subtitles.preferredLanguage, .german)
+        XCTAssertEqual(try Data(contentsOf: fileURL), legacyData)
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertThrowsError(try store.createProfile(name: "Blocked", options: EncodingOptions())) { error in
+            XCTAssertEqual(error as? ProfileStoreError, .recoveryRequired)
+        }
     }
 
     @MainActor
@@ -185,4 +294,42 @@ final class ProfileStoreTests: XCTestCase {
     private func temporaryProfileURL() -> URL {
         temporaryDirectoryURL().appendingPathComponent("profiles.json")
     }
+
+    private func legacyDocument(profiles: [[String: Any]]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["version": 1, "profiles": profiles], options: [.sortedKeys])
+    }
+
+    private func legacyProfile(
+        id: String,
+        name: String,
+        language: String,
+        includeSubtitles: Bool,
+        keepExtraLanguages: Bool
+    ) -> [String: Any] {
+        [
+            "id": id,
+            "name": name,
+            "options": [
+                "hevcQuality": 91,
+                "leftRightBitrate": 35,
+                "upscaleEnabled": true,
+                "upscaleQuality": 87,
+                "linkQuality": false,
+                "fieldOfView": 100,
+                "frameRateOverride": "24000/1001",
+                "resolutionOverride": "3840x2160",
+                "cropBlackBars": true,
+                "swapEyes": true,
+                "audioHandling": "transcodeAAC",
+                "audioBitrate": 512,
+                "language": language,
+                "includeSubtitles": includeSubtitles,
+                "keepExtraLanguages": keepExtraLanguages,
+            ],
+        ]
+    }
+}
+
+private enum TestWriteError: Error {
+    case failed
 }

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -119,7 +119,10 @@ class NativeAppPackagingTests(unittest.TestCase):
         encoding_editor = (MACOS_ROOT / "BluRayToVisionPro" / "Views" / "EncodingOptionsEditor.swift").read_text(
             encoding="utf-8"
         )
-        conversion_ui = setup_view + encoding_editor
+        language_picker = (MACOS_ROOT / "BluRayToVisionPro" / "Views" / "LanguagePickerField.swift").read_text(
+            encoding="utf-8"
+        )
+        conversion_ui = setup_view + encoding_editor + language_picker
 
         self.assertIn("Convert a 3D Blu-ray Disc", source_view)
         self.assertIn("Import MTS or M2TS transport stream", source_view)
@@ -136,6 +139,7 @@ class NativeAppPackagingTests(unittest.TestCase):
             "Crop black bars",
             "Swap left and right eyes",
             "Audio handling",
+            "Subtitle handling",
             "Preferred language",
             "Start stage",
             "Keep durable stage files",


### PR DESCRIPTION
## Summary
- replace the fixed native subtitle language enum with the shared 414-language ISO catalog and canonical alias normalization
- add an accessible searchable macOS picker with explicit off, preferred-only, and preferred-plus-others subtitle modes
- migrate custom profile documents atomically from v1 to v2 while preserving every unrelated encoding setting
- keep Worker protocol v5 output exact and preserve audio settings independently from subtitle choices

## Validation
- `uv run python scripts/native_app.py test` — 140 tests passed
- `uv run python -m unittest discover -s tests -t .` — 501 tests passed, 2 skipped
- `uv run ruff format --check tests/test_native_app.py`
- `uv run ruff check tests/test_native_app.py`
- `uv run mypy bd_to_avp`
- JetBrains changed-files inspection — clean
- live native UI review covered default, Dutch alias search, no-results, Return selection, and arrow-key navigation
- two final independent reviews reported no actionable findings

Closes #240