### PR TITLE
feat: add explicit audio handling modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ bd-to-avp --source <source> [--source-folder <source-folder>] [options]
 - `--fx-upscale`: Upscale video to 4K resolution using fx-upscale (disabled by default).
 - `--remove-original`: Remove the original source after processing completes successfully.
 - `--overwrite`: Overwrite existing output file.
-- `--keep-files`: Use durable stage boundaries and keep the source copy, extracted MVC, PCM audio, and later
-  intermediates. Without this option, BD_to_AVP automatically uses the minimum-materialization pipeline. An explicit
-  `--remove-original` still removes the selected source after a successful conversion.
+- `--keep-files`: Use durable stage boundaries and keep retained intermediates. This affects retention only; it does
+  not change the selected audio policy. An explicit `--remove-original` still removes the selected source after a
+  successful conversion.
 - `--output-root-folder`: Output folder path. Defaults to the current directory.
-- `--transcode-audio`: Enable audio transcoding to AAC (disabled by default).
-- `--audio-bitrate`: Audio bitrate for transcoding in kb/s do not include unit (default: "384").
+- `--audio-mode`: Audio handling mode: `automatic`, `convert_aac`, or `pcm` (default: `automatic`). Automatic copies
+  qualified AAC audio to an owned M4A, and converts the whole selected set to AAC if any selected stream is unqualified.
+- `--transcode-audio`: Legacy alias for `--audio-mode convert_aac`.
+- `--audio-bitrate`: Audio bitrate for AAC conversion in kb/s do not include unit (default: "384").
 - `--left-right-bitrate`: Bitrate for left and right views in Mb/s do not include unit (default: "20").
 - `--mv-hevc-quality`: Quality factor for MV-HEVC encoding (default: "75").
 - `--fov`: Horizontal field of view for MV-HEVC (default: "90").
@@ -159,7 +161,7 @@ bd-to-avp --source <source> [--source-folder <source-folder>] [options]
 - CREATE_LEFT_RIGHT_FILES
 - UPSCALE_VIDEO
 - COMBINE_TO_MV_HEVC
-- TRANSCODE_AUDIO
+- TRANSCODE_AUDIO (Prepare Audio)
 - CREATE_FINAL_FILE
 - MOVE_FILES
 

--- a/bd_to_avp/gui/main_window.py
+++ b/bd_to_avp/gui/main_window.py
@@ -27,12 +27,21 @@ from bd_to_avp.gui.dialog import AboutDialog
 from bd_to_avp.gui.processing import ProcessingController, ProcessingRequest
 from bd_to_avp.gui.updater import UpdateChannel, UpdaterManager
 from bd_to_avp.gui.widget import FileFolderPicker, LabeledComboBox, LabeledLineEdit, LabeledSpinBox
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import config, Stage
 from bd_to_avp.modules.disc import DiscInfo, MKVCreationError
 from bd_to_avp.modules.languages import language_code_for_name, language_name
 from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.modules.util import formatted_time_elapsed, format_timestamp, get_common_language_options
 from bd_to_avp.modules.command import Spinner
+
+
+AUDIO_MODE_LABELS = {
+    AudioMode.AUTOMATIC: "Automatic",
+    AudioMode.CONVERT_AAC: "Convert to AAC",
+    AudioMode.PCM: "Uncompressed PCM",
+}
+AUDIO_MODE_BY_LABEL = {label: mode for mode, label in AUDIO_MODE_LABELS.items()}
 
 
 # noinspection PyAttributeOutsideInit
@@ -85,7 +94,7 @@ class MainWindow(QMainWindow):
         self.create_processing_output(main_widget)
         self.create_status_bar(main_layout)
 
-        self.toggle_transcode()
+        self.toggle_audio_bitrate()
         self.toggle_upscale()
         self.toggle_read_from_disc()
 
@@ -189,9 +198,16 @@ class MainWindow(QMainWindow):
         )
         self.remove_original_checkbox = self.create_checkbox("Remove Original After Success", config.remove_original)
         self.overwrite_checkbox = self.create_checkbox("Overwrite", config.overwrite)
-        self.transcode_audio_checkbox = self.create_checkbox(
-            "Transcode Audio", config.transcode_audio, self.toggle_transcode
+        self.audio_mode_combobox = LabeledComboBox(
+            "Audio Handling",
+            list(AUDIO_MODE_BY_LABEL),
+            AUDIO_MODE_LABELS[config.audio_mode],
         )
+        self.audio_mode_combobox.setToolTip(
+            "Automatic copies qualified AAC audio and converts other audio to AAC. "
+            "Uncompressed PCM preserves the current lossless decode behavior."
+        )
+        self.audio_mode_combobox.combobox.currentIndexChanged.connect(self.toggle_audio_bitrate)
         self.continue_on_error = self.create_checkbox("Continue Processing On Error", config.continue_on_error)
         self.skip_subtitles_checkbox = self.create_checkbox("Skip Subtitles", config.skip_subtitles)
         self.remove_extra_languages_checkbox = self.create_checkbox(
@@ -206,7 +222,7 @@ class MainWindow(QMainWindow):
         config_layout.addWidget(self.fx_upscale_checkbox)
         config_layout.addWidget(self.remove_original_checkbox)
         config_layout.addWidget(self.overwrite_checkbox)
-        config_layout.addWidget(self.transcode_audio_checkbox)
+        config_layout.addWidget(self.audio_mode_combobox)
         config_layout.addWidget(self.continue_on_error)
         config_layout.addWidget(self.skip_subtitles_checkbox)
         config_layout.addWidget(self.remove_extra_languages_checkbox)
@@ -436,7 +452,8 @@ class MainWindow(QMainWindow):
         self.fx_upscale_checkbox.setChecked(config.fx_upscale)
         self.remove_original_checkbox.setChecked(config.remove_original)
         self.overwrite_checkbox.setChecked(config.overwrite)
-        self.transcode_audio_checkbox.setChecked(config.transcode_audio)
+        self.audio_mode_combobox.set_current_text(AUDIO_MODE_LABELS[config.audio_mode])
+        self.toggle_audio_bitrate()
         self.continue_on_error.setChecked(config.continue_on_error)
         self.skip_subtitles_checkbox.setChecked(config.skip_subtitles)
         self.start_stage_combobox.set_current_text(str(config.start_stage))
@@ -552,7 +569,7 @@ class MainWindow(QMainWindow):
         config.fx_upscale = self.fx_upscale_checkbox.isChecked()
         config.remove_original = self.remove_original_checkbox.isChecked()
         config.overwrite = self.overwrite_checkbox.isChecked()
-        config.transcode_audio = self.transcode_audio_checkbox.isChecked()
+        config.audio_mode = AUDIO_MODE_BY_LABEL[self.audio_mode_combobox.current_text()]
         selected_stage = int(self.start_stage_combobox.current_text().split(" - ")[0])
         config.continue_on_error = self.continue_on_error.isChecked()
         config.skip_subtitles = self.skip_subtitles_checkbox.isChecked()
@@ -621,5 +638,6 @@ class MainWindow(QMainWindow):
             check_box.stateChanged.connect(onchange_function)
         return check_box
 
-    def toggle_transcode(self) -> None:
-        self.audio_bitrate_spinbox.setVisible(self.transcode_audio_checkbox.isChecked())
+    def toggle_audio_bitrate(self) -> None:
+        mode = AUDIO_MODE_BY_LABEL[self.audio_mode_combobox.current_text()]
+        self.audio_bitrate_spinbox.setVisible(mode.prepares_m4a)

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -94,8 +94,6 @@ def create_prepared_audio_file(
         finally:
             temporary_audio_path.unlink(missing_ok=True)
 
-        if not config.keep_files and original_audio_path != config.source_path:
-            original_audio_path.unlink(missing_ok=True)
         return prepared_audio_path
 
     if prepared_audio_path.exists():

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -1,9 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Protocol
 
 import ffmpeg
 
-from bd_to_avp.modules.config import Stage, config, is_direct_audio_transcode_enabled
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.command import run_ffmpeg_print_errors
+from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.container import get_audio_stream_data
+
+
+class AudioActivityReporter(Protocol):
+    def warning(self, message: str, *, stage: str | None = None, **fields: object) -> None:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class AudioStreamQualification:
+    index: int
+    codec_name: str
+    profile: str | None
+    qualified: bool
+    reason: str | None = None
+
+
+AAC_COPY_CODECS = frozenset({"aac"})
+EXPLICITLY_UNQUALIFIED_CODECS = frozenset({"ac3", "eac3", "ac-3", "e-ac-3"})
+AAC_COPY_PROFILES = frozenset({"lc", "he-aac", "he-aacv2", "mpeg-4 aac lc", "aac lc"})
 
 
 def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int, audio_selector: str = "a") -> None:
@@ -13,34 +38,119 @@ def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int,
         str(f"file:{transcoded_audio_path}"),
         acodec="aac",
         audio_bitrate=f"{bitrate}k",
+        map_metadata=0,
     )
     run_ffmpeg_print_errors(audio_transcoded, f"transcode audio to {bitrate}kbps", overwrite_output=True)
 
 
-def create_transcoded_audio_file(original_audio_path: Path, output_folder: Path) -> Path:
-    transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.m4a"
-    legacy_transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.mov"
-    direct_audio_transcode = is_direct_audio_transcode_enabled()
+def copy_audio(input_path: Path, copied_audio_path: Path) -> None:
+    audio_input = ffmpeg.input(str(input_path))
+    copied_audio = ffmpeg.output(
+        audio_input["a"],
+        str(f"file:{copied_audio_path}"),
+        acodec="copy",
+        map_metadata=0,
+    )
+    run_ffmpeg_print_errors(copied_audio, "copy AAC audio tracks", overwrite_output=True)
 
-    if config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
-        temporary_audio_path = transcoded_audio_path.with_suffix(".part.m4a")
+
+def create_prepared_audio_file(
+    original_audio_path: Path,
+    output_folder: Path,
+    activity: AudioActivityReporter | None = None,
+) -> Path:
+    mode = config.audio_mode
+    if mode is AudioMode.PCM:
+        return original_audio_path
+
+    prepared_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.m4a"
+    legacy_transcoded_audio_path = output_folder / f"{output_folder.stem}_audio_AAC.mov"
+    should_prepare = config.start_stage.value <= Stage.TRANSCODE_AUDIO.value
+
+    if should_prepare:
+        temporary_audio_path = prepared_audio_path.with_suffix(".part.m4a")
         try:
-            transcode_audio(original_audio_path, temporary_audio_path, config.audio_bitrate)
-            temporary_audio_path.replace(transcoded_audio_path)
+            if mode is AudioMode.AUTOMATIC and selected_audio_is_qualified_aac(original_audio_path):
+                copy_audio(original_audio_path, temporary_audio_path)
+            else:
+                if mode is AudioMode.AUTOMATIC:
+                    emit_automatic_fallback_warning(original_audio_path, activity)
+                transcode_audio(original_audio_path, temporary_audio_path, config.audio_bitrate)
+            temporary_audio_path.replace(prepared_audio_path)
         finally:
             temporary_audio_path.unlink(missing_ok=True)
 
-        if not config.keep_files and not direct_audio_transcode:
+        if not config.keep_files and original_audio_path != config.source_path:
             original_audio_path.unlink(missing_ok=True)
-        return transcoded_audio_path
+        return prepared_audio_path
 
-    if config.transcode_audio and transcoded_audio_path.exists():
-        return transcoded_audio_path
-    if config.transcode_audio and legacy_transcoded_audio_path.exists():
+    if prepared_audio_path.exists():
+        return prepared_audio_path
+    if legacy_transcoded_audio_path.exists():
         raise FileNotFoundError(
-            "Legacy AAC audio artifact found. Restart from Transcode Audio to regenerate a compatible M4A file: "
+            "Legacy AAC audio artifact found. Restart from Prepare Audio to regenerate a compatible M4A file: "
             f"{legacy_transcoded_audio_path}"
         )
-    if direct_audio_transcode and config.transcode_audio:
-        raise FileNotFoundError(f"Direct AAC audio artifact not found: {transcoded_audio_path}")
-    return original_audio_path
+    raise FileNotFoundError(f"Prepared audio artifact not found: {prepared_audio_path}")
+
+
+def create_transcoded_audio_file(
+    original_audio_path: Path,
+    output_folder: Path,
+    activity: AudioActivityReporter | None = None,
+) -> Path:
+    return create_prepared_audio_file(original_audio_path, output_folder, activity)
+
+
+def selected_audio_is_qualified_aac(input_path: Path) -> bool:
+    qualifications = qualify_selected_audio_streams(input_path)
+    return bool(qualifications) and all(qualification.qualified for qualification in qualifications)
+
+
+def qualify_selected_audio_streams(input_path: Path) -> list[AudioStreamQualification]:
+    return [qualify_audio_stream(stream) for stream in get_audio_stream_data(input_path)]
+
+
+def qualify_audio_stream(stream: dict[str, Any]) -> AudioStreamQualification:
+    codec_name = str(stream.get("codec_name") or "").lower()
+    profile = stream.get("profile")
+    normalized_profile = str(profile).lower() if profile is not None else None
+    index = int(stream.get("index", -1))
+
+    if codec_name in EXPLICITLY_UNQUALIFIED_CODECS:
+        return AudioStreamQualification(index, codec_name, normalized_profile, False, "codec_not_allowed")
+    if codec_name not in AAC_COPY_CODECS:
+        return AudioStreamQualification(index, codec_name or "unknown", normalized_profile, False, "codec_not_aac")
+    if normalized_profile is None:
+        return AudioStreamQualification(index, codec_name, None, False, "aac_profile_missing")
+    if normalized_profile not in AAC_COPY_PROFILES:
+        return AudioStreamQualification(index, codec_name, normalized_profile, False, "aac_profile_not_qualified")
+    return AudioStreamQualification(index, codec_name, normalized_profile, True)
+
+
+def emit_automatic_fallback_warning(input_path: Path, activity: AudioActivityReporter | None) -> None:
+    qualifications = qualify_selected_audio_streams(input_path)
+    codecs = [qualification.codec_name for qualification in qualifications]
+    unqualified = [qualification for qualification in qualifications if not qualification.qualified]
+    message = "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC."
+    if activity is None:
+        print(message)
+        return
+
+    activity.warning(
+        message,
+        stage="transcode_audio",
+        code="audio_automatic_fallback_to_aac",
+        audio_mode=AudioMode.AUTOMATIC.value,
+        action="convert_aac",
+        source_codecs=codecs,
+        unqualified_streams=[
+            {
+                "index": qualification.index,
+                "codec": qualification.codec_name,
+                "profile": qualification.profile,
+                "reason": qualification.reason,
+            }
+            for qualification in unqualified
+        ],
+    )

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -256,9 +256,13 @@ def qualify_audio_stream(stream: dict[str, Any]) -> AudioStreamQualification:
 def parse_optional_int(value: object) -> int | None:
     if isinstance(value, bool):
         return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
     try:
-        return int(value) if value is not None else None
-    except (TypeError, ValueError):
+        return int(value)
+    except ValueError:
         return None
 
 

--- a/bd_to_avp/modules/audio_mode.py
+++ b/bd_to_avp/modules/audio_mode.py
@@ -1,0 +1,12 @@
+from enum import StrEnum
+
+
+class AudioMode(StrEnum):
+    AUTOMATIC = "automatic"
+    CONVERT_AAC = "convert_aac"
+    PCM = "pcm"
+
+    @property
+    def prepares_m4a(self) -> bool:
+        return self in {self.AUTOMATIC, self.CONVERT_AAC}
+

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -9,6 +9,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import ClassVar, Iterable
 
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.preview_range import PreviewRange
 from bd_to_avp.modules.languages import LanguageCodeError, normalize_language_code
 from bd_to_avp.modules.util import get_pyproject_data
@@ -81,7 +82,7 @@ class Stage(Enum):
             "CREATE_LEFT_RIGHT_FILES": "Create Left Right Files",
             "UPSCALE_VIDEO": "Upscale Video",
             "COMBINE_TO_MV_HEVC": "Combine to MV HEVC",
-            "TRANSCODE_AUDIO": "Transcode Audio",
+            "TRANSCODE_AUDIO": "Prepare Audio",
             "CREATE_FINAL_FILE": "Create Final File",
             "MOVE_FILES": "Move Files",
         }[self.name]
@@ -193,7 +194,7 @@ class Config:
         self.source_folder_path: Path | None = None
         self.output_root_path = Path.home() / "Movies"
         self.overwrite = False
-        self.transcode_audio = False
+        self.audio_mode = AudioMode.AUTOMATIC
         self.audio_bitrate = 384
         self.left_right_bitrate = 20
         self.link_quality = True
@@ -217,6 +218,14 @@ class Config:
         self.keep_awake = True
         self.preview_range: PreviewRange | None = None
         self.smoke_apple_vision_ocr = False
+
+    @property
+    def transcode_audio(self) -> bool:
+        return self.audio_mode is AudioMode.CONVERT_AAC
+
+    @transcode_audio.setter
+    def transcode_audio(self, value: bool) -> None:
+        self.audio_mode = AudioMode.CONVERT_AAC if value else AudioMode.AUTOMATIC
 
     def configure_tool_environment(self) -> None:
         configured_dirs = [
@@ -288,6 +297,10 @@ class Config:
                     setattr(self, key, Path(value))
 
         if config_parser.has_section("Options"):
+            if config_parser.has_option("Options", "transcode_audio") and not config_parser.has_option(
+                "Options", "audio_mode"
+            ):
+                self.transcode_audio = config_parser.getboolean("Options", "transcode_audio")
             for key, _value in config_parser.items("Options"):
                 if key in self.__dict__:
                     attribute_type = type(getattr(self, key))
@@ -298,6 +311,8 @@ class Config:
                     elif attribute_type is Stage:
                         stage_value = config_parser.get("Options", key).split(" - ")[0]
                         setattr(self, key, Stage.get_stage(int(stage_value)))
+                    elif attribute_type is AudioMode:
+                        setattr(self, key, AudioMode(config_parser.get("Options", key)))
                     else:
                         value = config_parser.get("Options", key)
                         if key == "language_code":
@@ -347,7 +362,12 @@ class Config:
         parser.add_argument(
             "--transcode-audio",
             action="store_true",
-            help="Transcode audio to AAC format.",
+            help="Legacy alias for --audio-mode convert_aac.",
+        )
+        parser.add_argument(
+            "--audio-mode",
+            choices=[mode.value for mode in AudioMode],
+            help="Audio handling mode: automatic, convert_aac, or pcm.",
         )
         parser.add_argument(
             "--audio-bitrate",
@@ -473,6 +493,10 @@ class Config:
                 self.language_code = normalize_language_code(args.language_code)
             except LanguageCodeError as error:
                 parser.error(str(error))
+        if args.audio_mode:
+            self.audio_mode = AudioMode(args.audio_mode)
+        elif args.transcode_audio:
+            self.audio_mode = AudioMode.CONVERT_AAC
 
 
 config = Config()
@@ -486,8 +510,12 @@ def is_direct_pipeline_source_reused() -> bool:
     )
 
 
+def is_audio_m4a_preparation_enabled() -> bool:
+    return config.audio_mode.prepares_m4a
+
+
 def is_direct_audio_transcode_enabled() -> bool:
-    return bool(config.transcode_audio and not config.keep_files)
+    return config.audio_mode is AudioMode.CONVERT_AAC and not config.keep_files
 
 
 def is_direct_mvc_stream_enabled() -> bool:

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -76,6 +76,9 @@ def create_mvc_and_audio(
 
 def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path, output_folder: Path) -> None:
     audio_streams = get_audio_stream_data(audio_path)
+    has_declared_audio_default = any(
+        int(stream.get("disposition", {}).get("default", 0) or 0) == 1 for stream in audio_streams
+    )
     output_track_index = 1
     command = [
         config.MP4BOX_PATH,
@@ -86,7 +89,7 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
         f"{mv_hevc_path}:forcesync",
     ]
     output_track_index += 1
-    for stream in audio_streams:
+    for audio_position, stream in enumerate(audio_streams):
         index = stream["index"] + 1
         language_code, audio_language_name = normalize_track_language(stream.get("tags", {}).get("language"))
         channel_layout = stream.get("channel_layout", "unknown")
@@ -95,10 +98,10 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
 
         audio_track_options = f":lang={language_code}:group=1:alternate_group=1"
 
-        if not default_disposition and index > 1:
-            audio_track_options += ":disable"
         if default_disposition:
             audio_track_options += ":enabled"
+        elif has_declared_audio_default or audio_position > 0:
+            audio_track_options += ":disable"
         track_name = title if isinstance(title, str) and title else f"{audio_language_name} {channel_layout} Audio"
 
         command += [

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -44,10 +44,6 @@ def create_muxed_file(
     muxed_path = output_folder / f"{disc_name}{config.FINAL_FILE_TAG}.mov"
     if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         mux_video_audio_subs(mv_hevc_path, audio_path, muxed_path, output_folder)
-
-    if not config.keep_files:
-        mv_hevc_path.unlink(missing_ok=True)
-        audio_path.unlink(missing_ok=True)
     return muxed_path
 
 
@@ -93,7 +89,8 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
         index = stream["index"] + 1
         language_code, audio_language_name = normalize_track_language(stream.get("tags", {}).get("language"))
         channel_layout = stream.get("channel_layout", "unknown")
-        title = stream.get("tags", {}).get("title")
+        tags = stream.get("tags", {})
+        title = tags.get("title") or tags.get("name")
         default_disposition = int(stream.get("disposition", {}).get("default", 0) or 0) == 1
 
         audio_track_options = f":lang={language_code}:group=1:alternate_group=1"

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -6,7 +6,7 @@ import ffmpeg
 from bd_to_avp.modules.config import (
     Stage,
     config,
-    is_direct_audio_transcode_enabled,
+    is_audio_m4a_preparation_enabled,
     is_direct_mvc_stream_enabled,
 )
 from bd_to_avp.modules.command import run_command, run_ffmpeg_print_errors
@@ -58,18 +58,18 @@ def create_mvc_and_audio(
 ) -> tuple[Path, Path]:
     video_output_path = output_folder / f"{disc_name}_mvc.h264"
     audio_output_path = output_folder / f"{disc_name}_audio_PCM.mov"
-    direct_audio_transcode = is_direct_audio_transcode_enabled()
+    m4a_audio_preparation = is_audio_m4a_preparation_enabled()
     direct_mvc_stream = is_direct_mvc_stream_enabled()
 
     if config.start_stage.value <= Stage.EXTRACT_MVC_AND_AUDIO.value:
         extract_mvc_and_audio(
             mkv_output_path,
             None if direct_mvc_stream else video_output_path,
-            None if direct_audio_transcode else audio_output_path,
+            None if m4a_audio_preparation else audio_output_path,
         )
 
     return (
-        mkv_output_path if direct_audio_transcode else audio_output_path,
+        mkv_output_path if m4a_audio_preparation else audio_output_path,
         mkv_output_path if direct_mvc_stream else video_output_path,
     )
 
@@ -90,17 +90,22 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
         index = stream["index"] + 1
         language_code, audio_language_name = normalize_track_language(stream.get("tags", {}).get("language"))
         channel_layout = stream.get("channel_layout", "unknown")
+        title = stream.get("tags", {}).get("title")
+        default_disposition = int(stream.get("disposition", {}).get("default", 0) or 0) == 1
 
         audio_track_options = f":lang={language_code}:group=1:alternate_group=1"
 
-        if index > 1:
+        if not default_disposition and index > 1:
             audio_track_options += ":disable"
+        if default_disposition:
+            audio_track_options += ":enabled"
+        track_name = title if isinstance(title, str) and title else f"{audio_language_name} {channel_layout} Audio"
 
         command += [
             "-add",
             f"{audio_path}#{index}{audio_track_options}",
             "-udta",
-            f"{output_track_index}:type=name:str='{audio_language_name} {channel_layout} Audio'",
+            f"{output_track_index}:type=name:str='{track_name}'",
         ]
         output_track_index += 1
 

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -213,6 +213,10 @@ def process_each(
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
 
+    if config.start_stage is Stage.MOVE_FILES:
+        muxed_output_path = output_folder / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
+        return move_completed_conversion(muxed_output_path, tmp_folder, cancellation_event, activity)
+
     raise_if_cancelled(cancellation_event)
     if activity and config.start_stage.value <= Stage.CREATE_MKV.value:
         activity.stage_started("create_mkv", "Preparing source video")
@@ -282,6 +286,16 @@ def process_each(
         output_folder,
         disc_info.name,
     )
+
+    return move_completed_conversion(muxed_output_path, tmp_folder, cancellation_event, activity)
+
+
+def move_completed_conversion(
+    muxed_output_path: Path,
+    tmp_folder: Path,
+    cancellation_event: Event | None,
+    activity: ActivityReporter | None,
+) -> Path:
     raise_if_cancelled(cancellation_event)
     if activity:
         activity.stage_started("move_files", "Moving completed video")

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -104,7 +104,7 @@ def conversion_stage_plan() -> tuple[str, ...]:
         stages.append("combine_to_mv_hevc")
     if config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
         stages.append("upscale_video")
-    if config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
+    if config.audio_mode.prepares_m4a and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
         stages.append("transcode_audio")
     if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         stages.append("create_final_file")
@@ -270,9 +270,9 @@ def process_each(
     mv_hevc_path = create_upscaled_file(mv_hevc_path)
 
     raise_if_cancelled(cancellation_event)
-    if activity and config.transcode_audio and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
-        activity.stage_started("transcode_audio", "Preparing audio")
-    audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder)
+    if activity and config.audio_mode.prepares_m4a and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
+        activity.stage_started("transcode_audio", "Prepare Audio")
+    audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder, activity)
     raise_if_cancelled(cancellation_event)
     if activity and config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         activity.stage_started("create_final_file", "Muxing final spatial video")

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -79,11 +79,10 @@ def find_batch_sources(source_folder_path: Path) -> tuple[Path, ...]:
 
 
 def conversion_stage_plan() -> tuple[str, ...]:
-    stages = [
-        "configure",
-        "preflight",
-        "inspect_source",
-    ]
+    stages = ["configure"]
+    if config.start_stage is Stage.MOVE_FILES:
+        return (*stages, "move_files")
+    stages.extend(["preflight", "inspect_source"])
     if config.start_stage.value <= Stage.CREATE_MKV.value:
         stages.append("create_mkv")
     if config.preview_range is not None:
@@ -186,6 +185,19 @@ def process_each(
 ) -> Path:
     raise_if_cancelled(cancellation_event)
     print(f"\nProcessing {config.source_path or config.source_str}")
+    if config.start_stage is Stage.MOVE_FILES:
+        muxed_output_path = completed_mux_path_for_move()
+        completed_path = config.output_root_path / muxed_output_path.name
+        if not config.overwrite and file_exists_normalized(completed_path):
+            raise FileExistsError(
+                f"Output file already exists for {muxed_output_path.stem}. Use --overwrite to replace."
+            )
+        return move_completed_conversion(
+            muxed_output_path,
+            config.output_root_path / "temp_files",
+            cancellation_event,
+            activity,
+        )
     if activity:
         activity.stage_started("preflight", "Checking required conversion tools")
     preflight.verify_runtime_ready()
@@ -212,10 +224,6 @@ def process_each(
     completed_path = config.output_root_path / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
-
-    if config.start_stage is Stage.MOVE_FILES:
-        muxed_output_path = output_folder / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
-        return move_completed_conversion(muxed_output_path, tmp_folder, cancellation_event, activity)
 
     raise_if_cancelled(cancellation_event)
     if activity and config.start_stage.value <= Stage.CREATE_MKV.value:
@@ -288,6 +296,34 @@ def process_each(
     )
 
     return move_completed_conversion(muxed_output_path, tmp_folder, cancellation_event, activity)
+
+
+def completed_mux_path_for_move() -> Path:
+    output_root = config.output_root_path
+    source_path = config.source_path
+    if source_path is not None:
+        source_name = source_path.stem
+        source_candidate = output_root / source_name / f"{source_name}{config.FINAL_FILE_TAG}.mov"
+        if source_candidate.is_file():
+            return source_candidate
+
+    candidates = sorted(
+        candidate
+        for output_folder in output_root.iterdir()
+        if output_folder.is_dir()
+        for candidate in [output_folder / f"{output_folder.name}{config.FINAL_FILE_TAG}.mov"]
+        if candidate.is_file()
+    )
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates:
+        raise FileNotFoundError(f"No completed movie is ready to move under {output_root}.")
+
+    candidate_names = ", ".join(candidate.relative_to(output_root).as_posix() for candidate in candidates)
+    raise RuntimeError(
+        "Multiple completed movies are ready to move. Select the matching direct-file source or isolate its output "
+        f"folder before resuming: {candidate_names}"
+    )
 
 
 def move_completed_conversion(

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -37,7 +37,7 @@ CONFIG_SNAPSHOT_FIELDS = (
     "source_folder_path",
     "output_root_path",
     "overwrite",
-    "transcode_audio",
+    "audio_mode",
     "audio_bitrate",
     "left_right_bitrate",
     "link_quality",
@@ -398,8 +398,8 @@ def configured_conversion(
         config.source_folder_path = None
         config.output_root_path = job.destination.path
         config.overwrite = job.job.overwrite
-        config.transcode_audio = job.encoding.transcode_audio
-        config.audio_bitrate = job.encoding.audio_bitrate
+        config.audio_mode = job.encoding.audio.mode
+        config.audio_bitrate = job.encoding.audio.bitrate
         config.left_right_bitrate = job.encoding.left_right_bitrate
         config.link_quality = job.encoding.link_quality
         config.mv_hevc_quality = job.encoding.mv_hevc_quality

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -10,9 +10,10 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence, TextIO
 from uuid import UUID
 
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.languages import LanguageCodeError, normalize_language_code
 
-PROTOCOL_VERSION = 5
+PROTOCOL_VERSION = 6
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_EVENT_BYTES = 1024 * 1024
 MAX_DETAIL_BYTES = 64 * 1024
@@ -91,6 +92,12 @@ class JobDestination:
 
 
 @dataclass(frozen=True)
+class AudioOptions:
+    mode: AudioMode
+    bitrate: int
+
+
+@dataclass(frozen=True)
 class SubtitleOptions:
     mode: SubtitleMode
     preferred_language: str | None
@@ -98,8 +105,7 @@ class SubtitleOptions:
 
 @dataclass(frozen=True)
 class EncodingOptions:
-    transcode_audio: bool
-    audio_bitrate: int
+    audio: AudioOptions
     left_right_bitrate: int
     link_quality: bool
     mv_hevc_quality: int
@@ -381,8 +387,7 @@ class JobSpec:
                 job_id=job_id,
             )
         required_keys = {
-            "transcode_audio",
-            "audio_bitrate",
+            "audio",
             "left_right_bitrate",
             "link_quality",
             "mv_hevc_quality",
@@ -397,8 +402,7 @@ class JobSpec:
         }
         cls._require_exact_keys(value, required_keys, "encoding", job_id)
         return EncodingOptions(
-            transcode_audio=cls._parse_bool(value, "transcode_audio", "encoding", job_id),
-            audio_bitrate=cls._parse_int(value, "audio_bitrate", "encoding", job_id, minimum=1, maximum=4096),
+            audio=cls._parse_audio_options(value.get("audio"), job_id),
             left_right_bitrate=cls._parse_int(value, "left_right_bitrate", "encoding", job_id, minimum=1, maximum=500),
             link_quality=cls._parse_bool(value, "link_quality", "encoding", job_id),
             mv_hevc_quality=cls._parse_int(value, "mv_hevc_quality", "encoding", job_id, minimum=0, maximum=100),
@@ -410,6 +414,51 @@ class JobSpec:
             swap_eyes=cls._parse_bool(value, "swap_eyes", "encoding", job_id),
             fx_upscale=cls._parse_bool(value, "fx_upscale", "encoding", job_id),
             subtitles=cls._parse_subtitle_options(value.get("subtitles"), job_id),
+        )
+
+    @classmethod
+    def _parse_audio_options(cls, value: Any, job_id: str) -> AudioOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.audio must be an object.",
+                job_id=job_id,
+            )
+        cls._require_exact_keys(
+            value,
+            {"mode", "bitrate"},
+            "encoding.audio",
+            job_id,
+            error_code="invalid_encoding_options",
+        )
+
+        raw_mode = value.get("mode")
+        if not isinstance(raw_mode, str):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.audio.mode must be a string.",
+                job_id=job_id,
+            )
+        try:
+            mode = AudioMode(raw_mode)
+        except ValueError as error:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"Unsupported audio mode: {raw_mode!r}.",
+                job_id=job_id,
+            ) from error
+
+        return AudioOptions(
+            mode=mode,
+            bitrate=cls._parse_int(
+                value,
+                "bitrate",
+                "encoding.audio",
+                job_id,
+                minimum=1,
+                maximum=4096,
+                error_code="invalid_encoding_options",
+            ),
         )
 
     @classmethod
@@ -609,17 +658,18 @@ class JobSpec:
         *,
         minimum: int,
         maximum: int,
+        error_code: str | None = None,
     ) -> int:
         field_value = value.get(key)
         if not isinstance(field_value, int) or isinstance(field_value, bool):
             raise WorkerProtocolError(
-                f"invalid_{label}_options",
+                error_code or f"invalid_{label}_options",
                 f"{label}.{key} must be an integer.",
                 job_id=job_id,
             )
         if not minimum <= field_value <= maximum:
             raise WorkerProtocolError(
-                f"invalid_{label}_options",
+                error_code or f"invalid_{label}_options",
                 f"{label}.{key} must be between {minimum} and {maximum}.",
                 job_id=job_id,
             )

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -58,15 +58,20 @@ named restartable file.
 - Restart/debug value: high. External and built-in upscale workflows need this
   boundary.
 
-### `TRANSCODE_AUDIO`
+### `TRANSCODE_AUDIO` / Prepare Audio
 
-- Input: source container in default AAC mode or PCM audio movie with
-  `--keep-files`.
-- Output: `<folder>_audio_AAC.m4a` when enabled. The MPEG-4 audio container
-  preserves AAC decoder configuration when MP4Box imports the tracks into the
-  final spatial movie.
+- Input: source container for `automatic` and `convert_aac`; generated PCM audio
+  movie for `pcm`.
+- Output: `<folder>_audio_AAC.m4a` for `automatic` and `convert_aac`. The MPEG-4
+  audio container is an owned artifact and preserves AAC decoder configuration
+  when MP4Box imports the tracks into the final spatial movie. `pcm` keeps the
+  existing generated `<folder>_audio_PCM.mov` behavior.
+- `automatic` remuxes/copies the selected audio set only when every selected
+  stream is qualified AAC. If any selected stream is unqualified, including
+  AC-3 or E-AC-3, the whole selected set is converted to AAC and the worker
+  emits a structured warning.
 - Older builds wrote `<folder>_audio_AAC.mov`. A resume directory containing
-  only that legacy artifact must restart from `TRANSCODE_AUDIO` so the app can
+  only that legacy artifact must restart from Prepare Audio so the app can
   regenerate a compatible M4A instead of attempting an unsafe final mux.
 - Restart/debug value: medium. This is the final mux input and useful for audio
   debugging.
@@ -151,16 +156,16 @@ boundary during processing and are retained after completion with
 
 ### Extracted Audio To Transcoded Audio
 
-When AAC transcoding is enabled without `--keep-files`, the
-`TRANSCODE_AUDIO` stage reads audio from the MKV/MTS/M2TS source and writes the
-final AAC M4A directly. MVC video uses the same source container through the
-direct splitter pipeline.
+When `automatic` or `convert_aac` is selected, the Prepare Audio stage reads
+audio from the MKV/MTS/M2TS source and writes the final owned M4A directly. MVC
+video uses the same source container through the direct splitter pipeline.
 
 The final mux still needs a seekable audio file, so the AAC M4A remains
-materialized. Durable mode and `--keep-files` retain the existing PCM boundary,
-and direct-mode resumes at `TRANSCODE_AUDIO` can recreate AAC from the source.
-As with durable resumes, video artifacts from earlier stages must already exist
-when restarting after `EXTRACT_MVC_AND_AUDIO`.
+materialized. `--keep-files` controls retention only and does not change the
+selected audio policy. Direct-mode resumes at Prepare Audio can recreate AAC
+from the source; resumes at the final mux require the owned prepared M4A to
+already exist. As with durable resumes, video artifacts from earlier stages must
+already exist when restarting after `EXTRACT_MVC_AND_AUDIO`.
 
 ### Final Move
 

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -170,8 +170,11 @@ already exist when restarting after `EXTRACT_MVC_AND_AUDIO`.
 
 ### Final Move
 
-`MOVE_FILES` can stay as a filesystem operation. There is little value in making
-it direct because it does not create a large intermediate by itself.
+`MOVE_FILES` is a filesystem-only resume boundary. It moves the completed movie
+without replaying source inspection, audio preparation, or muxing. Owned source,
+audio, and video artifacts remain available until that move succeeds; default
+cleanup then removes the completed output folder. A failed move therefore keeps
+all inputs needed for another final-mux or move attempt.
 
 ## Risky Boundaries
 
@@ -218,14 +221,14 @@ when `--keep-files` is enabled.
 ### MV-HEVC File
 
 The MV-HEVC intermediate is the input to optional upscaling and final MP4Box
-muxing. Default mode removes it after the final mux; `--keep-files` retains it
-for Apple playback debugging and staged resumes.
+muxing. Default mode removes it after the completed movie moves successfully;
+`--keep-files` retains it for Apple playback debugging and staged resumes.
 
 ### Subtitle Files
 
 `.srt` files are named final-mux inputs. Default mode removes the completed
-output folder after muxing; `--keep-files` retains subtitles for debugging and
-resume workflows.
+output folder after the final move succeeds; `--keep-files` retains subtitles
+for debugging and resume workflows.
 
 ## Benchmark Evidence
 

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -174,7 +174,10 @@ already exist when restarting after `EXTRACT_MVC_AND_AUDIO`.
 without replaying source inspection, audio preparation, or muxing. Owned source,
 audio, and video artifacts remain available until that move succeeds; default
 cleanup then removes the completed output folder. A failed move therefore keeps
-all inputs needed for another final-mux or move attempt.
+all inputs needed for another final-mux or move attempt. Direct-file resumes use
+the source stem to select the matching completed movie. If multiple other
+completed movies are present, isolate the intended output folder before
+resuming rather than guessing which artifact to move.
 
 ## Risky Boundaries
 

--- a/docs/native-worker-protocol-v1.md
+++ b/docs/native-worker-protocol-v1.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v1
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v4](native-worker-protocol-v4.md).
+> [Native Worker Protocol v6](native-worker-protocol-v6.md).
 
 The native macOS prototype communicates with the existing Python engine over a
 bounded JSON Lines (JSONL) protocol. The boundary is intentionally independent

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v2
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v4](native-worker-protocol-v4.md).
+> [Native Worker Protocol v6](native-worker-protocol-v6.md).
 
 The native macOS app communicates with its bundled Python engine over a bounded
 JSON Lines (JSONL) protocol. Version 2 makes the source kind explicit and adds

--- a/docs/native-worker-protocol-v3.md
+++ b/docs/native-worker-protocol-v3.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v3
 
 > Historical protocol. Current title-aware behavior is documented in
-> [Native Worker Protocol v4](native-worker-protocol-v4.md).
+> [Native Worker Protocol v6](native-worker-protocol-v6.md).
 
 Protocol v3 adds immutable conversion-preview child jobs while preserving the
 single-request, single-process JSON Lines transport from v2. The native app and

--- a/docs/native-worker-protocol-v4.md
+++ b/docs/native-worker-protocol-v4.md
@@ -1,5 +1,8 @@
 # Native Worker Protocol v4
 
+> Historical protocol. Current audio-mode behavior is documented in
+> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+
 Protocol v4 adds explicit 3D Blu-ray title discovery and selection while
 preserving the single-request, single-process transport from v3. The native app
 and bundled Python worker ship atomically and both require version 4.

--- a/docs/native-worker-protocol-v5.md
+++ b/docs/native-worker-protocol-v5.md
@@ -1,5 +1,8 @@
 # Native Worker Protocol v5
 
+> Historical protocol. Current audio-mode behavior is documented in
+> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+
 Protocol v5 replaces the three legacy subtitle fields with one explicit,
 backend-neutral subtitle policy. The native app and bundled Python worker ship
 atomically and both require version 5.

--- a/docs/native-worker-protocol-v6.md
+++ b/docs/native-worker-protocol-v6.md
@@ -1,0 +1,97 @@
+# Native Worker Protocol v6
+
+Protocol v6 replaces the flat audio fields with an exact nested audio policy.
+The native app and bundled Python worker ship atomically and both require
+version 6.
+
+## Audio Policy
+
+Conversion and preview requests include an `audio` object inside `encoding`:
+
+```json
+"encoding": {
+  "audio": {
+    "mode": "automatic",
+    "bitrate": 384
+  },
+  "left_right_bitrate": 20,
+  "link_quality": true,
+  "mv_hevc_quality": 75,
+  "upscale_quality": 75,
+  "fov": 90,
+  "frame_rate": "",
+  "resolution": "",
+  "crop_black_bars": false,
+  "swap_eyes": false,
+  "fx_upscale": false,
+  "subtitles": {
+    "mode": "preferred_plus_others",
+    "preferred_language": "eng"
+  }
+}
+```
+
+Supported audio modes are:
+
+- `automatic`: prepare one owned M4A. The worker remuxes/copies the selected
+  audio set only when every selected audio stream is qualified AAC. If any
+  selected stream is unqualified, the worker converts the whole selected set to
+  AAC at `bitrate` and emits a structured `warning` event.
+- `convert_aac`: convert the whole selected audio set to AAC at `bitrate` and
+  prepare one owned M4A.
+- `pcm`: keep the existing generated PCM audio movie behavior.
+
+The initial automatic qualification is deliberately conservative and
+deterministic. Only AAC streams with qualified AAC profiles are eligible for
+copy/remux. AC-3 and E-AC-3 are explicitly excluded from the allowlist until
+final-MOV, AVFoundation, seeking, channel-layout, and physical Apple Vision Pro
+evidence proves they are safe.
+
+`keep_files` controls artifact retention only. It must not change whether audio
+is copied, converted to AAC, or decoded to PCM.
+
+Final muxing receives an owned prepared audio artifact for `automatic` and
+`convert_aac`; it never receives a user-owned source container. The mux keeps
+audio track order and normalizes language metadata, and it preserves source
+track titles and default disposition when the current FFmpeg probe data and
+MP4Box import options expose them.
+
+## Fallback Warning
+
+Automatic whole-set fallback emits a structured warning similar to:
+
+```json
+{
+  "type": "warning",
+  "payload": {
+    "stage": "transcode_audio",
+    "message": "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC.",
+    "code": "audio_automatic_fallback_to_aac",
+    "audio_mode": "automatic",
+    "action": "convert_aac",
+    "source_codecs": ["aac", "ac3"],
+    "unqualified_streams": [
+      {
+        "index": 1,
+        "codec": "ac3",
+        "profile": null,
+        "reason": "codec_not_allowed"
+      }
+    ]
+  }
+}
+```
+
+## Compatibility
+
+The v6 `encoding` object has an exact schema. The v5
+`encoding.transcode_audio` and `encoding.audio_bitrate` fields are not accepted
+in worker protocol requests. Legacy Python CLI and Qt callers may still use the
+old `--transcode-audio` boolean surface; the Python backend maps it to
+`audio.mode = "convert_aac"` internally.
+
+The stage identifier remains `transcode_audio` and the stage number remains 7
+for resume compatibility. User-facing stage text is now **Prepare Audio**.
+
+Event ordering, title selection, subtitle policy, size limits, heartbeat
+behavior, and terminal-event meanings are unchanged from v5.

--- a/docs/native-worker-protocol-v6.md
+++ b/docs/native-worker-protocol-v6.md
@@ -55,7 +55,9 @@ Final muxing receives an owned prepared audio artifact for `automatic` and
 `convert_aac`; it never receives a user-owned source container. The mux keeps
 audio track order and normalizes language metadata, and it preserves source
 track titles and default disposition when the current FFmpeg probe data and
-MP4Box import options expose them.
+MP4Box import options expose them. Owned mux inputs remain available until the
+completed movie moves successfully, so final-mux and move-stage retries do not
+lose their recovery artifacts.
 
 ## Fallback Warning
 

--- a/docs/native-worker-protocol-v6.md
+++ b/docs/native-worker-protocol-v6.md
@@ -90,9 +90,10 @@ Automatic whole-set fallback emits a structured warning similar to:
 
 The v6 `encoding` object has an exact schema. The v5
 `encoding.transcode_audio` and `encoding.audio_bitrate` fields are not accepted
-in worker protocol requests. Legacy Python CLI and Qt callers may still use the
-old `--transcode-audio` boolean surface; the Python backend maps it to
-`audio.mode = "convert_aac"` internally.
+in worker protocol requests. Legacy Python callers may still use the old
+`--transcode-audio` boolean surface; the backend maps it to
+`audio.mode = "convert_aac"` internally. The Qt desktop UI exposes the same
+three explicit modes as the native app.
 
 The stage identifier remains `transcode_audio` and the stage number remains 7
 for resume compatibility. User-facing stage text is now **Prepare Audio**.

--- a/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
@@ -349,7 +349,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         "create_left_right_files",
         "combine_to_mv_hevc",
         "upscale_video",
-        "transcode_audio",
+        "prepare_audio",
         "create_final_file",
         "move_files",
     ]

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -20,17 +20,53 @@ enum ConversionSetupTab: String, CaseIterable, Identifiable {
 }
 
 enum AudioHandling: String, CaseIterable, Codable, Identifiable {
-    case preserve
-    case transcodeAAC
+    case automatic
+    case convertAAC = "transcodeAAC"
+    case pcm = "preserve"
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .preserve:
+        case .automatic:
+            "Automatic"
+        case .convertAAC:
+            "Convert to AAC"
+        case .pcm:
             "Uncompressed PCM"
-        case .transcodeAAC:
-            "Transcode to AAC"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .automatic:
+            "Copies the selected audio set only when every track is qualified AAC; otherwise converts the entire set to AAC."
+        case .convertAAC:
+            "Converts the entire selected audio set to AAC."
+        case .pcm:
+            "Decodes the selected audio set to uncompressed PCM."
+        }
+    }
+
+    var bitrateLabel: String? {
+        switch self {
+        case .automatic:
+            "AAC fallback bitrate"
+        case .convertAAC:
+            "AAC bitrate"
+        case .pcm:
+            nil
+        }
+    }
+
+    func compactSummary(bitrate: Int) -> String {
+        switch self {
+        case .automatic:
+            "automatic audio (AAC fallback \(bitrate) kbps)"
+        case .convertAAC:
+            "AAC \(bitrate) kbps"
+        case .pcm:
+            "uncompressed PCM audio"
         }
     }
 }
@@ -98,7 +134,7 @@ enum ConversionStage: Int, CaseIterable, Codable, Identifiable {
         case .upscaleVideo:
             "6 — Upscale Video"
         case .transcodeAudio:
-            "7 — Transcode Audio"
+            "7 — Prepare Audio"
         case .createFinalFile:
             "8 — Create Final File"
         case .moveFiles:
@@ -119,13 +155,13 @@ struct EncodingOptions: Codable, Equatable {
     var cropBlackBars = false
     var swapEyes = false
 
-    var audioHandling = AudioHandling.preserve
+    var audioHandling = AudioHandling.pcm
     var audioBitrate = 384
     var subtitles = SubtitlePolicy()
 
     var compactSummary: String {
         let resolution = upscaleEnabled ? "2× upscale" : "source resolution"
-        let audio = audioHandling == .preserve ? "uncompressed PCM audio" : "AAC \(audioBitrate) kbps"
+        let audio = audioHandling.compactSummary(bitrate: audioBitrate)
         return "HEVC \(hevcQuality) · \(leftRightBitrate) Mbps eyes · \(resolution) · \(audio)"
     }
 }

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -123,6 +123,48 @@ struct WorkerDecision: Decodable, Equatable {
     }
 }
 
+struct WorkerWarning: Decodable, Equatable {
+    let code: String?
+    let sourceCodecs: [String]?
+    let action: String?
+
+    init(code: String? = nil, sourceCodecs: [String]? = nil, action: String? = nil) {
+        self.code = code
+        self.sourceCodecs = sourceCodecs
+        self.action = action
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let code = try container.decodeIfPresent(String.self, forKey: .code) {
+            self.code = code
+        } else {
+            self.code = try container.decodeIfPresent(String.self, forKey: .warningCode)
+        }
+        sourceCodecs = try container.decodeIfPresent([String].self, forKey: .sourceCodecs)
+        if let action = try container.decodeIfPresent(String.self, forKey: .action) {
+            self.action = action
+        } else if let action = try container.decodeIfPresent(String.self, forKey: .actualAction) {
+            self.action = action
+        } else {
+            self.action = try container.decodeIfPresent(String.self, forKey: .audioAction)
+        }
+    }
+
+    var isEmpty: Bool {
+        code == nil && sourceCodecs == nil && action == nil
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case warningCode = "warning_code"
+        case sourceCodecs = "source_codecs"
+        case action
+        case actualAction = "actual_action"
+        case audioAction = "audio_action"
+    }
+}
+
 struct WorkerProgress: Decodable, Equatable {
     let currentStage: Int
     let totalStages: Int
@@ -236,6 +278,7 @@ struct WorkerEventPayload: Decodable, Equatable {
     let elapsedSeconds: Int?
     let progress: WorkerProgress?
     let level: String?
+    let warning: WorkerWarning?
     let result: SourceInspection?
     let conversionResult: ConversionResult?
     let artifact: PreviewArtifact?
@@ -252,6 +295,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         elapsedSeconds: Int? = nil,
         progress: WorkerProgress? = nil,
         level: String? = nil,
+        warning: WorkerWarning? = nil,
         result: SourceInspection? = nil,
         conversionResult: ConversionResult? = nil,
         artifact: PreviewArtifact? = nil,
@@ -267,6 +311,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         self.elapsedSeconds = elapsedSeconds
         self.progress = progress
         self.level = level
+        self.warning = warning
         self.result = result
         self.conversionResult = conversionResult
         self.artifact = artifact
@@ -274,6 +319,34 @@ struct WorkerEventPayload: Decodable, Equatable {
         self.error = error
         self.decision = decision
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workerVersion = try container.decodeIfPresent(String.self, forKey: .workerVersion)
+        processGroupID = try container.decodeIfPresent(Int32.self, forKey: .processGroupID)
+        operation = try container.decodeIfPresent(String.self, forKey: .operation)
+        stage = try container.decodeIfPresent(String.self, forKey: .stage)
+        message = try container.decodeIfPresent(String.self, forKey: .message)
+        elapsedSeconds = try container.decodeIfPresent(Int.self, forKey: .elapsedSeconds)
+        progress = try container.decodeIfPresent(WorkerProgress.self, forKey: .progress)
+        level = try container.decodeIfPresent(String.self, forKey: .level)
+        if let nestedWarning = try container.decodeIfPresent(WorkerWarning.self, forKey: .warning) {
+            warning = nestedWarning
+        } else {
+            let flatWarning = try WorkerWarning(from: decoder)
+            warning = flatWarning.isEmpty ? nil : flatWarning
+        }
+        result = try container.decodeIfPresent(SourceInspection.self, forKey: .result)
+        conversionResult = try container.decodeIfPresent(ConversionResult.self, forKey: .conversionResult)
+        artifact = try container.decodeIfPresent(PreviewArtifact.self, forKey: .artifact)
+        previewResult = try container.decodeIfPresent(PreviewArtifact.self, forKey: .previewResult)
+        error = try container.decodeIfPresent(WorkerFailure.self, forKey: .error)
+        decision = try container.decodeIfPresent(WorkerDecision.self, forKey: .decision)
+    }
+
+    var warningCode: String? { warning?.code }
+    var sourceCodecs: [String]? { warning?.sourceCodecs }
+    var audioAction: String? { warning?.action }
 
     enum CodingKeys: String, CodingKey {
         case workerVersion = "worker_version"
@@ -284,6 +357,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         case elapsedSeconds = "elapsed_seconds"
         case progress
         case level
+        case warning
         case result
         case conversionResult = "conversion_result"
         case artifact

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WorkerJobSpec: Encodable, Equatable {
-    static let protocolVersion = 5
+    static let protocolVersion = 6
 
     struct Source: Encodable, Equatable {
         enum Kind: String, Encodable {
@@ -54,6 +54,17 @@ struct WorkerJobSpec: Encodable, Equatable {
     }
 
     struct Encoding: Encodable, Equatable {
+        struct Audio: Encodable, Equatable {
+            enum Mode: String, Encodable, Equatable {
+                case automatic
+                case convertAAC = "convert_aac"
+                case pcm
+            }
+
+            let mode: Mode
+            let bitrate: Int
+        }
+
         struct Subtitles: Encodable, Equatable {
             let mode: SubtitleMode
             let preferredLanguage: String?
@@ -74,8 +85,7 @@ struct WorkerJobSpec: Encodable, Equatable {
             }
         }
 
-        let transcodeAudio: Bool
-        let audioBitrate: Int
+        let audio: Audio
         let leftRightBitrate: Int
         let linkQuality: Bool
         let mvHEVCQuality: Int
@@ -89,8 +99,7 @@ struct WorkerJobSpec: Encodable, Equatable {
         let subtitles: Subtitles
 
         enum CodingKeys: String, CodingKey {
-            case transcodeAudio = "transcode_audio"
-            case audioBitrate = "audio_bitrate"
+            case audio
             case leftRightBitrate = "left_right_bitrate"
             case linkQuality = "link_quality"
             case mvHEVCQuality = "mv_hevc_quality"
@@ -233,8 +242,10 @@ struct WorkerJobSpec: Encodable, Equatable {
 
     private static func encoding(from options: EncodingOptions) -> Encoding {
         Encoding(
-            transcodeAudio: options.audioHandling == .transcodeAAC,
-            audioBitrate: options.audioBitrate,
+            audio: Encoding.Audio(
+                mode: audioMode(from: options.audioHandling),
+                bitrate: options.audioBitrate
+            ),
             leftRightBitrate: options.leftRightBitrate,
             linkQuality: options.linkQuality,
             mvHEVCQuality: options.hevcQuality,
@@ -247,6 +258,17 @@ struct WorkerJobSpec: Encodable, Equatable {
             fxUpscale: options.upscaleEnabled,
             subtitles: subtitleOptions(from: options)
         )
+    }
+
+    private static func audioMode(from handling: AudioHandling) -> Encoding.Audio.Mode {
+        switch handling {
+        case .automatic:
+            .automatic
+        case .convertAAC:
+            .convertAAC
+        case .pcm:
+            .pcm
+        }
     }
 
     private static func subtitleOptions(from options: EncodingOptions) -> Encoding.Subtitles {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -578,6 +578,9 @@ struct ContentView: View {
     }
 
     private var secondaryStatusText: String? {
+        if let warningMessage = viewModel.state.warningMessage {
+            return "Warning: \(warningMessage)"
+        }
         if let batchQueue = viewModel.batchQueue {
             if batchQueue.isRunning {
                 return viewModel.state.stageMessage
@@ -624,6 +627,9 @@ struct ContentView: View {
             if batchQueue.failedCount > 0 {
                 return .red
             }
+            if viewModel.state.warningMessage != nil {
+                return .orange
+            }
             if batchQueue.stoppedCount > 0 || batchQueue.notStartedCount > 0 {
                 return .orange
             }
@@ -637,6 +643,9 @@ struct ContentView: View {
         }
         if viewModel.state.phase == .failed {
             return .red
+        }
+        if viewModel.state.warningMessage != nil {
+            return .orange
         }
         return viewModel.source == nil ? .secondary : .green
     }

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -96,8 +96,13 @@ struct EncodingOptionsEditor: View {
                     }
                     .pickerStyle(.segmented)
 
-                    if options.audioHandling == .transcodeAAC {
-                        LabeledContent("AAC bitrate") {
+                    Text(options.audioHandling.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let bitrateLabel = options.audioHandling.bitrateLabel {
+                        LabeledContent(bitrateLabel) {
                             Stepper(value: $options.audioBitrate, in: 128 ... 1_000, step: 32) {
                                 Text("\(options.audioBitrate) kbps")
                                     .monospacedDigit()

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -450,8 +450,8 @@ private struct ProfileEncodingSummaryView: View {
         var items = [
             ProfileSummaryItem(title: "Audio handling", value: options.audioHandling.title),
         ]
-        if options.audioHandling == .transcodeAAC {
-            items.append(ProfileSummaryItem(title: "AAC bitrate", value: "\(options.audioBitrate) kbps"))
+        if let bitrateLabel = options.audioHandling.bitrateLabel {
+            items.append(ProfileSummaryItem(title: bitrateLabel, value: "\(options.audioBitrate) kbps"))
         }
         return items
     }

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -902,10 +902,10 @@ final class ConversionWorkflowTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("tests/fixtures/\(name)")
-        guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
-            throw XCTSkip("Waiting for the backend v6 fixture \(name).")
-        }
-        return try Data(contentsOf: fixtureURL)
+        return try XCTUnwrap(
+            FileManager.default.contents(atPath: fixtureURL.path),
+            "Required shared worker fixture is missing: \(name)"
+        )
     }
 
     private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -144,10 +144,36 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(SubtitleLanguage.chinese.code, "zho")
     }
 
-    func testPCMHandlingIsDescribedTruthfullyWithoutChangingItsStoredValue() {
-        XCTAssertEqual(AudioHandling.preserve.rawValue, "preserve")
-        XCTAssertEqual(AudioHandling.preserve.title, "Uncompressed PCM")
+    func testAudioHandlingPreservesProfileValuesAndPCMDefaults() {
+        XCTAssertEqual(AudioHandling.allCases, [.automatic, .convertAAC, .pcm])
+        XCTAssertEqual(AudioHandling.automatic.rawValue, "automatic")
+        XCTAssertEqual(AudioHandling.convertAAC.rawValue, "transcodeAAC")
+        XCTAssertEqual(AudioHandling.pcm.rawValue, "preserve")
+        XCTAssertEqual(AudioHandling.pcm.title, "Uncompressed PCM")
+        XCTAssertEqual(EncodingOptions().audioHandling, .pcm)
+        XCTAssertTrue(BuiltInProfile.allCases.allSatisfy { $0.options.audioHandling == .pcm })
+        XCTAssertEqual(ConversionStage.transcodeAudio.title, "7 — Prepare Audio")
+    }
+
+    func testAudioHandlingHelpAndSummariesDescribeAllModesPrecisely() {
+        XCTAssertEqual(
+            AudioHandling.automatic.detail,
+            "Copies the selected audio set only when every track is qualified AAC; otherwise converts the entire set to AAC."
+        )
+        XCTAssertEqual(AudioHandling.convertAAC.detail, "Converts the entire selected audio set to AAC.")
+        XCTAssertEqual(AudioHandling.pcm.detail, "Decodes the selected audio set to uncompressed PCM.")
+        XCTAssertEqual(AudioHandling.automatic.bitrateLabel, "AAC fallback bitrate")
+        XCTAssertEqual(AudioHandling.convertAAC.bitrateLabel, "AAC bitrate")
+        XCTAssertNil(AudioHandling.pcm.bitrateLabel)
         XCTAssertTrue(EncodingOptions().compactSummary.contains("uncompressed PCM audio"))
+        XCTAssertEqual(
+            EncodingOptions(audioHandling: .automatic, audioBitrate: 448).compactSummary,
+            "HEVC 75 · 20 Mbps eyes · source resolution · automatic audio (AAC fallback 448 kbps)"
+        )
+        XCTAssertEqual(
+            EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
+            "HEVC 75 · 20 Mbps eyes · source resolution · AAC 448 kbps"
+        )
         XCTAssertTrue(BuiltInProfile.balanced.summary.contains("uncompressed PCM audio"))
     }
 
@@ -420,7 +446,7 @@ final class ConversionWorkflowTests: XCTestCase {
             resolutionOverride: "3840x2160",
             cropBlackBars: true,
             swapEyes: true,
-            audioHandling: .transcodeAAC,
+            audioHandling: .convertAAC,
             audioBitrate: 512,
             subtitles: SubtitlePolicy(mode: .off, preferredLanguage: .japanese)
         )
@@ -448,7 +474,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(spec.source.path, "/Sources/Feature.mkv")
         XCTAssertEqual(spec.destination?.path, "/Movies")
         XCTAssertEqual(spec.encoding?.mvHEVCQuality, 92)
-        XCTAssertEqual(spec.encoding?.audioBitrate, 512)
+        XCTAssertEqual(spec.encoding?.audio.bitrate, 512)
         XCTAssertTrue(spec.job?.keepFiles == true)
         XCTAssertTrue(spec.job?.overwrite == true)
         XCTAssertNil(json?["profile"])
@@ -503,7 +529,7 @@ final class ConversionWorkflowTests: XCTestCase {
         encoding.hevcQuality = 80
         encoding.upscaleEnabled = true
         encoding.fieldOfView = 120
-        encoding.audioHandling = .transcodeAAC
+        encoding.audioHandling = .convertAAC
         encoding.audioBitrate = 512
 
         let draft = ConversionDraft(
@@ -517,8 +543,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(spec.encoding?.mvHEVCQuality, 80)
         XCTAssertTrue(spec.encoding?.fxUpscale == true)
         XCTAssertEqual(spec.encoding?.fieldOfView, 120)
-        XCTAssertTrue(spec.encoding?.transcodeAudio == true)
-        XCTAssertEqual(spec.encoding?.audioBitrate, 512)
+        XCTAssertEqual(spec.encoding?.audio, WorkerJobSpec.Encoding.Audio(mode: .convertAAC, bitrate: 512))
     }
 
     func testConversionJobSpecEncodesJobSettings() {
@@ -631,10 +656,16 @@ final class ConversionWorkflowTests: XCTestCase {
         let source = try XCTUnwrap(json["source"] as? [String: Any])
 
         XCTAssertEqual(json["operation"] as? String, "convert_source")
-        XCTAssertEqual(json["protocol_version"] as? Int, 5)
+        XCTAssertEqual(json["protocol_version"] as? Int, 6)
         XCTAssertEqual(source["kind"] as? String, "direct_file")
         XCTAssertEqual((json["destination"] as? [String: Any])?["path"] as? String, "/Movies")
         XCTAssertEqual(encoding["mv_hevc_quality"] as? Int, 75)
+        let audio = try XCTUnwrap(encoding["audio"] as? [String: Any])
+        XCTAssertEqual(audio["mode"] as? String, "pcm")
+        XCTAssertEqual(audio["bitrate"] as? Int, 384)
+        XCTAssertEqual(Set(audio.keys), ["mode", "bitrate"])
+        XCTAssertNil(encoding["transcode_audio"])
+        XCTAssertNil(encoding["audio_bitrate"])
         let subtitles = try XCTUnwrap(encoding["subtitles"] as? [String: Any])
         XCTAssertEqual(subtitles["mode"] as? String, "preferred_plus_others")
         XCTAssertEqual(subtitles["preferred_language"] as? String, "eng")
@@ -682,9 +713,39 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertTrue(subtitles["preferred_language"] is NSNull)
     }
 
+    func testConversionJobSpecEncodesEveryAudioModeInNestedV6AudioObject() throws {
+        let expectedModes: [(AudioHandling, String)] = [
+            (.automatic, "automatic"),
+            (.convertAAC, "convert_aac"),
+            (.pcm, "pcm"),
+        ]
+
+        for (handling, expectedMode) in expectedModes {
+            var options = ConversionOptions()
+            options.encoding.audioHandling = handling
+            options.encoding.audioBitrate = 448
+            let draft = ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+                sourceDetails: nil,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+                options: options
+            )
+
+            let data = try JSONEncoder().encode(WorkerJobSpec(draft: draft))
+            let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+            let audio = try XCTUnwrap(encoding["audio"] as? [String: Any])
+
+            XCTAssertEqual(audio["mode"] as? String, expectedMode)
+            XCTAssertEqual(audio["bitrate"] as? Int, 448)
+            XCTAssertEqual(Set(audio.keys), ["mode", "bitrate"])
+        }
+    }
+
     func testSubtitlePolicyDoesNotChangeAudioEncodingFields() throws {
         var options = ConversionOptions()
-        options.encoding.audioHandling = .transcodeAAC
+        options.encoding.audioHandling = .convertAAC
         options.encoding.audioBitrate = 640
         let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv"))
 
@@ -703,11 +764,10 @@ final class ConversionWorkflowTests: XCTestCase {
         options.encoding.subtitles = SubtitlePolicy(mode: .off, preferredLanguage: .dutch)
         let changedEncoding = try workerEncoding(for: options)
 
-        XCTAssertEqual(changedEncoding.transcodeAudio, originalEncoding.transcodeAudio)
-        XCTAssertEqual(changedEncoding.audioBitrate, originalEncoding.audioBitrate)
+        XCTAssertEqual(changedEncoding.audio, originalEncoding.audio)
     }
 
-    func testConversionJobSpecMatchesSharedPythonFixture() throws {
+    func testConversionJobSpecMatchesSharedV6WorkerFixture() throws {
         let draft = ConversionDraft(
             source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
             sourceDetails: nil,
@@ -720,12 +780,9 @@ final class ConversionWorkflowTests: XCTestCase {
             jobID: try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_convert_v5.json")
-        let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
+        let fixture = try JSONSerialization.jsonObject(
+            with: sharedFixtureData(named: "native_worker_convert_v6.json")
+        ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
     }
@@ -755,7 +812,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(source["title_id"] as? String, "provider:playlist-01005")
     }
 
-    func testPreviewJobSpecMatchesSharedPythonFixture() throws {
+    func testPreviewJobSpecMatchesSharedV6WorkerFixture() throws {
         let conversion = ConversionDraft(
             source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
             sourceDetails: nil,
@@ -780,17 +837,14 @@ final class ConversionWorkflowTests: XCTestCase {
             jobID: UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_preview_v5.json")
-        let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
+        let fixture = try JSONSerialization.jsonObject(
+            with: sharedFixtureData(named: "native_worker_preview_v6.json")
+        ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
     }
 
-    func testPhysicalDiscJobSpecMatchesSharedPythonFixture() throws {
+    func testPhysicalDiscJobSpecMatchesSharedV6WorkerFixture() throws {
         let draft = ConversionDraft(
             source: ConversionSource(
                 kind: .physicalDisc,
@@ -816,12 +870,9 @@ final class ConversionWorkflowTests: XCTestCase {
             jobID: try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_convert_physical_disc_v5.json")
-        let fixture = try JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? NSDictionary
+        let fixture = try JSONSerialization.jsonObject(
+            with: sharedFixtureData(named: "native_worker_convert_physical_disc_v6.json")
+        ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
     }
@@ -837,6 +888,18 @@ final class ConversionWorkflowTests: XCTestCase {
             destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
             options: ConversionOptions()
         )
+    }
+
+    private func sharedFixtureData(named name: String) throws -> Data {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/\(name)")
+        guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
+            throw XCTSkip("Waiting for the backend v6 fixture \(name).")
+        }
+        return try Data(contentsOf: fixtureURL)
     }
 
     private func withTemporaryDirectory(_ operation: (URL) throws -> Void) throws {

--- a/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
@@ -76,6 +76,32 @@ final class PreviewViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testPrepareAudioStageUsesEncodingPhaseAndDisplayName() async throws {
+        try await withTemporaryPreviewEnvironment { sourceURL, cache in
+            let started = expectation(description: "prepare audio stage started")
+            let cancelled = expectation(description: "prepare audio preview cancelled")
+            let worker = PreviewWorkerClient(
+                initialStage: "prepare_audio",
+                initialStageMessage: "Prepare Audio",
+                waitsForCancellation: true,
+                onStarted: { started.fulfill() },
+                onCompleted: { cancelled.fulfill() }
+            )
+            let viewModel = PreviewViewModel(clientFactory: { worker }, cache: cache)
+            let previewDraft = try XCTUnwrap(makePreviewDraft(sourceURL: sourceURL))
+
+            viewModel.startPreview(previewDraft)
+
+            await fulfillment(of: [started], timeout: 2)
+            XCTAssertEqual(viewModel.phase, .encoding)
+            XCTAssertEqual(viewModel.stageMessage, "Prepare Audio")
+
+            viewModel.stopActiveWorker()
+            await fulfillment(of: [cancelled], timeout: 2)
+        }
+    }
+
+    @MainActor
     func testPreviewSnapshotDoesNotChangeWithEditableOptions() throws {
         let sourceURL = URL(fileURLWithPath: "/tmp/movie.mkv")
         var options = ConversionOptions()
@@ -186,6 +212,8 @@ final class PreviewCacheTests: XCTestCase {
 
 private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendable {
     private let lock = NSLock()
+    private let initialStage: String
+    private let initialStageMessage: String
     private let waitsForCancellation: Bool
     private let onStarted: (() -> Void)?
     private let onCancellationEventsDelivered: (() -> Void)?
@@ -198,11 +226,15 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     private(set) var receivedJob: WorkerJobSpec?
 
     init(
+        initialStage: String = "create_left_right_files",
+        initialStageMessage: String = "Encoding Preview",
         waitsForCancellation: Bool = false,
         onStarted: (() -> Void)? = nil,
         onCancellationEventsDelivered: (() -> Void)? = nil,
         onCompleted: (() -> Void)? = nil
     ) {
+        self.initialStage = initialStage
+        self.initialStageMessage = initialStageMessage
         self.waitsForCancellation = waitsForCancellation
         self.onStarted = onStarted
         self.onCancellationEventsDelivered = onCancellationEventsDelivered
@@ -229,8 +261,8 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             jobID: job.jobID,
             sequence: 1,
             payload: WorkerEventPayload(
-                stage: "create_left_right_files",
-                message: "Encoding Preview",
+                stage: initialStage,
+                message: initialStageMessage,
                 progress: WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: nil)
             )
         )

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -33,7 +33,7 @@ final class ProfileStoreTests: XCTestCase {
             resolutionOverride: "3840x2160",
             cropBlackBars: true,
             swapEyes: true,
-            audioHandling: .transcodeAAC,
+            audioHandling: .convertAAC,
             audioBitrate: 512,
             subtitles: SubtitlePolicy(mode: .off, preferredLanguage: .japanese)
         )
@@ -45,6 +45,54 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertEqual(profileID, "custom.\(identifier.uuidString.lowercased())")
         XCTAssertEqual(restoredStore.profile(withID: profileID).name, "Cinema")
         XCTAssertEqual(restoredStore.profile(withID: profileID).options, options)
+    }
+
+    @MainActor
+    func testVersionTwoProfilesKeepAllAudioHandlingRawValuesWithoutMigration() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let document: [String: Any] = [
+            "version": 2,
+            "profiles": [
+                [
+                    "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    "name": "PCM",
+                    "options": try optionsJSON(audioHandlingRawValue: "preserve"),
+                ],
+                [
+                    "id": "6C02DFB0-2B6A-4F6D-9335-3703487FB9D7",
+                    "name": "AAC",
+                    "options": try optionsJSON(audioHandlingRawValue: "transcodeAAC"),
+                ],
+                [
+                    "id": "9B58E388-CB38-46ED-ADE4-F690F6A40D81",
+                    "name": "Automatic",
+                    "options": try optionsJSON(audioHandlingRawValue: "automatic"),
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]).write(to: fileURL)
+
+        let store = ProfileStore(fileURL: fileURL)
+
+        XCTAssertNil(store.loadErrorMessage)
+        XCTAssertEqual(store.customProfiles.map(\.options.audioHandling), [.pcm, .convertAAC, .automatic])
+        for profile in store.customProfiles {
+            try store.updateProfile(profile.id, name: profile.name, options: profile.options)
+        }
+
+        let persistedDocument = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        )
+        XCTAssertEqual(persistedDocument["version"] as? Int, 2)
+        let persistedProfiles = try XCTUnwrap(persistedDocument["profiles"] as? [[String: Any]])
+        let persistedRawValues = try persistedProfiles.map { profile in
+            let options = try XCTUnwrap(profile["options"] as? [String: Any])
+            return try XCTUnwrap(options["audioHandling"] as? String)
+        }
+        XCTAssertEqual(persistedRawValues, ["preserve", "transcodeAAC", "automatic"])
     }
 
     @MainActor
@@ -106,7 +154,7 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertEqual(migratedOptions.resolutionOverride, "3840x2160")
         XCTAssertTrue(migratedOptions.cropBlackBars)
         XCTAssertTrue(migratedOptions.swapEyes)
-        XCTAssertEqual(migratedOptions.audioHandling, .transcodeAAC)
+        XCTAssertEqual(migratedOptions.audioHandling, .convertAAC)
         XCTAssertEqual(migratedOptions.audioBitrate, 512)
 
         let migratedJSON = try XCTUnwrap(
@@ -324,6 +372,14 @@ final class ProfileStoreTests: XCTestCase {
 
     private func legacyDocument(profiles: [[String: Any]]) throws -> Data {
         try JSONSerialization.data(withJSONObject: ["version": 1, "profiles": profiles], options: [.sortedKeys])
+    }
+
+    private func optionsJSON(audioHandlingRawValue: String) throws -> [String: Any] {
+        var options = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(EncodingOptions())) as? [String: Any]
+        )
+        options["audioHandling"] = audioHandlingRawValue
+        return options
     }
 
     private func legacyProfile(

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -102,14 +102,11 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertNil(state.progress)
     }
 
-    func testSharedPythonProgressFixtureDecodes() throws {
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_stage_started_progress_v5.json")
-
-        let event = try JSONDecoder().decode(WorkerEvent.self, from: Data(contentsOf: fixtureURL))
+    func testSharedV6ProgressFixtureDecodes() throws {
+        let event = try JSONDecoder().decode(
+            WorkerEvent.self,
+            from: sharedFixtureData(named: "native_worker_stage_started_progress_v6.json")
+        )
 
         XCTAssertEqual(event.payload.progress, WorkerProgress(currentStage: 1, totalStages: 2, stageFraction: nil))
     }
@@ -128,6 +125,42 @@ final class WorkerLifecycleTests: XCTestCase {
         )
 
         XCTAssertNil(state.progress)
+    }
+
+    func testStructuredAudioFallbackWarningExposesCodecsAndActualAction() throws {
+        let event = try JSONDecoder().decode(
+            WorkerEvent.self,
+            from: Data(
+                """
+                {
+                  "protocol_version": 6,
+                  "type": "warning",
+                  "job_id": "11111111-1111-4111-8111-111111111111",
+                  "sequence": 0,
+                  "payload": {
+                    "message": "Automatic audio used the AAC fallback for the selected track set.",
+                    "code": "automatic_audio_fallback",
+                    "source_codecs": ["aac", "dts"],
+                    "action": "convert_aac"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(event.payload.warningCode, "automatic_audio_fallback")
+        XCTAssertEqual(event.payload.sourceCodecs, ["aac", "dts"])
+        XCTAssertEqual(event.payload.audioAction, "convert_aac")
+
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: event.jobID, operationKind: .conversion)
+        try state.receive(event)
+
+        XCTAssertEqual(
+            state.warningMessage,
+            "Automatic audio used the AAC fallback for the selected track set."
+        )
     }
 
     func testCancellationTransitionsThroughStoppingAndCancelled() throws {
@@ -321,13 +354,11 @@ final class WorkerLifecycleTests: XCTestCase {
         }
     }
 
-    func testDecodesAndAppliesSharedPythonConversionCompletionFixture() throws {
-        let fixtureURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/native_worker_conversion_completed_v5.json")
-        let completed = try JSONDecoder().decode(WorkerEvent.self, from: Data(contentsOf: fixtureURL))
+    func testDecodesAndAppliesSharedV6ConversionCompletionFixture() throws {
+        let completed = try JSONDecoder().decode(
+            WorkerEvent.self,
+            from: sharedFixtureData(named: "native_worker_conversion_completed_v6.json")
+        )
         let fixtureJobID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         var state = WorkerLifecycleState()
         state.selectSource(sourceURL)
@@ -368,5 +399,17 @@ final class WorkerLifecycleTests: XCTestCase {
             sequence: sequence,
             payload: payload
         )
+    }
+
+    private func sharedFixtureData(named name: String) throws -> Data {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/\(name)")
+        guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
+            throw XCTSkip("Waiting for the backend v6 fixture \(name).")
+        }
+        return try Data(contentsOf: fixtureURL)
     }
 }

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -130,26 +130,11 @@ final class WorkerLifecycleTests: XCTestCase {
     func testStructuredAudioFallbackWarningExposesCodecsAndActualAction() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: Data(
-                """
-                {
-                  "protocol_version": 6,
-                  "type": "warning",
-                  "job_id": "11111111-1111-4111-8111-111111111111",
-                  "sequence": 0,
-                  "payload": {
-                    "message": "Automatic audio used the AAC fallback for the selected track set.",
-                    "code": "automatic_audio_fallback",
-                    "source_codecs": ["aac", "dts"],
-                    "action": "convert_aac"
-                  }
-                }
-                """.utf8
-            )
+            from: sharedFixtureData(named: "native_worker_audio_fallback_warning_v6.json")
         )
 
-        XCTAssertEqual(event.payload.warningCode, "automatic_audio_fallback")
-        XCTAssertEqual(event.payload.sourceCodecs, ["aac", "dts"])
+        XCTAssertEqual(event.payload.warningCode, "audio_automatic_fallback_to_aac")
+        XCTAssertEqual(event.payload.sourceCodecs, ["aac", "ac3"])
         XCTAssertEqual(event.payload.audioAction, "convert_aac")
 
         var state = WorkerLifecycleState()
@@ -159,7 +144,7 @@ final class WorkerLifecycleTests: XCTestCase {
 
         XCTAssertEqual(
             state.warningMessage,
-            "Automatic audio used the AAC fallback for the selected track set."
+            "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC."
         )
     }
 
@@ -407,9 +392,9 @@ final class WorkerLifecycleTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("tests/fixtures/\(name)")
-        guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
-            throw XCTSkip("Waiting for the backend v6 fixture \(name).")
-        }
-        return try Data(contentsOf: fixtureURL)
+        return try XCTUnwrap(
+            FileManager.default.contents(atPath: fixtureURL.path),
+            "Required shared worker fixture is missing: \(name)"
+        )
     }
 }

--- a/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
@@ -7,8 +7,8 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testDecodesEventsFromWorkerProcess() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 5, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
-        print(json.dumps({"protocol_version": 5, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
         var events: [WorkerEvent] = []
@@ -52,7 +52,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testRejectsTerminalEventBeforeWorkerReady() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 5, "type": "job.completed", "job_id": job_id, "sequence": 0, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": 0, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
 
@@ -68,7 +68,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     func testRejectsWorkerReadyWithoutOwnedProcessGroup() async throws {
         let client = fixtureClient(body: """
-        print(json.dumps({"protocol_version": 5, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
 
@@ -85,8 +85,8 @@ final class WorkerProcessClientTests: XCTestCase {
     func testRejectsEventAfterTerminal() async throws {
         let client = fixtureClient(body: """
         \(readyEvent())
-        print(json.dumps({"protocol_version": 5, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
-        print(json.dumps({"protocol_version": 5, "type": "log", "job_id": job_id, "sequence": 2, "payload": {"level": "info", "message": "late event"}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "log", "job_id": job_id, "sequence": 2, "payload": {"level": "info", "message": "late event"}}), flush=True)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
 
@@ -103,7 +103,7 @@ final class WorkerProcessClientTests: XCTestCase {
     func testCancellationReapsWorkerAfterTerminalEvent() async throws {
         let client = fixtureClient(body: """
         \(readyEvent())
-        print(json.dumps({"protocol_version": 5, "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
         time.sleep(30)
         """)
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
@@ -147,7 +147,7 @@ final class WorkerProcessClientTests: XCTestCase {
 
     private func readyEvent() -> String {
         """
-        print(json.dumps({"protocol_version": 5, "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
         """
     }
 

--- a/tests/fixtures/native_worker_audio_fallback_warning_v6.json
+++ b/tests/fixtures/native_worker_audio_fallback_warning_v6.json
@@ -1,0 +1,28 @@
+{
+  "protocol_version": 6,
+  "type": "warning",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "transcode_audio",
+    "message": "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC.",
+    "code": "audio_automatic_fallback_to_aac",
+    "audio_mode": "automatic",
+    "action": "convert_aac",
+    "source_codecs": [
+      "aac",
+      "ac3"
+    ],
+    "unqualified_streams": [
+      {
+        "index": 1,
+        "codec": "ac3",
+        "profile": null,
+        "sample_rate": 48000,
+        "channels": 6,
+        "channel_layout": "5.1(side)",
+        "reason": "codec_not_allowed"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/native_worker_conversion_completed_v6.json
+++ b/tests/fixtures/native_worker_conversion_completed_v6.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 6,
+  "type": "job.completed",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 2,
+  "payload": {
+    "conversion_result": {
+      "source_path": "/tmp/movie.mkv",
+      "destination_path": "/tmp/output",
+      "output_path": "/tmp/output/movie_AVP.mov",
+      "size_bytes": 1024
+    }
+  }
+}

--- a/tests/fixtures/native_worker_convert_physical_disc_v6.json
+++ b/tests/fixtures/native_worker_convert_physical_disc_v6.json
@@ -1,0 +1,44 @@
+{
+  "protocol_version": 6,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "physical_disc",
+    "path": "/dev/disk9",
+    "title_id": "makemkv:0"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384
+    },
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_convert_v6.json
+++ b/tests/fixtures/native_worker_convert_v6.json
@@ -1,0 +1,43 @@
+{
+  "protocol_version": 6,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384
+    },
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_preview_v6.json
+++ b/tests/fixtures/native_worker_preview_v6.json
@@ -1,0 +1,48 @@
+{
+  "protocol_version": 6,
+  "type": "job.start",
+  "job_id": "22222222-2222-4222-8222-222222222222",
+  "operation": "preview_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/previews/22222222-2222-4222-8222-222222222222"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384
+    },
+    "left_right_bitrate": 20,
+    "link_quality": true,
+    "mv_hevc_quality": 75,
+    "upscale_quality": 75,
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "fx_upscale": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": true,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  },
+  "preview": {
+    "parent_job_id": "11111111-1111-4111-8111-111111111111",
+    "position": "middle",
+    "duration_seconds": 60
+  }
+}

--- a/tests/fixtures/native_worker_stage_started_progress_v6.json
+++ b/tests/fixtures/native_worker_stage_started_progress_v6.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 6,
+  "type": "stage.started",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "configure",
+    "message": "Preparing conversion settings",
+    "progress": {
+      "current_stage": 1,
+      "total_stages": 2
+    }
+  }
+}

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -161,6 +161,31 @@ class AudioPreparationTests(unittest.TestCase):
             copy.assert_called_once()
             transcode.assert_not_called()
 
+    def test_prepared_audio_retains_owned_source_until_final_move(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.iso"
+            output_folder = temp_path / "Movie"
+            owned_mkv_path = output_folder / "Movie.mkv"
+            source_path.write_bytes(b"disc-image")
+            output_folder.mkdir()
+            owned_mkv_path.write_bytes(b"owned-mkv")
+
+            def copy_audio(_input_path: Path, output_path: Path) -> None:
+                output_path.write_bytes(b"copied-aac")
+
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "source_path", source_path),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio, "qualify_selected_audio_streams", return_value=[audio_qualification()]),
+                patch.object(audio, "copy_audio", side_effect=copy_audio),
+            ):
+                audio.create_prepared_audio_file(owned_mkv_path, output_folder)
+
+            self.assertTrue(owned_mkv_path.exists())
+
     def test_pcm_returns_existing_generated_pcm(self) -> None:
         original_audio_path = Path("Movie_audio_PCM.mov")
         with (

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,16 +1,17 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import ffmpeg
 
 from bd_to_avp.modules import audio
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import Stage
 
 
-class DirectAudioTranscodeTests(unittest.TestCase):
-    def test_direct_transcode_reads_source_and_atomically_writes_aac(self) -> None:
+class AudioPreparationTests(unittest.TestCase):
+    def test_automatic_copies_all_qualified_aac_to_owned_m4a(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -18,29 +19,68 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             source_path.write_bytes(b"source")
             output_folder.mkdir()
 
-            def write_audio(_input_path: Path, output_path: Path, _bitrate: int) -> None:
-                output_path.write_bytes(b"aac")
+            def copy_audio(_input_path: Path, output_path: Path) -> None:
+                output_path.write_bytes(b"copied-aac")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "source_path", source_path),
                 patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
-                patch.object(audio.config, "audio_bitrate", 384),
-                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+                patch.object(audio, "qualify_selected_audio_streams", return_value=[audio_qualification()]),
+                patch.object(audio, "copy_audio", side_effect=copy_audio) as copy,
+                patch.object(audio, "transcode_audio") as transcode,
             ):
-                result = audio.create_transcoded_audio_file(source_path, output_folder)
+                result = audio.create_prepared_audio_file(source_path, output_folder)
 
             final_path = output_folder / "Movie_audio_AAC.m4a"
             temporary_path = output_folder / "Movie_audio_AAC.part.m4a"
             self.assertEqual(result, final_path)
-            self.assertEqual(final_path.read_bytes(), b"aac")
+            self.assertEqual(final_path.read_bytes(), b"copied-aac")
             self.assertFalse(temporary_path.exists())
-            self.assertFalse((output_folder / "Movie_audio_PCM.mov").exists())
             self.assertTrue(source_path.exists())
-            transcode.assert_called_once_with(source_path, temporary_path, 384)
+            copy.assert_called_once_with(source_path, temporary_path)
+            transcode.assert_not_called()
 
-    def test_subtitle_language_filter_preserves_all_audio_tracks(self) -> None:
+    def test_automatic_mixed_codecs_transcodes_whole_set_and_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            activity = Mock()
+
+            def write_audio(_input_path: Path, output_path: Path, _bitrate: int) -> None:
+                output_path.write_bytes(b"aac")
+
+            qualifications = [
+                audio_qualification(index=0, codec_name="aac"),
+                audio_qualification(index=1, codec_name="ac3", qualified=False, reason="codec_not_allowed"),
+            ]
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
+                patch.object(audio.config, "keep_files", False),
+                patch.object(audio.config, "source_path", source_path),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio.config, "audio_bitrate", 512),
+                patch.object(audio, "qualify_selected_audio_streams", return_value=qualifications),
+                patch.object(audio, "copy_audio") as copy,
+                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+            ):
+                result = audio.create_prepared_audio_file(source_path, output_folder, activity)
+
+            self.assertEqual(result, output_folder / "Movie_audio_AAC.m4a")
+            copy.assert_not_called()
+            transcode.assert_called_once_with(source_path, output_folder / "Movie_audio_AAC.part.m4a", 512)
+            activity.warning.assert_called_once()
+            _, kwargs = activity.warning.call_args
+            self.assertEqual(kwargs["code"], "audio_automatic_fallback_to_aac")
+            self.assertEqual(kwargs["action"], "convert_aac")
+            self.assertEqual(kwargs["source_codecs"], ["aac", "ac3"])
+            self.assertEqual(kwargs["unqualified_streams"][0]["reason"], "codec_not_allowed")
+
+    def test_convert_aac_transcodes_without_qualification(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -52,18 +92,22 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 output_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "audio_mode", AudioMode.CONVERT_AAC),
                 patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", True),
+                patch.object(audio.config, "source_path", source_path),
                 patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
                 patch.object(audio.config, "audio_bitrate", 384),
+                patch.object(audio, "qualify_selected_audio_streams") as qualify,
+                patch.object(audio, "copy_audio") as copy,
                 patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
             ):
-                audio.create_transcoded_audio_file(source_path, output_folder)
+                audio.create_prepared_audio_file(source_path, output_folder)
 
+            qualify.assert_not_called()
+            copy.assert_not_called()
             transcode.assert_called_once_with(source_path, output_folder / "Movie_audio_AAC.part.m4a", 384)
 
-    def test_failed_direct_transcode_removes_partial_output_but_preserves_source(self) -> None:
+    def test_failed_preparation_removes_partial_output_but_preserves_source(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -76,43 +120,60 @@ class DirectAudioTranscodeTests(unittest.TestCase):
                 raise RuntimeError("transcode failed")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "audio_mode", AudioMode.CONVERT_AAC),
                 patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "source_path", source_path),
                 patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
                 patch.object(audio, "transcode_audio", side_effect=fail_after_partial_write),
                 self.assertRaisesRegex(RuntimeError, "transcode failed"),
             ):
-                audio.create_transcoded_audio_file(source_path, output_folder)
+                audio.create_prepared_audio_file(source_path, output_folder)
 
             self.assertTrue(source_path.exists())
             self.assertFalse((output_folder / "Movie_audio_AAC.part.m4a").exists())
             self.assertFalse((output_folder / "Movie_audio_AAC.m4a").exists())
 
-    def test_keep_files_uses_durable_pcm_input(self) -> None:
+    def test_keep_files_does_not_change_automatic_copy_policy(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            output_folder = Path(temp_dir) / "Movie"
+            temp_path = Path(temp_dir)
+            retained_source_copy = temp_path / "Movie" / "source.mkv"
+            output_folder = retained_source_copy.parent
             output_folder.mkdir()
-            pcm_path = output_folder / "Movie_audio_PCM.mov"
-            pcm_path.write_bytes(b"pcm")
+            retained_source_copy.write_bytes(b"source")
 
-            def write_audio(_input_path: Path, output_path: Path, _bitrate: int) -> None:
-                output_path.write_bytes(b"aac")
+            def copy_audio(_input_path: Path, output_path: Path) -> None:
+                output_path.write_bytes(b"copied-aac")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "keep_files", True),
-                patch.object(audio.config, "remove_extra_languages", True),
+                patch.object(audio.config, "source_path", retained_source_copy),
                 patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
-                patch.object(audio, "transcode_audio", side_effect=write_audio) as transcode,
+                patch.object(audio, "qualify_selected_audio_streams", return_value=[audio_qualification()]),
+                patch.object(audio, "copy_audio", side_effect=copy_audio) as copy,
+                patch.object(audio, "transcode_audio") as transcode,
             ):
-                audio.create_transcoded_audio_file(pcm_path, output_folder)
+                audio.create_prepared_audio_file(retained_source_copy, output_folder)
 
-            self.assertTrue(pcm_path.exists())
-            self.assertEqual(transcode.call_args.args[0], pcm_path)
-            self.assertEqual(len(transcode.call_args.args), 3)
+            self.assertTrue(retained_source_copy.exists())
+            copy.assert_called_once()
+            transcode.assert_not_called()
 
-    def test_final_mux_resume_uses_existing_direct_aac(self) -> None:
+    def test_pcm_returns_existing_generated_pcm(self) -> None:
+        original_audio_path = Path("Movie_audio_PCM.mov")
+        with (
+            patch.object(audio.config, "audio_mode", AudioMode.PCM),
+            patch.object(audio.config, "start_stage", Stage.TRANSCODE_AUDIO),
+            patch.object(audio, "transcode_audio") as transcode,
+            patch.object(audio, "copy_audio") as copy,
+        ):
+            result = audio.create_prepared_audio_file(original_audio_path, Path("Movie"))
+
+        self.assertEqual(result, original_audio_path)
+        transcode.assert_not_called()
+        copy.assert_not_called()
+
+    def test_final_mux_resume_uses_existing_prepared_m4a(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -123,19 +184,18 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             aac_path.write_bytes(b"aac")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
-                patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
-                patch.object(audio.config, "audio_bitrate", 384),
                 patch.object(audio, "transcode_audio") as transcode,
+                patch.object(audio, "copy_audio") as copy,
             ):
-                result = audio.create_transcoded_audio_file(source_path, output_folder)
+                result = audio.create_prepared_audio_file(source_path, output_folder)
 
             self.assertEqual(result, aac_path)
             transcode.assert_not_called()
+            copy.assert_not_called()
 
-    def test_final_mux_resume_requires_existing_direct_aac(self) -> None:
+    def test_final_mux_resume_requires_owned_prepared_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             source_path = temp_path / "source.mkv"
@@ -144,14 +204,11 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             output_folder.mkdir()
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
-                patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
-                patch.object(audio.config, "audio_bitrate", 384),
-                self.assertRaisesRegex(FileNotFoundError, "Direct AAC audio artifact not found"),
+                self.assertRaisesRegex(FileNotFoundError, "Prepared audio artifact not found"),
             ):
-                audio.create_transcoded_audio_file(source_path, output_folder)
+                audio.create_prepared_audio_file(source_path, output_folder)
 
     def test_final_mux_resume_rejects_legacy_aac_mov_with_recovery_guidance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -164,37 +221,59 @@ class DirectAudioTranscodeTests(unittest.TestCase):
             legacy_aac_path.write_bytes(b"legacy-aac")
 
             with (
-                patch.object(audio.config, "transcode_audio", True),
-                patch.object(audio.config, "keep_files", False),
-                patch.object(audio.config, "remove_extra_languages", False),
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
-                patch.object(audio.config, "audio_bitrate", 384),
-                self.assertRaisesRegex(FileNotFoundError, "Restart from Transcode Audio"),
+                self.assertRaisesRegex(FileNotFoundError, "Restart from Prepare Audio"),
             ):
-                audio.create_transcoded_audio_file(source_path, output_folder)
+                audio.create_prepared_audio_file(source_path, output_folder)
 
             self.assertTrue(legacy_aac_path.exists())
 
-    def test_transcode_disabled_returns_original_audio(self) -> None:
-        original_audio_path = Path("Movie_audio_PCM.mov")
-        with (
-            patch.object(audio.config, "transcode_audio", False),
-            patch.object(audio.config, "keep_files", False),
-            patch.object(audio.config, "start_stage", Stage.TRANSCODE_AUDIO),
-            patch.object(audio, "transcode_audio") as transcode,
-        ):
-            result = audio.create_transcoded_audio_file(original_audio_path, Path("Movie"))
+    def test_qualification_is_conservative_and_excludes_ac3_eac3(self) -> None:
+        streams = [
+            {"index": 0, "codec_name": "aac", "profile": "LC"},
+            {"index": 1, "codec_name": "ac3"},
+            {"index": 2, "codec_name": "eac3"},
+            {"index": 3, "codec_name": "dts"},
+            {"index": 4, "codec_name": "aac", "profile": "Main"},
+        ]
 
-        self.assertEqual(result, original_audio_path)
-        transcode.assert_not_called()
+        results = [audio.qualify_audio_stream(stream) for stream in streams]
+
+        self.assertTrue(results[0].qualified)
+        self.assertEqual(results[1].reason, "codec_not_allowed")
+        self.assertEqual(results[2].reason, "codec_not_allowed")
+        self.assertEqual(results[3].reason, "codec_not_aac")
+        self.assertEqual(results[4].reason, "aac_profile_not_qualified")
 
     def test_transcode_audio_maps_requested_stream_selector(self) -> None:
         with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
-            audio.transcode_audio(Path("source.mkv"), Path("audio.mov"), 384, "a:0")
+            audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384, "a:0")
 
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
         self.assertIn("0:a:0", command)
-        self.assertIn("file:audio.mov", command)
+        self.assertIn("file:audio.m4a", command)
+        self.assertIn("-map_metadata", command)
+
+    def test_copy_audio_maps_all_audio_tracks_without_encoder(self) -> None:
+        with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
+            audio.copy_audio(Path("source.mkv"), Path("audio.m4a"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertIn("0:a", command)
+        self.assertIn("copy", command)
+        self.assertIn("file:audio.m4a", command)
+
+
+def audio_qualification(
+    *,
+    index: int = 0,
+    codec_name: str = "aac",
+    profile: str | None = "lc",
+    qualified: bool = True,
+    reason: str | None = None,
+) -> audio.AudioStreamQualification:
+    return audio.AudioStreamQualification(index, codec_name, profile, qualified, reason)
 
 
 if __name__ == "__main__":

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -66,6 +67,52 @@ class AudioExtractionTests(unittest.TestCase):
 
 
 class MuxCommandTests(unittest.TestCase):
+    def test_final_mux_retains_inputs_until_completed_file_moves(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir) / "Movie"
+            output_folder.mkdir()
+            mv_hevc_path = output_folder / "movie_MV-HEVC.mov"
+            audio_path = output_folder / "movie_audio.m4a"
+            mv_hevc_path.write_bytes(b"video")
+            audio_path.write_bytes(b"audio")
+
+            with (
+                patch.object(container.config, "keep_files", False),
+                patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(container, "mux_video_audio_subs") as mux,
+            ):
+                result = container.create_muxed_file(audio_path, mv_hevc_path, output_folder, "Movie")
+
+            self.assertEqual(result, output_folder / "Movie_AVP.mov")
+            mux.assert_called_once_with(
+                mv_hevc_path,
+                audio_path,
+                output_folder / "Movie_AVP.mov",
+                output_folder,
+            )
+            self.assertTrue(mv_hevc_path.exists())
+            self.assertTrue(audio_path.exists())
+
+    def test_final_mux_failure_retains_inputs_for_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_folder = Path(temp_dir) / "Movie"
+            output_folder.mkdir()
+            mv_hevc_path = output_folder / "movie_MV-HEVC.mov"
+            audio_path = output_folder / "movie_audio.m4a"
+            mv_hevc_path.write_bytes(b"video")
+            audio_path.write_bytes(b"audio")
+
+            with (
+                patch.object(container.config, "keep_files", False),
+                patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(container, "mux_video_audio_subs", side_effect=RuntimeError("mux failed")),
+                self.assertRaisesRegex(RuntimeError, "mux failed"),
+            ):
+                container.create_muxed_file(audio_path, mv_hevc_path, output_folder, "Movie")
+
+            self.assertTrue(mv_hevc_path.exists())
+            self.assertTrue(audio_path.exists())
+
     def test_final_mux_forces_video_sync_samples_for_quicktime_seeking(self) -> None:
         with (
             patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
@@ -150,6 +197,33 @@ class MuxCommandTests(unittest.TestCase):
         self.assertIn("2:type=name:str='Commentary'", command)
         self.assertIn("Movie_audio_AAC.m4a#2:lang=jpn:group=1:alternate_group=1:enabled", command)
         self.assertIn("3:type=name:str='Main Japanese'", command)
+
+    def test_final_mux_uses_m4a_name_tag_as_audio_title(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {
+                        "index": 0,
+                        "tags": {"language": "eng", "name": "Director Commentary"},
+                        "channel_layout": "stereo",
+                    }
+                ],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("Movie_audio_AAC.m4a"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("2:type=name:str='Director Commentary'", command)
 
     def test_final_mux_normalizes_bibliographic_audio_language(self) -> None:
         with (

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import ffmpeg
 
 from bd_to_avp.modules import container
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import Stage
 
 
@@ -22,7 +23,7 @@ class AudioExtractionTests(unittest.TestCase):
 
     def test_direct_pipeline_skips_intermediate_video_and_pcm(self) -> None:
         with (
-            patch.object(container.config, "transcode_audio", True),
+            patch.object(container.config, "audio_mode", AudioMode.CONVERT_AAC),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
@@ -33,24 +34,24 @@ class AudioExtractionTests(unittest.TestCase):
         self.assertEqual(video_path, Path("source.mkv"))
         run_ffmpeg.assert_not_called()
 
-    def test_keep_files_preserves_mvc_and_pcm_boundaries(self) -> None:
+    def test_keep_files_preserves_mvc_without_changing_aac_policy(self) -> None:
         with (
-            patch.object(container.config, "transcode_audio", True),
+            patch.object(container.config, "audio_mode", AudioMode.CONVERT_AAC),
             patch.object(container.config, "keep_files", True),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
             audio_path, video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
 
-        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
-        self.assertEqual(audio_path, Path("output/Movie_audio_PCM.mov"))
+        self.assertEqual(audio_path, Path("source.mkv"))
         self.assertEqual(video_path, Path("output/Movie_mvc.h264"))
-        self.assertIn("pcm_s24le", command)
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertNotIn("pcm_s24le", command)
         self.assertIn("file:output/Movie_mvc.h264", command)
 
-    def test_direct_mode_without_audio_transcode_preserves_pcm_boundary(self) -> None:
+    def test_pcm_mode_preserves_pcm_boundary(self) -> None:
         with (
-            patch.object(container.config, "transcode_audio", False),
+            patch.object(container.config, "audio_mode", AudioMode.PCM),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
@@ -112,6 +113,43 @@ class MuxCommandTests(unittest.TestCase):
         command = run_command.call_args.args[0]
         self.assertIn("Movie_audio_AAC.m4a#1:lang=eng:group=1:alternate_group=1", command)
         self.assertIn("Movie_audio_AAC.m4a#2:lang=fra:group=1:alternate_group=1:disable", command)
+
+    def test_final_mux_preserves_audio_title_and_default_disposition(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {
+                        "index": 0,
+                        "tags": {"language": "eng", "title": "Commentary"},
+                        "channel_layout": "stereo",
+                        "disposition": {"default": 0},
+                    },
+                    {
+                        "index": 1,
+                        "tags": {"language": "jpn", "title": "Main Japanese"},
+                        "channel_layout": "5.1",
+                        "disposition": {"default": 1},
+                    },
+                ],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("Movie_audio_AAC.m4a"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("Movie_audio_AAC.m4a#1:lang=eng:group=1:alternate_group=1", command)
+        self.assertIn("2:type=name:str='Commentary'", command)
+        self.assertIn("Movie_audio_AAC.m4a#2:lang=jpn:group=1:alternate_group=1:enabled", command)
+        self.assertIn("3:type=name:str='Main Japanese'", command)
 
     def test_final_mux_normalizes_bibliographic_audio_language(self) -> None:
         with (

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -146,7 +146,7 @@ class MuxCommandTests(unittest.TestCase):
             )
 
         command = run_command.call_args.args[0]
-        self.assertIn("Movie_audio_AAC.m4a#1:lang=eng:group=1:alternate_group=1", command)
+        self.assertIn("Movie_audio_AAC.m4a#1:lang=eng:group=1:alternate_group=1:disable", command)
         self.assertIn("2:type=name:str='Commentary'", command)
         self.assertIn("Movie_audio_AAC.m4a#2:lang=jpn:group=1:alternate_group=1:enabled", command)
         self.assertIn("3:type=name:str='Main Japanese'", command)

--- a/tests/test_gui_processing.py
+++ b/tests/test_gui_processing.py
@@ -24,6 +24,7 @@ from bd_to_avp.gui.processing import (
     ProcessingThread,
     ThreadScopedOutput,
 )
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.command import get_spinner_update_func
 from bd_to_avp.modules.disc import MKVCreationError
@@ -471,6 +472,31 @@ class MainWindowProcessingLifecycleTests(unittest.TestCase):
         self.assertEqual(self.window.process_button.text(), self.window.STOP_PROCESSING_TEXT)
         self.assertFalse(self.window.load_config_button.isEnabled())
         self.assertFalse(self.window.save_config_button.isEnabled())
+
+    def test_audio_mode_selector_round_trips_all_modes(self) -> None:
+        cases = [
+            (AudioMode.AUTOMATIC, "Automatic", True),
+            (AudioMode.CONVERT_AAC, "Convert to AAC", True),
+            (AudioMode.PCM, "Uncompressed PCM", False),
+        ]
+
+        for mode, label, bitrate_visible in cases:
+            with self.subTest(mode=mode):
+                self.window.audio_mode_combobox.set_current_text(label)
+                self.window.save_config()
+
+                self.assertEqual(config.audio_mode, mode)
+                self.assertEqual(self.window.audio_bitrate_spinbox.isHidden(), not bitrate_visible)
+
+    def test_loading_automatic_mode_does_not_flatten_to_pcm(self) -> None:
+        config.audio_mode = AudioMode.AUTOMATIC
+
+        with patch.object(config, "load_config_from_file"):
+            self.window.load_config_and_update_ui()
+        self.window.save_config()
+
+        self.assertEqual(self.window.audio_mode_combobox.current_text(), "Automatic")
+        self.assertEqual(config.audio_mode, AudioMode.AUTOMATIC)
 
     def test_continuation_requires_explicit_request(self) -> None:
         with self.assertRaisesRegex(ValueError, "continuation request"):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,8 @@ import unittest
 from unittest.mock import patch
 
 from bd_to_avp import __main__
+from bd_to_avp.modules.audio_mode import AudioMode
+from bd_to_avp.modules.config import Config
 
 
 class MainSmokeTests(unittest.TestCase):
@@ -18,6 +20,31 @@ class MainSmokeTests(unittest.TestCase):
         load_frameworks.assert_called_once()
         start_process.assert_not_called()
         print_mock.assert_called_once_with("Apple Vision OCR import smoke passed")
+
+    def test_legacy_transcode_audio_cli_maps_to_convert_aac_mode(self) -> None:
+        config = Config()
+
+        with patch.object(
+            sys,
+            "argv",
+            ["bd-to-avp", "--source", "/tmp/movie.mkv", "--transcode-audio"],
+        ):
+            config.parse_args()
+
+        self.assertEqual(config.audio_mode, AudioMode.CONVERT_AAC)
+
+    def test_audio_mode_cli_selects_pcm_without_legacy_boolean(self) -> None:
+        config = Config()
+
+        with patch.object(
+            sys,
+            "argv",
+            ["bd-to-avp", "--source", "/tmp/movie.mkv", "--audio-mode", "pcm"],
+        ):
+            config.parse_args()
+
+        self.assertEqual(config.audio_mode, AudioMode.PCM)
+        self.assertFalse(config.transcode_audio)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -169,6 +169,8 @@ class NativeAppPackagingTests(unittest.TestCase):
 
         content_view = (MACOS_ROOT / "BluRayToVisionPro" / "Views" / "ContentView.swift").read_text(encoding="utf-8")
         self.assertIn(".onChange(of: defaultJobOptions)", content_view)
+        self.assertIn("if let warningMessage = viewModel.state.warningMessage", content_view)
+        self.assertIn('return "Warning: \\(warningMessage)"', content_view)
 
     def test_native_build_settings_support_hosted_ci_deployment_override(self) -> None:
         settings = native_build_settings(

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -534,6 +534,35 @@ class WorkerEventEmitterTests(unittest.TestCase):
 
 
 class WorkerActivityReporterTests(unittest.TestCase):
+    def test_warning_emits_shared_automatic_fallback_fixture(self) -> None:
+        output = io.StringIO()
+        job_id = "11111111-1111-4111-8111-111111111111"
+        activity = WorkerActivityReporter(WorkerEventEmitter(output, job_id))
+
+        activity.warning(
+            "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC.",
+            stage="transcode_audio",
+            code="audio_automatic_fallback_to_aac",
+            audio_mode="automatic",
+            action="convert_aac",
+            source_codecs=["aac", "ac3"],
+            unqualified_streams=[
+                {
+                    "index": 1,
+                    "codec": "ac3",
+                    "profile": None,
+                    "sample_rate": 48_000,
+                    "channels": 6,
+                    "channel_layout": "5.1(side)",
+                    "reason": "codec_not_allowed",
+                }
+            ],
+        )
+
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_fallback_warning_v6.json"
+        expected = json.loads(fixture_path.read_text())
+        self.assertEqual(decoded_events(output), [expected])
+
     def test_stage_plan_emits_shared_progress_fixture(self) -> None:
         output = io.StringIO()
         job_id = "11111111-1111-4111-8111-111111111111"

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.disc import DiscInfo, DiscTitleInfo, MKVCreationError
 from bd_to_avp.modules.process import process_each
 from bd_to_avp.modules.sub import SRTCreationError
@@ -83,8 +84,7 @@ def conversion_request_line(
         "source": source,
         "destination": {"path": str(destination_path)},
         "encoding": {
-            "transcode_audio": True,
-            "audio_bitrate": 384,
+            "audio": {"mode": "convert_aac", "bitrate": 384},
             "left_right_bitrate": 20,
             "link_quality": True,
             "mv_hevc_quality": 75,
@@ -166,7 +166,8 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.operation.value, "convert_source")
         self.assertEqual(job.source.path, source_path)
         self.assertEqual(job.destination.path if job.destination else None, destination_path)
-        self.assertTrue(job.encoding.transcode_audio if job.encoding else False)
+        self.assertEqual(job.encoding.audio.mode if job.encoding else None, AudioMode.CONVERT_AAC)
+        self.assertEqual(job.encoding.audio.bitrate if job.encoding else None, 384)
         self.assertEqual(job.encoding.subtitles.mode.value if job.encoding else None, "preferred_plus_others")
         self.assertEqual(job.encoding.subtitles.preferred_language if job.encoding else None, "eng")
         self.assertEqual(job.job.start_stage if job.job else None, 1)
@@ -227,7 +228,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(context.exception.code, "invalid_source")
 
     def test_parses_shared_swift_conversion_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v5.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v6.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -238,7 +239,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
 
     def test_parses_shared_swift_physical_disc_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v5.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v6.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -248,7 +249,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertFalse(job.job.remove_original if job.job else True)
 
     def test_parses_shared_swift_preview_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v5.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v6.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -332,6 +333,34 @@ class JobSpecTests(unittest.TestCase):
             JobSpec.from_json_line(json.dumps(request) + "\n")
 
         self.assertEqual(context.exception.code, "invalid_request")
+
+    def test_rejects_legacy_audio_fields_in_protocol_v6(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["transcode_audio"] = False
+        request["encoding"]["audio_bitrate"] = 384
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_request")
+
+    def test_rejects_unknown_audio_mode(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["audio"]["mode"] = "keep_original"
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_encoding_options")
+
+    def test_rejects_unknown_nested_audio_field_with_stable_error_code(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["audio"]["surprise"] = True
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(json.dumps(request) + "\n")
+
+        self.assertEqual(context.exception.code, "invalid_encoding_options")
 
     def test_normalizes_subtitle_language_aliases(self) -> None:
         request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
@@ -513,7 +542,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
 
         activity.stage_started("configure", "Preparing conversion settings")
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v5.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v6.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -660,7 +689,7 @@ class WorkerRuntimeTests(unittest.TestCase):
                 }
             },
         )
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v5.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v6.json"
         fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(decoded_events(output)[-1], fixture)
@@ -1333,7 +1362,7 @@ class SourceConversionTests(unittest.TestCase):
             activity = WorkerActivityReporter(emitter)
             previous_source_path = config.source_path
             previous_output_root_path = config.output_root_path
-            previous_transcode_audio = config.transcode_audio
+            previous_audio_mode = config.audio_mode
             previous_remove_original = config.remove_original
             previous_environment = {
                 key: os.environ.get(key) for key in ("PATH", "FFMPEG_BINARY", "FFPROBE_BINARY", "TMPDIR")
@@ -1360,7 +1389,7 @@ class SourceConversionTests(unittest.TestCase):
             process_each_mock.assert_called_once()
             self.assertEqual(config.source_path, previous_source_path)
             self.assertEqual(config.output_root_path, previous_output_root_path)
-            self.assertEqual(config.transcode_audio, previous_transcode_audio)
+            self.assertEqual(config.audio_mode, previous_audio_mode)
             self.assertEqual(config.remove_original, previous_remove_original)
             for key, value in previous_environment.items():
                 self.assertEqual(os.environ.get(key), value)
@@ -1377,8 +1406,7 @@ class SourceConversionTests(unittest.TestCase):
             request = json.loads(conversion_request_line(source_path, destination_path))
             request["encoding"].update(
                 {
-                    "transcode_audio": False,
-                    "audio_bitrate": 512,
+                    "audio": {"mode": "pcm", "bitrate": 512},
                     "left_right_bitrate": 42,
                     "mv_hevc_quality": 88,
                     "upscale_quality": 66,
@@ -1416,7 +1444,7 @@ class SourceConversionTests(unittest.TestCase):
                     {
                         "source_path": config.source_path,
                         "output_root_path": config.output_root_path,
-                        "transcode_audio": config.transcode_audio,
+                        "audio_mode": config.audio_mode,
                         "audio_bitrate": config.audio_bitrate,
                         "left_right_bitrate": config.left_right_bitrate,
                         "mv_hevc_quality": config.mv_hevc_quality,
@@ -1451,7 +1479,7 @@ class SourceConversionTests(unittest.TestCase):
 
             self.assertEqual(observed["source_path"], source_path)
             self.assertEqual(observed["output_root_path"], destination_path)
-            self.assertFalse(observed["transcode_audio"])
+            self.assertEqual(observed["audio_mode"], AudioMode.PCM)
             self.assertEqual(observed["audio_bitrate"], 512)
             self.assertEqual(observed["left_right_bitrate"], 42)
             self.assertEqual(observed["mv_hevc_quality"], 88)

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -11,6 +11,44 @@ from bd_to_avp.modules.disc import DiscInfo
 
 
 class ProcessAudioWiringTests(unittest.TestCase):
+    def test_move_files_resume_skips_prior_processing_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            muxed_path = output_folder / "Movie_AVP.mov"
+            final_path = temp_path / "Movie_AVP.mov"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            muxed_path.write_bytes(b"final")
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(process.config, "source_path", source_path))
+                stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
+                stack.enter_context(patch.object(process.config, "overwrite", True))
+                stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "start_stage", Stage.MOVE_FILES))
+                stack.enter_context(patch.object(process.config, "remove_original", False))
+                stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                stack.enter_context(
+                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
+                )
+                stack.enter_context(
+                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
+                )
+                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                create_mkv = stack.enter_context(patch.object(process, "create_mkv_file"))
+                move_file = stack.enter_context(
+                    patch.object(process, "move_file_to_output_root_folder", return_value=final_path)
+                )
+                stack.enter_context(patch.object(process, "remove_output_folder_if_safe"))
+
+                result = process.process_each()
+
+            self.assertEqual(result, final_path)
+            create_mkv.assert_not_called()
+            move_file.assert_called_once_with(muxed_path)
+
     def test_direct_audio_source_is_replaced_by_aac_and_removed_after_success(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from bd_to_avp.modules import process
+from bd_to_avp.modules.audio_mode import AudioMode
+from bd_to_avp.modules.config import Stage
 from bd_to_avp.modules.disc import DiscInfo
 
 
@@ -28,6 +30,8 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
                 stack.enter_context(patch.object(process.config, "overwrite", True))
                 stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC))
+                stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
                 stack.enter_context(patch.object(process.config, "remove_original", True))
                 stack.enter_context(patch.object(process.config, "language_code", "eng"))
                 stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
@@ -50,7 +54,7 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 )
                 stack.enter_context(patch.object(process, "create_mv_hevc_file", return_value=mv_hevc_path))
                 stack.enter_context(patch.object(process, "create_upscaled_file", return_value=mv_hevc_path))
-                transcode = stack.enter_context(
+                prepare_audio = stack.enter_context(
                     patch.object(process, "create_transcoded_audio_file", return_value=aac_path)
                 )
                 mux = stack.enter_context(patch.object(process, "create_muxed_file", return_value=final_path))
@@ -58,9 +62,80 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.dict(process.os.environ, {}, clear=False))
                 process.process_each()
 
-                transcode.assert_called_once_with(source_path, output_folder)
+                self.assertEqual(prepare_audio.call_args.args[:2], (source_path, output_folder))
                 mux.assert_called_once_with(aac_path, mv_hevc_path, output_folder, "Movie")
                 self.assertFalse(source_path.exists())
+
+    def test_prepare_audio_stage_preserves_stage_id_with_new_message(self) -> None:
+        class StopAfterAudio(Exception):
+            pass
+
+        class Activity:
+            def __init__(self) -> None:
+                self.started: list[tuple[str, str]] = []
+
+            def stage_started(self, stage: str, message: str) -> None:
+                self.started.append((stage, message))
+
+            def log(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def warning(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def stage_progress(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def set_stage_plan(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            video_path = output_folder / "Movie_mvc.h264"
+            left_path = output_folder / "Movie_left.mov"
+            right_path = output_folder / "Movie_right.mov"
+            mv_hevc_path = output_folder / "Movie_MV-HEVC.mov"
+            aac_path = output_folder / "Movie_audio_AAC.m4a"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            activity = Activity()
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(process.config, "source_path", source_path))
+                stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
+                stack.enter_context(patch.object(process.config, "overwrite", True))
+                stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC))
+                stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
+                stack.enter_context(patch.object(process.config, "remove_original", False))
+                stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                stack.enter_context(
+                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
+                )
+                stack.enter_context(
+                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
+                )
+                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                stack.enter_context(patch.object(process, "create_mkv_file", return_value=source_path))
+                stack.enter_context(patch.object(process, "get_video_color_depth", return_value=8))
+                stack.enter_context(patch.object(process, "detect_crop_parameters", return_value=None))
+                stack.enter_context(
+                    patch.object(process, "create_mvc_and_audio", return_value=(source_path, video_path))
+                )
+                stack.enter_context(patch.object(process, "create_srt_from_mkv"))
+                stack.enter_context(
+                    patch.object(process, "create_left_right_files", return_value=(left_path, right_path))
+                )
+                stack.enter_context(patch.object(process, "create_mv_hevc_file", return_value=mv_hevc_path))
+                stack.enter_context(patch.object(process, "create_upscaled_file", return_value=mv_hevc_path))
+                stack.enter_context(patch.object(process, "create_transcoded_audio_file", return_value=aac_path))
+                stack.enter_context(patch.object(process, "create_muxed_file", side_effect=StopAfterAudio))
+                stack.enter_context(self.assertRaises(StopAfterAudio))
+                process.process_each(activity=activity)
+
+            self.assertIn(("transcode_audio", "Prepare Audio"), activity.started)
 
 
 if __name__ == "__main__":

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -14,11 +14,10 @@ class ProcessAudioWiringTests(unittest.TestCase):
     def test_move_files_resume_skips_prior_processing_stages(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            source_path = temp_path / "source.mkv"
+            source_path = temp_path / "missing-source.iso"
             output_folder = temp_path / "Movie"
             muxed_path = output_folder / "Movie_AVP.mov"
             final_path = temp_path / "Movie_AVP.mov"
-            source_path.write_bytes(b"source")
             output_folder.mkdir()
             muxed_path.write_bytes(b"final")
 
@@ -29,25 +28,64 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.object(process.config, "keep_files", False))
                 stack.enter_context(patch.object(process.config, "start_stage", Stage.MOVE_FILES))
                 stack.enter_context(patch.object(process.config, "remove_original", False))
-                stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
-                stack.enter_context(
-                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
-                )
-                stack.enter_context(
-                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
-                )
-                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                preflight = stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                inspect_source = stack.enter_context(patch.object(process, "get_disc_and_mvc_video_info"))
+                prepare_output = stack.enter_context(patch.object(process, "prepare_output_folder_for_source"))
                 create_mkv = stack.enter_context(patch.object(process, "create_mkv_file"))
-                move_file = stack.enter_context(
-                    patch.object(process, "move_file_to_output_root_folder", return_value=final_path)
-                )
-                stack.enter_context(patch.object(process, "remove_output_folder_if_safe"))
 
                 result = process.process_each()
 
             self.assertEqual(result, final_path)
+            self.assertEqual(final_path.read_bytes(), b"final")
+            self.assertFalse(output_folder.exists())
+            preflight.assert_not_called()
+            inspect_source.assert_not_called()
+            prepare_output.assert_not_called()
             create_mkv.assert_not_called()
-            move_file.assert_called_once_with(muxed_path)
+
+    def test_move_files_resume_selects_matching_direct_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            selected_folder = temp_path / "Selected"
+            other_folder = temp_path / "Other"
+            selected_folder.mkdir()
+            other_folder.mkdir()
+            (selected_folder / "Selected_AVP.mov").write_bytes(b"selected")
+            (other_folder / "Other_AVP.mov").write_bytes(b"other")
+
+            with (
+                patch.object(process.config, "source_path", temp_path / "Selected.mkv"),
+                patch.object(process.config, "output_root_path", temp_path),
+                patch.object(process.config, "overwrite", True),
+                patch.object(process.config, "keep_files", False),
+                patch.object(process.config, "start_stage", Stage.MOVE_FILES),
+                patch.object(process.config, "remove_original", False),
+            ):
+                result = process.process_each()
+
+            self.assertEqual(result, temp_path / "Selected_AVP.mov")
+            self.assertEqual(result.read_bytes(), b"selected")
+            self.assertTrue((other_folder / "Other_AVP.mov").exists())
+
+    def test_move_files_resume_rejects_ambiguous_completed_movies(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            for name in ("First", "Second"):
+                output_folder = temp_path / name
+                output_folder.mkdir()
+                (output_folder / f"{name}_AVP.mov").write_bytes(name.encode())
+
+            with (
+                patch.object(process.config, "source_path", temp_path / "unavailable.iso"),
+                patch.object(process.config, "output_root_path", temp_path),
+                patch.object(process.config, "start_stage", Stage.MOVE_FILES),
+                self.assertRaisesRegex(RuntimeError, "Multiple completed movies are ready to move"),
+            ):
+                process.process_each()
+
+    def test_move_files_stage_plan_is_filesystem_only(self) -> None:
+        with patch.object(process.config, "start_stage", Stage.MOVE_FILES):
+            self.assertEqual(process.conversion_stage_plan(), ("configure", "move_files"))
 
     def test_direct_audio_source_is_replaced_by_aac_and_removed_after_success(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 from bd_to_avp import preflight
 from bd_to_avp.modules import process
+from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.disc import MKVCreationError
 from bd_to_avp.modules.file import (
@@ -21,7 +22,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "preview_range", None),
             patch.object(process.config, "skip_subtitles", False),
             patch.object(process.config, "fx_upscale", False),
-            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "audio_mode", AudioMode.CONVERT_AAC),
             patch.object(process.config, "start_stage", Stage.CREATE_MKV),
         ):
             default_plan = process.conversion_stage_plan()
@@ -49,7 +50,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "preview_range", Mock()),
             patch.object(process.config, "skip_subtitles", True),
             patch.object(process.config, "fx_upscale", True),
-            patch.object(process.config, "transcode_audio", False),
+            patch.object(process.config, "audio_mode", AudioMode.PCM),
             patch.object(process.config, "start_stage", Stage.CREATE_MKV),
         ):
             optional_plan = process.conversion_stage_plan()
@@ -64,7 +65,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "preview_range", None),
             patch.object(process.config, "skip_subtitles", False),
             patch.object(process.config, "fx_upscale", False),
-            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC),
             patch.object(process.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
         ):
             mkv_recovery_plan = process.conversion_stage_plan()
@@ -77,7 +78,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "preview_range", None),
             patch.object(process.config, "skip_subtitles", True),
             patch.object(process.config, "fx_upscale", False),
-            patch.object(process.config, "transcode_audio", True),
+            patch.object(process.config, "audio_mode", AudioMode.CONVERT_AAC),
             patch.object(process.config, "start_stage", Stage.EXTRACT_SUBTITLES),
         ):
             subtitle_recovery_plan = process.conversion_stage_plan()


### PR DESCRIPTION
## Summary
- add first-class Automatic, Convert to AAC, and Uncompressed PCM modes across the native app, Qt UI, profiles, CLI/config, and worker protocol v6
- implement conservative whole-set Automatic behavior: copy only fully qualified AAC sets, otherwise convert the selected set to AAC and emit a structured visible warning
- preserve legacy profile semantics and keep PCM as the default until signed-package and physical Apple Vision Pro evidence is complete
- preserve stream order, language, titles, and default disposition through final muxing
- keep owned recovery artifacts through successful final move; `MOVE_FILES` is filesystem-only, selects direct-source artifacts deterministically, and rejects ambiguous candidates

## Validation
- Python: 523 tests passed, 2 skipped
- Native: 146 tests passed
- Ruff format/check and mypy passed
- packaged native startup smoke passed
- JetBrains changed-files inspection passed
- independent backend, native UX/accessibility, release-risk, and recovery-safety reviews completed

## Remaining Hardware Gate
Physical Apple Vision Pro playback evidence remains required before Automatic becomes the default or AC-3/E-AC-3 enter the passthrough allowlist. That evidence is tracked separately in #200 and is intentionally not claimed by this PR.

Refs #56