### PR TITLE
Fix language picker VoiceOver label

### DIFF
--- a/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
+++ b/macos/BluRayToVisionPro/Views/LanguagePickerField.swift
@@ -20,7 +20,7 @@ struct LanguagePickerField: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .accessibilityLabel("Preferred language: \(selection.displayName)")
+            .accessibilityLabel(selection.displayName)
             .accessibilityHint("Opens a searchable list of languages")
             .popover(isPresented: $isPresented, arrowEdge: .trailing) {
                 LanguagePickerPopover(selection: $selection, isPresented: $isPresented)

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -124,6 +124,9 @@ class NativeAppPackagingTests(unittest.TestCase):
         )
         conversion_ui = setup_view + encoding_editor + language_picker
 
+        self.assertIn(".accessibilityLabel(selection.displayName)", language_picker)
+        self.assertNotIn('.accessibilityLabel("Preferred language:', language_picker)
+
         self.assertIn("Convert a 3D Blu-ray Disc", source_view)
         self.assertIn("Import MTS or M2TS transport stream", source_view)
         self.assertIn(".disabled(outputControlsLocked)", source_view)


### PR DESCRIPTION
## Summary
- remove the duplicated field name from the language picker button’s accessibility label inside `LabeledContent`
- add a source-level regression assertion so the VoiceOver label cannot silently revert

## Validation
- `uv run python scripts/native_app.py test` — 141 tests passed
- `uv run python -m unittest discover -s tests -t .` — 501 tests passed, 2 skipped
- `uv run ruff format --check tests/test_native_app.py`
- `uv run ruff check tests/test_native_app.py`

Follow-up to #243 and #240.