### PR TITLE
Validate stereo and spatial playback modes

### DIFF
--- a/docs/visionos-playback-validator.md
+++ b/docs/visionos-playback-validator.md
@@ -20,8 +20,8 @@ Movies selected through Files are copied into the app's cache so playback can co
 - `VTIsStereoMVHEVCDecodeSupported()` on the current device.
 - `AVPlayerItem.status == .readyToPlay` for the selected movie.
 - `VideoPlayerComponent.currentRenderingStatus == .ready`.
-- Actual stereoscopic playback, reported separately from optional spatial treatment and portal presentation.
-- Beginning, middle, and end seeks, including preservation of stereoscopic playback and any spatial treatment that was active before the seek.
+- Actual stereoscopic playback and whether the presentation matches the selected validation expectation.
+- Beginning, middle, and end seeks, including preservation of stereoscopic playback and required spatial treatment.
 - Available audio and subtitle choices for manual review under **Technical details**.
 
 After the automatic sequence, the validator asks only:
@@ -37,13 +37,22 @@ The movie, playback controls, guided instructions, observations, result, and col
 
 Technical terms such as `Stereo · Spatial · Portal` appear only under **Technical details**. The primary flow uses plain language and exposes one next action at a time.
 
+## Presentation Expectations
+
+The validator has two intentional expectations:
+
+- **Stereo release movie** is the default. A converted Blu-ray movie should report `Stereo · Screen` because its capture baseline, field of view, and disparity can vary between shots.
+- **Spatial calibration fixture** is enabled with `BD_TO_AVP_PROBE_EXPECTED_PRESENTATION=spatial`. The controlled fixture should report `Stereo · Spatial · Portal` and proves that the validator can detect RealityKit spatial treatment.
+
+Apple requires spatial metadata to describe the true, constant properties of the cameras that captured the media. Its guidance specifically notes that a movie or TV show captured with changing camera geometry may not be appropriate for spatial presentation and should remain stereo. BD to AVP therefore does not invent a camera baseline for normal Blu-ray output. See [Creating spatial photos and videos with spatial metadata](https://developer.apple.com/documentation/imageio/creating-spatial-photos-and-videos-with-spatial-metadata) and [Converting side-by-side 3D video to multiview HEVC and spatial video](https://developer.apple.com/documentation/avfoundation/converting-side-by-side-3d-video-to-multiview-hevc-and-spatial-video).
+
 ## Result Meanings
 
 - **Playback check passed**: every automatic check passed and both visible observations were **Yes**.
 - **One result needs review**: the automatic checks did not fail, but at least one observation was **Not sure** or a check did not reach a final pass state.
 - **Playback check found a problem**: an automatic check failed or either visible observation was **No**.
 
-The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The report contains a schema version, validator version and build, visionOS version, filename, full-file SHA-256 fingerprint, file size, duration, media-option counts, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
+The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The schema-3 report contains the expected presentation, validator version and build, visionOS version, filename, full-file SHA-256 fingerprint, file size, duration, media-option counts, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
 
 ## Build
 
@@ -53,7 +62,7 @@ Create a six-second finalized MV-HEVC fixture with English audio and subtitles:
 scripts/create_spatial_playback_fixture.sh
 ```
 
-The fixture contains three labeled depth markers: blue should appear behind the screen plane, green on the screen plane, and red in front. This gives the operator an unambiguous depth-order check instead of a single flat test pattern.
+The fixture contains three labeled depth markers: blue should appear behind the screen plane, green on the screen plane, and red in front. It uses controlled 64 mm, rectilinear camera metadata so RealityKit recognizes it as spatial media. This gives the operator an unambiguous depth-order check and a deterministic `Stereo · Spatial · Portal` calibration asset without changing production Blu-ray metadata.
 
 Generate the project and build for the simulator:
 
@@ -94,7 +103,7 @@ xcodebuild build \
 
 ## Automated Physical-Device Setup
 
-Install the signed app, copy a finalized movie into its Documents container as `Probe.mov`, and launch the UI test or app with `BD_TO_AVP_PROBE_AUTORUN=1`:
+Install the signed app and copy a finalized movie into its Documents container as `Probe.mov`:
 
 ```bash
 xcrun devicectl device copy to \
@@ -105,7 +114,27 @@ xcrun devicectl device copy to \
   --domain-identifier com.shinycomputers.bd-to-avp.spatial-playback-probe
 ```
 
-Autorun starts the automatic sequence after the player is ready. It stops at the two human observations; automation does not fabricate visible playback answers. The physical UI test requires all automatic checks to pass and verifies that the observation screen is presented.
+For a normal Blu-ray release movie, launch the app with the default stereo expectation:
+
+```bash
+xcrun devicectl device process launch \
+  --device <device-id> \
+  --terminate-existing \
+  --environment-variables '{"BD_TO_AVP_PROBE_ASSET":"Probe.mov","BD_TO_AVP_PROBE_AUTORUN":"1"}' \
+  com.shinycomputers.bd-to-avp.spatial-playback-probe
+```
+
+For the generated calibration fixture, require spatial portal presentation:
+
+```bash
+xcrun devicectl device process launch \
+  --device <device-id> \
+  --terminate-existing \
+  --environment-variables '{"BD_TO_AVP_PROBE_ASSET":"Probe.mov","BD_TO_AVP_PROBE_AUTORUN":"1","BD_TO_AVP_PROBE_EXPECTED_PRESENTATION":"spatial"}' \
+  com.shinycomputers.bd-to-avp.spatial-playback-probe
+```
+
+Autorun starts the automatic sequence after the player is ready. It stops at the two human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
 
 After the operator selects **Finish Check**, retrieve the report directly without asking them to save share-sheet text manually:
 
@@ -118,7 +147,7 @@ xcrun devicectl device copy from \
   --domain-identifier com.shinycomputers.bd-to-avp.spatial-playback-probe
 ```
 
-The synthetic `Probe.mov` is the controlled visibility, stereo, and seek smoke test. A stereo-screen pass proves visible stereoscopic playback; it does not by itself prove RealityKit spatial treatment. The report keeps those outcomes separate so a missing spatial mode does not create three misleading seek failures.
+Use both expectations before release. A normal finalized movie proves the production stereo, audio, subtitle, and seek path. The synthetic calibration fixture separately proves that the app and device can enter RealityKit spatial portal presentation. Keeping those contracts separate prevents either missing spatial treatment or fabricated camera metadata from producing misleading release evidence.
 
 ## Audio Validation Matrix
 
@@ -141,6 +170,7 @@ Structured events use the `BD_TO_AVP_PLAYBACK_PROBE` prefix. `automated_probe_co
 Physical acceptance requires:
 
 - `automated_probe_complete` with `result=pass`.
+- `expected_presentation=stereo` for normal finalized Blu-ray movies, or `expected_presentation=spatial` for the generated calibration fixture.
 - Visible video throughout beginning, middle, and end playback.
 - Comfortable, non-inverted depth.
 - A shared report whose result matches the operator's observations.

--- a/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
@@ -127,6 +127,9 @@ final class PlaybackProbeModel: ObservableObject {
     @Published private(set) var playerComponentInstalled = false
 
     let stereoDecodeSupported = VTIsStereoMVHEVCDecodeSupported()
+    let presentationExpectation = PlaybackPresentationExpectation.resolve(
+        environment: ProcessInfo.processInfo.environment
+    )
 
     private var itemStatusObservation: NSKeyValueObservation?
     private var timeObserver: Any?
@@ -148,6 +151,7 @@ final class PlaybackProbeModel: ObservableObject {
     private var actualSpatialVideoModeValue = "screen"
     private var actualImmersiveViewingModeValue = "none"
     private var validatedPresentation = PlaybackPresentationSummary(
+        expectation: .stereo,
         viewingMode: "unknown",
         spatialVideoMode: "screen",
         immersiveViewingMode: "none"
@@ -163,6 +167,14 @@ final class PlaybackProbeModel: ObservableObject {
 
     var decodeSupportText: String {
         stereoDecodeSupported ? "Supported" : "Unavailable"
+    }
+
+    var expectedPresentationText: String {
+        presentationExpectation.technicalDescription
+    }
+
+    var expectedPresentationGuidance: String {
+        presentationExpectation.guidance
     }
 
     var canControlPlayback: Bool {
@@ -416,6 +428,7 @@ final class PlaybackProbeModel: ObservableObject {
         validationReportURL = nil
         validationReportSaveError = nil
         validatedPresentation = PlaybackPresentationSummary(
+            expectation: presentationExpectation,
             viewingMode: "unknown",
             spatialVideoMode: "screen",
             immersiveViewingMode: "none"
@@ -451,7 +464,7 @@ final class PlaybackProbeModel: ObservableObject {
 
         let generatedAt = Date()
         let report = PlaybackValidationReport(
-            schemaVersion: 2,
+            schemaVersion: 3,
             validatorVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "development",
             validatorBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "development",
             generatedAt: ISO8601DateFormatter().string(from: generatedAt),
@@ -866,20 +879,16 @@ final class PlaybackProbeModel: ObservableObject {
                 : "The movie remained monoscopic instead of stereoscopic."
         )
 
-        currentValidationStepText = "Checking 3D presentation…"
-        updateCheck(.spatialPresentation, status: .running, detail: "Waiting for spatial treatment and portal presentation.")
-        let spatialPresentationReady = await waitForCondition(maxAttempts: 40) { [weak self] in
-            self?.isActuallySpatial == true
-        }
+        currentValidationStepText = "Checking the expected 3D presentation…"
+        updateCheck(.presentationMode, status: .running, detail: "Waiting for the expected 3D presentation mode.")
+        let presentationMatchesExpectation = await waitForExpectedPresentation()
         guard isValidationCurrent(generation, item: validationItem) else {
             return
         }
         updateCheck(
-            .spatialPresentation,
-            status: spatialPresentationReady ? .passed : .failed,
-            detail: spatialPresentationReady
-                ? "The movie is rendering with spatial treatment in a portal."
-                : "Stereoscopic playback is available, but RealityKit remained in screen mode without spatial treatment."
+            .presentationMode,
+            status: presentationMatchesExpectation ? .passed : .failed,
+            detail: presentationModeDetail(matchesExpectation: presentationMatchesExpectation)
         )
 
         for position in ProbeSeekPosition.allCases {
@@ -937,7 +946,8 @@ final class PlaybackProbeModel: ObservableObject {
                 renderingReady: receivedFreshStatus && renderingStatusText == "Ready",
                 stereoPresentation: receivedFreshStatus && isActuallyStereo,
                 spatialPresentation: receivedFreshStatus && isActuallySpatial,
-                requiresSpatialPresentation: spatialPresentationReady
+                requiresSpatialPresentation: presentationExpectation.requiresSpatialPresentation
+                    && presentationMatchesExpectation
             )
             let passed = PlaybackValidationRules.seekPassed(evidence)
 
@@ -976,6 +986,7 @@ final class PlaybackProbeModel: ObservableObject {
                 "result": automaticChecksPassed ? "pass" : "fail",
                 "rendering_status": renderingStatusText.lowercased(),
                 "actual_presentation": actualPresentationText.lowercased(),
+                "expected_presentation": presentationExpectation.rawValue,
                 "checks_passed": String(automaticChecksPassed),
                 "audio_options": String(audioOptions.count),
                 "subtitle_options": String(max(0, subtitleOptions.count - 1)),
@@ -983,6 +994,7 @@ final class PlaybackProbeModel: ObservableObject {
         )
 
         validatedPresentation = PlaybackPresentationSummary(
+            expectation: presentationExpectation,
             viewingMode: actualViewingModeValue,
             spatialVideoMode: actualSpatialVideoModeValue,
             immersiveViewingMode: actualImmersiveViewingModeValue
@@ -1011,6 +1023,36 @@ final class PlaybackProbeModel: ObservableObject {
             try? await Task.sleep(nanoseconds: 250_000_000)
         }
         return condition()
+    }
+
+    private func waitForExpectedPresentation() async -> Bool {
+        switch presentationExpectation {
+        case .spatial:
+            return await waitForCondition(maxAttempts: 40) { [weak self] in
+                self?.isActuallySpatial == true
+            }
+        case .stereo:
+            _ = await waitForCondition(maxAttempts: 8) { [weak self] in
+                self?.isActuallySpatial == true
+            }
+            return presentationExpectation.matches(
+                isStereo: isActuallyStereo,
+                isSpatial: isActuallySpatial
+            )
+        }
+    }
+
+    private func presentationModeDetail(matchesExpectation: Bool) -> String {
+        switch (presentationExpectation, matchesExpectation) {
+        case (.stereo, true):
+            return "RealityKit reports stereoscopic screen playback, the expected mode for converted Blu-ray movies."
+        case (.stereo, false):
+            return "The movie did not remain in the expected stereoscopic screen presentation."
+        case (.spatial, true):
+            return "The calibration fixture is rendering with spatial treatment in a portal."
+        case (.spatial, false):
+            return "The calibration fixture remained in screen mode without spatial treatment."
+        }
     }
 
     private func seekTarget(for position: ProbeSeekPosition) -> Double {
@@ -1109,6 +1151,7 @@ final class PlaybackProbeModel: ObservableObject {
         validationReportURL = nil
         validationReportSaveError = nil
         validatedPresentation = PlaybackPresentationSummary(
+            expectation: presentationExpectation,
             viewingMode: "unknown",
             spatialVideoMode: "screen",
             immersiveViewingMode: "none"

--- a/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
@@ -258,6 +258,10 @@ struct PlaybackProbeView: View {
             Text("The check takes about 15 seconds. Keep this window visible while it plays the beginning, middle, and end.")
                 .foregroundStyle(.secondary)
 
+            Text(model.expectedPresentationGuidance)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
             VStack(alignment: .leading, spacing: 12) {
                 instructionRow(number: 1, text: "Start the guided check")
                 instructionRow(number: 2, text: "Watch the picture during three short seeks")
@@ -431,8 +435,9 @@ struct PlaybackProbeView: View {
                 statusRow(title: "Stereo decode support", value: model.decodeSupportText)
                 statusRow(title: "Player", value: model.playerItemStatusText)
                 statusRow(title: "Rendering", value: model.renderingStatusText)
+                statusRow(title: "Expected presentation", value: model.expectedPresentationText)
                 statusRow(
-                    title: "Requested presentation",
+                    title: "Mode requested during check",
                     value: model.isSpatialPresentationRequested ? "Stereo · Spatial · Portal" : "Contained screen preview"
                 )
                 statusRow(title: "Actual presentation", value: model.actualPresentationText)

--- a/macos/SpatialPlaybackProbe/PlaybackValidation.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackValidation.swift
@@ -10,12 +10,54 @@ enum PlaybackValidationPhase: Equatable {
     case complete
 }
 
+enum PlaybackPresentationExpectation: String, Codable, Equatable {
+    static let environmentKey = "BD_TO_AVP_PROBE_EXPECTED_PRESENTATION"
+
+    case stereo
+    case spatial
+
+    static func resolve(environment: [String: String]) -> Self {
+        environment[environmentKey]?.lowercased() == spatial.rawValue ? .spatial : .stereo
+    }
+
+    var requiresSpatialPresentation: Bool {
+        self == .spatial
+    }
+
+    func matches(isStereo: Bool, isSpatial: Bool) -> Bool {
+        switch self {
+        case .stereo:
+            return isStereo && !isSpatial
+        case .spatial:
+            return isSpatial
+        }
+    }
+
+    var technicalDescription: String {
+        switch self {
+        case .stereo:
+            return "Stereo · Screen"
+        case .spatial:
+            return "Stereo · Spatial · Portal"
+        }
+    }
+
+    var guidance: String {
+        switch self {
+        case .stereo:
+            return "This run expects normal stereoscopic screen playback for a converted Blu-ray movie."
+        case .spatial:
+            return "This run expects the controlled spatial calibration fixture to enter portal presentation."
+        }
+    }
+}
+
 enum PlaybackCheckID: String, Codable, CaseIterable {
     case stereoDecode
     case playerReady
     case renderingReady
     case stereoPresentation
-    case spatialPresentation
+    case presentationMode
     case beginningSeek
     case middleSeek
     case endSeek
@@ -30,8 +72,8 @@ enum PlaybackCheckID: String, Codable, CaseIterable {
             return "Picture is ready"
         case .stereoPresentation:
             return "Stereoscopic playback is active"
-        case .spatialPresentation:
-            return "Spatial treatment is active"
+        case .presentationMode:
+            return "3D presentation matches the movie type"
         case .beginningSeek:
             return "Beginning plays"
         case .middleSeek:
@@ -109,7 +151,7 @@ enum PlaybackValidationResult: String, Codable {
     var summary: String {
         switch self {
         case .passed:
-            return "The movie played spatially, survived all three seeks, and matched what you saw."
+            return "The movie played in the expected 3D mode, survived all three seeks, and matched what you saw."
         case .needsReview:
             return "The automatic checks completed, but one observation was uncertain. The report preserves the details without treating this as approval."
         case .failed:
@@ -139,6 +181,7 @@ struct PlaybackSourceSummary: Codable, Equatable {
 }
 
 struct PlaybackPresentationSummary: Codable, Equatable {
+    let expectation: PlaybackPresentationExpectation
     let viewingMode: String
     let spatialVideoMode: String
     let immersiveViewingMode: String

--- a/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
+++ b/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import SpatialPlaybackProbe
 
 final class PlaybackValidationTests: XCTestCase {
+    func testPresentationExpectationDefaultsToStereoAndAcceptsSpatialOverride() {
+        XCTAssertEqual(PlaybackPresentationExpectation.resolve(environment: [:]), .stereo)
+        XCTAssertEqual(
+            PlaybackPresentationExpectation.resolve(
+                environment: [PlaybackPresentationExpectation.environmentKey: "spatial"]
+            ),
+            .spatial
+        )
+        XCTAssertTrue(PlaybackPresentationExpectation.stereo.matches(isStereo: true, isSpatial: false))
+        XCTAssertFalse(PlaybackPresentationExpectation.stereo.matches(isStereo: true, isSpatial: true))
+        XCTAssertTrue(PlaybackPresentationExpectation.spatial.matches(isStereo: true, isSpatial: true))
+    }
+
     func testPassingChecksAndObservationsProducePass() {
         let checks = PlaybackCheckID.allCases.map {
             PlaybackCheck(id: $0, status: .passed, detail: "Passed")
@@ -65,7 +78,7 @@ final class PlaybackValidationTests: XCTestCase {
 
     func testReportContainsFilenameWithoutSourcePath() throws {
         let report = PlaybackValidationReport(
-            schemaVersion: 2,
+            schemaVersion: 3,
             validatorVersion: "0.1.0",
             validatorBuild: "42",
             generatedAt: "2026-07-17T20:00:00Z",
@@ -79,6 +92,7 @@ final class PlaybackValidationTests: XCTestCase {
                 subtitleOptionCount: 1
             ),
             presentation: PlaybackPresentationSummary(
+                expectation: .stereo,
                 viewingMode: "stereo",
                 spatialVideoMode: "screen",
                 immersiveViewingMode: "none"
@@ -99,6 +113,7 @@ final class PlaybackValidationTests: XCTestCase {
         XCTAssertTrue(reportText.contains("audioOptionCount"))
         XCTAssertTrue(reportText.contains("subtitleOptionCount"))
         XCTAssertTrue(reportText.contains("spatialVideoMode"))
+        XCTAssertTrue(reportText.contains("expectation"))
         XCTAssertFalse(reportText.contains("/Users/"))
         XCTAssertFalse(reportText.contains("sourcePath"))
     }

--- a/macos/SpatialPlaybackProbeUITests/SpatialPlaybackProbeUITests.swift
+++ b/macos/SpatialPlaybackProbeUITests/SpatialPlaybackProbeUITests.swift
@@ -21,6 +21,7 @@ final class SpatialPlaybackProbeUITests: XCTestCase {
         #else
         let app = XCUIApplication()
         app.launchEnvironment["BD_TO_AVP_PROBE_AUTORUN"] = "1"
+        app.launchEnvironment["BD_TO_AVP_PROBE_EXPECTED_PRESENTATION"] = "spatial"
         app.launch()
 
         let automaticStatus = app.staticTexts["automatic-check-status"]

--- a/scripts/add_spatial_video_metadata.py
+++ b/scripts/add_spatial_video_metadata.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import argparse
+import math
+import struct
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MP4BOX_PATH = REPO_ROOT / "bd_to_avp" / "bin" / "MP4Box"
+MV_HEVC_SAMPLE_ENTRY_PATH = "trak.mdia.minf.stbl.stsd.hvc1"
+
+
+def make_box(box_type: bytes, payload: bytes) -> bytes:
+    if len(box_type) != 4:
+        raise ValueError("box_type must contain exactly four bytes")
+    return struct.pack(">I4s", len(payload) + 8, box_type) + payload
+
+
+def make_full_box(box_type: bytes, payload: bytes) -> bytes:
+    return make_box(box_type, b"\0\0\0\0" + payload)
+
+
+def spatial_vexu_content(baseline_mm: float, disparity_adjustment: float) -> bytes:
+    if not math.isfinite(baseline_mm) or baseline_mm <= 0:
+        raise ValueError("baseline_mm must be a positive finite number")
+    if not math.isfinite(disparity_adjustment) or not -1 <= disparity_adjustment <= 1:
+        raise ValueError("disparity_adjustment must be between -1 and 1")
+
+    baseline_micrometers = round(baseline_mm * 1_000)
+    if baseline_micrometers > 0xFFFFFFFF:
+        raise ValueError("baseline_mm is too large for Apple spatial metadata")
+    encoded_disparity = round(disparity_adjustment * 10_000)
+
+    stereo_views = make_full_box(b"stri", b"\x03")
+    camera_baseline = make_box(b"cams", make_box(b"blin", struct.pack(">Q", baseline_micrometers)))
+    disparity = make_box(b"cmfy", make_box(b"dadj", struct.pack(">q", encoded_disparity)))
+    eyes = make_box(b"eyes", stereo_views + camera_baseline + disparity)
+    projection = make_box(b"proj", make_full_box(b"prji", b"rect"))
+    return eyes + projection
+
+
+def spatial_metadata_patch_xml(baseline_mm: float, disparity_adjustment: float) -> str:
+    content = spatial_vexu_content(baseline_mm, disparity_adjustment).hex().upper()
+    return (
+        '<?xml version="1.0"?>\n'
+        "<GPACBOXES>\n"
+        f'  <Box path="{MV_HEVC_SAMPLE_ENTRY_PATH}.vexu" trackID="1"/>\n'
+        f'  <Box path="{MV_HEVC_SAMPLE_ENTRY_PATH}.lhvC+" trackID="1">\n'
+        '    <BS fcc="vexu"/>\n'
+        f'    <BS data="{content}"/>\n'
+        "  </Box>\n"
+        "</GPACBOXES>\n"
+    )
+
+
+def add_spatial_video_metadata(
+    input_path: Path,
+    output_path: Path,
+    baseline_mm: float,
+    disparity_adjustment: float,
+    mp4box_path: Path = DEFAULT_MP4BOX_PATH,
+) -> None:
+    if input_path == output_path:
+        raise ValueError("input_path and output_path must be different")
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Input movie does not exist: {input_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.unlink(missing_ok=True)
+    patch_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix="bd-to-avp-spatial-metadata-",
+            suffix=".xml",
+            delete=False,
+        ) as patch_file:
+            patch_file.write(spatial_metadata_patch_xml(baseline_mm, disparity_adjustment))
+            patch_path = Path(patch_file.name)
+
+        subprocess.run(
+            [
+                str(mp4box_path),
+                "-patch",
+                str(patch_path),
+                str(input_path),
+                "-out",
+                str(output_path),
+            ],
+            check=True,
+        )
+    finally:
+        if patch_path is not None:
+            patch_path.unlink(missing_ok=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Replace MV-HEVC extended-usage metadata with complete Apple spatial-video metadata."
+    )
+    parser.add_argument("input_path", type=Path)
+    parser.add_argument("output_path", type=Path)
+    parser.add_argument("--baseline-mm", required=True, type=float)
+    parser.add_argument("--disparity-adjustment", default=0.0, type=float)
+    parser.add_argument("--mp4box", default=DEFAULT_MP4BOX_PATH, type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    add_spatial_video_metadata(
+        args.input_path,
+        args.output_path,
+        args.baseline_mm,
+        args.disparity_adjustment,
+        args.mp4box,
+    )
+    print(f"Added Apple spatial-video metadata: {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_spatial_playback_fixture.sh
+++ b/scripts/create_spatial_playback_fixture.sh
@@ -6,7 +6,7 @@ output_path="${1:-/tmp/bd-to-avp-spatial-fixture/Probe.mov}"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 
-for command_name in ffmpeg ffprobe; do
+for command_name in ffmpeg ffprobe python3; do
 	if ! command -v "$command_name" >/dev/null 2>&1; then
 		printf 'Required command is unavailable: %s\n' "$command_name" >&2
 		exit 1
@@ -56,7 +56,13 @@ EOF
 	-add "$work_dir/spatial.mov:forcesync" \
 	-add "$work_dir/audio.m4a#1:lang=eng:group=1:alternate_group=1" \
 	-add "$work_dir/subtitles.srt#1:hdlr=sbtl:lang=eng:group=2:name=English Subtitles:tx3g" \
-	"$output_path"
+	"$work_dir/finalized.mov"
+
+python3 "$repo_root/scripts/add_spatial_video_metadata.py" \
+	"$work_dir/finalized.mov" \
+	"$output_path" \
+	--baseline-mm 64 \
+	--disparity-adjustment 0
 
 ffprobe -v error -show_entries format=duration:stream=index,codec_name,codec_type:stream_tags=language -of json "$output_path"
 printf 'Created spatial playback fixture: %s\n' "$output_path"

--- a/tests/test_spatial_video_metadata.py
+++ b/tests/test_spatial_video_metadata.py
@@ -1,0 +1,61 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import add_spatial_video_metadata
+
+
+class SpatialVideoMetadataTests(unittest.TestCase):
+    def test_vexu_content_matches_apple_spatial_box_structure(self) -> None:
+        content = add_spatial_video_metadata.spatial_vexu_content(64, 0.02).hex().upper()
+
+        self.assertEqual(
+            content,
+            "00000045657965730000000D7374726900000000030000001863616D73"
+            "00000010626C696E000000000000FA0000000018636D6679000000106461646A"
+            "00000000000000C80000001870726F6A0000001070726A690000000072656374",
+        )
+
+    def test_patch_replaces_incomplete_vexu_after_layered_hevc_configuration(self) -> None:
+        patch_xml = add_spatial_video_metadata.spatial_metadata_patch_xml(64, 0)
+
+        self.assertIn('path="trak.mdia.minf.stbl.stsd.hvc1.vexu"', patch_xml)
+        self.assertIn('path="trak.mdia.minf.stbl.stsd.hvc1.lhvC+"', patch_xml)
+        self.assertIn('fcc="vexu"', patch_xml)
+        self.assertIn("626C696E000000000000FA00", patch_xml)
+        self.assertIn("70726A690000000072656374", patch_xml)
+
+    def test_spatial_metadata_rejects_invalid_geometry(self) -> None:
+        with self.assertRaisesRegex(ValueError, "baseline_mm"):
+            add_spatial_video_metadata.spatial_vexu_content(0, 0)
+        with self.assertRaisesRegex(ValueError, "disparity_adjustment"):
+            add_spatial_video_metadata.spatial_vexu_content(64, 1.1)
+
+    def test_add_spatial_metadata_removes_temporary_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            input_path = root / "input.mov"
+            output_path = root / "output.mov"
+            input_path.touch()
+
+            with patch.object(add_spatial_video_metadata.subprocess, "run") as run:
+                add_spatial_video_metadata.add_spatial_video_metadata(
+                    input_path,
+                    output_path,
+                    64,
+                    0,
+                    Path("/tools/MP4Box"),
+                )
+
+            command = run.call_args.args[0]
+            patch_path = Path(command[2])
+            self.assertEqual(command[0], "/tools/MP4Box")
+            self.assertEqual(command[1], "-patch")
+            self.assertEqual(command[3:], [str(input_path), "-out", str(output_path)])
+            self.assertFalse(patch_path.exists())
+            self.assertTrue(run.call_args.kwargs["check"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- distinguish normal Blu-ray stereo-screen playback from the controlled spatial calibration expectation
- complete the generated calibration fixture's Apple spatial metadata with stereo-eye, camera-baseline, and rectilinear-projection boxes
- record the expected presentation in schema-3 reports and document why production Blu-ray output must not receive invented camera geometry

## Validation

- `uv run python -m unittest discover -s tests` — 574 passed, 2 skipped
- `xcodebuild test -scheme SpatialPlaybackProbe` on the visionOS 27 simulator — passed, physical-only UI test skipped
- `uv run ruff format --check`, `uv run ruff check`, `uv run mypy`, `shfmt -d`, and `shellcheck` — passed on changed files
- physical M2 Apple Vision Pro: calibration fixture SHA-256 `656f259f917f67f2a0641fc22a9e547e00657be8b2237a71c050f8cb83a5d27e` passed `Stereo · Spatial · Portal`, audio/subtitle discovery, and all three seeks
- physical M2 Apple Vision Pro: production-style fixture SHA-256 `ab7d241d1a480942b0e137e3c5932642552798492e825a27433a1c351488ec4f` passed the default `Stereo · Screen` expectation and all three seeks
- final schema-3 operator report records `result=passed`, all eight automatic checks passed, `videoRemainedVisible=yes`, and `appearedThreeDimensional=yes`

Refs #248
Refs #200
