### PR TITLE
Add optional software AV1 stereo export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ file compatible with the Apple Vision Pro. It uses FFmpeg, MakeMKV, and a bundle
 extraction, audio transcoding, and video stream merging to convert from Mpeg 4 MVC 3D video to MV-HEVC 3D video. The
 tool also injects 360° metadata
 into the video file for spatial media playback. You have the option of AI upscaling the video to 4K resolution and AI
-OCR of subtitles.
+OCR of subtitles. MV-HEVC remains the default native Apple spatial output; an opt-in software AV1 mode produces a
+full-resolution side-by-side stereo MOV for storage-conscious and custom-playback workflows.
 
-The videos will play directly in the Files or
+The default MV-HEVC videos play directly in the Files or
 [Screenlit](https://apps.apple.com/us/app/screenlit/id6499478407) app on the AVP.
+AV1 stereo playback depends on the device generation and player; see the
+feasibility record before choosing it for headset delivery.
 
 ## Screenshots
 
@@ -34,8 +37,8 @@ automatic minimum-materialization behavior and the durable `--keep-files`
 stage contracts.
 
 See [AV1 Stereo Feasibility](docs/av1-stereo-feasibility.md) for the
-evidence-backed decision to keep MV-HEVC as the native Apple spatial-video
-output instead of adding an AV1 mode.
+standards evidence, Apple metadata probe, and boundaries between native
+MV-HEVC spatial output and software AV1 stereo export.
 
 ## Terminal install or update (power users)
 

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -13,6 +13,7 @@ from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.preview_range import PreviewRange
 from bd_to_avp.modules.languages import LanguageCodeError, normalize_language_code
 from bd_to_avp.modules.util import get_pyproject_data
+from bd_to_avp.modules.video_mode import VideoMode
 
 
 SCRIPT_PATH = Path(__file__).parent.parent
@@ -183,6 +184,8 @@ class Config:
     FX_UPSCALE_PATH = SCRIPT_PATH_BIN / "fx-upscale"
 
     FINAL_FILE_TAG = "_AVP"
+    AV1_FINAL_FILE_TAG = "_AV1_Stereo"
+    AV1_PRESET = 9
     IMAGE_EXTENSIONS: ClassVar[list[str]] = [".iso", ".img", ".bin"]
     MTS_EXTENSIONS: ClassVar[list[str]] = [".mts", ".m2ts"]
 
@@ -196,6 +199,8 @@ class Config:
         self.overwrite = False
         self.audio_mode = AudioMode.PCM
         self.audio_bitrate = 384
+        self.video_mode = VideoMode.MV_HEVC
+        self.av1_crf = 32
         self.left_right_bitrate = 20
         self.link_quality = True
         self.mv_hevc_quality = 75
@@ -314,6 +319,8 @@ class Config:
                         setattr(self, key, Stage.get_stage(int(stage_value)))
                     elif attribute_type is AudioMode:
                         setattr(self, key, AudioMode(config_parser.get("Options", key)))
+                    elif attribute_type is VideoMode:
+                        setattr(self, key, VideoMode(config_parser.get("Options", key)))
                     else:
                         value = config_parser.get("Options", key)
                         if key == "language_code":
@@ -380,6 +387,18 @@ class Config:
             "--skip-subtitles",
             action="store_true",
             help="Skip extracting subtitles from MKV.",
+        )
+        parser.add_argument(
+            "--video-mode",
+            choices=[mode.value for mode in VideoMode],
+            help="Video output mode: mv_hevc for native Apple spatial video or av1_sbs for software AV1 stereo.",
+        )
+        parser.add_argument(
+            "--av1-crf",
+            type=int,
+            choices=range(0, 64),
+            metavar="0-63",
+            help="SVT-AV1 constant-rate factor for AV1 stereo output. Lower values produce higher quality.",
         )
         parser.add_argument(
             "--left-right-bitrate",
@@ -498,6 +517,12 @@ class Config:
             self.audio_mode = AudioMode(args.audio_mode)
         elif args.transcode_audio:
             self.audio_mode = AudioMode.CONVERT_AAC
+        if args.video_mode:
+            self.video_mode = VideoMode(args.video_mode)
+
+    @property
+    def final_file_tag(self) -> str:
+        return self.AV1_FINAL_FILE_TAG if self.video_mode is VideoMode.AV1_SBS else self.FINAL_FILE_TAG
 
 
 config = Config()

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -12,6 +12,7 @@ from bd_to_avp.modules.config import (
 from bd_to_avp.modules.command import run_command, run_ffmpeg_print_errors
 from bd_to_avp.modules.languages import language_name, normalize_source_language
 from bd_to_avp.modules.util import sorted_files_by_creation_filtered_on_suffix
+from bd_to_avp.modules.video_mode import VideoMode
 
 
 def extract_mvc_and_audio(
@@ -37,13 +38,13 @@ def extract_mvc_and_audio(
 
 def create_muxed_file(
     audio_path: Path,
-    mv_hevc_path: Path,
+    video_path: Path,
     output_folder: Path,
     disc_name: str,
 ) -> Path:
-    muxed_path = output_folder / f"{disc_name}{config.FINAL_FILE_TAG}.mov"
+    muxed_path = output_folder / f"{disc_name}{config.final_file_tag}.mov"
     if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
-        mux_video_audio_subs(mv_hevc_path, audio_path, muxed_path, output_folder)
+        mux_video_audio_subs(video_path, audio_path, muxed_path, output_folder)
     return muxed_path
 
 
@@ -70,19 +71,20 @@ def create_mvc_and_audio(
     )
 
 
-def mux_video_audio_subs(mv_hevc_path: Path, audio_path: Path, muxed_path: Path, output_folder: Path) -> None:
+def mux_video_audio_subs(video_path: Path, audio_path: Path, muxed_path: Path, output_folder: Path) -> None:
     audio_streams = get_audio_stream_data(audio_path)
     has_declared_audio_default = any(
         int(stream.get("disposition", {}).get("default", 0) or 0) == 1 for stream in audio_streams
     )
     output_track_index = 1
+    video_import = f"{video_path}:forcesync" if config.video_mode is VideoMode.MV_HEVC else video_path
     command = [
         config.MP4BOX_PATH,
         "-new",
         "-add",
         # QuickTime and AVP seeking depend on a useful sync sample table. MP4Box can
         # collapse imported MV-HEVC tracks to one sync sample unless this is forced.
-        f"{mv_hevc_path}:forcesync",
+        video_import,
     ]
     output_track_index += 1
     for audio_position, stream in enumerate(audio_streams):

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -21,7 +21,10 @@ from bd_to_avp.modules.file import (
 )
 from bd_to_avp.modules.preview import create_bounded_preview_source
 from bd_to_avp.modules.sub import create_srt_from_mkv, SRTCreationError
+from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.modules.video import (
+    create_av1_sbs_file,
+    create_av1_stereo_file,
     create_left_right_files,
     create_mv_hevc_file,
     detect_crop_parameters,
@@ -98,9 +101,9 @@ def conversion_stage_plan() -> tuple[str, ...]:
     if not config.skip_subtitles and config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
         stages.append("extract_subtitles")
     if config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
-        stages.append("create_left_right_files")
+        stages.append("encode_av1_stereo" if config.video_mode is VideoMode.AV1_SBS else "create_left_right_files")
     if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
-        stages.append("combine_to_mv_hevc")
+        stages.append("finalize_av1_stereo" if config.video_mode is VideoMode.AV1_SBS else "combine_to_mv_hevc")
     if config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
         stages.append("upscale_video")
     if config.audio_mode.prepares_m4a and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
@@ -184,6 +187,10 @@ def process_each(
     selected_title_id: str | None = None,
 ) -> Path:
     raise_if_cancelled(cancellation_event)
+    if config.video_mode is VideoMode.AV1_SBS and config.fx_upscale:
+        raise ValueError("AV1 stereo export does not support AI FX upscale.")
+    if config.video_mode is VideoMode.AV1_SBS and config.resolution:
+        raise ValueError("AV1 stereo export always preserves full source resolution per eye.")
     print(f"\nProcessing {config.source_path or config.source_str}")
     if config.start_stage is Stage.MOVE_FILES:
         muxed_output_path = completed_mux_path_for_move()
@@ -221,7 +228,7 @@ def process_each(
     if activity:
         activity.log("Temporary workspace ready", stage="inspect_source", path=os.environ["TMPDIR"])
 
-    completed_path = config.output_root_path / f"{disc_info.name}{config.FINAL_FILE_TAG}.mov"
+    completed_path = config.output_root_path / f"{disc_info.name}{config.final_file_tag}.mov"
     if not config.overwrite and file_exists_normalized(completed_path):
         raise FileExistsError(f"Output file already exists for {disc_info.name}. Use --overwrite to replace.")
 
@@ -267,19 +274,28 @@ def process_each(
         (lambda message: activity.warning(message, stage="extract_subtitles") if activity else None),
     )
     raise_if_cancelled(cancellation_event)
-    if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
-        activity.stage_started("create_left_right_files", "Creating left and right eye video")
-    left_output_path, right_output_path = create_left_right_files(
-        disc_info, output_folder, video_output_path, crop_params
-    )
-    raise_if_cancelled(cancellation_event)
-    if activity and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
-        activity.stage_started("combine_to_mv_hevc", "Combining stereo video into MV-HEVC")
-    mv_hevc_path = create_mv_hevc_file(left_output_path, right_output_path, output_folder, disc_info)
+    if config.video_mode is VideoMode.AV1_SBS:
+        if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+            activity.stage_started("encode_av1_stereo", "Encoding side-by-side AV1 stereo video")
+        av1_sbs_path = create_av1_sbs_file(disc_info, output_folder, video_output_path, crop_params)
+        raise_if_cancelled(cancellation_event)
+        if activity and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+            activity.stage_started("finalize_av1_stereo", "Adding Apple stereo metadata to AV1 video")
+        video_path = create_av1_stereo_file(av1_sbs_path, output_folder, disc_info)
+    else:
+        if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+            activity.stage_started("create_left_right_files", "Creating left and right eye video")
+        left_output_path, right_output_path = create_left_right_files(
+            disc_info, output_folder, video_output_path, crop_params
+        )
+        raise_if_cancelled(cancellation_event)
+        if activity and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+            activity.stage_started("combine_to_mv_hevc", "Combining stereo video into MV-HEVC")
+        video_path = create_mv_hevc_file(left_output_path, right_output_path, output_folder, disc_info)
     raise_if_cancelled(cancellation_event)
     if activity and config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
         activity.stage_started("upscale_video", "Upscaling video")
-    mv_hevc_path = create_upscaled_file(mv_hevc_path)
+    video_path = create_upscaled_file(video_path)
 
     raise_if_cancelled(cancellation_event)
     if activity and config.audio_mode.prepares_m4a and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
@@ -287,10 +303,10 @@ def process_each(
     audio_output_path = create_transcoded_audio_file(audio_output_path, output_folder, activity)
     raise_if_cancelled(cancellation_event)
     if activity and config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
-        activity.stage_started("create_final_file", "Muxing final spatial video")
+        activity.stage_started("create_final_file", "Muxing final stereo video")
     muxed_output_path = create_muxed_file(
         audio_output_path,
-        mv_hevc_path,
+        video_path,
         output_folder,
         disc_info.name,
     )
@@ -303,7 +319,7 @@ def completed_mux_path_for_move() -> Path:
     source_path = config.source_path
     if source_path is not None:
         source_name = source_path.stem
-        source_candidate = output_root / source_name / f"{source_name}{config.FINAL_FILE_TAG}.mov"
+        source_candidate = output_root / source_name / f"{source_name}{config.final_file_tag}.mov"
         if source_candidate.is_file():
             return source_candidate
 
@@ -311,7 +327,7 @@ def completed_mux_path_for_move() -> Path:
         candidate
         for output_folder in output_root.iterdir()
         if output_folder.is_dir()
-        for candidate in [output_folder / f"{output_folder.name}{config.FINAL_FILE_TAG}.mov"]
+        for candidate in [output_folder / f"{output_folder.name}{config.final_file_tag}.mov"]
         if candidate.is_file()
     )
     if len(candidates) == 1:

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -57,6 +57,9 @@ NATIVE_MVC_RETRY_SIGNALS = {
     signal.SIGILL,
     signal.SIGSEGV,
 }
+AV1_STEREO_VEXU_CONTENT_HEX = (
+    "00000015657965730000000D737472690000000003000000187061636B00000010706B696E0000000073696465"
+)
 
 
 def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threaded: bool = False) -> list[str | Path]:
@@ -167,6 +170,57 @@ def generate_native_mvc_ffmpeg_command(
     return [arg if arg != "pipe:0" else "-" for arg in command]
 
 
+def generate_native_mvc_av1_command(
+    output_path: Path,
+    disc_info: DiscInfo,
+    crop_params: str,
+) -> list[str]:
+    if disc_info.color_depth != 8:
+        raise ValueError("Native MVC splitting currently supports 8-bit 4:2:0 Blu-ray MVC sources only.")
+
+    source_width, source_height = parse_resolution(config.resolution or disc_info.resolution)
+    stream = ffmpeg.input(
+        "pipe:0",
+        f="yuv4mpegpipe",
+        r=config.frame_rate or disc_info.frame_rate,
+    )
+    split_streams = ffmpeg.filter_multi_output(stream, "split", 2)
+    left_stream = ffmpeg.filter(split_streams[0], "crop", source_width, source_height, 0, 0)
+    right_stream = ffmpeg.filter(split_streams[1], "crop", source_width, source_height, source_width, 0)
+
+    if crop_params:
+        left_stream = ffmpeg.filter(left_stream, "crop", *crop_params.split(":"))
+        right_stream = ffmpeg.filter(right_stream, "crop", *crop_params.split(":"))
+
+    if disc_info.is_interlaced:
+        left_stream = ffmpeg.filter(left_stream, "bwdif")
+        right_stream = ffmpeg.filter(right_stream, "bwdif")
+
+    if config.swap_eyes:
+        left_stream, right_stream = right_stream, left_stream
+
+    packed_stream = ffmpeg.filter([left_stream, right_stream], "hstack", inputs=2)
+    output = ffmpeg.output(
+        packed_stream,
+        f"file:{output_path}",
+        **{
+            "vcodec": "libsvtav1",
+            "bsf:v": ("av1_metadata=color_primaries=1:transfer_characteristics=1:matrix_coefficients=1:color_range=tv"),
+            "crf": config.av1_crf,
+            "preset": config.AV1_PRESET,
+            "pix_fmt": "yuv420p",
+            "color_primaries": "bt709",
+            "color_trc": "bt709",
+            "colorspace": "bt709",
+            "color_range": "tv",
+            "r": config.frame_rate or disc_info.frame_rate,
+            "movflags": "+faststart",
+        },
+    )
+    command = ffmpeg.compile(output, cmd=config.FFMPEG_PATH.as_posix(), overwrite_output=True)
+    return [arg if arg != "pipe:0" else "-" for arg in command]
+
+
 def parse_resolution(resolution: str) -> tuple[int, int]:
     width, height = resolution.lower().split("x", 1)
     return int(width), int(height)
@@ -180,12 +234,33 @@ def split_mvc_to_stereo_native(
     crop_params: str,
 ) -> tuple[Path, Path]:
     ffmpeg_command = generate_native_mvc_ffmpeg_command(left_output_path, right_output_path, disc_info, crop_params)
+    run_native_mvc_encoding(video_input_path, (left_output_path, right_output_path), ffmpeg_command)
+    return left_output_path, right_output_path
+
+
+def encode_mvc_to_av1_sbs_native(
+    video_input_path: Path,
+    output_path: Path,
+    disc_info: DiscInfo,
+    crop_params: str,
+) -> Path:
+    ffmpeg_command = generate_native_mvc_av1_command(output_path, disc_info, crop_params)
+    run_native_mvc_encoding(video_input_path, (output_path,), ffmpeg_command)
+    return output_path
+
+
+def run_native_mvc_encoding(
+    video_input_path: Path,
+    output_paths: tuple[Path, ...],
+    ffmpeg_command: list[str],
+) -> None:
+    primary_output_path = output_paths[0]
     stream_from_container = should_stream_mvc_from_container(video_input_path)
     producer_command = generate_mvc_annex_b_stream_command(video_input_path) if stream_from_container else None
     native_input_path = Path("-") if stream_from_container else prepare_native_mvc_input(video_input_path)
-    splitter_log_path = left_output_path.with_suffix(".native_mvc.log")
-    ffmpeg_log_path = left_output_path.with_suffix(".native_ffmpeg.log")
-    producer_log_path = left_output_path.with_suffix(".mvc_extract.log")
+    splitter_log_path = primary_output_path.with_suffix(".native_mvc.log")
+    ffmpeg_log_path = primary_output_path.with_suffix(".native_ffmpeg.log")
+    producer_log_path = primary_output_path.with_suffix(".mvc_extract.log")
     try:
         skip_multithreaded_attempt = False
         if not stream_from_container and should_probe_native_multithread_splitter():
@@ -224,8 +299,8 @@ def split_mvc_to_stereo_native(
                 raise
 
             print("Native MVC splitter crashed; retrying once in single-threaded mode.")
-            left_output_path.unlink(missing_ok=True)
-            right_output_path.unlink(missing_ok=True)
+            for output_path in output_paths:
+                output_path.unlink(missing_ok=True)
             run_native_mvc_split_attempt(
                 native_input_path,
                 ffmpeg_command,
@@ -242,8 +317,6 @@ def split_mvc_to_stereo_native(
     finally:
         if not stream_from_container and native_input_path != video_input_path:
             native_input_path.unlink(missing_ok=True)
-
-    return left_output_path, right_output_path
 
 
 def native_multithread_splitter_probe_crashed(native_input_path: Path, splitter_log_path: Path) -> bool:
@@ -488,6 +561,52 @@ def split_mvc_to_stereo(
     raise RuntimeError(explain_native_mvc_unavailable(disc_info))
 
 
+def encode_mvc_to_av1_sbs(
+    video_input_path: Path,
+    output_path: Path,
+    disc_info: DiscInfo,
+    crop_params: str,
+) -> Path:
+    if can_use_native_mvc_splitter(disc_info):
+        result = encode_mvc_to_av1_sbs_native(video_input_path, output_path, disc_info, crop_params)
+        if not config.keep_files:
+            output_path.with_suffix(".native_ffmpeg.log").unlink(missing_ok=True)
+            output_path.with_suffix(".native_mvc.log").unlink(missing_ok=True)
+            output_path.with_suffix(".mvc_extract.log").unlink(missing_ok=True)
+            if not should_stream_mvc_from_container(video_input_path):
+                video_input_path.unlink(missing_ok=True)
+        return result
+
+    raise RuntimeError(explain_native_mvc_unavailable(disc_info))
+
+
+def av1_stereo_patch_xml() -> str:
+    return (
+        '<?xml version="1.0"?>\n'
+        "<GPACBOXES>\n"
+        '  <Box path="trak.mdia.minf.stbl.stsd.av01.av1C+" trackID="1">\n'
+        '    <BS fcc="vexu"/>\n'
+        f'    <BS data="{AV1_STEREO_VEXU_CONTENT_HEX}"/>\n'
+        "  </Box>\n"
+        "</GPACBOXES>\n"
+    )
+
+
+def add_av1_stereo_metadata(input_path: Path, output_path: Path) -> None:
+    output_path.unlink(missing_ok=True)
+    file_descriptor, patch_name = tempfile.mkstemp(prefix="bd-to-avp-av1-stereo-", suffix=".xml")
+    os.close(file_descriptor)
+    patch_path = Path(patch_name)
+    try:
+        patch_path.write_text(av1_stereo_patch_xml(), encoding="utf-8")
+        run_command(
+            [config.MP4BOX_PATH, "-patch", patch_path, input_path, "-out", output_path],
+            "add Apple stereo packing metadata to AV1 video.",
+        )
+    finally:
+        patch_path.unlink(missing_ok=True)
+
+
 def combine_to_mv_hevc(
     left_video_path: Path,
     right_video_path: Path,
@@ -612,6 +731,18 @@ def create_left_right_files(
     return left_eye_output_path, right_eye_output_path
 
 
+def create_av1_sbs_file(
+    disc_info: DiscInfo,
+    output_folder: Path,
+    mvc_video: Path,
+    crop_params: str,
+) -> Path:
+    output_path = output_folder / f"{disc_info.name}_AV1-SBS-unmarked.mp4"
+    if config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+        encode_mvc_to_av1_sbs(mvc_video, output_path, disc_info, crop_params)
+    return output_path
+
+
 def get_video_color_depth(input_path: Path) -> int:
     try:
         probe = ffmpeg.probe(
@@ -642,6 +773,15 @@ def create_mv_hevc_file(
         left_video_path.unlink(missing_ok=True)
         right_video_path.unlink(missing_ok=True)
     return mv_hevc_path
+
+
+def create_av1_stereo_file(input_path: Path, output_folder: Path, disc_info: DiscInfo) -> Path:
+    output_path = output_folder / f"{disc_info.name}_AV1-Stereo.mp4"
+    if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+        add_av1_stereo_metadata(input_path, output_path)
+    if not config.keep_files:
+        input_path.unlink(missing_ok=True)
+    return output_path
 
 
 def create_upscaled_file(input_path: Path) -> Path:

--- a/bd_to_avp/modules/video_mode.py
+++ b/bd_to_avp/modules/video_mode.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class VideoMode(StrEnum):
+    MV_HEVC = "mv_hevc"
+    AV1_SBS = "av1_sbs"

--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from bd_to_avp.vendor.pgsrip.ocr import AppleVisionOcr, OcrError
 from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.video_mode import VideoMode
 
 
 class DependencyPreflightError(RuntimeError):
@@ -13,6 +14,7 @@ class DependencyPreflightError(RuntimeError):
 def verify_runtime_ready() -> None:
     missing_binaries = get_missing_dependency_binaries_for_current_job()
     if not missing_binaries:
+        verify_av1_encoder_ready()
         verify_apple_vision_ocr_ready()
         return
 
@@ -39,7 +41,7 @@ def get_required_dependency_binaries_for_current_job() -> list[Path]:
         required_paths.append(config.MAKEMKVCON_PATH)
     if needs_native_mvc_splitter():
         required_paths.append(config.EDGE264_TEST_PATH)
-    if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+    if config.video_mode is VideoMode.MV_HEVC and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
         required_paths.append(config.SPATIAL_MEDIA_PATH)
     if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         required_paths.append(config.MP4BOX_PATH)
@@ -130,6 +132,39 @@ def ensure_native_mvc_splitter_executable() -> bool:
     except OSError:
         return False
     return os.access(config.EDGE264_TEST_PATH, os.X_OK)
+
+
+def verify_av1_encoder_ready() -> None:
+    if config.video_mode is not VideoMode.AV1_SBS or config.start_stage.value > Stage.CREATE_LEFT_RIGHT_FILES.value:
+        return
+
+    import subprocess
+
+    try:
+        encoders = subprocess.run(
+            [config.FFMPEG_PATH, "-hide_banner", "-encoders"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+        bitstream_filters = subprocess.run(
+            [config.FFMPEG_PATH, "-hide_banner", "-bsfs"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as error:
+        raise DependencyPreflightError("FFmpeg could not verify the required AV1 encoding support.") from error
+    if "libsvtav1" not in encoders:
+        raise DependencyPreflightError(
+            "AV1 stereo export requires an FFmpeg build with the libsvtav1 software encoder."
+        )
+    if "av1_metadata" not in bitstream_filters:
+        raise DependencyPreflightError(
+            "AV1 stereo export requires an FFmpeg build with the av1_metadata bitstream filter."
+        )
 
 
 def verify_apple_vision_ocr_ready() -> None:

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -39,6 +39,8 @@ CONFIG_SNAPSHOT_FIELDS = (
     "overwrite",
     "audio_mode",
     "audio_bitrate",
+    "video_mode",
+    "av1_crf",
     "left_right_bitrate",
     "link_quality",
     "mv_hevc_quality",
@@ -400,6 +402,8 @@ def configured_conversion(
         config.overwrite = job.job.overwrite
         config.audio_mode = job.encoding.audio.mode
         config.audio_bitrate = job.encoding.audio.bitrate
+        config.video_mode = job.encoding.video_mode
+        config.av1_crf = job.encoding.av1_crf
         config.left_right_bitrate = job.encoding.left_right_bitrate
         config.link_quality = job.encoding.link_quality
         config.mv_hevc_quality = job.encoding.mv_hevc_quality

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -12,8 +12,9 @@ from uuid import UUID
 
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.languages import LanguageCodeError, normalize_language_code
+from bd_to_avp.modules.video_mode import VideoMode
 
-PROTOCOL_VERSION = 6
+PROTOCOL_VERSION = 7
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_EVENT_BYTES = 1024 * 1024
 MAX_DETAIL_BYTES = 64 * 1024
@@ -106,6 +107,8 @@ class SubtitleOptions:
 @dataclass(frozen=True)
 class EncodingOptions:
     audio: AudioOptions
+    video_mode: VideoMode
+    av1_crf: int
     left_right_bitrate: int
     link_quality: bool
     mv_hevc_quality: int
@@ -388,6 +391,8 @@ class JobSpec:
             )
         required_keys = {
             "audio",
+            "video_mode",
+            "av1_crf",
             "left_right_bitrate",
             "link_quality",
             "mv_hevc_quality",
@@ -401,8 +406,10 @@ class JobSpec:
             "subtitles",
         }
         cls._require_exact_keys(value, required_keys, "encoding", job_id)
-        return EncodingOptions(
+        encoding = EncodingOptions(
             audio=cls._parse_audio_options(value.get("audio"), job_id),
+            video_mode=cls._parse_video_mode(value.get("video_mode"), job_id),
+            av1_crf=cls._parse_int(value, "av1_crf", "encoding", job_id, minimum=0, maximum=63),
             left_right_bitrate=cls._parse_int(value, "left_right_bitrate", "encoding", job_id, minimum=1, maximum=500),
             link_quality=cls._parse_bool(value, "link_quality", "encoding", job_id),
             mv_hevc_quality=cls._parse_int(value, "mv_hevc_quality", "encoding", job_id, minimum=0, maximum=100),
@@ -415,6 +422,36 @@ class JobSpec:
             fx_upscale=cls._parse_bool(value, "fx_upscale", "encoding", job_id),
             subtitles=cls._parse_subtitle_options(value.get("subtitles"), job_id),
         )
+        if encoding.video_mode is VideoMode.AV1_SBS and encoding.fx_upscale:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "AV1 stereo export does not support AI FX upscale.",
+                job_id=job_id,
+            )
+        if encoding.video_mode is VideoMode.AV1_SBS and encoding.resolution:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "AV1 stereo export always preserves full source resolution per eye.",
+                job_id=job_id,
+            )
+        return encoding
+
+    @staticmethod
+    def _parse_video_mode(value: Any, job_id: str) -> VideoMode:
+        if not isinstance(value, str):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.video_mode must be a string.",
+                job_id=job_id,
+            )
+        try:
+            return VideoMode(value)
+        except ValueError as error:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"Unsupported encoding.video_mode: {value!r}.",
+                job_id=job_id,
+            ) from error
 
     @classmethod
     def _parse_audio_options(cls, value: Any, job_id: str) -> AudioOptions:

--- a/docs/av1-stereo-feasibility.md
+++ b/docs/av1-stereo-feasibility.md
@@ -2,12 +2,14 @@
 
 ## Decision
 
-BD_to_AVP should not add an AV1 output mode for stereoscopic or Apple spatial
-video.
+BD_to_AVP should offer an opt-in, software-encoded AV1 stereo export while
+retaining MV-HEVC as the default native Apple spatial-video output.
 
-AV1 can encode a frame-packed side-by-side or over-under raster, and the
-packaged FFmpeg build already contains software AV1 encoders. That does not make
-AV1 an interoperable replacement for MVC or MV-HEVC:
+AV1 can encode a full-resolution side-by-side raster, and the packaged FFmpeg
+build contains `libsvtav1`, `libaom-av1`, and `librav1e`. Apple's codec-agnostic
+ISOBMFF metadata can identify the packed eyes on an `av01` track. This makes a
+distinct AV1 stereo export viable, but it does not make AV1 an interoperable
+replacement for MV-HEVC spatial delivery:
 
 - AV1 spatial layers and operating points describe generic scalable video, not
   left-eye and right-eye views.
@@ -16,15 +18,15 @@ AV1 an interoperable replacement for MVC or MV-HEVC:
   stereoscopic playback.
 - Apple's native multi-image encode and decode APIs are explicitly MV-HEVC
   APIs. Apple documents MV-HEVC as the spatial-video delivery path.
-- Apple file-format metadata can describe frame-packed stereo for codecs other
-  than MV-HEVC, but there is no documented Apple playback contract that makes
-  frame-packed AV1 a RealityKit spatial video.
+- Apple file-format metadata describes frame-packed stereo for codecs other
+  than MV-HEVC. The corrected probe is recognized by AVFoundation as stereo
+  video, but not as multiview-compressed or spatial video.
 - AV1 hardware support is fragmented across the Apple devices this project
   targets, and Apple exposes no VideoToolbox AV1 encoder in the macOS 27 SDK.
 
-MV-HEVC therefore remains the only supported 3D output. A flat-compatible AV1
-side-by-side file could be revisited as a separate non-spatial export only if a
-concrete user need justifies another format and its support burden.
+MV-HEVC therefore remains the native Apple spatial output. AV1 is a separate
+software stereo export for storage-conscious or custom-playback workflows; the
+UI and documentation must not describe it as MV-HEVC or native spatial video.
 
 ## Standards Evidence
 
@@ -47,17 +49,18 @@ The binding defines `av01`, `av1C`, one temporal unit per sample, and AV1 sample
 groups, but no eye-view selector or multiview track relationship comparable to
 MVC or MV-HEVC.
 
-### Apple metadata does not prove Apple spatial playback
+### Apple metadata defines packed stereo independently of the codec
 
-Apple's [Stereo Video ISOBMFF Extensions][apple-stereo-isobmff] define
-`StereoVideoInfoBox` (`svmi`). The box can identify frame-packed side-by-side or
-over-under video, and the specification allows the descriptors to be used with
-codecs other than MV-HEVC.
+Apple's [Stereo Video ISOBMFF Extensions][apple-stereo-isobmff] define a
+`VideoExtendedUsageBox` (`vexu`) that applies to visual sample entries without
+requiring MV-HEVC. For full side-by-side video, `vexu` contains:
+
+- `eyes/stri`, which declares that the track carries left and right eye views;
+- `pack/pkin`, whose `side` value declares side-by-side packing.
 
 That metadata describes how two pictures are packed. It does not define AV1
-view prediction, and Apple does not document AV1 as an input to
-`VideoPlayerComponent`'s stereo spatial presentation. Apple's supported
-conversion guidance instead converts side-by-side 3D into
+inter-view prediction or make the stream multiview-compressed. Apple's native
+spatial-video conversion guidance still produces
 [MV-HEVC spatial video][apple-sbs-to-mvhevc].
 
 The macOS 27 SDK reinforces the distinction:
@@ -107,11 +110,13 @@ The pinned runtime tools provide only part of a hypothetical AV1 path:
 - `spatial-media-kit-tool` accepts per-eye HEVC and produces MV-HEVC. It is not
   an AV1 multiview packager.
 
-Basic AV1 encoding would not require adding another shipped codec binary, but a
-product implementation would still require a new video-mode contract across
-the CLI, worker protocol, profiles, both UIs, restart stages, summaries, tests,
-and clean-machine release gates. That cost is not justified by a flat output
-that cannot replace native spatial playback.
+The implemented AV1 path adds no runtime dependency. The native splitter feeds
+one FFmpeg `libsvtav1` encode, FFmpeg's `av1_metadata` bitstream filter writes
+limited-range BT.709 matrix/primary/transfer signaling, MP4Box applies the
+deterministic `vexu/eyes/pack` patch, and the existing MP4Box final mux adds
+audio and subtitles to the completed MOV. The CLI, worker protocol, persisted
+profiles, native UI, restart stages, summaries, tests, and release gates all
+carry the explicit mode without changing the MV-HEVC default.
 
 ## Reproducible Probes
 
@@ -196,31 +201,51 @@ FFprobe reported `stereo_mode=left_right` and `Stereo 3D: side by side`.
 AVFoundation rejected the file with `AVFoundationErrorDomain -11828` because
 WebM is not a supported native media container in this path.
 
-### Apple `svmi` metadata on AV1
+### Apple `vexu/eyes/pack` metadata on AV1
 
-The AV1 side-by-side MP4 was copied and patched with this GPAC box patch:
+The corrected probe patched the AV1 side-by-side MP4 with the current Apple box
+structure:
 
 ```xml
 <?xml version="1.0"?>
 <GPACBOXES>
   <Box path="trak.mdia.minf.stbl.stsd.av01.av1C+" trackID="1">
-    <BS fcc="svmi"/>
-    <BS data="000000000002"/>
+    <BS fcc="vexu"/>
+    <BS data="00000015657965730000000D737472690000000003000000187061636B00000010706B696E0000000073696465"/>
   </Box>
 </GPACBOXES>
 ```
 
-The `svmi` payload selects frame-packed side-by-side video with the left view
-first and permits a monoscopic fallback. MP4Box preserved it as a 14-byte child
-of the `av01` sample entry. The trailing `+` in the patch path inserts `svmi`
-after `av1C`, making the two boxes siblings within the sample entry.
+MP4Box 26.02 created a 53-byte `vexu` sibling after `av1C`, containing a 21-byte
+`eyes` box with mandatory `stri` and a 24-byte `pack` box with mandatory
+`pkin=side`. A second MP4Box pass that added the video to the final MOV preserved
+the complete unknown box tree.
 
-AVFoundation still decoded and sought the movie as one 640x180 image. The
-format description preserved `svmi` in `SampleDescriptionExtensionAtoms`, but
-did not expose left-eye, right-eye, or view-packing format-description values in
-the tested macOS path. This does not prove what a future or device-specific
-RealityKit renderer could do; it proves only that a valid packed AV1 file plus
-metadata is not equivalent to the documented MV-HEVC spatial pipeline.
+On macOS 27, AVFoundation exposed `HasLeftStereoEyeView = 1`,
+`HasRightStereoEyeView = 1`, and `ViewPackingKind = SideBySide` on the AV1 format
+description. `AVAssetPlaybackAssistant` returned
+`AVAssetPlaybackConfigurationOptionStereoVideo`; the bare AV1 control returned
+no playback configuration options. It did not return
+`StereoMultiviewVideo` or `SpatialVideo`.
+
+This proves an Apple-recognized packed-stereo asset contract. It does not prove
+stereoscopic rendering on every Apple Vision Pro generation; that device
+qualification remains separate in issue #200.
+
+### Implemented production-path probe
+
+On July 17, 2026, the production command generator encoded a native-splitter
+Y4M stream with bundled FFmpeg 8.1.2 and SVT-AV1 3.1.2, wrote the AV1 MP4
+intermediate, applied the `vexu/eyes/pack` patch with bundled MP4Box 26.02, and
+imported the marked track plus AAC audio into the final MOV. Packaged FFprobe
+reported one `av01` video track and one `mp4a` audio track. Beginning, middle,
+and end frames decoded successfully.
+
+The finalized AV1 stream reports limited range and BT.709 matrix, primaries,
+and transfer characteristics. MP4Box's box dump shows `vexu` as a sibling of
+`av1C`, containing `eyes/stri` and `pack/pkin=side`. AVFoundation reports both
+eye views and `ViewPackingKind = SideBySide`; `AVAssetPlaybackAssistant`
+returns only `StereoVideo`, not `StereoMultiviewVideo` or `SpatialVideo`.
 
 ### MV-HEVC control
 
@@ -230,36 +255,68 @@ video sample entry contained `hvcC`, `lhvC`, `vexu/eyes`, and `hfov`, and
 contract exercised by `SpatialPlaybackProbe` and remains the acceptance
 baseline.
 
-The tiny synthetic output sizes and encode times are intentionally not used as
-a compression-quality comparison. The codecs used different rate-control
-modes, and synthetic two-second clips do not predict feature-film quality,
-storage, or thermals.
+### Bounded default comparison
+
+A bounded product-path comparison used the same two-second, 48-frame,
+1920x1080-per-eye `testsrc2` source with a 16-pixel horizontal disparity for
+the right eye and the same 128 kbps AAC audio. Timing excluded source
+generation and included video encoding, mode-specific stereo finalization, and
+the final audio mux. Quality was measured per eye after decoding against the
+generated source, then averaged.
+
+| Mode | Product settings | Pipeline time | Final MOV size | Mean PSNR | Mean SSIM | AVFoundation playback options |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| MV-HEVC | VideoToolbox HEVC, 20 Mbps per eye, merge quality 75 | 2.201 s | 4,005,130 bytes | 59.934823 dB | 0.999850 | `StereoVideo`, `StereoMultiviewVideo` |
+| AV1 stereo | `libsvtav1`, preset 9, CRF 32, full side-by-side | 1.529 s | 3,688,383 bytes | 41.393707 dB | 0.993237 | `StereoVideo` |
+
+This is a pipeline sanity check, not a quality-matched codec comparison. The
+MV-HEVC path uses a fixed per-eye bitrate while AV1 uses CRF, the source is a
+short synthetic stress pattern, and fixed setup/mux overhead dominates such a
+short run. The result cannot predict feature-film speed, size, thermals, or
+subjective quality. It does show that both completed defaults are decodable and
+that CRF 32 trades measurable quality for the storage-oriented AV1 mode.
+
+The same source was swept at preset 9 to validate the exposed CRF control:
+
+| CRF | Encoded AV1 bytes | Mean PSNR | Mean SSIM |
+| ---: | ---: | ---: | ---: |
+| 20 | 6,414,286 | 43.268265 dB | 0.996338 |
+| 24 | 5,704,307 | 42.900199 dB | 0.995748 |
+| 28 | 4,709,320 | 42.283759 dB | 0.994744 |
+| 30 | 4,226,448 | 41.908174 dB | 0.994129 |
+| 32 | 3,656,352 | 41.393707 dB | 0.993237 |
+
+CRF 32 remains the storage-conscious default; users can lower it when quality
+matters more than output size. The sweep is still synthetic and is not a
+feature-film recommendation by itself.
 
 ## Result Matrix
 
 | Representation | Tool result | Apple-framework result | Product meaning |
 | --- | --- | --- | --- |
-| One side-by-side `av01` MP4 track | Encodes and muxes | Playable and seekable as 640x180 | Flat packed video |
-| Side-by-side `av01` plus `svmi` | Generic box patch works | Raw box preserved; still decoded as one packed image | Unqualified, undocumented spatial behavior |
+| One side-by-side `av01` MP4 track | Encodes and muxes | Playable and seekable as 640x180; no stereo playback option | Unmarked packed video |
+| Side-by-side `av01` plus `vexu/eyes/pack` | Deterministic GPAC patch and final remux work | Left/right eyes and side-by-side packing recognized; `StereoVideo` option returned | Supported AV1 stereo asset, not spatial video |
 | Two independent `av01` MP4 tracks | Encodes and muxes | Two selectable tracks; default track decoded | Alternatives, not eye views |
 | AV1 WebM with `StereoMode` | Standards-based packed metadata works | AVFoundation cannot open the container | Non-Apple delivery only |
-| MV-HEVC MOV | Existing pipeline works | Native stereo capability and spatial metadata | Supported Apple spatial output |
+| MV-HEVC MOV | Existing pipeline works | Native stereo multiview and spatial metadata | Default Apple spatial output |
 
-## Revisit Conditions
+## Product Boundaries And Remaining Qualification
 
-Reconsider an AV1 3D mode only if all applicable conditions become true:
+The first AV1 mode is deliberately narrow:
 
-1. Apple documents AV1 multiview or frame-packed AV1 as a native
-   `VideoPlayerComponent` stereo/spatial input.
-2. The minimum supported Apple Vision Pro hardware has a qualified AV1 decode
-   path at the target resolution, frame rate, bit depth, and sustained thermal
-   load.
-3. AOM or Apple defines interoperable eye-view semantics and a production mux
-   path that the packaged tools can create and validate.
-4. AV1 encoding is fast enough for full feature films without adding an
-   unacceptable clean-machine dependency or support burden.
-5. A concrete use case needs AV1 rather than the existing MV-HEVC spatial movie
-   or a conventional side-by-side archival file.
+1. Software `libsvtav1` encoding with a fixed practical preset and explicit CRF.
+2. One full-resolution side-by-side `av01` track in MOV with Apple packed-stereo
+   metadata.
+3. No AI FX upscale in the initial AV1 path.
+4. No claim that AV1 is MV-HEVC, multiview-compressed, or Apple spatial video.
+5. MV-HEVC remains the default and retains the `_AVP.mov` filename; AV1 uses the
+   distinct `_AV1_Stereo.mov` suffix.
+
+Physical Apple Vision Pro testing should determine which device generations and
+renderers honor the recognized stereo contract at sustained feature-film
+resolution. Long-form compression, encode-time, thermal, file-size, and
+subjective-quality qualification remains separate from the bounded synthetic
+comparison above.
 
 [av1-spec]: https://aomediacodec.github.io/av1-spec/av1-spec.pdf
 [av1-isobmff]: https://aomediacodec.github.io/av1-isobmff/v1.3.0.html

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -40,16 +40,23 @@ named restartable file.
 
 - Input: streamed source container in default mode or extracted MVC elementary
   stream with `--keep-files`, plus crop/title metadata.
-- Output: `<name>_left_movie.mov` and `<name>_right_movie.mov`.
+- MV-HEVC output: `<name>_left_movie.mov` and `<name>_right_movie.mov`.
+- AV1 stereo output: `<name>_AV1-SBS-unmarked.mp4`, encoded directly from the
+  native splitter's Y4M output without a lossy HEVC intermediate. The AV1
+  sequence header carries limited-range BT.709 matrix, primaries, and transfer
+  signaling.
 - Restart/debug value: very high. External AI upscaling workflows often start
-  here.
+  here for MV-HEVC; AV1 resumes use the packed file.
 
 ### `COMBINE_TO_MV_HEVC`
 
-- Input: left/right eye movie files.
-- Output: `<name>_MV-HEVC.mov`.
-- Restart/debug value: high. This is the Apple spatial video intermediate and
-  final mux input.
+- MV-HEVC input/output: left/right eye movie files become
+  `<name>_MV-HEVC.mov`.
+- AV1 input/output: `<name>_AV1-SBS-unmarked.mp4` receives Apple
+  `vexu/eyes/pack` metadata and becomes `<name>_AV1-Stereo.mp4`. MP4Box imports
+  that track into the final MOV.
+- Restart/debug value: high. This creates the mode-specific final video input
+  for audio/subtitle muxing.
 
 ### `UPSCALE_VIDEO`
 
@@ -79,8 +86,10 @@ named restartable file.
 
 ### `CREATE_FINAL_FILE`
 
-- Input: MV-HEVC/upscaled movie, audio movie, and `.srt` files.
-- Output: `<name>_AVP.mov` inside the output folder.
+- Input: finalized MV-HEVC/upscaled or AV1 stereo movie, audio movie, and `.srt`
+  files.
+- Output: `<name>_AVP.mov` for MV-HEVC or `<name>_AV1_Stereo.mov` for AV1 inside
+  the output folder.
 - Restart/debug value: high. This is the MP4Box subtitle/audio/video mux
   boundary.
 
@@ -114,10 +123,12 @@ intermediate PCM MOV, and MVC video is demuxed as Annex B into the native
 splitter without an intermediate `.h264` file.
 
 The MVC path is a bounded three-process pipeline: source FFmpeg to
-`edge264_test` to encoding FFmpeg. Subtitles, AAC, left/right eye files,
-MV-HEVC, and the final movie remain named stage artifacts. Default mode removes
-consumed intermediates after the final output is complete; `--keep-files`
-retains them. Disc/ISO inputs retain their MakeMKV materialization.
+`edge264_test` to encoding FFmpeg. MV-HEVC materializes left/right eye files;
+AV1 directly materializes one packed software-encoded video. Subtitles, AAC,
+the mode-specific finalized video, and the final movie remain named stage
+artifacts. Default mode removes consumed intermediates after the final output
+is complete; `--keep-files` retains them. Disc/ISO inputs retain their MakeMKV
+materialization.
 
 The reused source is user-owned. Automatic cleanup never deletes it.
 `--remove-original` is the explicit exception and removes the source only after
@@ -144,16 +155,16 @@ That keeps downstream stage code path-based and avoids one large copy. The
 ownership rule is the critical part: direct mode must never delete a user source
 that was not created by BD_to_AVP.
 
-### Native MVC Splitter To Left/Right Encode
+### Native MVC Splitter To Stereo Encode
 
 This boundary streams internally: source FFmpeg writes Annex B MVC to
 `edge264_test` stdin, `edge264_test` writes Y4M to stdout, and encoding FFmpeg
-produces left/right eye movie files. The output files remain important because
-they are the main external upscaler/restart boundary.
+either produces left/right HEVC eye movies or one full side-by-side AV1 movie.
+The output files remain the restart boundary.
 
-Left/right outputs remain materialized as the external-upscaler and restart
-boundary during processing and are retained after completion with
-`--keep-files`.
+Left/right HEVC outputs remain the external-upscaler boundary. AV1 does not use
+FX Upscale in its initial contract; its packed intermediate is retained after
+completion only with `--keep-files`.
 
 ### Extracted Audio To Transcoded Audio
 

--- a/docs/native-worker-protocol-v1.md
+++ b/docs/native-worker-protocol-v1.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v1
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
 
 The native macOS prototype communicates with the existing Python engine over a
 bounded JSON Lines (JSONL) protocol. The boundary is intentionally independent

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v2
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
 
 The native macOS app communicates with its bundled Python engine over a bounded
 JSON Lines (JSONL) protocol. Version 2 makes the source kind explicit and adds

--- a/docs/native-worker-protocol-v3.md
+++ b/docs/native-worker-protocol-v3.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v3
 
 > Historical protocol. Current title-aware behavior is documented in
-> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
 
 Protocol v3 adds immutable conversion-preview child jobs while preserving the
 single-request, single-process JSON Lines transport from v2. The native app and

--- a/docs/native-worker-protocol-v4.md
+++ b/docs/native-worker-protocol-v4.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v4
 
 > Historical protocol. Current audio-mode behavior is documented in
-> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
 
 Protocol v4 adds explicit 3D Blu-ray title discovery and selection while
 preserving the single-request, single-process transport from v3. The native app

--- a/docs/native-worker-protocol-v5.md
+++ b/docs/native-worker-protocol-v5.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v5
 
 > Historical protocol. Current audio-mode behavior is documented in
-> [Native Worker Protocol v6](native-worker-protocol-v6.md).
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
 
 Protocol v5 replaces the three legacy subtitle fields with one explicit,
 backend-neutral subtitle policy. The native app and bundled Python worker ship

--- a/docs/native-worker-protocol-v6.md
+++ b/docs/native-worker-protocol-v6.md
@@ -1,5 +1,8 @@
 # Native Worker Protocol v6
 
+> Historical protocol. The current contract is
+> [Native Worker Protocol v7](native-worker-protocol-v7.md).
+
 Protocol v6 replaces the flat audio fields with an exact nested audio policy.
 The native app and bundled Python worker ship atomically and both require
 version 6.

--- a/docs/native-worker-protocol-v7.md
+++ b/docs/native-worker-protocol-v7.md
@@ -1,0 +1,95 @@
+# Native Worker Protocol v7
+
+Protocol v7 adds an explicit video output mode and software AV1 quality to the
+exact `encoding` schema. The native app and bundled Python worker ship
+atomically and both require version 7.
+
+## Video Output
+
+Conversion and preview requests include `video_mode` and `av1_crf`:
+
+```json
+"encoding": {
+  "audio": {
+    "mode": "automatic",
+    "bitrate": 384
+  },
+  "video_mode": "mv_hevc",
+  "av1_crf": 32,
+  "left_right_bitrate": 20,
+  "link_quality": true,
+  "mv_hevc_quality": 75,
+  "upscale_quality": 75,
+  "fov": 90,
+  "frame_rate": "",
+  "resolution": "",
+  "crop_black_bars": false,
+  "swap_eyes": false,
+  "fx_upscale": false,
+  "subtitles": {
+    "mode": "preferred_plus_others",
+    "preferred_language": "eng"
+  }
+}
+```
+
+Supported video modes are:
+
+- `mv_hevc`: the existing native Apple spatial-video path. The worker encodes
+  left and right HEVC eye files and combines them into MV-HEVC. This remains the
+  default.
+- `av1_sbs`: a software-encoded, full-resolution side-by-side AV1 stereo path.
+  The worker encodes one `av01` track with `libsvtav1`, writes limited-range
+  BT.709 signaling with FFmpeg's AV1 metadata bitstream filter, then adds
+  Apple's codec-agnostic stereo metadata (`vexu` containing `eyes/stri` and
+  `pack/pkin=side`) with MP4Box.
+
+`av1_crf` accepts `0...63`; lower values preserve more detail and create larger
+files. The default is `32`. The AV1 preset is intentionally fixed at `9` so the
+first protocol surface exposes quality without creating an unstable matrix of
+encoder-specific controls.
+
+AV1 output is software-only. `fx_upscale = true` is rejected with
+`video_mode = "av1_sbs"`; the existing FX Upscale stage currently targets the
+MV-HEVC workflow. Eye swapping, symmetric black-bar cropping, frame-rate
+override, audio policy, subtitle policy, cancellation, cleanup, final mux, and
+resume semantics remain active.
+
+The completed filename distinguishes the modes:
+
+- MV-HEVC: `<name>_AVP.mov`
+- AV1 stereo: `<name>_AV1_Stereo.mov`
+
+## Stereo Metadata Contract
+
+The AV1 output is not described as MV-HEVC, multiview-compressed video, or
+Apple spatial video. On macOS 27, the finalized AV1 sample description exposes
+both `HasLeftStereoEyeView` and `HasRightStereoEyeView`, reports
+`ViewPackingKind = SideBySide`, and causes `AVAssetPlaybackAssistant` to return
+`AVAssetPlaybackConfigurationOptionStereoVideo`. A bare AV1 control returns no
+stereo playback option.
+
+That proves an Apple-recognized packed-stereo asset contract. It does not, by
+itself, prove stereoscopic rendering on every Apple Vision Pro generation;
+device evidence remains tracked separately in issue #200.
+
+## Audio Policy
+
+The nested v6 audio policy is unchanged. Supported modes remain `automatic`,
+`convert_aac`, and `pcm`. Prepared audio ownership, automatic AAC fallback,
+track ordering, language normalization, title/default-disposition retention,
+and move-stage recovery semantics are unchanged.
+
+## Compatibility
+
+The v7 `encoding` object has an exact schema. Protocol v6 requests do not
+contain `video_mode` or `av1_crf` and are rejected. Persisted native profiles
+are migrated atomically from profile schema v2 to v3 with
+`videoOutputMode = "mv_hevc"` and `av1CRF = 32`, preserving prior behavior.
+
+The numeric conversion stages remain unchanged for resume compatibility. AV1
+jobs report `encode_av1_stereo` at stage 4 and `finalize_av1_stereo` at stage 5;
+MV-HEVC jobs retain `create_left_right_files` and `combine_to_mv_hevc`.
+
+Event ordering, source/title selection, size limits, heartbeat behavior, and
+terminal-event meanings are unchanged from v6.

--- a/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
@@ -348,6 +348,8 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
     private static let encodingStages: Set<String> = [
         "create_left_right_files",
         "combine_to_mv_hevc",
+        "encode_av1_stereo",
+        "finalize_av1_stereo",
         "upscale_video",
         "transcode_audio",
         "create_final_file",

--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -151,6 +151,10 @@ final class ProfileStore: ObservableObject {
                 let legacyDocument = try decoder.decode(LegacyProfileDocumentV1.self, from: data)
                 storedProfiles = try legacyDocument.profiles.map { try $0.migrated() }
                 needsMigration = true
+            case 2:
+                let legacyDocument = try decoder.decode(LegacyProfileDocumentV2.self, from: data)
+                storedProfiles = legacyDocument.profiles.map { $0.migrated() }
+                needsMigration = true
             case ProfileDocument.currentVersion:
                 storedProfiles = try decoder.decode(ProfileDocument.self, from: data).profiles
                 needsMigration = false
@@ -277,7 +281,7 @@ enum ProfileStoreError: LocalizedError, Equatable {
 }
 
 private struct ProfileDocument: Codable {
-    static let currentVersion = 2
+    static let currentVersion = 3
 
     let version: Int
     let profiles: [StoredProfile]
@@ -291,6 +295,57 @@ private struct StoredProfile: Codable {
     let id: UUID
     let name: String
     let options: EncodingOptions
+}
+
+private struct LegacyProfileDocumentV2: Decodable {
+    let version: Int
+    let profiles: [LegacyStoredProfileV2]
+}
+
+private struct LegacyStoredProfileV2: Decodable {
+    let id: UUID
+    let name: String
+    let options: LegacyEncodingOptionsV2
+
+    func migrated() -> StoredProfile {
+        StoredProfile(id: id, name: name, options: options.migrated())
+    }
+}
+
+private struct LegacyEncodingOptionsV2: Decodable {
+    let hevcQuality: Int
+    let leftRightBitrate: Int
+    let upscaleEnabled: Bool
+    let upscaleQuality: Int
+    let linkQuality: Bool
+    let fieldOfView: Int
+    let frameRateOverride: String
+    let resolutionOverride: String
+    let cropBlackBars: Bool
+    let swapEyes: Bool
+    let audioHandling: AudioHandling
+    let audioBitrate: Int
+    let subtitles: SubtitlePolicy
+
+    func migrated() -> EncodingOptions {
+        EncodingOptions(
+            videoOutputMode: .mvHEVC,
+            av1CRF: 32,
+            hevcQuality: hevcQuality,
+            leftRightBitrate: leftRightBitrate,
+            upscaleEnabled: upscaleEnabled,
+            upscaleQuality: upscaleQuality,
+            linkQuality: linkQuality,
+            fieldOfView: fieldOfView,
+            frameRateOverride: frameRateOverride,
+            resolutionOverride: resolutionOverride,
+            cropBlackBars: cropBlackBars,
+            swapEyes: swapEyes,
+            audioHandling: audioHandling,
+            audioBitrate: audioBitrate,
+            subtitles: subtitles
+        )
+    }
 }
 
 private struct LegacyProfileDocumentV1: Decodable {

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -106,6 +106,40 @@ struct SubtitlePolicy: Codable, Equatable {
     var preferredLanguage = SubtitleLanguage.english
 }
 
+enum VideoOutputMode: String, CaseIterable, Codable, Identifiable {
+    case mvHEVC = "mv_hevc"
+    case av1Stereo = "av1_sbs"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .mvHEVC:
+            "Apple Spatial (MV-HEVC)"
+        case .av1Stereo:
+            "AV1 Stereo (Software)"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .mvHEVC:
+            "Native Apple spatial-video output using hardware HEVC encoding by default."
+        case .av1Stereo:
+            "Full-resolution side-by-side AV1 with Apple stereo metadata. Encoding is software-only and may take substantially longer."
+        }
+    }
+
+    var outputFileTag: String {
+        switch self {
+        case .mvHEVC:
+            "_AVP"
+        case .av1Stereo:
+            "_AV1_Stereo"
+        }
+    }
+}
+
 enum ConversionStage: Int, CaseIterable, Codable, Identifiable {
     case createMKV = 1
     case extractMVCAndAudio
@@ -128,9 +162,9 @@ enum ConversionStage: Int, CaseIterable, Codable, Identifiable {
         case .extractSubtitles:
             "3 — Extract Subtitles"
         case .createLeftRightFiles:
-            "4 — Create Left / Right Video"
+            "4 — Encode Stereo Video"
         case .combineToMVHEVC:
-            "5 — Create Spatial Video"
+            "5 — Finalize Stereo Video"
         case .upscaleVideo:
             "6 — Upscale Video"
         case .transcodeAudio:
@@ -144,6 +178,8 @@ enum ConversionStage: Int, CaseIterable, Codable, Identifiable {
 }
 
 struct EncodingOptions: Codable, Equatable {
+    var videoOutputMode = VideoOutputMode.mvHEVC
+    var av1CRF = 32
     var hevcQuality = 75
     var leftRightBitrate = 20
     var upscaleEnabled = false
@@ -162,7 +198,12 @@ struct EncodingOptions: Codable, Equatable {
     var compactSummary: String {
         let resolution = upscaleEnabled ? "2× upscale" : "source resolution"
         let audio = audioHandling.compactSummary(bitrate: audioBitrate)
-        return "HEVC \(hevcQuality) · \(leftRightBitrate) Mbps eyes · \(resolution) · \(audio)"
+        switch videoOutputMode {
+        case .mvHEVC:
+            return "MV-HEVC \(hevcQuality) · \(leftRightBitrate) Mbps eyes · \(resolution) · \(audio)"
+        case .av1Stereo:
+            return "AV1 stereo CRF \(av1CRF) · full side-by-side · source resolution · \(audio)"
+        }
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -173,7 +173,7 @@ struct ConversionDraft: Equatable {
     }
 
     var proposedOutputURL: URL {
-        destinationURL.appendingPathComponent("\(outputStem)_AVP.mov")
+        destinationURL.appendingPathComponent("\(outputStem)\(options.encoding.videoOutputMode.outputFileTag).mov")
     }
 
     func withSourceDetails(_ sourceDetails: SourceInspection?) -> ConversionDraft {

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WorkerJobSpec: Encodable, Equatable {
-    static let protocolVersion = 6
+    static let protocolVersion = 7
 
     struct Source: Encodable, Equatable {
         enum Kind: String, Encodable {
@@ -86,6 +86,8 @@ struct WorkerJobSpec: Encodable, Equatable {
         }
 
         let audio: Audio
+        let videoMode: VideoOutputMode
+        let av1CRF: Int
         let leftRightBitrate: Int
         let linkQuality: Bool
         let mvHEVCQuality: Int
@@ -100,6 +102,8 @@ struct WorkerJobSpec: Encodable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case audio
+            case videoMode = "video_mode"
+            case av1CRF = "av1_crf"
             case leftRightBitrate = "left_right_bitrate"
             case linkQuality = "link_quality"
             case mvHEVCQuality = "mv_hevc_quality"
@@ -241,21 +245,24 @@ struct WorkerJobSpec: Encodable, Equatable {
     }
 
     private static func encoding(from options: EncodingOptions) -> Encoding {
-        Encoding(
+        let isAV1Stereo = options.videoOutputMode == .av1Stereo
+        return Encoding(
             audio: Encoding.Audio(
                 mode: audioMode(from: options.audioHandling),
                 bitrate: options.audioBitrate
             ),
+            videoMode: options.videoOutputMode,
+            av1CRF: options.av1CRF,
             leftRightBitrate: options.leftRightBitrate,
             linkQuality: options.linkQuality,
             mvHEVCQuality: options.hevcQuality,
             upscaleQuality: options.upscaleQuality,
             fieldOfView: options.fieldOfView,
             frameRate: options.frameRateOverride,
-            resolution: options.resolutionOverride,
+            resolution: isAV1Stereo ? "" : options.resolutionOverride,
             cropBlackBars: options.cropBlackBars,
             swapEyes: options.swapEyes,
-            fxUpscale: options.upscaleEnabled,
+            fxUpscale: isAV1Stereo ? false : options.upscaleEnabled,
             subtitles: subtitleOptions(from: options)
         )
     }

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -115,7 +115,13 @@ struct ConversionSetupView: View {
 
                 Toggle("Keep durable stage files", isOn: $options.job.keepStageFiles)
                 Toggle("Continue processing after recoverable errors", isOn: $options.job.continueOnError)
-                Toggle("Use software encoder", isOn: $options.job.softwareEncoder)
+                Toggle("Use software HEVC encoder", isOn: $options.job.softwareEncoder)
+                    .disabled(options.encoding.videoOutputMode == .av1Stereo)
+                    .help(
+                        options.encoding.videoOutputMode == .av1Stereo
+                            ? "AV1 output always uses the bundled software encoder."
+                            : "Use libx265 instead of the default VideoToolbox HEVC encoder."
+                    )
             }
 
             Section("Output Files") {

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -32,41 +32,80 @@ struct EncodingOptionsEditor: View {
     private var videoForm: some View {
         Form {
             Group {
-                Section("Spatial Video Encoding") {
-                    EncodingQualitySliderRow(title: "HEVC quality", value: hevcQualityBinding)
-                    LabeledContent("Left / right bitrate") {
-                        Stepper(value: $options.leftRightBitrate, in: 1 ... 100) {
-                            Text("\(options.leftRightBitrate) Mbps")
-                                .monospacedDigit()
-                                .frame(width: 76, alignment: .trailing)
+                Section("Video Output") {
+                    Picker("Format", selection: $options.videoOutputMode) {
+                        ForEach(VideoOutputMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
                         }
                     }
-                    Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
+                    .onChange(of: options.videoOutputMode) { _, mode in
+                        if mode == .av1Stereo {
+                            options.upscaleEnabled = false
+                            options.resolutionOverride = ""
+                        }
+                    }
 
-                    if options.upscaleEnabled {
-                        EncodingQualitySliderRow(title: "Upscale quality", value: upscaleQualityBinding)
-                        Toggle("Link HEVC and upscale quality", isOn: $options.linkQuality)
-                            .onChange(of: options.linkQuality) { _, linked in
-                                if linked {
-                                    options.upscaleQuality = options.hevcQuality
-                                }
+                    Text(options.videoOutputMode.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if options.videoOutputMode == .mvHEVC {
+                        EncodingQualitySliderRow(title: "HEVC quality", value: hevcQualityBinding)
+                        LabeledContent("Left / right bitrate") {
+                            Stepper(value: $options.leftRightBitrate, in: 1 ... 100) {
+                                Text("\(options.leftRightBitrate) Mbps")
+                                    .monospacedDigit()
+                                    .frame(width: 76, alignment: .trailing)
                             }
+                        }
+                        Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
+
+                        if options.upscaleEnabled {
+                            EncodingQualitySliderRow(title: "Upscale quality", value: upscaleQualityBinding)
+                            Toggle("Link HEVC and upscale quality", isOn: $options.linkQuality)
+                                .onChange(of: options.linkQuality) { _, linked in
+                                    if linked {
+                                        options.upscaleQuality = options.hevcQuality
+                                    }
+                                }
+                        }
+                    } else {
+                        LabeledContent("AV1 quality") {
+                            Stepper(value: $options.av1CRF, in: 0 ... 63) {
+                                Text("CRF \(options.av1CRF)")
+                                    .monospacedDigit()
+                                    .frame(width: 74, alignment: .trailing)
+                            }
+                        }
+
+                        Text("Lower CRF values preserve more detail and create larger files. CRF 32 is the balanced default.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 
                 Section("Picture") {
-                    LabeledContent("Field of view") {
-                        Stepper(value: $options.fieldOfView, in: 0 ... 360) {
-                            Text("\(options.fieldOfView)°")
-                                .monospacedDigit()
-                                .frame(width: 48, alignment: .trailing)
+                    if options.videoOutputMode == .mvHEVC {
+                        LabeledContent("Field of view") {
+                            Stepper(value: $options.fieldOfView, in: 0 ... 360) {
+                                Text("\(options.fieldOfView)°")
+                                    .monospacedDigit()
+                                    .frame(width: 48, alignment: .trailing)
+                            }
                         }
-                    }
 
-                    LabeledContent("Resolution override") {
-                        TextField("", text: $options.resolutionOverride, prompt: Text("Use source"))
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 170)
+                        LabeledContent("Resolution override") {
+                            TextField("", text: $options.resolutionOverride, prompt: Text("Use source"))
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 170)
+                        }
+                    } else {
+                        LabeledContent("Resolution") {
+                            Text("Full source resolution per eye")
+                                .foregroundStyle(.secondary)
+                        }
                     }
 
                     LabeledContent("Frame-rate override") {

--- a/macos/BluRayToVisionPro/Views/PreviewSheet.swift
+++ b/macos/BluRayToVisionPro/Views/PreviewSheet.swift
@@ -113,6 +113,18 @@ struct PreviewSheet: View {
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                        .gridCellColumns(2)
+                }
+
+                if conversionDraft.options.encoding.videoOutputMode == .av1Stereo {
+                    Divider()
+                        .gridCellColumns(2)
+                    Label(
+                        "AV1 previews contain a full side-by-side frame. Stereo presentation depends on the player and device.",
+                        systemImage: "rectangle.split.2x1"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                     .gridCellColumns(2)
                 }
             }
@@ -254,7 +266,9 @@ struct PreviewSheet: View {
         viewModel.failureMessage
             ?? viewModel.activityMessage
             ?? (viewModel.phase == .idle
-                ? "Choose a representative range, then generate a finalized spatial-video sample."
+                ? conversionDraft.options.encoding.videoOutputMode == .av1Stereo
+                    ? "Choose a representative range, then generate a finalized side-by-side AV1 stereo sample."
+                    : "Choose a representative range, then generate a finalized spatial-video sample."
                 : nil)
     }
 

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -400,23 +400,13 @@ private struct ProfileEncodingSummaryView: View {
                 switch section {
                 case .video:
                     ProfileSummarySection(
-                        title: "Spatial Video Encoding",
-                        items: [
-                            ProfileSummaryItem(title: "HEVC quality", value: "\(options.hevcQuality)"),
-                            ProfileSummaryItem(title: "Left / right bitrate", value: "\(options.leftRightBitrate) Mbps"),
-                            ProfileSummaryItem(title: "AI FX upscale to 2× resolution", value: enabledText(options.upscaleEnabled)),
-                            ProfileSummaryItem(title: "Upscale quality", value: "\(options.upscaleQuality)"),
-                            ProfileSummaryItem(title: "Link HEVC and upscale quality", value: enabledText(options.linkQuality)),
-                        ]
+                        title: "Video Output",
+                        items: videoItems
                     )
 
                     ProfileSummarySection(
                         title: "Picture",
-                        items: [
-                            ProfileSummaryItem(title: "Field of view", value: "\(options.fieldOfView)°"),
-                            ProfileSummaryItem(title: "Resolution override", value: fallbackText(options.resolutionOverride)),
-                            ProfileSummaryItem(title: "Frame-rate override", value: fallbackText(options.frameRateOverride)),
-                        ]
+                        items: pictureItems
                     )
 
                     ProfileSummarySection(
@@ -454,6 +444,41 @@ private struct ProfileEncodingSummaryView: View {
             items.append(ProfileSummaryItem(title: bitrateLabel, value: "\(options.audioBitrate) kbps"))
         }
         return items
+    }
+
+    private var videoItems: [ProfileSummaryItem] {
+        var items = [ProfileSummaryItem(title: "Format", value: options.videoOutputMode.title)]
+        switch options.videoOutputMode {
+        case .mvHEVC:
+            items.append(contentsOf: [
+                ProfileSummaryItem(title: "HEVC quality", value: "\(options.hevcQuality)"),
+                ProfileSummaryItem(title: "Left / right bitrate", value: "\(options.leftRightBitrate) Mbps"),
+                ProfileSummaryItem(title: "AI FX upscale to 2× resolution", value: enabledText(options.upscaleEnabled)),
+                ProfileSummaryItem(title: "Upscale quality", value: "\(options.upscaleQuality)"),
+                ProfileSummaryItem(title: "Link HEVC and upscale quality", value: enabledText(options.linkQuality)),
+            ])
+        case .av1Stereo:
+            items.append(contentsOf: [
+                ProfileSummaryItem(title: "AV1 quality", value: "CRF \(options.av1CRF)"),
+                ProfileSummaryItem(title: "Packing", value: "Full side-by-side"),
+                ProfileSummaryItem(title: "Encoder", value: "Software SVT-AV1"),
+            ])
+        }
+        return items
+    }
+
+    private var pictureItems: [ProfileSummaryItem] {
+        if options.videoOutputMode == .av1Stereo {
+            return [
+                ProfileSummaryItem(title: "Resolution", value: "Full source resolution per eye"),
+                ProfileSummaryItem(title: "Frame-rate override", value: fallbackText(options.frameRateOverride)),
+            ]
+        }
+        return [
+            ProfileSummaryItem(title: "Field of view", value: "\(options.fieldOfView)°"),
+            ProfileSummaryItem(title: "Resolution override", value: fallbackText(options.resolutionOverride)),
+            ProfileSummaryItem(title: "Frame-rate override", value: fallbackText(options.frameRateOverride)),
+        ]
     }
 
     private func enabledText(_ enabled: Bool) -> String {

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -539,13 +539,23 @@ struct SourceWorkspaceView: View {
                 HStack(spacing: 5) {
                     PipelineStep(systemImage: "opticaldisc", title: "1 Create MKV")
                     pipelineChevron
-                    PipelineStep(systemImage: "rectangle.split.2x1", title: "2–4 Extract 3D")
+                    PipelineStep(
+                        systemImage: "rectangle.split.2x1",
+                        title: options.encoding.videoOutputMode == .av1Stereo ? "2–3 Extract 3D" : "2–4 Extract 3D"
+                    )
                     pipelineChevron
-                    PipelineStep(systemImage: "visionpro", title: "5–6 Encode")
+                    PipelineStep(
+                        systemImage: options.encoding.videoOutputMode == .av1Stereo ? "rectangle.split.2x1" : "visionpro",
+                        title: options.encoding.videoOutputMode == .av1Stereo ? "4–5 AV1 Stereo" : "5–6 Spatial"
+                    )
                     pipelineChevron
                     PipelineStep(systemImage: "checkmark.circle", title: "7–9 Finish")
                 }
-                Text("Nine restartable stages are available under Files & Recovery.")
+                Text(
+                    options.encoding.videoOutputMode == .av1Stereo
+                        ? "AV1 uses stages 1–5 and 7–9; stage 6 FX Upscale is unavailable."
+                        : "Nine restartable stages are available under Files & Recovery."
+                )
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -24,6 +24,20 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(draft.proposedOutputURL.path, "/Movies/Feature_AVP.mov")
     }
 
+    func testAV1DraftUsesDistinctOutputName() {
+        var options = ConversionOptions()
+        options.encoding.videoOutputMode = .av1Stereo
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/Feature.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            options: options
+        )
+
+        XCTAssertEqual(draft.proposedOutputURL.path, "/Movies/Feature_AV1_Stereo.mov")
+    }
+
     func testDraftPreservesDotsInExtensionlessInspectedName() {
         let draft = ConversionDraft(
             source: ConversionSource(
@@ -168,11 +182,11 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertTrue(EncodingOptions().compactSummary.contains("uncompressed PCM audio"))
         XCTAssertEqual(
             EncodingOptions(audioHandling: .automatic, audioBitrate: 448).compactSummary,
-            "HEVC 75 · 20 Mbps eyes · source resolution · automatic audio (AAC fallback 448 kbps)"
+            "MV-HEVC 75 · 20 Mbps eyes · source resolution · automatic audio (AAC fallback 448 kbps)"
         )
         XCTAssertEqual(
             EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
-            "HEVC 75 · 20 Mbps eyes · source resolution · AAC 448 kbps"
+            "MV-HEVC 75 · 20 Mbps eyes · source resolution · AAC 448 kbps"
         )
         XCTAssertTrue(BuiltInProfile.balanced.summary.contains("uncompressed PCM audio"))
     }
@@ -546,6 +560,28 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(spec.encoding?.audio, WorkerJobSpec.Encoding.Audio(mode: .convertAAC, bitrate: 512))
     }
 
+    func testAV1JobSpecClearsIncompatibleUpscaleAndResolution() {
+        var encoding = EncodingOptions()
+        encoding.videoOutputMode = .av1Stereo
+        encoding.av1CRF = 28
+        encoding.upscaleEnabled = true
+        encoding.resolutionOverride = "3840x2160"
+
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/src/m.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            options: ConversionOptions(encoding: encoding)
+        )
+        let workerEncoding = WorkerJobSpec(draft: draft).encoding
+
+        XCTAssertEqual(workerEncoding?.videoMode, .av1Stereo)
+        XCTAssertEqual(workerEncoding?.av1CRF, 28)
+        XCTAssertEqual(workerEncoding?.resolution, "")
+        XCTAssertFalse(workerEncoding?.fxUpscale == true)
+    }
+
     func testConversionJobSpecEncodesJobSettings() {
         var job = JobOptions()
         job.startStage = .extractMVCAndAudio
@@ -656,10 +692,12 @@ final class ConversionWorkflowTests: XCTestCase {
         let source = try XCTUnwrap(json["source"] as? [String: Any])
 
         XCTAssertEqual(json["operation"] as? String, "convert_source")
-        XCTAssertEqual(json["protocol_version"] as? Int, 6)
+        XCTAssertEqual(json["protocol_version"] as? Int, 7)
         XCTAssertEqual(source["kind"] as? String, "direct_file")
         XCTAssertEqual((json["destination"] as? [String: Any])?["path"] as? String, "/Movies")
         XCTAssertEqual(encoding["mv_hevc_quality"] as? Int, 75)
+        XCTAssertEqual(encoding["video_mode"] as? String, "mv_hevc")
+        XCTAssertEqual(encoding["av1_crf"] as? Int, 32)
         let audio = try XCTUnwrap(encoding["audio"] as? [String: Any])
         XCTAssertEqual(audio["mode"] as? String, "pcm")
         XCTAssertEqual(audio["bitrate"] as? Int, 384)
@@ -767,7 +805,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(changedEncoding.audio, originalEncoding.audio)
     }
 
-    func testConversionJobSpecMatchesSharedV6WorkerFixture() throws {
+    func testConversionJobSpecMatchesSharedV7WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let draft = ConversionDraft(
@@ -783,7 +821,7 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_convert_v6.json")
+            with: sharedFixtureData(named: "native_worker_convert_v7.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
@@ -814,7 +852,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(source["title_id"] as? String, "provider:playlist-01005")
     }
 
-    func testPreviewJobSpecMatchesSharedV6WorkerFixture() throws {
+    func testPreviewJobSpecMatchesSharedV7WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let conversion = ConversionDraft(
@@ -842,13 +880,13 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_preview_v6.json")
+            with: sharedFixtureData(named: "native_worker_preview_v7.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
     }
 
-    func testPhysicalDiscJobSpecMatchesSharedV6WorkerFixture() throws {
+    func testPhysicalDiscJobSpecMatchesSharedV7WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let draft = ConversionDraft(
@@ -877,7 +915,7 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_convert_physical_disc_v6.json")
+            with: sharedFixtureData(named: "native_worker_convert_physical_disc_v7.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -23,9 +23,11 @@ final class ProfileStoreTests: XCTestCase {
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
         let identifier = UUID(uuidString: "A4CC523E-72FA-4F36-A38D-1FB0D6A84742")!
         let options = EncodingOptions(
+            videoOutputMode: .av1Stereo,
+            av1CRF: 24,
             hevcQuality: 91,
             leftRightBitrate: 35,
-            upscaleEnabled: true,
+            upscaleEnabled: false,
             upscaleQuality: 87,
             linkQuality: false,
             fieldOfView: 100,
@@ -48,7 +50,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionTwoProfilesKeepAllAudioHandlingRawValuesWithoutMigration() throws {
+    func testVersionTwoProfilesMigrateAllAudioHandlingRawValuesToVersionThree() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -79,6 +81,8 @@ final class ProfileStoreTests: XCTestCase {
 
         XCTAssertNil(store.loadErrorMessage)
         XCTAssertEqual(store.customProfiles.map(\.options.audioHandling), [.pcm, .convertAAC, .automatic])
+        XCTAssertTrue(store.customProfiles.allSatisfy { $0.options.videoOutputMode == .mvHEVC })
+        XCTAssertTrue(store.customProfiles.allSatisfy { $0.options.av1CRF == 32 })
         for profile in store.customProfiles {
             try store.updateProfile(profile.id, name: profile.name, options: profile.options)
         }
@@ -86,7 +90,7 @@ final class ProfileStoreTests: XCTestCase {
         let persistedDocument = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(persistedDocument["version"] as? Int, 2)
+        XCTAssertEqual(persistedDocument["version"] as? Int, 3)
         let persistedProfiles = try XCTUnwrap(persistedDocument["profiles"] as? [[String: Any]])
         let persistedRawValues = try persistedProfiles.map { profile in
             let options = try XCTUnwrap(profile["options"] as? [String: Any])
@@ -96,7 +100,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionOneProfilesMigrateAtomicallyToCanonicalVersionTwoData() throws {
+    func testVersionOneProfilesMigrateAtomicallyToCanonicalVersionThreeData() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -144,6 +148,8 @@ final class ProfileStoreTests: XCTestCase {
             [.off, .preferredOnly, .preferredPlusOthers, .preferredPlusOthers]
         )
         let migratedOptions = try XCTUnwrap(store.customProfiles.first?.options)
+        XCTAssertEqual(migratedOptions.videoOutputMode, .mvHEVC)
+        XCTAssertEqual(migratedOptions.av1CRF, 32)
         XCTAssertEqual(migratedOptions.hevcQuality, 91)
         XCTAssertEqual(migratedOptions.leftRightBitrate, 35)
         XCTAssertTrue(migratedOptions.upscaleEnabled)
@@ -160,7 +166,7 @@ final class ProfileStoreTests: XCTestCase {
         let migratedJSON = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(migratedJSON["version"] as? Int, 2)
+        XCTAssertEqual(migratedJSON["version"] as? Int, 3)
         let profiles = try XCTUnwrap(migratedJSON["profiles"] as? [[String: Any]])
         let options = try XCTUnwrap(profiles.first?["options"] as? [String: Any])
         let subtitles = try XCTUnwrap(options["subtitles"] as? [String: Any])
@@ -378,6 +384,8 @@ final class ProfileStoreTests: XCTestCase {
         var options = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: JSONEncoder().encode(EncodingOptions())) as? [String: Any]
         )
+        options.removeValue(forKey: "videoOutputMode")
+        options.removeValue(forKey: "av1CRF")
         options["audioHandling"] = audioHandlingRawValue
         return options
     }

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -105,7 +105,7 @@ final class WorkerLifecycleTests: XCTestCase {
     func testSharedV6ProgressFixtureDecodes() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_stage_started_progress_v6.json")
+            from: sharedFixtureData(named: "native_worker_stage_started_progress_v7.json")
         )
 
         XCTAssertEqual(event.payload.progress, WorkerProgress(currentStage: 1, totalStages: 2, stageFraction: nil))
@@ -130,7 +130,7 @@ final class WorkerLifecycleTests: XCTestCase {
     func testStructuredAudioFallbackWarningExposesCodecsAndActualAction() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_audio_fallback_warning_v6.json")
+            from: sharedFixtureData(named: "native_worker_audio_fallback_warning_v7.json")
         )
 
         XCTAssertEqual(event.payload.warningCode, "audio_automatic_fallback_to_aac")
@@ -342,7 +342,7 @@ final class WorkerLifecycleTests: XCTestCase {
     func testDecodesAndAppliesSharedV6ConversionCompletionFixture() throws {
         let completed = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_conversion_completed_v6.json")
+            from: sharedFixtureData(named: "native_worker_conversion_completed_v7.json")
         )
         let fixtureJobID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         var state = WorkerLifecycleState()

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -146,6 +146,14 @@ def verify_bundled_tool(
         output = getattr(error, "output", "") or ""
         raise SmokeFailure(f"Bundled tool did not run: {tool_path}\n{output.strip()}") from error
 
+    if tool_path.name == "ffmpeg":
+        encoders = run([tool_path, "-hide_banner", "-encoders"], env=clean_env).stdout
+        if "libsvtav1" not in encoders:
+            raise SmokeFailure("Bundled FFmpeg does not expose the required libsvtav1 encoder.")
+        bitstream_filters = run([tool_path, "-hide_banner", "-bsfs"], env=clean_env).stdout
+        if "av1_metadata" not in bitstream_filters:
+            raise SmokeFailure("Bundled FFmpeg does not expose the required av1_metadata bitstream filter.")
+
     if not check_links:
         return
 

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -45,6 +45,13 @@ def verify_tool(tool_path: Path, probe_args: list[str]) -> None:
     for forbidden_path in ["/opt/homebrew", "/usr/local"]:
         if forbidden_path in linked_libraries:
             raise RuntimeError(f"Bundled {tool_path.name} still links to {forbidden_path}:\n{linked_libraries}")
+    if tool_path.name == "ffmpeg":
+        encoders = run([tool_path, "-hide_banner", "-encoders"]).stdout
+        if "libsvtav1" not in encoders:
+            raise RuntimeError("Bundled FFmpeg does not expose the required libsvtav1 encoder.")
+        bitstream_filters = run([tool_path, "-hide_banner", "-bsfs"]).stdout
+        if "av1_metadata" not in bitstream_filters:
+            raise RuntimeError("Bundled FFmpeg does not expose the required av1_metadata bitstream filter.")
 
 
 def verify_mach_o_minimum_versions(app_path: Path) -> None:

--- a/tests/fixtures/native_worker_audio_fallback_warning_v7.json
+++ b/tests/fixtures/native_worker_audio_fallback_warning_v7.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "warning",
   "job_id": "11111111-1111-4111-8111-111111111111",
   "sequence": 0,

--- a/tests/fixtures/native_worker_conversion_completed_v7.json
+++ b/tests/fixtures/native_worker_conversion_completed_v7.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "job.completed",
   "job_id": "11111111-1111-4111-8111-111111111111",
   "sequence": 2,

--- a/tests/fixtures/native_worker_convert_physical_disc_v7.json
+++ b/tests/fixtures/native_worker_convert_physical_disc_v7.json
@@ -1,11 +1,12 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "job.start",
   "job_id": "11111111-1111-4111-8111-111111111111",
   "operation": "convert_source",
   "source": {
-    "kind": "direct_file",
-    "path": "/tmp/movie.mkv"
+    "kind": "physical_disc",
+    "path": "/dev/disk9",
+    "title_id": "makemkv:0"
   },
   "destination": {
     "path": "/tmp/output"
@@ -15,6 +16,8 @@
       "mode": "automatic",
       "bitrate": 384
     },
+    "video_mode": "mv_hevc",
+    "av1_crf": 32,
     "left_right_bitrate": 20,
     "link_quality": true,
     "mv_hevc_quality": 75,

--- a/tests/fixtures/native_worker_convert_v7.json
+++ b/tests/fixtures/native_worker_convert_v7.json
@@ -1,20 +1,22 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "job.start",
-  "job_id": "22222222-2222-4222-8222-222222222222",
-  "operation": "preview_source",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
   "source": {
     "kind": "direct_file",
     "path": "/tmp/movie.mkv"
   },
   "destination": {
-    "path": "/tmp/previews/22222222-2222-4222-8222-222222222222"
+    "path": "/tmp/output"
   },
   "encoding": {
     "audio": {
       "mode": "automatic",
       "bitrate": 384
     },
+    "video_mode": "mv_hevc",
+    "av1_crf": 32,
     "left_right_bitrate": 20,
     "link_quality": true,
     "mv_hevc_quality": 75,
@@ -33,16 +35,11 @@
   "job": {
     "start_stage": 1,
     "keep_files": false,
-    "overwrite": true,
+    "overwrite": false,
     "remove_original": false,
     "continue_on_error": false,
     "software_encoder": false,
     "output_commands": false,
     "keep_awake": true
-  },
-  "preview": {
-    "parent_job_id": "11111111-1111-4111-8111-111111111111",
-    "position": "middle",
-    "duration_seconds": 60
   }
 }

--- a/tests/fixtures/native_worker_preview_v7.json
+++ b/tests/fixtures/native_worker_preview_v7.json
@@ -1,21 +1,22 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "job.start",
-  "job_id": "11111111-1111-4111-8111-111111111111",
-  "operation": "convert_source",
+  "job_id": "22222222-2222-4222-8222-222222222222",
+  "operation": "preview_source",
   "source": {
-    "kind": "physical_disc",
-    "path": "/dev/disk9",
-    "title_id": "makemkv:0"
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
   },
   "destination": {
-    "path": "/tmp/output"
+    "path": "/tmp/previews/22222222-2222-4222-8222-222222222222"
   },
   "encoding": {
     "audio": {
       "mode": "automatic",
       "bitrate": 384
     },
+    "video_mode": "mv_hevc",
+    "av1_crf": 32,
     "left_right_bitrate": 20,
     "link_quality": true,
     "mv_hevc_quality": 75,
@@ -34,11 +35,16 @@
   "job": {
     "start_stage": 1,
     "keep_files": false,
-    "overwrite": false,
+    "overwrite": true,
     "remove_original": false,
     "continue_on_error": false,
     "software_encoder": false,
     "output_commands": false,
     "keep_awake": true
+  },
+  "preview": {
+    "parent_job_id": "11111111-1111-4111-8111-111111111111",
+    "position": "middle",
+    "duration_seconds": 60
   }
 }

--- a/tests/fixtures/native_worker_stage_started_progress_v7.json
+++ b/tests/fixtures/native_worker_stage_started_progress_v7.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 6,
+  "protocol_version": 7,
   "type": "stage.started",
   "job_id": "11111111-1111-4111-8111-111111111111",
   "sequence": 0,

--- a/tests/test_av1_stereo.py
+++ b/tests/test_av1_stereo.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import video
+from bd_to_avp.modules.config import config
+from bd_to_avp.modules.disc import DiscInfo
+from bd_to_avp.modules.video_mode import VideoMode
+
+
+class Av1StereoTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disc_info = DiscInfo(
+            name="Sample",
+            frame_rate="24000/1001",
+            resolution="1920x1080",
+            color_depth=8,
+        )
+
+    def test_native_av1_command_encodes_one_full_side_by_side_stream(self) -> None:
+        with (
+            patch.object(video.config, "av1_crf", 30),
+            patch.object(video.config, "swap_eyes", False),
+            patch.object(video.config, "frame_rate", ""),
+            patch.object(video.config, "resolution", ""),
+        ):
+            command = video.generate_native_mvc_av1_command(Path("stereo.mp4"), self.disc_info, "")
+
+        filter_graph = command[command.index("-filter_complex") + 1]
+        self.assertIn("split=2", filter_graph)
+        self.assertIn("crop=1920:1080:0:0", filter_graph)
+        self.assertIn("crop=1920:1080:1920:0", filter_graph)
+        self.assertIn("hstack=inputs=2", filter_graph)
+        self.assertEqual(command[command.index("-vcodec") + 1], "libsvtav1")
+        self.assertEqual(
+            command[command.index("-bsf:v") + 1],
+            "av1_metadata=color_primaries=1:transfer_characteristics=1:matrix_coefficients=1:color_range=tv",
+        )
+        self.assertEqual(command[command.index("-crf") + 1], "30")
+        self.assertEqual(command[command.index("-preset") + 1], "9")
+        self.assertEqual(command[command.index("-color_primaries") + 1], "bt709")
+        self.assertEqual(command[command.index("-color_trc") + 1], "bt709")
+        self.assertEqual(command[command.index("-colorspace") + 1], "bt709")
+        self.assertEqual(command[command.index("-color_range") + 1], "tv")
+        self.assertNotIn("-svtav1-params", command)
+        self.assertNotIn("-svtav1_params", command)
+        self.assertIn("file:stereo.mp4", command)
+
+    def test_native_av1_command_preserves_crop_per_eye(self) -> None:
+        with (
+            patch.object(video.config, "av1_crf", 32),
+            patch.object(video.config, "swap_eyes", True),
+            patch.object(video.config, "frame_rate", ""),
+            patch.object(video.config, "resolution", ""),
+        ):
+            command = video.generate_native_mvc_av1_command(
+                Path("stereo.mp4"),
+                self.disc_info,
+                "1880:1040:20:20",
+            )
+
+        filter_graph = command[command.index("-filter_complex") + 1]
+        self.assertEqual(filter_graph.count("crop=1880:1040:20:20"), 2)
+        self.assertIn("hstack=inputs=2", filter_graph)
+
+    def test_av1_stereo_patch_contains_current_apple_eye_and_packing_boxes(self) -> None:
+        patch_xml = video.av1_stereo_patch_xml().lower()
+
+        self.assertIn("av01.av1c+", patch_xml)
+        self.assertIn('fcc="vexu"', patch_xml)
+        self.assertIn("73747269", patch_xml)
+        self.assertIn("7061636b", patch_xml)
+        self.assertIn("706b696e", patch_xml)
+        self.assertIn("73696465", patch_xml)
+
+    def test_add_av1_stereo_metadata_removes_temporary_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            patch_path = Path(temp_dir) / "stereo.xml"
+            file_descriptor = os.open(patch_path, os.O_CREAT | os.O_RDWR)
+            input_path = Path(temp_dir) / "input.mp4"
+            output_path = Path(temp_dir) / "output.mp4"
+
+            with (
+                patch.object(video.tempfile, "mkstemp", return_value=(file_descriptor, str(patch_path))),
+                patch.object(video, "run_command") as run_command,
+                patch.object(video.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            ):
+                video.add_av1_stereo_metadata(input_path, output_path)
+
+            run_command.assert_called_once_with(
+                [Path("/tools/MP4Box"), "-patch", patch_path, input_path, "-out", output_path],
+                "add Apple stereo packing metadata to AV1 video.",
+            )
+            self.assertFalse(patch_path.exists())
+
+    def test_final_file_tag_distinguishes_av1_from_mv_hevc(self) -> None:
+        with patch.object(config, "video_mode", VideoMode.MV_HEVC):
+            self.assertEqual(config.final_file_tag, "_AVP")
+        with patch.object(config, "video_mode", VideoMode.AV1_SBS):
+            self.assertEqual(config.final_file_tag, "_AV1_Stereo")

--- a/tests/test_av1_stereo.py
+++ b/tests/test_av1_stereo.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -78,17 +77,19 @@ class Av1StereoTests(unittest.TestCase):
     def test_add_av1_stereo_metadata_removes_temporary_patch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             patch_path = Path(temp_dir) / "stereo.xml"
-            file_descriptor = os.open(patch_path, os.O_CREAT | os.O_RDWR)
+            patch_path.touch()
             input_path = Path(temp_dir) / "input.mp4"
             output_path = Path(temp_dir) / "output.mp4"
 
             with (
-                patch.object(video.tempfile, "mkstemp", return_value=(file_descriptor, str(patch_path))),
+                patch.object(video.tempfile, "mkstemp", return_value=(42, str(patch_path))),
+                patch.object(video.os, "close") as close,
                 patch.object(video, "run_command") as run_command,
                 patch.object(video.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
             ):
                 video.add_av1_stereo_metadata(input_path, output_path)
 
+            close.assert_called_once_with(42)
             run_command.assert_called_once_with(
                 [Path("/tools/MP4Box"), "-patch", patch_path, input_path, "-out", output_path],
                 "add Apple stereo packing metadata to AV1 video.",

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -8,6 +8,7 @@ import ffmpeg
 from bd_to_avp.modules import container
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import Stage
+from bd_to_avp.modules.video_mode import VideoMode
 
 
 class AudioExtractionTests(unittest.TestCase):
@@ -79,6 +80,7 @@ class MuxCommandTests(unittest.TestCase):
             with (
                 patch.object(container.config, "keep_files", False),
                 patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(container.config, "video_mode", VideoMode.MV_HEVC),
                 patch.object(container, "mux_video_audio_subs") as mux,
             ):
                 result = container.create_muxed_file(audio_path, mv_hevc_path, output_folder, "Movie")
@@ -105,6 +107,7 @@ class MuxCommandTests(unittest.TestCase):
             with (
                 patch.object(container.config, "keep_files", False),
                 patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(container.config, "video_mode", VideoMode.MV_HEVC),
                 patch.object(container, "mux_video_audio_subs", side_effect=RuntimeError("mux failed")),
                 self.assertRaisesRegex(RuntimeError, "mux failed"),
             ):
@@ -116,6 +119,7 @@ class MuxCommandTests(unittest.TestCase):
     def test_final_mux_forces_video_sync_samples_for_quicktime_seeking(self) -> None:
         with (
             patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(container.config, "video_mode", VideoMode.MV_HEVC),
             patch.object(
                 container,
                 "get_audio_stream_data",
@@ -135,6 +139,24 @@ class MuxCommandTests(unittest.TestCase):
         self.assertEqual(command[:4], [Path("/tools/MP4Box"), "-new", "-add", "movie_MV-HEVC.mov:forcesync"])
         self.assertIn("audio_PCM.mov#1:lang=eng:group=1:alternate_group=1", command)
         self.assertEqual(command[-1], Path("movie_AVP.mov"))
+
+    def test_av1_final_mux_preserves_existing_sync_samples(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(container.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(container, "get_audio_stream_data", return_value=[]),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_command") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_AV1-Stereo.mp4"),
+                Path("audio_PCM.mov"),
+                Path("movie_AV1_Stereo.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(command[:4], [Path("/tools/MP4Box"), "-new", "-add", Path("movie_AV1-Stereo.mp4")])
 
     def test_final_mux_preserves_multiple_direct_aac_tracks(self) -> None:
         with (

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -138,6 +138,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         for label in (
             "HEVC quality",
             "Left / right bitrate",
+            "Video Output",
+            "AV1 quality",
             "AI FX upscale to 2\u00d7 resolution",
             "Crop black bars",
             "Swap left and right eyes",
@@ -147,7 +149,7 @@ class NativeAppPackagingTests(unittest.TestCase):
             "Start stage",
             "Keep durable stage files",
             "Continue processing after recoverable errors",
-            "Use software encoder",
+            "Use software HEVC encoder",
             "Overwrite an existing output file",
             "Remove original after success",
             "Show generated commands in activity",

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -18,6 +18,7 @@ from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.disc import DiscInfo, DiscTitleInfo, MKVCreationError
 from bd_to_avp.modules.process import process_each
 from bd_to_avp.modules.sub import SRTCreationError
+from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.worker.__main__ import run_worker
 from bd_to_avp.worker.operations import (
     WorkerDecisionRequired,
@@ -85,6 +86,8 @@ def conversion_request_line(
         "destination": {"path": str(destination_path)},
         "encoding": {
             "audio": {"mode": "convert_aac", "bitrate": 384},
+            "video_mode": "mv_hevc",
+            "av1_crf": 32,
             "left_right_bitrate": 20,
             "link_quality": True,
             "mv_hevc_quality": 75,
@@ -228,7 +231,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(context.exception.code, "invalid_source")
 
     def test_parses_shared_swift_conversion_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v7.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -237,9 +240,27 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.source.path, Path("/tmp/movie.mkv"))
         self.assertEqual(job.destination.path if job.destination else None, Path("/tmp/output"))
         self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
+        self.assertEqual(job.encoding.video_mode if job.encoding else None, VideoMode.MV_HEVC)
+        self.assertEqual(job.encoding.av1_crf if job.encoding else None, 32)
+
+    def test_rejects_av1_export_with_fx_upscale(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video_mode"] = "av1_sbs"
+        request["encoding"]["fx_upscale"] = True
+
+        with self.assertRaisesRegex(WorkerProtocolError, "does not support AI FX upscale"):
+            JobSpec.from_json_line(json.dumps(request))
+
+    def test_rejects_av1_export_with_resolution_override(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video_mode"] = "av1_sbs"
+        request["encoding"]["resolution"] = "3840x2160"
+
+        with self.assertRaisesRegex(WorkerProtocolError, "full source resolution"):
+            JobSpec.from_json_line(json.dumps(request))
 
     def test_parses_shared_swift_physical_disc_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v7.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -249,7 +270,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertFalse(job.job.remove_original if job.job else True)
 
     def test_parses_shared_swift_preview_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v7.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -559,7 +580,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
             ],
         )
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_fallback_warning_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_fallback_warning_v7.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -571,7 +592,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
 
         activity.stage_started("configure", "Preparing conversion settings")
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v7.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -718,7 +739,7 @@ class WorkerRuntimeTests(unittest.TestCase):
                 }
             },
         )
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v6.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v7.json"
         fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(decoded_events(output)[-1], fixture)
@@ -1436,6 +1457,8 @@ class SourceConversionTests(unittest.TestCase):
             request["encoding"].update(
                 {
                     "audio": {"mode": "pcm", "bitrate": 512},
+                    "video_mode": "mv_hevc",
+                    "av1_crf": 27,
                     "left_right_bitrate": 42,
                     "mv_hevc_quality": 88,
                     "upscale_quality": 66,
@@ -1475,6 +1498,8 @@ class SourceConversionTests(unittest.TestCase):
                         "output_root_path": config.output_root_path,
                         "audio_mode": config.audio_mode,
                         "audio_bitrate": config.audio_bitrate,
+                        "video_mode": config.video_mode,
+                        "av1_crf": config.av1_crf,
                         "left_right_bitrate": config.left_right_bitrate,
                         "mv_hevc_quality": config.mv_hevc_quality,
                         "upscale_quality": config.upscale_quality,
@@ -1510,6 +1535,8 @@ class SourceConversionTests(unittest.TestCase):
             self.assertEqual(observed["output_root_path"], destination_path)
             self.assertEqual(observed["audio_mode"], AudioMode.PCM)
             self.assertEqual(observed["audio_bitrate"], 512)
+            self.assertEqual(observed["video_mode"], VideoMode.MV_HEVC)
+            self.assertEqual(observed["av1_crf"], 27)
             self.assertEqual(observed["left_right_bitrate"], 42)
             self.assertEqual(observed["mv_hevc_quality"], 88)
             self.assertEqual(observed["upscale_quality"], 66)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -6,6 +7,7 @@ from unittest.mock import patch
 
 from bd_to_avp import preflight
 from bd_to_avp.modules.config import Stage
+from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.vendor.pgsrip.ocr import OcrError
 
 
@@ -149,6 +151,67 @@ class DependencyPreflightTests(unittest.TestCase):
             required_paths = preflight.get_required_dependency_binaries_for_current_job()
 
         self.assertIn(preflight.config.MP4BOX_PATH, required_paths)
+
+    def test_av1_mode_requires_mp4box_but_not_spatial_media_tool(self) -> None:
+        with (
+            patch.object(preflight.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(preflight.config, "source_path", Path("/movie/source.mkv")),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job()
+
+        self.assertIn(preflight.config.MP4BOX_PATH, required_paths)
+        self.assertNotIn(preflight.config.SPATIAL_MEDIA_PATH, required_paths)
+
+    def test_av1_mode_requires_libsvtav1_before_encoding_stage(self) -> None:
+        with (
+            patch.object(preflight.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
+            patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    subprocess.CompletedProcess(
+                        args=[],
+                        returncode=0,
+                        stdout=" V..... libsvtav1 SVT-AV1 encoder\n",
+                    ),
+                    subprocess.CompletedProcess(args=[], returncode=0, stdout="av1_metadata\n"),
+                ],
+            ) as run,
+        ):
+            preflight.verify_av1_encoder_ready()
+
+        self.assertEqual(run.call_count, 2)
+
+    def test_av1_mode_rejects_ffmpeg_without_libsvtav1(self) -> None:
+        with (
+            patch.object(preflight.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
+            patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
+            patch(
+                "subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=" V..... libaom-av1\n"),
+            ),
+            self.assertRaisesRegex(preflight.DependencyPreflightError, "libsvtav1"),
+        ):
+            preflight.verify_av1_encoder_ready()
+
+    def test_av1_mode_rejects_ffmpeg_without_metadata_filter(self) -> None:
+        with (
+            patch.object(preflight.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
+            patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    subprocess.CompletedProcess(args=[], returncode=0, stdout=" V..... libsvtav1\n"),
+                    subprocess.CompletedProcess(args=[], returncode=0, stdout="extract_extradata\n"),
+                ],
+            ),
+            self.assertRaisesRegex(preflight.DependencyPreflightError, "av1_metadata"),
+        ):
+            preflight.verify_av1_encoder_ready()
 
     def test_fx_upscale_tool_is_required_only_when_enabled(self) -> None:
         with (

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -8,6 +8,7 @@ from bd_to_avp.modules import process
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import Stage
 from bd_to_avp.modules.disc import DiscInfo
+from bd_to_avp.modules.video_mode import VideoMode
 
 
 class ProcessAudioWiringTests(unittest.TestCase):
@@ -107,6 +108,7 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.object(process.config, "overwrite", True))
                 stack.enter_context(patch.object(process.config, "keep_files", False))
                 stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC))
+                stack.enter_context(patch.object(process.config, "video_mode", VideoMode.MV_HEVC))
                 stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
                 stack.enter_context(patch.object(process.config, "remove_original", True))
                 stack.enter_context(patch.object(process.config, "language_code", "eng"))
@@ -184,6 +186,7 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 stack.enter_context(patch.object(process.config, "overwrite", True))
                 stack.enter_context(patch.object(process.config, "keep_files", False))
                 stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC))
+                stack.enter_context(patch.object(process.config, "video_mode", VideoMode.MV_HEVC))
                 stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
                 stack.enter_context(patch.object(process.config, "remove_original", False))
                 stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
@@ -212,6 +215,64 @@ class ProcessAudioWiringTests(unittest.TestCase):
                 process.process_each(activity=activity)
 
             self.assertIn(("transcode_audio", "Prepare Audio"), activity.started)
+
+    def test_av1_mode_uses_packed_encode_and_preserves_final_mux_wiring(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            mvc_path = output_folder / "Movie_mvc.h264"
+            unmarked_path = output_folder / "Movie_AV1-SBS-unmarked.mp4"
+            stereo_path = output_folder / "Movie_AV1-Stereo.mp4"
+            audio_path = output_folder / "Movie_audio_PCM.mov"
+            final_path = output_folder / "Movie_AV1_Stereo.mov"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(process.config, "source_path", source_path))
+                stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
+                stack.enter_context(patch.object(process.config, "overwrite", True))
+                stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.PCM))
+                stack.enter_context(patch.object(process.config, "video_mode", VideoMode.AV1_SBS))
+                stack.enter_context(patch.object(process.config, "fx_upscale", False))
+                stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
+                stack.enter_context(patch.object(process.config, "remove_original", False))
+                stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                stack.enter_context(
+                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
+                )
+                stack.enter_context(
+                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
+                )
+                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                stack.enter_context(patch.object(process, "create_mkv_file", return_value=source_path))
+                stack.enter_context(patch.object(process, "get_video_color_depth", return_value=8))
+                stack.enter_context(patch.object(process, "detect_crop_parameters", return_value=None))
+                stack.enter_context(patch.object(process, "create_mvc_and_audio", return_value=(audio_path, mvc_path)))
+                stack.enter_context(patch.object(process, "create_srt_from_mkv"))
+                create_sbs = stack.enter_context(
+                    patch.object(process, "create_av1_sbs_file", return_value=unmarked_path)
+                )
+                finalize = stack.enter_context(
+                    patch.object(process, "create_av1_stereo_file", return_value=stereo_path)
+                )
+                create_left_right = stack.enter_context(patch.object(process, "create_left_right_files"))
+                create_mv_hevc = stack.enter_context(patch.object(process, "create_mv_hevc_file"))
+                stack.enter_context(patch.object(process, "create_upscaled_file", return_value=stereo_path))
+                stack.enter_context(patch.object(process, "create_transcoded_audio_file", return_value=audio_path))
+                mux = stack.enter_context(patch.object(process, "create_muxed_file", return_value=final_path))
+                stack.enter_context(patch.object(process, "move_file_to_output_root_folder"))
+                stack.enter_context(patch.dict(process.os.environ, {}, clear=False))
+
+                process.process_each()
+
+            create_sbs.assert_called_once_with(DiscInfo(name="Movie", color_depth=8), output_folder, mvc_path, None)
+            finalize.assert_called_once_with(unmarked_path, output_folder, DiscInfo(name="Movie", color_depth=8))
+            create_left_right.assert_not_called()
+            create_mv_hevc.assert_not_called()
+            mux.assert_called_once_with(audio_path, stereo_path, output_folder, "Movie")
 
 
 if __name__ == "__main__":

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -9,6 +9,7 @@ from bd_to_avp.modules import process
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.disc import MKVCreationError
+from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.modules.file import (
     move_file_to_output_root_folder,
     prepare_output_folder_for_source,
@@ -23,6 +24,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "skip_subtitles", False),
             patch.object(process.config, "fx_upscale", False),
             patch.object(process.config, "audio_mode", AudioMode.CONVERT_AAC),
+            patch.object(process.config, "video_mode", VideoMode.MV_HEVC),
             patch.object(process.config, "start_stage", Stage.CREATE_MKV),
         ):
             default_plan = process.conversion_stage_plan()
@@ -51,6 +53,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "skip_subtitles", True),
             patch.object(process.config, "fx_upscale", True),
             patch.object(process.config, "audio_mode", AudioMode.PCM),
+            patch.object(process.config, "video_mode", VideoMode.MV_HEVC),
             patch.object(process.config, "start_stage", Stage.CREATE_MKV),
         ):
             optional_plan = process.conversion_stage_plan()
@@ -60,12 +63,28 @@ class ProcessPreflightTests(unittest.TestCase):
         self.assertNotIn("extract_subtitles", optional_plan)
         self.assertNotIn("transcode_audio", optional_plan)
 
+        with (
+            patch.object(process.config, "preview_range", None),
+            patch.object(process.config, "skip_subtitles", False),
+            patch.object(process.config, "fx_upscale", False),
+            patch.object(process.config, "audio_mode", AudioMode.PCM),
+            patch.object(process.config, "video_mode", VideoMode.AV1_SBS),
+            patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            av1_plan = process.conversion_stage_plan()
+
+        self.assertIn("encode_av1_stereo", av1_plan)
+        self.assertIn("finalize_av1_stereo", av1_plan)
+        self.assertNotIn("create_left_right_files", av1_plan)
+        self.assertNotIn("combine_to_mv_hevc", av1_plan)
+
     def test_conversion_stage_plan_excludes_completed_recovery_stages(self) -> None:
         with (
             patch.object(process.config, "preview_range", None),
             patch.object(process.config, "skip_subtitles", False),
             patch.object(process.config, "fx_upscale", False),
             patch.object(process.config, "audio_mode", AudioMode.AUTOMATIC),
+            patch.object(process.config, "video_mode", VideoMode.MV_HEVC),
             patch.object(process.config, "start_stage", Stage.EXTRACT_MVC_AND_AUDIO),
         ):
             mkv_recovery_plan = process.conversion_stage_plan()
@@ -79,6 +98,7 @@ class ProcessPreflightTests(unittest.TestCase):
             patch.object(process.config, "skip_subtitles", True),
             patch.object(process.config, "fx_upscale", False),
             patch.object(process.config, "audio_mode", AudioMode.CONVERT_AAC),
+            patch.object(process.config, "video_mode", VideoMode.MV_HEVC),
             patch.object(process.config, "start_stage", Stage.EXTRACT_SUBTITLES),
         ):
             subtitle_recovery_plan = process.conversion_stage_plan()

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -216,8 +216,13 @@ def make_fake_app(
         if tool_name == "ffmpeg":
             lines = [
                 "#!/bin/sh",
-                'if [ "$2" = "-encoders" ]; then echo " V..... libsvtav1"; '
-                'elif [ "$2" = "-bsfs" ]; then echo "av1_metadata"; else echo ok; fi',
+                " ".join(
+                    [
+                        'if [ "$2" = "-encoders" ]; then echo " V..... libsvtav1";',
+                        'elif [ "$2" = "-bsfs" ]; then echo "av1_metadata";',
+                        "else echo ok; fi",
+                    ]
+                ),
             ]
         write_executable(bin_path / tool_name, lines)
 

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -84,6 +84,14 @@ class ReleaseSmokeTests(unittest.TestCase):
                         returncode=0,
                         stdout="/opt/homebrew/lib/libexample.dylib\n",
                     )
+                if "-encoders" in command:
+                    return smoke_release_app.subprocess.CompletedProcess(
+                        args=command, returncode=0, stdout=" V..... libsvtav1\n"
+                    )
+                if "-bsfs" in command:
+                    return smoke_release_app.subprocess.CompletedProcess(
+                        args=command, returncode=0, stdout="av1_metadata\n"
+                    )
                 return smoke_release_app.subprocess.CompletedProcess(args=command, returncode=0, stdout="")
 
             with patch.object(smoke_release_app, "run", side_effect=fake_run):
@@ -124,7 +132,11 @@ class ReleaseSmokeTests(unittest.TestCase):
             app_path = make_fake_app(Path(temp_dir), version="1.2.3")
             bundle = smoke_release_app.read_bundle(app_path)
 
-            with patch.object(smoke_release_app, "run") as run:
+            def fake_run(command: list[str | Path], *, env: dict[str, str] | None = None):
+                output = "av1_metadata\n" if "-bsfs" in command else " V..... libsvtav1\n"
+                return smoke_release_app.subprocess.CompletedProcess(args=command, returncode=0, stdout=output)
+
+            with patch.object(smoke_release_app, "run", side_effect=fake_run) as run:
                 smoke_release_app.verify_bundled_tool(
                     bundle.bin_dir / "ffmpeg",
                     ["-version"],
@@ -132,7 +144,27 @@ class ReleaseSmokeTests(unittest.TestCase):
                     check_links=False,
                 )
 
-        self.assertEqual(run.call_count, 1)
+        self.assertEqual(run.call_count, 3)
+
+    def test_bundled_ffmpeg_requires_av1_metadata_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+
+            def fake_run(command: list[str | Path], *, env: dict[str, str] | None = None):
+                output = "extract_extradata\n" if "-bsfs" in command else " V..... libsvtav1\n"
+                return smoke_release_app.subprocess.CompletedProcess(args=command, returncode=0, stdout=output)
+
+            with (
+                patch.object(smoke_release_app, "run", side_effect=fake_run),
+                self.assertRaisesRegex(smoke_release_app.SmokeFailure, "av1_metadata"),
+            ):
+                smoke_release_app.verify_bundled_tool(
+                    bundle.bin_dir / "ffmpeg",
+                    ["-version"],
+                    clean_env=smoke_release_app.build_clean_env(),
+                    check_links=False,
+                )
 
 
 def make_fake_app(
@@ -180,7 +212,14 @@ def make_fake_app(
     )
 
     for tool_name in [*smoke_release_app.REQUIRED_BUNDLED_TOOLS, *smoke_release_app.OPTIONAL_BUNDLED_TOOLS]:
-        write_executable(bin_path / tool_name, ["#!/bin/sh", "echo ok"])
+        lines = ["#!/bin/sh", "echo ok"]
+        if tool_name == "ffmpeg":
+            lines = [
+                "#!/bin/sh",
+                'if [ "$2" = "-encoders" ]; then echo " V..... libsvtav1"; '
+                'elif [ "$2" = "-bsfs" ]; then echo "av1_metadata"; else echo ok; fi',
+            ]
+        write_executable(bin_path / tool_name, lines)
 
     return app_path
 

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -54,6 +54,46 @@ class VerifyAppToolsTests(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, "/usr/local"):
                     verify_app_tools.verify_tool(tool_path, ["-version"])
 
+    def test_verify_ffmpeg_requires_libsvtav1(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tool_path = Path(temp_dir) / "ffmpeg"
+            tool_path.write_text("tool")
+            tool_path.chmod(0o755)
+
+            def fake_run(command: list[str | Path]):
+                if command[:2] == ["otool", "-L"]:
+                    return subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+                if "-encoders" in command:
+                    return subprocess.CompletedProcess(args=command, returncode=0, stdout=" V..... libaom-av1\n")
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+
+            with (
+                patch.object(verify_app_tools, "run", side_effect=fake_run),
+                self.assertRaisesRegex(RuntimeError, "libsvtav1"),
+            ):
+                verify_app_tools.verify_tool(tool_path, ["-version"])
+
+    def test_verify_ffmpeg_requires_av1_metadata_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tool_path = Path(temp_dir) / "ffmpeg"
+            tool_path.write_text("tool")
+            tool_path.chmod(0o755)
+
+            def fake_run(command: list[str | Path]):
+                if command[:2] == ["otool", "-L"]:
+                    return subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+                if "-encoders" in command:
+                    return subprocess.CompletedProcess(args=command, returncode=0, stdout=" V..... libsvtav1\n")
+                if "-bsfs" in command:
+                    return subprocess.CompletedProcess(args=command, returncode=0, stdout="extract_extradata\n")
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="")
+
+            with (
+                patch.object(verify_app_tools, "run", side_effect=fake_run),
+                self.assertRaisesRegex(RuntimeError, "av1_metadata"),
+            ):
+                verify_app_tools.verify_tool(tool_path, ["-version"])
+
     def test_rejects_mach_o_newer_than_app_minimum(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = Path(temp_dir) / "Test.app"


### PR DESCRIPTION
## Summary

- add an opt-in `av1_sbs` video mode while keeping MV-HEVC as the default native Apple spatial output
- encode one full-resolution side-by-side AV1 stream with bundled `libsvtav1` preset 9 and configurable CRF
- preserve limited-range BT.709 signaling, apply Apple `vexu/eyes/pack` stereo metadata, and import the AV1 MP4 intermediate into the final MOV
- carry the mode through CLI/config, worker protocol v7, profile schema v3 migration, restart stages, output naming, previews, summaries, and native UI
- verify bundled FFmpeg exposes both `libsvtav1` and the `av1_metadata` bitstream filter
- update feasibility and pipeline documentation with the corrected product decision, limitations, production probe, and bounded comparison

## Product Boundary

AV1 output is described as software-encoded packed stereo, not MV-HEVC, multiview compression, or Apple spatial video. MV-HEVC remains the default. Physical headset qualification remains tracked in #200.

## Validation

- Python: 544 passed, 2 skipped
- Native: 148 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/release.py validate`
- `uv build`
- bounded production-path probe on the merged branch:
  - final MOV contains `av01` video plus AAC audio
  - beginning/middle/end decoding succeeds
  - FFprobe reports limited-range BT.709 matrix, primaries, and transfer
  - MP4Box preserves `vexu/eyes/stri` and `pack/pkin=side`
  - AVFoundation reports left/right eye views and `ViewPackingKind = SideBySide`
  - `AVAssetPlaybackAssistant`: `StereoVideo=true`, `StereoMultiviewVideo=false`, `SpatialVideo=false`

## Bounded Comparison

Same two-second, 48-frame, 1920x1080-per-eye synthetic source and AAC audio; timing includes encode, stereo finalization, and final mux.

| Mode | Settings | Time | Final size | Mean PSNR | Mean SSIM |
| --- | --- | ---: | ---: | ---: | ---: |
| MV-HEVC | VideoToolbox HEVC, 20 Mbps/eye, merge quality 75 | 2.201 s | 4,005,130 bytes | 59.934823 dB | 0.999850 |
| AV1 stereo | SVT-AV1 preset 9, CRF 32 | 1.529 s | 3,688,383 bytes | 41.393707 dB | 0.993237 |

This is a pipeline sanity check, not a quality-matched codec comparison or feature-film performance claim. The feasibility record includes the CRF sweep and caveats.

Closes #220
