### PR TITLE
Add Homebrew CLI distribution path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,21 @@ jobs:
           uv run python -c
           "import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app"
 
+      - name: CLI-only install smoke
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv-cli
+        run: |
+          uv sync --locked --no-default-groups --no-editable --python 3.12
+          .venv-cli/bin/python -c \
+            "import importlib.util; assert importlib.util.find_spec('PySide6') is None"
+          .venv-cli/bin/bd-to-avp --version
+          .venv-cli/bin/bd-to-avp --help >/dev/null
+          if OUTPUT=$(.venv-cli/bin/bd-to-avp 2>&1); then
+            echo "CLI-only install unexpectedly started the GUI." >&2
+            exit 1
+          fi
+          grep -F 'bd_to_avp[gui]' <<< "$OUTPUT"
+
       - name: Build Python package
         run: uv build
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,22 @@ MV-HEVC spatial output and software AV1 stereo export.
 
 ## Terminal install or update (power users)
 
-The terminal/PyPI version is for power users who manage their own command-line dependencies. Install the tools listed
-below, create a Python environment, then install `BD_to_AVP` with `pip`.
+The Homebrew formula is the preferred terminal install. It installs the locked CLI dependencies and FFmpeg while
+intentionally omitting the PySide6 GUI. Use the signed release DMG for the desktop app.
+
+### Homebrew formula
+
+```bash
+brew tap cbusillo/tap
+brew trust cbusillo/tap
+brew install bd-to-avp
+bd-to-avp --help
+```
+
+MakeMKV remains a separate optional install for Blu-ray disc input. Install the current macOS version from the
+[MakeMKV] website; existing MKV, MTS, and M2TS sources do not require it.
+
+The manual PyPI path remains available for power users who prefer to manage their own Python environment and FFmpeg.
 
 ## Prerequisites
 
@@ -51,12 +65,10 @@ Ensure the following are installed on your Mac *(if using the terminal/PyPI vers
 
 - **Apple Silicon [Mac]**: A Mac with Apple Silicon, such as the M1, M1 Pro, or M1 Max
 - **[macOS Sonoma]**: macOS 14 or later.
-- **[Python] 3.12**: The latest version of Python.
+- **[Python] 3.12**: The supported Python runtime for the PyPI package.
 - **[Homebrew]**: The missing package manager for macOS (or Linux).
 - **[FFmpeg]**: A complete, cross-platform solution to record, convert, and stream audio and video.
-- **[MakeMKV]**: For converting disc video content into MKV files.
-- **[spatial-media-kit-tool]**: A tool for injecting 360° metadata into video files.
-- **[MP4Box]**: A multimedia packager available for Windows, Mac, and Linux.
+- **[MakeMKV]**: Required only for reading Blu-ray discs and extracting titles.
 
 Current release note: BD_to_AVP still uses MakeMKV for Blu-ray title extraction. By default, existing MKV/MTS/M2TS
 sources are reused in place, MVC video streams directly into the bundled native Apple Silicon splitter, and AAC
@@ -78,8 +90,8 @@ and install MakeMKV from the [MakeMKV] website.
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# Install Homebrew formula dependencies. MP4Box is provided by gpac.
-brew install ffmpeg gpac python@3.12
+# Install the external command-line dependencies.
+brew install ffmpeg python@3.12
 
 # Install the current macOS MakeMKV build from https://www.makemkv.com/.
 # The app bundle is detected automatically from /Applications/MakeMKV.app.
@@ -96,12 +108,13 @@ pip install bd_to_avp
 bd-to-avp --help
 ```
 
-## GUI Usage
+## PyPI GUI extra
 
-If you have installed the terminal version and wish to use the GUI version, you can run the following command in your
-terminal:
+The signed release DMG is the supported GUI install. PyPI users who intentionally want the legacy Python GUI can add
+the optional dependency and then launch without arguments:
 
 ```bash
+pip install "bd_to_avp[gui]"
 bd-to-avp
 ```
 

--- a/bd_to_avp/__main__.py
+++ b/bd_to_avp/__main__.py
@@ -3,10 +3,25 @@ import signal
 
 import psutil
 
-from bd_to_avp.app import start_gui
 from bd_to_avp.modules.process import start_process
 from bd_to_avp.modules.config import config
 from bd_to_avp.vendor.pgsrip.ocr import AppleVisionOcr
+
+
+GUI_DEPENDENCY_MESSAGE = (
+    'GUI dependencies are not installed. Install them with `pip install "bd_to_avp[gui]"` or use the release DMG.'
+)
+
+
+def _start_gui() -> None:
+    try:
+        from bd_to_avp.app import start_gui
+    except ModuleNotFoundError as error:
+        if error.name != "PySide6" and not (error.name or "").startswith("PySide6."):
+            raise
+        raise SystemExit(GUI_DEPENDENCY_MESSAGE) from None
+
+    start_gui()
 
 
 def kill_child_processes() -> None:
@@ -38,7 +53,7 @@ def main() -> None:
 
     if config.app.is_gui:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
-        start_gui()
+        _start_gui()
     else:
         start_process()
 

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -56,11 +56,20 @@ reinstalling BD_to_AVP.
   to a focused follow-up issue. Do not tell users to reinstall the current app
   unless the current release artifact actually contains the missing dependency.
 
-## Terminal And PyPI Channel
+## Terminal, PyPI, And Homebrew Channel
 
-The terminal/PyPI channel is for users who intentionally manage dependencies
-themselves. README terminal instructions may continue to use Homebrew because
-that channel is explicitly command-line oriented.
+The custom `cbusillo/tap` Homebrew formula is the preferred terminal install.
+It builds from the stable GitHub tag, consumes the committed `uv.lock`, depends
+on Homebrew FFmpeg and Python 3.12, and omits the PySide6 GUI packages. The base
+PyPI package follows the same CLI-only boundary; users who intentionally want
+the legacy Python GUI may install the `gui` extra, while the Briefcase release
+continues to declare PySide6 explicitly.
+
+The formula does not depend on a MakeMKV cask. MakeMKV is optional for existing
+MKV, MTS, and M2TS inputs, remains external for disc extraction, and should be
+installed from its current supported macOS distribution. A Homebrew cask for
+BD_to_AVP is not maintained because it would duplicate the signed DMG channel
+without providing a reliable CLI link for the Briefcase launcher.
 
 Terminal dependency changes should not weaken the GUI policy. If a tool is
 required by the GUI, the release workflow should either bundle and verify it or
@@ -86,7 +95,6 @@ document it as an external dependency with preflight behavior.
   allowlist is the notarized DMG and `SHA256SUMS`.
 - PKG artifact policy is tracked in #118. Until that issue decides otherwise,
   PKG output is not the normal-user release path.
-- Homebrew distribution for CLI users is tracked in #119.
 - The Sparkle direct-DMG implementation and Stable/Release Candidates policy is
   documented in [sparkle-updates.md](sparkle-updates.md) and tracked through
   #162 through #165.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -84,10 +84,16 @@ The workflow performs these ordered boundaries:
    Publishing with PEP 740 attestations; RC releases never publish to PyPI.
 8. Deploy the durable `appcast.xml` release asset to GitHub Pages. A deployment
    failure can be retried without rebuilding, retagging, or re-signing.
+9. The separate `cbusillo/homebrew-tap` repository checks the latest stable
+   GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
+   update pull request when the version changes; tap CI must pass formula audit,
+   source installation, command tests, and linkage checks before merge. RC
+   releases do not update the formula.
 
-For Stable releases, PyPI publication and Sparkle Pages deployment are
-independent post-publication jobs. Either channel can be retried without
-rebuilding or changing the published GitHub Release.
+For Stable releases, PyPI publication, Sparkle Pages deployment, and the
+Homebrew tap update are independent post-publication jobs. Each channel can be
+retried without rebuilding or changing the published GitHub Release. The tap
+uses its own repository token and requires no cross-repository release secret.
 
 Release bodies are also the updater's native Markdown source. Keep the opening
 paragraph useful as the version summary and prefer headings, lists, links,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,15 @@ dependencies = [
     "opencv-python==5.0.0.93",
     "psutil>=5.9.8,<8",
     "pyobjc-framework-vision>=11.0,<13",
-    # PySide6 6.10+ includes macOS binaries that require macOS 15.
-    "pyside6>=6.7.1,<6.10",
     "pysrt>=1.1.2,<2",
     "trakit>=0.2.2,<0.3",
     "wakepy>=0.9.1,<1.1",
+]
+
+[project.optional-dependencies]
+gui = [
+    # PySide6 6.10+ includes macOS binaries that require macOS 15.
+    "pyside6>=6.7.1,<6.10",
 ]
 
 [project.urls]
@@ -45,6 +49,7 @@ dev = [
     "black>=26.5.1,<27",
     "briefcase==0.4.4",
     "mypy>=2.1.0,<3",
+    "pyside6>=6.7.1,<6.10",
     "ruff>=0.15.20,<0.16",
     "types-psutil>=5.9.5.20240516",
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 import unittest
 from pathlib import Path
@@ -10,6 +11,32 @@ from bd_to_avp.modules.config import Config
 
 
 class MainSmokeTests(unittest.TestCase):
+    def test_gui_start_is_lazy(self) -> None:
+        with (
+            patch.object(__main__.config.app, "is_gui", True),
+            patch("bd_to_avp.__main__._start_gui") as start_gui,
+            patch("bd_to_avp.__main__.start_process") as start_process,
+            patch("bd_to_avp.__main__.signal.signal"),
+        ):
+            __main__.main()
+
+        start_gui.assert_called_once_with()
+        start_process.assert_not_called()
+
+    def test_missing_gui_extra_exits_with_install_guidance(self) -> None:
+        real_import = builtins.__import__
+
+        def import_without_pyside(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "bd_to_avp.app":
+                raise ModuleNotFoundError("No module named 'PySide6'", name="PySide6")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with (
+            patch("builtins.__import__", side_effect=import_without_pyside),
+            self.assertRaisesRegex(SystemExit, r"bd_to_avp\[gui\].*release DMG"),
+        ):
+            __main__._start_gui()
+
     def test_audio_mode_defaults_to_automatic_and_legacy_false_remains_pcm(self) -> None:
         config = Config()
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -71,6 +71,16 @@ def fake_lock_runner(stage_root: Path, _uv_executable: str) -> None:
 
 
 class ReleaseMetadataTests(unittest.TestCase):
+    def test_repository_keeps_gui_dependency_out_of_cli_base(self) -> None:
+        with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+            pyproject = tomllib.load(handle)
+
+        pyside_requirement = "pyside6>=6.7.1,<6.10"
+        self.assertNotIn(pyside_requirement, pyproject["project"]["dependencies"])
+        self.assertEqual(pyproject["project"]["optional-dependencies"]["gui"], [pyside_requirement])
+        self.assertIn(pyside_requirement, pyproject["dependency-groups"]["dev"])
+        self.assertIn(pyside_requirement, pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["requires"])
+
     def test_repository_uses_expected_briefcase_version(self) -> None:
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
             pyproject = tomllib.load(handle)

--- a/uv.lock
+++ b/uv.lock
@@ -99,10 +99,14 @@ dependencies = [
     { name = "opencv-python" },
     { name = "psutil" },
     { name = "pyobjc-framework-vision" },
-    { name = "pyside6" },
     { name = "pysrt" },
     { name = "trakit" },
     { name = "wakepy" },
+]
+
+[package.optional-dependencies]
+gui = [
+    { name = "pyside6" },
 ]
 
 [package.dev-dependencies]
@@ -110,6 +114,7 @@ dev = [
     { name = "black" },
     { name = "briefcase" },
     { name = "mypy" },
+    { name = "pyside6" },
     { name = "ruff" },
     { name = "types-psutil" },
 ]
@@ -125,17 +130,19 @@ requires-dist = [
     { name = "opencv-python", specifier = "==5.0.0.93" },
     { name = "psutil", specifier = ">=5.9.8,<8" },
     { name = "pyobjc-framework-vision", specifier = ">=11.0,<13" },
-    { name = "pyside6", specifier = ">=6.7.1,<6.10" },
+    { name = "pyside6", marker = "extra == 'gui'", specifier = ">=6.7.1,<6.10" },
     { name = "pysrt", specifier = ">=1.1.2,<2" },
     { name = "trakit", specifier = ">=0.2.2,<0.3" },
     { name = "wakepy", specifier = ">=0.9.1,<1.1" },
 ]
+provides-extras = ["gui"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=26.5.1,<27" },
     { name = "briefcase", specifier = "==0.4.4" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
+    { name = "pyside6", specifier = ">=6.7.1,<6.10" },
     { name = "ruff", specifier = ">=0.15.20,<0.16" },
     { name = "types-psutil", specifier = ">=5.9.5.20240516" },
 ]


### PR DESCRIPTION
## Summary
- make PySide6 an explicit `gui` extra so the base PyPI package is CLI-only
- lazy-load the GUI and provide actionable guidance when the extra is absent
- add a clean CLI-only CI smoke and lockfile/package metadata coverage
- document Homebrew as the preferred terminal channel and record cask/MakeMKV boundaries
- document stable-release upkeep through `cbusillo/homebrew-tap#1`

## Validation
- `uv run python -m unittest discover -s tests -t .` (550 passed, 2 skipped)
- `uv run mypy bd_to_avp`
- targeted Ruff check and format check
- `actionlint .github/workflows/ci.yml`
- `uv build` with PySide6 verified as `extra == 'gui'`
- clean CLI-only `uv sync --locked --no-default-groups --no-editable` smoke
- JetBrains changed-file inspection: GREEN
- Homebrew formula audit/install/test/linkage/livecheck completed in `cbusillo/homebrew-tap#1`

Refs #119