### PR TITLE
Clarify custom Homebrew tap documentation

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -145,7 +145,7 @@
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": ["https://cbusillo.github.io/BD_to_AVP/appcast.xml"],
-  "relatedRepos": [],
+  "relatedRepos": ["cbusillo/homebrew-tap"],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ MV-HEVC spatial output and software AV1 stereo export.
 
 ## Terminal install or update (power users)
 
-The Homebrew formula is the preferred terminal install. It installs the locked CLI dependencies and FFmpeg while
-intentionally omitting the PySide6 GUI. Use the signed release DMG for the desktop app.
+The formula in the custom third-party `cbusillo/tap` repository is the preferred terminal install. It installs the
+locked CLI dependencies and FFmpeg while intentionally omitting the PySide6 GUI. Use the signed release DMG for the
+desktop app.
 
-### Homebrew formula
+### Custom Homebrew tap
 
 ```bash
 brew tap cbusillo/tap


### PR DESCRIPTION
## Summary
- explicitly identify `cbusillo/tap` as a custom third-party Homebrew repository
- rename the install subsection to `Custom Homebrew tap`
- record `cbusillo/homebrew-tap` in repository relationship metadata

## Validation
- `jq empty .github/github.json`
- `git diff --check`