### PR TITLE
Add Vision Pro audio validation matrix

### DIFF
--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -9,7 +9,7 @@ import ffmpeg
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.command import run_ffmpeg_print_errors
 from bd_to_avp.modules.config import Stage, config
-from bd_to_avp.modules.container import get_audio_stream_data
+from bd_to_avp.modules.container import audio_handler_metadata_options, get_audio_stream_data
 
 
 class AudioActivityReporter(Protocol):
@@ -50,6 +50,7 @@ def transcode_audio(input_path: Path, transcoded_audio_path: Path, bitrate: int,
         acodec="aac",
         audio_bitrate=f"{bitrate}k",
         map_metadata=0,
+        **audio_handler_metadata_options(input_path, audio_selector),
     )
     run_ffmpeg_print_errors(audio_transcoded, f"transcode audio to {bitrate}kbps", overwrite_output=True)
 
@@ -61,6 +62,7 @@ def copy_audio(input_path: Path, copied_audio_path: Path) -> None:
         str(f"file:{copied_audio_path}"),
         acodec="copy",
         map_metadata=0,
+        **audio_handler_metadata_options(input_path),
     )
     run_ffmpeg_print_errors(copied_audio, "copy AAC audio tracks", overwrite_output=True)
 

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -14,6 +14,13 @@ from bd_to_avp.modules.languages import language_name, normalize_source_language
 from bd_to_avp.modules.util import sorted_files_by_creation_filtered_on_suffix
 
 
+AUDIO_CHANNEL_LAYOUT_NAMES = {
+    1: "mono",
+    2: "stereo",
+}
+GENERIC_AUDIO_HANDLER_NAMES = frozenset({"soundhandler"})
+
+
 def extract_mvc_and_audio(
     input_path: Path,
     video_output_path: Path | None,
@@ -28,7 +35,14 @@ def extract_mvc_and_audio(
         )
 
     if audio_output_path:
-        output_streams.append(ffmpeg.output(stream["a"], f"file:{audio_output_path}", c="pcm_s24le"))
+        output_streams.append(
+            ffmpeg.output(
+                stream["a"],
+                f"file:{audio_output_path}",
+                c="pcm_s24le",
+                **audio_handler_metadata_options(input_path),
+            )
+        )
 
     if output_streams:
         output_message = "ffmpeg to extract MVC video and audio from source"
@@ -88,9 +102,8 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
     for audio_position, stream in enumerate(audio_streams):
         index = stream["index"] + 1
         language_code, audio_language_name = normalize_track_language(stream.get("tags", {}).get("language"))
-        channel_layout = stream.get("channel_layout", "unknown")
-        tags = stream.get("tags", {})
-        title = tags.get("title") or tags.get("name")
+        channel_layout = audio_channel_layout_name(stream)
+        title = audio_track_title(stream)
         default_disposition = int(stream.get("disposition", {}).get("default", 0) or 0) == 1
 
         audio_track_options = f":lang={language_code}:group=1:alternate_group=1"
@@ -128,6 +141,56 @@ def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path,
 
     command += [muxed_path]
     run_command(command, "mux video, audio, and subtitles.")
+
+
+def audio_channel_layout_name(stream: dict[str, Any]) -> str:
+    channel_layout = stream.get("channel_layout")
+    if isinstance(channel_layout, str) and channel_layout.strip():
+        return channel_layout.strip()
+
+    raw_channel_count = stream.get("channels")
+    if raw_channel_count is None:
+        return "unknown"
+    try:
+        channel_count = int(raw_channel_count)
+    except (TypeError, ValueError):
+        return "unknown"
+    return AUDIO_CHANNEL_LAYOUT_NAMES.get(channel_count, f"{channel_count}-channel")
+
+
+def audio_track_title(stream: dict[str, Any]) -> str | None:
+    tags = stream.get("tags", {})
+    if not isinstance(tags, dict):
+        return None
+
+    for key in ("title", "name", "handler_name"):
+        title = tags.get(key)
+        if not isinstance(title, str):
+            continue
+        normalized_title = title.strip()
+        if not normalized_title:
+            continue
+        if key == "handler_name" and normalized_title.casefold() in GENERIC_AUDIO_HANDLER_NAMES:
+            continue
+        return normalized_title
+    return None
+
+
+def audio_handler_metadata_options(input_path: Path, audio_selector: str = "a") -> dict[str, str]:
+    streams = get_audio_stream_data(input_path)
+    if audio_selector != "a":
+        stream_type, separator, stream_index = audio_selector.partition(":")
+        if stream_type != "a" or not separator or not stream_index.isdigit():
+            return {}
+        selected_index = int(stream_index)
+        streams = streams[selected_index : selected_index + 1]
+
+    options: dict[str, str] = {}
+    for output_index, stream in enumerate(streams):
+        title = audio_track_title(stream)
+        if title is not None:
+            options[f"metadata:s:a:{output_index}"] = f"handler_name={title}"
+    return options
 
 
 def normalize_track_language(language_code: object) -> tuple[str, str]:

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -507,6 +507,8 @@ def combine_to_mv_hevc(
         "--left-is-primary",
         "--horizontal-field-of-view",
         config.fov,
+        "--horizontal-disparity-adjustment",
+        0,
         "--color-depth",
         color_depth,
         "--output-file",

--- a/docs/visionos-spatial-playback-probe.md
+++ b/docs/visionos-spatial-playback-probe.md
@@ -64,7 +64,7 @@ The generator exercises the production audio preparation and final-mux functions
 - `03-Convert-AAC.mov`: E-AC-3 plus FLAC input that must convert both tracks to AAC.
 - `04-PCM.mov`: E-AC-3 plus FLAC input that must extract both tracks as 24-bit PCM.
 
-Each movie is 24 seconds long with a default English 5.1 track, a French alternate stereo track, selectable English subtitles, and a white flash synchronized to each channel beep. The generator fails unless codec, language, channel-layout, packet/sample integrity, warning, subtitle, and left/right MV-HEVC split checks pass. `manifest.json` records the machine-verifiable evidence, and `CHECKLIST.md` contains the headset operator gate.
+Each movie is 24 seconds long with a default English 5.1 track, a French alternate stereo track, selectable English subtitles, and a white flash synchronized to each channel beep. MV-HEVC generation writes an explicit neutral horizontal disparity adjustment so AVFoundation reports QuickTime stereo metadata instead of treating the file as stereo multiview alone. The generator fails unless codec, language, channel-layout, packet/sample integrity, warning, subtitle, and left/right MV-HEVC split checks pass. `manifest.json` records the machine-verifiable evidence, and `CHECKLIST.md` contains the headset operator gate.
 
 After installing the signed app, copy the matrix into its Documents container and place the first fixture at the autorun path:
 

--- a/docs/visionos-spatial-playback-probe.md
+++ b/docs/visionos-spatial-playback-probe.md
@@ -47,6 +47,43 @@ xcodebuild build \
 
 The `SpatialPlaybackProbeUITests` target performs the user-initiated **Open Spatial View** action required by visionOS and verifies the reported stereo, spatial, portal presentation on a physical headset. Simulator runs skip this acceptance test. The headset must allow Xcode to enter UI automation mode; a timeout while enabling automation is an environment blocker, not spatial-playback evidence.
 
+## Generate the Audio Validation Matrix
+
+Create the four representative finalized movies used by the physical audio gate:
+
+```bash
+uv run python scripts/create_spatial_audio_validation_fixtures.py \
+  --output "$HOME/Movies/BD to AVP Audio Validation" \
+  --force
+```
+
+The generator exercises the production audio preparation and final-mux functions. It produces:
+
+- `01-Automatic-AAC-Copy.mov`: two qualified AAC tracks whose packet payloads must remain unchanged.
+- `02-Automatic-AAC-Fallback.mov`: AC-3 plus AAC input that must emit the structured fallback warning and convert the whole selected set.
+- `03-Convert-AAC.mov`: E-AC-3 plus FLAC input that must convert both tracks to AAC.
+- `04-PCM.mov`: E-AC-3 plus FLAC input that must extract both tracks as 24-bit PCM.
+
+Each movie is 24 seconds long with a default English 5.1 track, a French alternate stereo track, selectable English subtitles, and a white flash synchronized to each channel beep. The generator fails unless codec, language, channel-layout, packet/sample integrity, warning, subtitle, and left/right MV-HEVC split checks pass. `manifest.json` records the machine-verifiable evidence, and `CHECKLIST.md` contains the headset operator gate.
+
+After installing the signed app, copy the matrix into its Documents container and place the first fixture at the autorun path:
+
+```bash
+xcrun devicectl device copy to \
+  --device <device-id> \
+  --source "$HOME/Movies/BD to AVP Audio Validation" \
+  --destination "Documents/Audio Validation" \
+  --domain-type appDataContainer \
+  --domain-identifier com.shinycomputers.bd-to-avp.spatial-playback-probe
+
+xcrun devicectl device copy to \
+  --device <device-id> \
+  --source "$HOME/Movies/BD to AVP Audio Validation/01-Automatic-AAC-Copy.mov" \
+  --destination Documents/Probe.mov \
+  --domain-type appDataContainer \
+  --domain-identifier com.shinycomputers.bd-to-avp.spatial-playback-probe
+```
+
 ## Open a Finalized Movie
 
 Launch the app on Apple Vision Pro and choose **Open Preview…**. The file importer accepts a movie from Files, copies it into the app container, and keeps playback independent from the source file's security-scoped lifetime. The default volumetric window renders through `VideoPlayerComponent`; **Open Spatial View** requests a mixed immersive-space portal for focused review.

--- a/scripts/create_spatial_audio_validation_fixtures.py
+++ b/scripts/create_spatial_audio_validation_fixtures.py
@@ -1,0 +1,634 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from bd_to_avp.modules.audio import create_prepared_audio_file
+from bd_to_avp.modules.audio_mode import AudioMode
+from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.container import extract_mvc_and_audio, mux_video_audio_subs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = Path.home() / "Movies" / "BD to AVP Audio Validation"
+DURATION_SECONDS = 24
+VIDEO_WIDTH = 640
+VIDEO_HEIGHT = 360
+FRAME_RATE = 30
+
+
+@dataclass(frozen=True)
+class FixtureCase:
+    filename: str
+    label: str
+    mode: AudioMode
+    source_name: str
+    expected_codecs: tuple[str, str]
+    expected_action: str
+
+
+@dataclass(frozen=True)
+class CapturedWarning:
+    message: str
+    stage: str | None
+    fields: dict[str, object]
+
+
+class WarningRecorder:
+    def __init__(self) -> None:
+        self.warnings: list[CapturedWarning] = []
+
+    def warning(self, message: str, *, stage: str | None = None, **fields: object) -> None:
+        self.warnings.append(CapturedWarning(message=message, stage=stage, fields=fields))
+
+
+FIXTURE_CASES = (
+    FixtureCase(
+        filename="01-Automatic-AAC-Copy.mov",
+        label="Automatic — qualified AAC copy",
+        mode=AudioMode.AUTOMATIC,
+        source_name="qualified-aac.mkv",
+        expected_codecs=("aac", "aac"),
+        expected_action="copy_aac",
+    ),
+    FixtureCase(
+        filename="02-Automatic-AAC-Fallback.mov",
+        label="Automatic — whole-set AAC fallback",
+        mode=AudioMode.AUTOMATIC,
+        source_name="mixed-ac3-aac.mkv",
+        expected_codecs=("aac", "aac"),
+        expected_action="convert_aac",
+    ),
+    FixtureCase(
+        filename="03-Convert-AAC.mov",
+        label="Convert AAC — explicit whole-set conversion",
+        mode=AudioMode.CONVERT_AAC,
+        source_name="eac3-flac.mkv",
+        expected_codecs=("aac", "aac"),
+        expected_action="convert_aac",
+    ),
+    FixtureCase(
+        filename="04-PCM.mov",
+        label="PCM — lossless extraction",
+        mode=AudioMode.PCM,
+        source_name="eac3-flac.mkv",
+        expected_codecs=("pcm_s24le", "pcm_s24le"),
+        expected_action="extract_pcm",
+    ),
+)
+
+
+def run(command: list[str | Path], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(part) for part in command],
+        check=True,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def require_tools() -> None:
+    required_tools = (
+        config.FFMPEG_PATH,
+        config.FFPROBE_PATH,
+        config.MP4BOX_PATH,
+        config.SPATIAL_MEDIA_PATH,
+    )
+    missing = [path for path in required_tools if not path.is_file()]
+    if missing:
+        raise RuntimeError("Required validation tools are missing:\n" + "\n".join(str(path) for path in missing))
+
+
+def prepare_output_directory(output_directory: Path, force: bool) -> None:
+    resolved_output = output_directory.expanduser().resolve()
+    if resolved_output in {Path("/"), Path.home().resolve()}:
+        raise ValueError(f"Refusing to use unsafe output directory: {resolved_output}")
+    if resolved_output.exists():
+        if not force:
+            raise FileExistsError(f"Output directory already exists; pass --force to replace it: {resolved_output}")
+        shutil.rmtree(resolved_output)
+    resolved_output.mkdir(parents=True)
+
+
+def create_spatial_video(work_directory: Path) -> Path:
+    left_path = work_directory / "left.mov"
+    right_path = work_directory / "right.mov"
+    spatial_path = work_directory / "spatial-video.mov"
+    flash_filter = "drawbox=x=0:y=0:w=iw:h=ih:color=white@0.55:t=fill:enable='lt(mod(t,1),0.12)'"
+
+    for output_path, crop_x in ((left_path, 0), (right_path, 16)):
+        run(
+            [
+                config.FFMPEG_PATH,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                f"testsrc2=size={VIDEO_WIDTH + 16}x{VIDEO_HEIGHT}:rate={FRAME_RATE}",
+                "-t",
+                str(DURATION_SECONDS),
+                "-vf",
+                f"crop={VIDEO_WIDTH}:{VIDEO_HEIGHT}:{crop_x}:0,{flash_filter}",
+                "-c:v",
+                "hevc_videotoolbox",
+                "-tag:v",
+                "hvc1",
+                "-b:v",
+                "2M",
+                "-an",
+                "-y",
+                output_path,
+            ]
+        )
+
+    run(
+        [
+            config.SPATIAL_MEDIA_PATH,
+            "merge",
+            "--left-file",
+            left_path,
+            "--right-file",
+            right_path,
+            "--quality",
+            "60",
+            "--left-is-primary",
+            "--horizontal-field-of-view",
+            "90",
+            "--output-file",
+            spatial_path,
+        ]
+    )
+    return spatial_path
+
+
+def create_audio_beds(work_directory: Path) -> tuple[Path, Path]:
+    surround_path = work_directory / "surround-5.1.wav"
+    alternate_path = work_directory / "alternate-stereo.wav"
+    channel_frequencies = (330, 440, 550, 110, 660, 770)
+    surround_expressions = [
+        f"0.32*sin(2*PI*{frequency}*t)*between(mod(t\\,6)\\,{index}\\,{index + 1})*lt(mod(t\\,1)\\,0.12)"
+        for index, frequency in enumerate(channel_frequencies)
+    ]
+    stereo_expressions = (
+        "0.26*sin(2*PI*990*t)*lt(mod(t\\,2)\\,1)*lt(mod(t\\,1)\\,0.12)",
+        "0.26*sin(2*PI*1320*t)*between(mod(t\\,2)\\,1\\,2)*lt(mod(t\\,1)\\,0.12)",
+    )
+
+    run(
+        [
+            config.FFMPEG_PATH,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"aevalsrc={'|'.join(surround_expressions)}:s=48000:d={DURATION_SECONDS}:c=5.1",
+            "-c:a",
+            "pcm_s24le",
+            "-y",
+            surround_path,
+        ]
+    )
+    run(
+        [
+            config.FFMPEG_PATH,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"aevalsrc={'|'.join(stereo_expressions)}:s=48000:d={DURATION_SECONDS}:c=stereo",
+            "-c:a",
+            "pcm_s24le",
+            "-y",
+            alternate_path,
+        ]
+    )
+    return surround_path, alternate_path
+
+
+def create_source_audio(
+    output_path: Path,
+    surround_path: Path,
+    alternate_path: Path,
+    codecs: tuple[str, str],
+    bitrates: tuple[str | None, str | None],
+) -> None:
+    command: list[str | Path] = [
+        config.FFMPEG_PATH,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        surround_path,
+        "-i",
+        alternate_path,
+        "-map",
+        "0:a:0",
+        "-map",
+        "1:a:0",
+        "-c:a:0",
+        codecs[0],
+        "-c:a:1",
+        codecs[1],
+    ]
+    for index, bitrate in enumerate(bitrates):
+        if bitrate is not None:
+            command.extend([f"-b:a:{index}", bitrate])
+    command.extend(
+        [
+            "-metadata:s:a:0",
+            "language=eng",
+            "-metadata:s:a:0",
+            "title=Validation Main 5.1",
+            "-metadata:s:a:1",
+            "language=fra",
+            "-metadata:s:a:1",
+            "title=Validation Alternate Stereo",
+            "-disposition:a:0",
+            "default",
+            "-disposition:a:1",
+            "0",
+            "-y",
+            output_path,
+        ]
+    )
+    run(command)
+
+
+def create_source_set(work_directory: Path) -> dict[str, Path]:
+    surround_path, alternate_path = create_audio_beds(work_directory)
+    source_directory = work_directory / "sources"
+    source_directory.mkdir()
+    sources = {
+        "qualified-aac.mkv": source_directory / "qualified-aac.mkv",
+        "mixed-ac3-aac.mkv": source_directory / "mixed-ac3-aac.mkv",
+        "eac3-flac.mkv": source_directory / "eac3-flac.mkv",
+    }
+    create_source_audio(sources["qualified-aac.mkv"], surround_path, alternate_path, ("aac", "aac"), ("384k", "192k"))
+    create_source_audio(sources["mixed-ac3-aac.mkv"], surround_path, alternate_path, ("ac3", "aac"), ("448k", "192k"))
+    create_source_audio(sources["eac3-flac.mkv"], surround_path, alternate_path, ("eac3", "flac"), ("768k", None))
+    return sources
+
+
+def srt_timestamp(seconds: int) -> str:
+    return f"00:00:{seconds:02d},000"
+
+
+def write_subtitles(path: Path, case: FixtureCase) -> None:
+    channels = ("Front Left", "Front Right", "Center", "LFE", "Surround Left", "Surround Right")
+    cues = []
+    for second in range(DURATION_SECONDS):
+        channel = channels[second % len(channels)]
+        cues.append(
+            "\n".join(
+                [
+                    str(second + 1),
+                    f"{srt_timestamp(second)} --> {srt_timestamp(second + 1)}",
+                    case.label,
+                    f"Default 5.1 track: {channel} beep should align with the white flash",
+                ]
+            )
+        )
+    path.write_text("\n\n".join(cues) + "\n", encoding="utf-8")
+
+
+def probe(path: Path) -> dict[str, Any]:
+    result = run(
+        [
+            config.FFPROBE_PATH,
+            "-v",
+            "error",
+            "-show_streams",
+            "-show_format",
+            "-of",
+            "json",
+            path,
+        ],
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def packet_fingerprint(path: Path, audio_index: int) -> dict[str, object]:
+    result = run(
+        [
+            config.FFPROBE_PATH,
+            "-v",
+            "error",
+            "-select_streams",
+            f"a:{audio_index}",
+            "-show_packets",
+            "-show_entries",
+            "packet=data_hash",
+            "-show_data_hash",
+            "sha256",
+            "-of",
+            "json",
+            path,
+        ],
+        capture_output=True,
+    )
+    packets = json.loads(result.stdout).get("packets", [])
+    packet_hashes = [packet["data_hash"] for packet in packets if packet.get("data_hash")]
+    digest = hashlib.sha256("\n".join(packet_hashes).encode()).hexdigest()
+    return {"packet_count": len(packet_hashes), "sha256": digest}
+
+
+def decoded_audio_fingerprint(path: Path, audio_index: int) -> str:
+    result = run(
+        [
+            config.FFMPEG_PATH,
+            "-v",
+            "error",
+            "-i",
+            path,
+            "-map",
+            f"0:a:{audio_index}",
+            "-c:a",
+            "pcm_s24le",
+            "-f",
+            "hash",
+            "-hash",
+            "sha256",
+            "-",
+        ],
+        capture_output=True,
+    )
+    return result.stdout.strip().removeprefix("SHA256=")
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for block in iter(lambda: input_file.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def audio_streams(probe_data: dict[str, Any]) -> list[dict[str, Any]]:
+    return [stream for stream in probe_data.get("streams", []) if stream.get("codec_type") == "audio"]
+
+
+def stream_summary(stream: dict[str, Any]) -> dict[str, object]:
+    tags = stream.get("tags", {})
+    disposition = stream.get("disposition", {})
+    return {
+        "codec": stream.get("codec_name"),
+        "profile": stream.get("profile"),
+        "sample_rate": stream.get("sample_rate"),
+        "channels": stream.get("channels"),
+        "channel_layout": stream.get("channel_layout"),
+        "language": tags.get("language"),
+        "title": tags.get("title") or tags.get("handler_name"),
+        "default": disposition.get("default"),
+    }
+
+
+def mp4box_track_section(path: Path, track_number: int) -> str:
+    result = run([config.MP4BOX_PATH, "-info", path], capture_output=True)
+    output = result.stdout + result.stderr
+    marker = f"# Track {track_number} Info"
+    section = output.partition(marker)[2]
+    if not section:
+        raise RuntimeError(f"{path.name}: MP4Box did not report track {track_number}")
+    return section.partition("# Track ")[0]
+
+
+def validate_fixture(
+    case: FixtureCase,
+    source_path: Path,
+    prepared_audio_path: Path,
+    final_path: Path,
+    recorder: WarningRecorder,
+    case_directory: Path,
+) -> dict[str, object]:
+    source_probe = probe(source_path)
+    prepared_probe = probe(prepared_audio_path)
+    final_probe = probe(final_path)
+    prepared_audio_streams = audio_streams(prepared_probe)
+    final_audio_streams = audio_streams(final_probe)
+    final_video_streams = [stream for stream in final_probe.get("streams", []) if stream.get("codec_type") == "video"]
+    final_subtitle_streams = [
+        stream for stream in final_probe.get("streams", []) if stream.get("codec_type") == "subtitle"
+    ]
+
+    actual_codecs = tuple(str(stream.get("codec_name")) for stream in prepared_audio_streams)
+    if actual_codecs != case.expected_codecs:
+        raise RuntimeError(f"{case.filename}: expected prepared codecs {case.expected_codecs}, found {actual_codecs}")
+    if tuple(str(stream.get("codec_name")) for stream in final_audio_streams) != case.expected_codecs:
+        raise RuntimeError(f"{case.filename}: final mux changed the expected audio codecs")
+    if [stream.get("channels") for stream in final_audio_streams] != [6, 2]:
+        raise RuntimeError(f"{case.filename}: expected 5.1 and stereo audio tracks")
+    if [stream.get("tags", {}).get("language") for stream in final_audio_streams] != ["eng", "fra"]:
+        raise RuntimeError(f"{case.filename}: expected English and French audio metadata")
+    expected_titles = ["Validation Main 5.1", "Validation Alternate Stereo"]
+    if [stream_summary(stream)["title"] for stream in prepared_audio_streams] != expected_titles:
+        raise RuntimeError(f"{case.filename}: prepared audio did not preserve source track titles")
+    if len(final_video_streams) != 1 or final_video_streams[0].get("codec_name") != "hevc":
+        raise RuntimeError(f"{case.filename}: expected one HEVC video stream")
+    if len(final_subtitle_streams) != 1 or final_subtitle_streams[0].get("codec_name") != "mov_text":
+        raise RuntimeError(f"{case.filename}: expected one selectable mov_text subtitle stream")
+    final_duration = float(final_probe["format"]["duration"])
+    if abs(final_duration - DURATION_SECONDS) > 0.05:
+        raise RuntimeError(f"{case.filename}: expected a {DURATION_SECONDS}-second final movie")
+    for stream in final_probe.get("streams", []):
+        start_time = float(stream.get("start_time", 0))
+        duration = float(stream.get("duration", final_duration))
+        if abs(start_time) > 0.01 or abs(duration - DURATION_SECONDS) > 0.05:
+            raise RuntimeError(f"{case.filename}: stream timing is not aligned for the lip-sync gate")
+
+    main_track_info = mp4box_track_section(final_path, 2)
+    alternate_track_info = mp4box_track_section(final_path, 3)
+    if "Track flags: Enabled In Movie" not in main_track_info or "Alternate Group ID 1" not in main_track_info:
+        raise RuntimeError(f"{case.filename}: main audio track is not the enabled alternate-group default")
+    if (
+        "Track flags: Disabled In Movie" not in alternate_track_info
+        or "Alternate Group ID 1" not in alternate_track_info
+    ):
+        raise RuntimeError(f"{case.filename}: alternate audio track is not disabled in the audio alternate group")
+    if "name: 'Validation Main 5.1'" not in main_track_info:
+        raise RuntimeError(f"{case.filename}: final mux did not preserve the main audio title")
+    if "name: 'Validation Alternate Stereo'" not in alternate_track_info:
+        raise RuntimeError(f"{case.filename}: final mux did not preserve the alternate audio title")
+
+    source_fingerprints = [packet_fingerprint(source_path, index) for index in range(2)]
+    prepared_fingerprints = [packet_fingerprint(prepared_audio_path, index) for index in range(2)]
+    final_fingerprints = [packet_fingerprint(final_path, index) for index in range(2)]
+    prepared_decoded_fingerprints = [decoded_audio_fingerprint(prepared_audio_path, index) for index in range(2)]
+    final_decoded_fingerprints = [decoded_audio_fingerprint(final_path, index) for index in range(2)]
+    if prepared_decoded_fingerprints != final_decoded_fingerprints:
+        raise RuntimeError(f"{case.filename}: final mux changed decoded audio samples")
+    if case.mode is not AudioMode.PCM and prepared_fingerprints != final_fingerprints:
+        raise RuntimeError(f"{case.filename}: final mux changed prepared audio packet payloads")
+    if case.expected_action == "copy_aac" and source_fingerprints != prepared_fingerprints:
+        raise RuntimeError(f"{case.filename}: Automatic did not preserve qualified AAC packet payloads")
+    if case.filename.startswith("02-") and source_fingerprints[1] == prepared_fingerprints[1]:
+        raise RuntimeError(f"{case.filename}: Automatic fallback did not convert the qualified AAC sibling track")
+
+    warning_codes = [warning.fields.get("code") for warning in recorder.warnings]
+    if case.filename.startswith("02-"):
+        if warning_codes != ["audio_automatic_fallback_to_aac"]:
+            raise RuntimeError(f"{case.filename}: missing structured Automatic fallback warning")
+    elif warning_codes:
+        raise RuntimeError(f"{case.filename}: unexpected warnings: {warning_codes}")
+
+    split_directory = case_directory / "spatial-split"
+    split_directory.mkdir()
+    run(
+        [
+            config.SPATIAL_MEDIA_PATH,
+            "split",
+            "--input-file",
+            final_path,
+            "--output-dir",
+            split_directory,
+        ]
+    )
+    split_outputs = sorted(path.name for path in split_directory.glob("*.mov"))
+    if len(split_outputs) != 2:
+        raise RuntimeError(f"{case.filename}: spatial split did not produce left and right views")
+
+    return {
+        "file": final_path.name,
+        "label": case.label,
+        "audio_mode": case.mode.value,
+        "expected_action": case.expected_action,
+        "sha256": file_sha256(final_path),
+        "bytes": final_path.stat().st_size,
+        "duration_seconds": final_duration,
+        "source_audio": [stream_summary(stream) for stream in audio_streams(source_probe)],
+        "prepared_audio": [stream_summary(stream) for stream in prepared_audio_streams],
+        "final_audio": [stream_summary(stream) for stream in final_audio_streams],
+        "source_packet_fingerprints": source_fingerprints,
+        "prepared_packet_fingerprints": prepared_fingerprints,
+        "prepared_decoded_fingerprints": prepared_decoded_fingerprints,
+        "final_decoded_fingerprints": final_decoded_fingerprints,
+        "warnings": [asdict(warning) for warning in recorder.warnings],
+        "spatial_split_outputs": split_outputs,
+        "mp4box_audio_tracks_verified": True,
+    }
+
+
+def build_fixture(
+    case: FixtureCase,
+    source_path: Path,
+    spatial_path: Path,
+    output_directory: Path,
+    work_directory: Path,
+) -> dict[str, object]:
+    case_directory = work_directory / case.filename.removesuffix(".mov")
+    case_directory.mkdir()
+    subtitle_path = case_directory / "validation.eng.srt"
+    write_subtitles(subtitle_path, case)
+    recorder = WarningRecorder()
+
+    config.audio_mode = case.mode
+    config.audio_bitrate = 384
+    config.start_stage = Stage.TRANSCODE_AUDIO
+    if case.mode is AudioMode.PCM:
+        prepared_audio_path = case_directory / "validation_audio_PCM.mov"
+        extract_mvc_and_audio(source_path, None, prepared_audio_path)
+    else:
+        prepared_audio_path = create_prepared_audio_file(source_path, case_directory, recorder)
+
+    final_path = output_directory / case.filename
+    mux_video_audio_subs(spatial_path, prepared_audio_path, final_path, case_directory)
+    return validate_fixture(case, source_path, prepared_audio_path, final_path, recorder, case_directory)
+
+
+def render_checklist(manifest_entries: list[dict[str, object]]) -> str:
+    fixture_rows = "\n".join(f"| [ ] | `{entry['file']}` | {entry['label']} | Notes: |" for entry in manifest_entries)
+    return f"""# Apple Vision Pro Audio Validation
+
+Generated fixtures are {DURATION_SECONDS} seconds long. A white flash occurs once per second.
+
+## Per-Fixture Gate
+
+1. Open the movie and select **Open Spatial View**.
+2. Confirm decode support is **Supported**, player and rendering are **Ready**, and actual presentation is **spatial**.
+3. Confirm depth is comfortable and not inverted; the left eye must remain primary.
+4. Enable English subtitles and play the default English 5.1 track. Each channel beep must align with the white flash.
+5. Seek to **Beginning**, **Middle**, and **End** twice. Playback must resume without drift, silence,
+   or loss of spatial mode.
+6. Switch to the French alternate stereo track. The sound must change to alternating left/right higher-pitched beeps.
+7. Switch back to English 5.1 and confirm the six-position sequence returns.
+
+| Pass | Fixture | Pipeline path | Result |
+| --- | --- | --- | --- |
+{fixture_rows}
+
+## Acceptance Notes
+
+- Automatic copy has no fallback warning and preserves both qualified AAC packet payloads.
+- Automatic fallback emits `audio_automatic_fallback_to_aac` and converts both the AC-3 track and its
+  qualified AAC sibling.
+- Convert AAC converts both E-AC-3 and FLAC source tracks to AAC.
+- PCM extracts both source tracks as 24-bit PCM.
+- `manifest.json` records hashes, stream metadata, packet fingerprints, warnings, and successful left/right
+  spatial splits.
+
+## Final Decision
+
+- [ ] All four fixtures pass spatial presentation, seeking, lip-sync, track switching, and audible surround checks.
+- [ ] No fixture produces a playback failure, unexplained silence, or mislabeled media option.
+
+Notes:
+
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create the physical Vision Pro audio validation fixture matrix.")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--force", action="store_true", help="Replace an existing output directory.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_directory = args.output.expanduser().resolve()
+    require_tools()
+    prepare_output_directory(output_directory, args.force)
+    config.configure_tool_environment()
+
+    work_directory = output_directory / ".work"
+    work_directory.mkdir()
+    spatial_path = create_spatial_video(work_directory)
+    sources = create_source_set(work_directory)
+    entries = [
+        build_fixture(case, sources[case.source_name], spatial_path, output_directory, work_directory)
+        for case in FIXTURE_CASES
+    ]
+    manifest = {
+        "schema_version": 1,
+        "duration_seconds": DURATION_SECONDS,
+        "video": {
+            "codec": "MV-HEVC",
+            "dimensions": f"{VIDEO_WIDTH}x{VIDEO_HEIGHT}",
+            "frame_rate": FRAME_RATE,
+            "left_is_primary": True,
+            "horizontal_field_of_view": 90,
+        },
+        "fixtures": entries,
+    }
+    (output_directory / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    (output_directory / "CHECKLIST.md").write_text(render_checklist(entries), encoding="utf-8")
+    shutil.rmtree(work_directory)
+    print(f"Created and verified {len(entries)} Vision Pro fixtures in {output_directory}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_spatial_audio_validation_fixtures.py
+++ b/scripts/create_spatial_audio_validation_fixtures.py
@@ -164,6 +164,8 @@ def create_spatial_video(work_directory: Path) -> Path:
             "--left-is-primary",
             "--horizontal-field-of-view",
             "90",
+            "--horizontal-disparity-adjustment",
+            "0",
             "--output-file",
             spatial_path,
         ]
@@ -621,6 +623,7 @@ def main() -> None:
             "frame_rate": FRAME_RATE,
             "left_is_primary": True,
             "horizontal_field_of_view": 90,
+            "horizontal_disparity_adjustment": 0,
         },
         "fixtures": entries,
     }

--- a/scripts/create_spatial_playback_fixture.sh
+++ b/scripts/create_spatial_playback_fixture.sh
@@ -33,6 +33,7 @@ ffmpeg -hide_banner -loglevel error -f lavfi -i 'testsrc2=size=656x360:rate=30' 
 	--quality 60 \
 	--left-is-primary \
 	--horizontal-field-of-view 90 \
+	--horizontal-disparity-adjustment 0 \
 	--output-file "$work_dir/spatial.mov"
 
 ffmpeg -hide_banner -loglevel error -f lavfi -i 'sine=frequency=880:sample_rate=48000' -t 6 -c:a aac -b:a 192k -metadata:s:a:0 language=eng -y "$work_dir/audio.m4a"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -282,7 +282,10 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertEqual(results[8].reason, "sample_rate_missing")
 
     def test_transcode_audio_maps_requested_stream_selector(self) -> None:
-        with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
+        with (
+            patch.object(audio, "audio_handler_metadata_options", return_value={}),
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
             audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384, "a:0")
 
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
@@ -291,13 +294,35 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertIn("-map_metadata", command)
 
     def test_copy_audio_maps_all_audio_tracks_without_encoder(self) -> None:
-        with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
+        with (
+            patch.object(audio, "audio_handler_metadata_options", return_value={}),
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
             audio.copy_audio(Path("source.mkv"), Path("audio.m4a"))
 
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
         self.assertIn("0:a", command)
         self.assertIn("copy", command)
         self.assertIn("file:audio.m4a", command)
+
+    def test_audio_preparation_preserves_stream_titles_as_handler_names(self) -> None:
+        with (
+            patch.object(audio, "audio_handler_metadata_options") as metadata_options,
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            metadata_options.return_value = {
+                "metadata:s:a:0": "handler_name=Main 5.1",
+                "metadata:s:a:1": "handler_name=Alternate Stereo",
+            }
+            audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384)
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertIn("-metadata:s:a:0", command)
+        self.assertIn("handler_name=Main 5.1", command)
+        self.assertIn("-metadata:s:a:1", command)
+        self.assertIn("handler_name=Alternate Stereo", command)
+        self.assertNotIn("-metadata:s:a:2", command)
+        metadata_options.assert_called_once_with(Path("source.mkv"), "a")
 
 
 def audio_qualification(

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -14,6 +14,7 @@ class AudioExtractionTests(unittest.TestCase):
     def test_subtitle_filter_does_not_limit_extracted_audio_tracks(self) -> None:
         with (
             patch.object(container.config, "remove_extra_languages", True),
+            patch.object(container, "get_audio_stream_data", return_value=[]),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
             container.extract_mvc_and_audio(Path("source.mkv"), None, Path("audio.mov"))
@@ -21,6 +22,26 @@ class AudioExtractionTests(unittest.TestCase):
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
         self.assertIn("0:a", command)
         self.assertNotIn("0:a:0", command)
+
+    def test_pcm_extraction_preserves_audio_titles_as_handler_names(self) -> None:
+        with (
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {"tags": {"title": "Main 5.1"}},
+                    {"tags": {"name": "Alternate Stereo"}},
+                ],
+            ),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            container.extract_mvc_and_audio(Path("source.mkv"), None, Path("audio.mov"))
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0][0])
+        self.assertIn("-metadata:s:a:0", command)
+        self.assertIn("handler_name=Main 5.1", command)
+        self.assertIn("-metadata:s:a:1", command)
+        self.assertIn("handler_name=Alternate Stereo", command)
 
     def test_direct_pipeline_skips_intermediate_video_and_pcm(self) -> None:
         with (
@@ -55,6 +76,7 @@ class AudioExtractionTests(unittest.TestCase):
             patch.object(container.config, "audio_mode", AudioMode.PCM),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "audio_handler_metadata_options", return_value={}),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
             audio_path, video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
@@ -224,6 +246,60 @@ class MuxCommandTests(unittest.TestCase):
 
         command = run_command.call_args.args[0]
         self.assertIn("2:type=name:str='Director Commentary'", command)
+
+    def test_final_mux_uses_preserved_handler_name_as_audio_title(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {
+                        "index": 0,
+                        "tags": {"language": "eng", "handler_name": "Main 5.1"},
+                        "channels": 6,
+                    }
+                ],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("Movie_audio_AAC.m4a"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("2:type=name:str='Main 5.1'", command)
+
+    def test_final_mux_uses_channel_count_when_layout_and_title_are_missing(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(
+                container,
+                "get_audio_stream_data",
+                return_value=[
+                    {
+                        "index": 0,
+                        "tags": {"language": "eng", "handler_name": "SoundHandler"},
+                        "channels": 6,
+                    }
+                ],
+            ),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("Movie_audio_AAC.m4a"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("2:type=name:str='English 6-channel Audio'", command)
 
     def test_final_mux_normalizes_bibliographic_audio_language(self) -> None:
         with (

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -97,6 +97,20 @@ class NativeMvcCommandTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "8-bit"):
             video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
+    def test_mv_hevc_merge_writes_neutral_stereo_disparity_metadata(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.object(video.config, "SPATIAL_MEDIA_PATH", Path("/tools/spatial-media-kit-tool")),
+            patch.object(video.config, "mv_hevc_quality", 75),
+            patch.object(video.config, "fov", 90),
+            patch.object(video, "run_command", return_value="") as run_command,
+        ):
+            video.combine_to_mv_hevc(Path("left.mov"), Path("right.mov"), Path(temp_dir) / "spatial.mov", 8)
+
+        command = run_command.call_args.args[0]
+        disparity_option = command.index("--horizontal-disparity-adjustment")
+        self.assertEqual(str(command[disparity_option + 1]), "0")
+
 
 class NativeMvcSelectionTests(unittest.TestCase):
     def test_direct_pipeline_keeps_streamed_source_file(self) -> None:


### PR DESCRIPTION
## Summary
- add a reproducible four-file physical Apple Vision Pro validation matrix for Automatic AAC copy, Automatic whole-set fallback, explicit AAC conversion, and PCM
- generate synchronized white-flash/channel-beep fixtures with two selectable audio tracks, 5.1 coverage, subtitles, repeated-seek length, packet/sample hashes, MP4Box default/alternate-group checks, and MV-HEVC left/right split verification
- preserve source audio titles as M4A/MOV handler metadata through copy, transcode, and PCM extraction; ignore generic `SoundHandler` labels and use truthful channel-count fallback names
- write an explicit neutral horizontal disparity adjustment in production and fixture MV-HEVC generation so AVFoundation exposes QuickTime stereo metadata
- document signed-device generation and transfer commands

## Validation
- 528 Python tests passed, 2 skipped
- targeted neutral-disparity regression test passed after independent review fixes
- Ruff format/check passed on changed Python files
- mypy passed on changed source files
- ShellCheck passed on the fixture shell script
- all four finalized fixtures generated and passed codec, title, language, channel count, timing, fallback-warning, packet/sample integrity, alternate-group, and spatial split checks
- AVFoundation reported `com.apple.quicktime.video.stereo-metadata` for every finalized fixture
- signed `SpatialPlaybackProbe` built and installed on physical Apple Vision Pro `4E8627DA-A354-5A74-93CF-61F3D17CE324`
- fixture hashes matched after round-trip transfer from the headset app container
- physical launch reported stereo MV-HEVC decode support, 24.000-second duration, two audio options, two subtitle options, ready AVPlayerItem, and ready RealityKit rendering
- changed-files PyCharm inspection was inconclusive because the IDE helper returned stale results after its built-in retry; independent focused reviews found only test-isolation/type-assertion issues, both corrected in `ee7ae1d`

## Physical Evidence And Remaining Gate
The physical session displayed the stereoscopic test pattern in preview, and the user reported that audio and the other exercised controls appeared to work. Entering the experimental RealityKit spatial portal hid the video until **Close Spatial View** was selected. That portal lifecycle defect and the unvalidated two-window experiments are isolated in #248 and draft PR #249.

This PR intentionally does not claim successful portal presentation or a formally recorded pass of surround placement, flash/beep lip-sync after repeated seeks, and both audio-track selections for every fixture. Those remaining human-observable audio acceptance checks continue to gate #56, without blocking this validated fixture/metadata slice.

Refs #200
Refs #248
Refs #56
