### PR TITLE
Add private diagnostic upload and retrieval service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: support-diagnostics
         run: npm run check
 
+      - name: Validate support diagnostics deployment config
+        working-directory: support-diagnostics
+        run: npm run deploy:dry-run
+
       - name: Install direct SSIF prototype dependencies
         run: brew install libbluray libudfread pkgconf
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: support-diagnostics/package-lock.json
+
       - name: Set up uv
         # Trusted toolchain publisher for uv; see CodeQL alert triage from 2026-07-07.
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -38,6 +45,14 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --locked --all-groups --python 3.12
+
+      - name: Install support diagnostics dependencies
+        working-directory: support-diagnostics
+        run: npm ci
+
+      - name: Validate support diagnostics service
+        working-directory: support-diagnostics
+        run: npm run check
 
       - name: Install direct SSIF prototype dependencies
         run: brew install libbluray libudfread pkgconf

--- a/scripts/support_diagnostics.py
+++ b/scripts/support_diagnostics.py
@@ -46,11 +46,14 @@ class SupportDiagnosticsError(RuntimeError):
 class ResponseLike(Protocol):
     headers: Mapping[str, str]
 
-    def __enter__(self) -> ResponseLike: ...
+    def __enter__(self) -> ResponseLike:
+        raise NotImplementedError
 
-    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None: ...
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        raise NotImplementedError
 
-    def read(self, amount: int = -1) -> bytes: ...
+    def read(self, amount: int = -1) -> bytes:
+        raise NotImplementedError
 
 
 ResponseOpener = Callable[..., object]

--- a/scripts/support_diagnostics.py
+++ b/scripts/support_diagnostics.py
@@ -2,26 +2,38 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import io
 import json
 import os
 import re
+import struct
 import sys
-import tarfile
 import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+import zlib
 
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Callable, Mapping, Protocol, cast
 
 
 MAX_BUNDLE_BYTES = 2 * 1024 * 1024
-MAX_DIAGNOSTIC_JSON_BYTES = 1024 * 1024
-MAX_ARCHIVE_MEMBERS = 16
-MAX_UNCOMPRESSED_ARCHIVE_BYTES = 8 * 1024 * 1024
+MAX_UNCOMPRESSED_ARCHIVE_BYTES = 1_500_000
+ENTRY_LIMITS = {
+    "manifest.json": 64 * 1024,
+    "events.jsonl": 320 * 1024,
+    "storage.json": 160 * 1024,
+    "tool-tail.txt": 640 * 1024,
+}
+ALLOWED_ZIP_FLAGS = {0, 0x0800}
+CENTRAL_DIRECTORY_HEADER = struct.Struct("<IHHHHHHIIIHHHHHII")
+CENTRAL_DIRECTORY_SIGNATURE = 0x02014B50
+END_OF_CENTRAL_DIRECTORY = struct.Struct("<IHHHHIIH")
+END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054B50
+LOCAL_FILE_HEADER = struct.Struct("<IHHHHHIIIHH")
+LOCAL_FILE_HEADER_SIGNATURE = 0x04034B50
+ZIP_DEFLATED = 8
 SCHEMA_VERSION = 1
 SUPPORT_CODE_PATTERN = re.compile(r"^BDAVP-[0-9ABCDEFGHJKMNPQRSTVWXYZ]{16}$")
 SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
@@ -57,6 +69,16 @@ class FetchResult:
     sha256: str
     size_bytes: int
     support_code: str
+
+
+@dataclass(frozen=True)
+class _ZipEntry:
+    name: str
+    flags: int
+    crc32: int
+    compressed_size: int
+    uncompressed_size: int
+    local_header_offset: int
 
 
 def _environment_value(environ: Mapping[str, str], name: str) -> str:
@@ -102,7 +124,7 @@ def _request(url: str, method: str, token: str) -> urllib.request.Request:
     return urllib.request.Request(
         url,
         headers={
-            "Accept": "application/gzip",
+            "Accept": "application/zip",
             "Authorization": f"Bearer {token}",
             "User-Agent": "bd-to-avp-support-diagnostics-cli/1",
         },
@@ -136,9 +158,184 @@ def _parse_content_length(headers: Mapping[str, str]) -> int:
     return length
 
 
-def _safe_member_name(name: str) -> bool:
-    path = PurePosixPath(name)
-    return bool(name) and not path.is_absolute() and ".." not in path.parts
+def _schema_document(payload: bytes, name: str, expected_schema_version: int) -> dict[str, object]:
+    try:
+        document = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SupportDiagnosticsError(f"{name} is not valid UTF-8 JSON.") from error
+    if (
+        not isinstance(document, dict)
+        or type(document.get("schema_version")) is not int
+        or document["schema_version"] != expected_schema_version
+    ):
+        raise SupportDiagnosticsError(f"{name} schema verification failed.")
+    return document
+
+
+def _require_archive_range(data: bytes, offset: int, length: int) -> None:
+    if offset < 0 or length < 0 or offset + length > len(data):
+        raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.")
+
+
+def _archive_payloads(data: bytes) -> dict[str, bytes]:
+    end_offset = len(data) - END_OF_CENTRAL_DIRECTORY.size
+    _require_archive_range(data, end_offset, END_OF_CENTRAL_DIRECTORY.size)
+    (
+        signature,
+        disk_number,
+        central_directory_disk,
+        disk_entry_count,
+        entry_count,
+        central_directory_size,
+        central_directory_offset,
+        comment_length,
+    ) = END_OF_CENTRAL_DIRECTORY.unpack_from(data, end_offset)
+    if (
+        signature != END_OF_CENTRAL_DIRECTORY_SIGNATURE
+        or disk_number != 0
+        or central_directory_disk != 0
+        or disk_entry_count != len(ENTRY_LIMITS)
+        or entry_count != len(ENTRY_LIMITS)
+        or comment_length != 0
+        or central_directory_offset + central_directory_size != end_offset
+    ):
+        raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.")
+
+    entries: list[_ZipEntry] = []
+    names: set[str] = set()
+    total_uncompressed_size = 0
+    offset = central_directory_offset
+    for _ in range(entry_count):
+        _require_archive_range(data, offset, CENTRAL_DIRECTORY_HEADER.size)
+        (
+            entry_signature,
+            _version_made_by,
+            version_needed,
+            flags,
+            compression_method,
+            _modification_time,
+            _modification_date,
+            checksum,
+            compressed_size,
+            uncompressed_size,
+            name_length,
+            extra_length,
+            entry_comment_length,
+            disk_start,
+            _internal_attributes,
+            _external_attributes,
+            local_header_offset,
+        ) = CENTRAL_DIRECTORY_HEADER.unpack_from(data, offset)
+        variable_length = name_length + extra_length + entry_comment_length
+        _require_archive_range(data, offset + CENTRAL_DIRECTORY_HEADER.size, variable_length)
+        try:
+            name = data[
+                offset + CENTRAL_DIRECTORY_HEADER.size : offset + CENTRAL_DIRECTORY_HEADER.size + name_length
+            ].decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.") from error
+        limit = ENTRY_LIMITS.get(name)
+        if (
+            entry_signature != CENTRAL_DIRECTORY_SIGNATURE
+            or version_needed != 20
+            or flags not in ALLOWED_ZIP_FLAGS
+            or compression_method != ZIP_DEFLATED
+            or extra_length != 0
+            or entry_comment_length != 0
+            or disk_start != 0
+            or limit is None
+            or name in names
+            or uncompressed_size > limit
+        ):
+            raise SupportDiagnosticsError("Diagnostic bundle contains an invalid archive entry.")
+        names.add(name)
+        total_uncompressed_size += uncompressed_size
+        if total_uncompressed_size > MAX_UNCOMPRESSED_ARCHIVE_BYTES:
+            raise SupportDiagnosticsError("Diagnostic bundle expands beyond the allowed size.")
+        entries.append(
+            _ZipEntry(
+                name=name,
+                flags=flags,
+                crc32=checksum,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                local_header_offset=local_header_offset,
+            )
+        )
+        offset += CENTRAL_DIRECTORY_HEADER.size + variable_length
+    if offset != end_offset or names != set(ENTRY_LIMITS):
+        raise SupportDiagnosticsError("Diagnostic bundle has an invalid file set.")
+
+    payloads: dict[str, bytes] = {}
+    ranges: list[tuple[int, int]] = []
+    for entry in entries:
+        offset = entry.local_header_offset
+        _require_archive_range(data, offset, LOCAL_FILE_HEADER.size)
+        (
+            local_signature,
+            version_needed,
+            flags,
+            compression_method,
+            _modification_time,
+            _modification_date,
+            checksum,
+            compressed_size,
+            uncompressed_size,
+            name_length,
+            extra_length,
+        ) = LOCAL_FILE_HEADER.unpack_from(data, offset)
+        _require_archive_range(data, offset + LOCAL_FILE_HEADER.size, name_length + extra_length)
+        try:
+            local_name = data[offset + LOCAL_FILE_HEADER.size : offset + LOCAL_FILE_HEADER.size + name_length].decode(
+                "utf-8"
+            )
+        except UnicodeDecodeError as error:
+            raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.") from error
+        if (
+            local_signature != LOCAL_FILE_HEADER_SIGNATURE
+            or version_needed != 20
+            or flags != entry.flags
+            or compression_method != ZIP_DEFLATED
+            or checksum != entry.crc32
+            or compressed_size != entry.compressed_size
+            or uncompressed_size != entry.uncompressed_size
+            or extra_length != 0
+            or local_name != entry.name
+        ):
+            raise SupportDiagnosticsError("Diagnostic bundle contains an invalid archive entry.")
+        data_offset = offset + LOCAL_FILE_HEADER.size + name_length
+        range_end = data_offset + compressed_size
+        _require_archive_range(data, data_offset, compressed_size)
+        if range_end > central_directory_offset:
+            raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.")
+        compressed = data[data_offset:range_end]
+        limit = ENTRY_LIMITS[entry.name]
+        try:
+            decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+            payload = decompressor.decompress(compressed, limit + 1)
+            if len(payload) <= limit:
+                payload += decompressor.flush(limit + 1 - len(payload))
+        except zlib.error as error:
+            raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.") from error
+        if (
+            len(payload) != entry.uncompressed_size
+            or len(payload) > limit
+            or not decompressor.eof
+            or decompressor.unconsumed_tail
+            or decompressor.unused_data
+            or zlib.crc32(payload) & 0xFFFFFFFF != entry.crc32
+        ):
+            raise SupportDiagnosticsError("Diagnostic bundle contains an invalid archive entry.")
+        ranges.append((offset, range_end))
+        payloads[entry.name] = payload
+
+    ranges.sort()
+    if not ranges or ranges[0][0] != 0 or ranges[-1][1] != central_directory_offset:
+        raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.")
+    for index in range(1, len(ranges)):
+        if ranges[index - 1][1] != ranges[index][0]:
+            raise SupportDiagnosticsError("Diagnostic bundle is not a valid ZIP archive.")
+    return payloads
 
 
 def verify_bundle(data: bytes, expected_sha256: str, expected_schema_version: int) -> None:
@@ -151,40 +348,23 @@ def verify_bundle(data: bytes, expected_sha256: str, expected_schema_version: in
     if expected_schema_version != SCHEMA_VERSION:
         raise SupportDiagnosticsError("Diagnostic bundle uses an unsupported schema version.")
 
-    diagnostic_payload: bytes | None = None
-    member_count = 0
-    uncompressed_size = 0
-    try:
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
-            for member in archive:
-                member_count += 1
-                if member_count > MAX_ARCHIVE_MEMBERS:
-                    raise SupportDiagnosticsError("Diagnostic bundle contains too many files.")
-                if not _safe_member_name(member.name) or not member.isreg():
-                    raise SupportDiagnosticsError("Diagnostic bundle contains an unsafe archive entry.")
-                uncompressed_size += member.size
-                if uncompressed_size > MAX_UNCOMPRESSED_ARCHIVE_BYTES:
-                    raise SupportDiagnosticsError("Diagnostic bundle expands beyond the allowed size.")
-                if member.name == "diagnostic.json":
-                    if diagnostic_payload is not None or member.size > MAX_DIAGNOSTIC_JSON_BYTES:
-                        raise SupportDiagnosticsError("Diagnostic bundle has an invalid diagnostic.json entry.")
-                    member_file = archive.extractfile(member)
-                    if member_file is None:
-                        raise SupportDiagnosticsError("Diagnostic bundle has an unreadable diagnostic.json entry.")
-                    diagnostic_payload = member_file.read(MAX_DIAGNOSTIC_JSON_BYTES + 1)
-                    if len(diagnostic_payload) > MAX_DIAGNOSTIC_JSON_BYTES:
-                        raise SupportDiagnosticsError("Diagnostic bundle has an oversized diagnostic.json entry.")
-    except (OSError, tarfile.TarError) as error:
-        raise SupportDiagnosticsError("Diagnostic bundle is not a valid gzip tar archive.") from error
+    payloads = _archive_payloads(data)
 
-    if diagnostic_payload is None:
-        raise SupportDiagnosticsError("Diagnostic bundle is missing diagnostic.json.")
+    _schema_document(payloads["manifest.json"], "manifest.json", expected_schema_version)
+    _schema_document(payloads["storage.json"], "storage.json", expected_schema_version)
     try:
-        diagnostic = json.loads(diagnostic_payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise SupportDiagnosticsError("diagnostic.json is not valid UTF-8 JSON.") from error
-    if not isinstance(diagnostic, dict) or diagnostic.get("schema_version") != expected_schema_version:
-        raise SupportDiagnosticsError("diagnostic.json schema verification failed.")
+        events = payloads["events.jsonl"].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise SupportDiagnosticsError("events.jsonl is not valid UTF-8.") from error
+    for line in events.splitlines():
+        if line:
+            _schema_document(line.encode("utf-8"), "events.jsonl entry", expected_schema_version)
+    try:
+        tool_tail = payloads["tool-tail.txt"].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise SupportDiagnosticsError("tool-tail.txt is not valid UTF-8.") from error
+    if not tool_tail.startswith(f"# bd_to_avp_support_tool_tail schema_version={expected_schema_version}\n"):
+        raise SupportDiagnosticsError("tool-tail.txt schema verification failed.")
 
 
 def _atomic_write(output: Path, data: bytes) -> None:
@@ -215,7 +395,7 @@ def fetch_report(
     response = _open(opener, request)
     with response:
         content_type = _required_header(response.headers, "Content-Type").split(";", 1)[0].strip().lower()
-        if content_type != "application/gzip":
+        if content_type != "application/zip":
             raise SupportDiagnosticsError("Service response has an unexpected Content-Type.")
         size_bytes = _parse_content_length(response.headers)
         checksum = _required_header(response.headers, "X-Diagnostic-SHA256")
@@ -278,7 +458,7 @@ def main(
         configuration = load_configuration(environ)
         support_code = validate_support_code(arguments.support_code)
         if arguments.command == "fetch":
-            output = arguments.output or Path(f"{support_code}.tar.gz")
+            output = arguments.output or Path(f"{support_code}.zip")
             result = fetch_report(configuration, support_code, output, opener)
             print(
                 json.dumps(

--- a/scripts/support_diagnostics.py
+++ b/scripts/support_diagnostics.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable, Mapping, Protocol, cast
+
+
+MAX_BUNDLE_BYTES = 2 * 1024 * 1024
+MAX_DIAGNOSTIC_JSON_BYTES = 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 16
+MAX_UNCOMPRESSED_ARCHIVE_BYTES = 8 * 1024 * 1024
+SCHEMA_VERSION = 1
+SUPPORT_CODE_PATTERN = re.compile(r"^BDAVP-[0-9ABCDEFGHJKMNPQRSTVWXYZ]{16}$")
+SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+
+
+class SupportDiagnosticsError(RuntimeError):
+    pass
+
+
+class ResponseLike(Protocol):
+    headers: Mapping[str, str]
+
+    def __enter__(self) -> ResponseLike: ...
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None: ...
+
+    def read(self, amount: int = -1) -> bytes: ...
+
+
+ResponseOpener = Callable[..., object]
+
+
+@dataclass(frozen=True)
+class ClientConfiguration:
+    endpoint: str
+    token: str
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    output: Path
+    schema_version: int
+    sha256: str
+    size_bytes: int
+    support_code: str
+
+
+def _environment_value(environ: Mapping[str, str], name: str) -> str:
+    value = environ.get(name, "").strip()
+    if not value:
+        raise SupportDiagnosticsError(f"{name} must be set.")
+    return value
+
+
+def load_configuration(environ: Mapping[str, str] | None = None) -> ClientConfiguration:
+    source = os.environ if environ is None else environ
+    endpoint = _environment_value(source, "SUPPORT_DIAGNOSTICS_ENDPOINT")
+    token = _environment_value(source, "SUPPORT_DIAGNOSTICS_TOKEN")
+    parsed = urllib.parse.urlsplit(endpoint)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise SupportDiagnosticsError(
+            "SUPPORT_DIAGNOSTICS_ENDPOINT must be an HTTPS origin or path prefix without credentials."
+        )
+    if len(token) < 32 or any(character.isspace() for character in token):
+        raise SupportDiagnosticsError("SUPPORT_DIAGNOSTICS_TOKEN must be a non-empty maintainer bearer token.")
+    return ClientConfiguration(endpoint=endpoint.rstrip("/"), token=token)
+
+
+def validate_support_code(support_code: str) -> str:
+    if SUPPORT_CODE_PATTERN.fullmatch(support_code) is None:
+        raise SupportDiagnosticsError("Support code must use the BDAVP-XXXXXXXXXXXXXXX format.")
+    return support_code
+
+
+def report_url(configuration: ClientConfiguration, support_code: str) -> str:
+    encoded_code = urllib.parse.quote(validate_support_code(support_code), safe="")
+    return f"{configuration.endpoint}/v1/maintainer/reports/{encoded_code}"
+
+
+def _request(url: str, method: str, token: str) -> urllib.request.Request:
+    return urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/gzip",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "bd-to-avp-support-diagnostics-cli/1",
+        },
+        method=method,
+    )
+
+
+def _open(opener: ResponseOpener, request: urllib.request.Request) -> ResponseLike:
+    try:
+        return cast(ResponseLike, opener(request, timeout=30))
+    except urllib.error.HTTPError as error:
+        raise SupportDiagnosticsError(f"Service returned HTTP {error.code}.") from error
+    except urllib.error.URLError as error:
+        raise SupportDiagnosticsError("Could not reach the diagnostic service.") from error
+
+
+def _required_header(headers: Mapping[str, str], name: str) -> str:
+    value = headers.get(name)
+    if value is None:
+        raise SupportDiagnosticsError(f"Service response is missing {name}.")
+    return value
+
+
+def _parse_content_length(headers: Mapping[str, str]) -> int:
+    value = _required_header(headers, "Content-Length")
+    if not value.isdecimal():
+        raise SupportDiagnosticsError("Service response has an invalid Content-Length.")
+    length = int(value)
+    if length <= 0 or length > MAX_BUNDLE_BYTES:
+        raise SupportDiagnosticsError("Service response exceeds the diagnostic bundle limit.")
+    return length
+
+
+def _safe_member_name(name: str) -> bool:
+    path = PurePosixPath(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts
+
+
+def verify_bundle(data: bytes, expected_sha256: str, expected_schema_version: int) -> None:
+    if len(data) == 0 or len(data) > MAX_BUNDLE_BYTES:
+        raise SupportDiagnosticsError("Diagnostic bundle has an invalid size.")
+    if SHA256_PATTERN.fullmatch(expected_sha256) is None:
+        raise SupportDiagnosticsError("Service response has an invalid checksum.")
+    if hashlib.sha256(data).hexdigest() != expected_sha256:
+        raise SupportDiagnosticsError("Diagnostic bundle checksum verification failed.")
+    if expected_schema_version != SCHEMA_VERSION:
+        raise SupportDiagnosticsError("Diagnostic bundle uses an unsupported schema version.")
+
+    diagnostic_payload: bytes | None = None
+    member_count = 0
+    uncompressed_size = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
+            for member in archive:
+                member_count += 1
+                if member_count > MAX_ARCHIVE_MEMBERS:
+                    raise SupportDiagnosticsError("Diagnostic bundle contains too many files.")
+                if not _safe_member_name(member.name) or not member.isreg():
+                    raise SupportDiagnosticsError("Diagnostic bundle contains an unsafe archive entry.")
+                uncompressed_size += member.size
+                if uncompressed_size > MAX_UNCOMPRESSED_ARCHIVE_BYTES:
+                    raise SupportDiagnosticsError("Diagnostic bundle expands beyond the allowed size.")
+                if member.name == "diagnostic.json":
+                    if diagnostic_payload is not None or member.size > MAX_DIAGNOSTIC_JSON_BYTES:
+                        raise SupportDiagnosticsError("Diagnostic bundle has an invalid diagnostic.json entry.")
+                    member_file = archive.extractfile(member)
+                    if member_file is None:
+                        raise SupportDiagnosticsError("Diagnostic bundle has an unreadable diagnostic.json entry.")
+                    diagnostic_payload = member_file.read(MAX_DIAGNOSTIC_JSON_BYTES + 1)
+                    if len(diagnostic_payload) > MAX_DIAGNOSTIC_JSON_BYTES:
+                        raise SupportDiagnosticsError("Diagnostic bundle has an oversized diagnostic.json entry.")
+    except (OSError, tarfile.TarError) as error:
+        raise SupportDiagnosticsError("Diagnostic bundle is not a valid gzip tar archive.") from error
+
+    if diagnostic_payload is None:
+        raise SupportDiagnosticsError("Diagnostic bundle is missing diagnostic.json.")
+    try:
+        diagnostic = json.loads(diagnostic_payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SupportDiagnosticsError("diagnostic.json is not valid UTF-8 JSON.") from error
+    if not isinstance(diagnostic, dict) or diagnostic.get("schema_version") != expected_schema_version:
+        raise SupportDiagnosticsError("diagnostic.json schema verification failed.")
+
+
+def _atomic_write(output: Path, data: bytes) -> None:
+    if output.exists():
+        raise SupportDiagnosticsError(f"Refusing to overwrite existing file: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{output.name}.", suffix=".tmp", dir=output.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(data)
+            destination.flush()
+            os.fsync(destination.fileno())
+        temporary_path.replace(output)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def fetch_report(
+    configuration: ClientConfiguration,
+    support_code: str,
+    output: Path,
+    opener: ResponseOpener = urllib.request.urlopen,
+) -> FetchResult:
+    code = validate_support_code(support_code)
+    request = _request(report_url(configuration, code), "GET", configuration.token)
+    response = _open(opener, request)
+    with response:
+        content_type = _required_header(response.headers, "Content-Type").split(";", 1)[0].strip().lower()
+        if content_type != "application/gzip":
+            raise SupportDiagnosticsError("Service response has an unexpected Content-Type.")
+        size_bytes = _parse_content_length(response.headers)
+        checksum = _required_header(response.headers, "X-Diagnostic-SHA256")
+        schema_text = _required_header(response.headers, "X-Diagnostic-Schema-Version")
+        if not schema_text.isdecimal():
+            raise SupportDiagnosticsError("Service response has an invalid schema version.")
+        data = response.read(MAX_BUNDLE_BYTES + 1)
+
+    if len(data) != size_bytes:
+        raise SupportDiagnosticsError("Service response body size does not match Content-Length.")
+    schema_version = int(schema_text)
+    verify_bundle(data, checksum, schema_version)
+    _atomic_write(output, data)
+    return FetchResult(
+        output=output,
+        schema_version=schema_version,
+        sha256=checksum,
+        size_bytes=size_bytes,
+        support_code=code,
+    )
+
+
+def delete_report(
+    configuration: ClientConfiguration,
+    support_code: str,
+    opener: ResponseOpener = urllib.request.urlopen,
+) -> None:
+    code = validate_support_code(support_code)
+    request = _request(report_url(configuration, code), "DELETE", configuration.token)
+    response = _open(opener, request)
+    with response:
+        status = getattr(response, "status", 204)
+        if status != 204:
+            raise SupportDiagnosticsError(f"Service returned unexpected HTTP {status}.")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch or delete private BD_to_AVP diagnostic bundles by support code."
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subcommands.add_parser("fetch", help="Fetch, checksum, and schema-validate a diagnostic bundle.")
+    fetch_parser.add_argument("support_code")
+    fetch_parser.add_argument("--output", type=Path)
+
+    delete_parser = subcommands.add_parser("delete", help="Delete a diagnostic bundle from private storage.")
+    delete_parser.add_argument("support_code")
+    delete_parser.add_argument("--yes", action="store_true", help="Confirm permanent deletion.")
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: list[str] | None = None,
+    environ: Mapping[str, str] | None = None,
+    opener: ResponseOpener = urllib.request.urlopen,
+) -> int:
+    try:
+        arguments = parse_args(argv)
+        configuration = load_configuration(environ)
+        support_code = validate_support_code(arguments.support_code)
+        if arguments.command == "fetch":
+            output = arguments.output or Path(f"{support_code}.tar.gz")
+            result = fetch_report(configuration, support_code, output, opener)
+            print(
+                json.dumps(
+                    {
+                        "output": str(result.output),
+                        "schema_version": result.schema_version,
+                        "sha256": result.sha256,
+                        "size_bytes": result.size_bytes,
+                        "support_code": result.support_code,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if arguments.command == "delete":
+            if not arguments.yes:
+                raise SupportDiagnosticsError("Deletion requires --yes.")
+            delete_report(configuration, support_code, opener)
+            print(json.dumps({"deleted": True, "support_code": support_code}, sort_keys=True))
+            return 0
+        raise SupportDiagnosticsError("Unknown command.")
+    except SupportDiagnosticsError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/support-diagnostics/.gitignore
+++ b/support-diagnostics/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+.dev.vars.*

--- a/support-diagnostics/README.md
+++ b/support-diagnostics/README.md
@@ -1,0 +1,200 @@
+# Private Diagnostic Upload Service
+
+This directory is a self-contained Cloudflare Worker for user-initiated,
+private BD_to_AVP diagnostic bundles. It has no public read or list endpoint,
+does not embed a service credential in the macOS application, and stores
+bundles only in the private `DIAGNOSTIC_BUNDLES` R2 binding.
+
+The service uses a SQLite-backed Durable Object to serialize report state
+transitions. This makes each upload authorization single-use even when two
+clients race to use the same token. It uses two Cloudflare Rate Limiting
+bindings plus a 24-hour hashed-client quota and a 500 live-report limit to
+bound abuse and storage exposure.
+
+## Bundle Contract
+
+- Content type: `application/gzip`
+- Maximum compressed size: `2 MiB` (`2,097,152` bytes)
+- Archive format: gzip-compressed tar archive
+- Required archive member: a regular top-level `diagnostic.json`
+- Required JSON field: `{"schema_version": 1, ...}`
+- The client declares the exact size, SHA-256, content type, and bundle schema
+  before receiving upload authorization.
+
+The Worker validates size, content type, request checksum header, and the
+SHA-256 of the received bytes. It records the same checksum and expiry in R2
+metadata. The maintainer CLI validates those response headers, the downloaded
+checksum, archive safety, and the `diagnostic.json` schema before writing an
+archive to disk.
+
+## HTTP Contract
+
+All production requests must use HTTPS. Responses are `Cache-Control:
+no-store`; the Worker deliberately emits no CORS headers.
+
+### Create a report
+
+`POST /v1/reports`
+
+```json
+{
+  "bundle_schema_version": 1,
+  "content_type": "application/gzip",
+  "sha256": "<64-character lowercase SHA-256 hex>",
+  "size_bytes": 12345
+}
+```
+
+On `201 Created`, the service returns an opaque UUID `report_id`, a random
+`BDAVP-...` support code, a ten-minute single-use upload authorization, and a
+ten-minute status authorization. Both authorizations are random bearer values
+returned only in this response. A support code is an identifier for a
+maintainer; it never authorizes reads.
+
+```json
+{
+  "expires_at": "2026-08-17T12:00:00.000Z",
+  "report_id": "<opaque UUID>",
+  "schema_version": 1,
+  "status": {
+    "expires_at": "2026-07-18T12:10:00.000Z",
+    "headers": { "Authorization": "Bearer <status-token>" },
+    "method": "GET",
+    "url": "https://support.example/v1/reports/<opaque UUID>/status"
+  },
+  "support_code": "BDAVP-0123456789ABCDEF",
+  "upload": {
+    "expires_at": "2026-07-18T12:10:00.000Z",
+    "headers": {
+      "Authorization": "Bearer <upload-token>",
+      "Content-Length": "12345",
+      "Content-Type": "application/gzip",
+      "X-Content-SHA256": "<64-character lowercase SHA-256 hex>"
+    },
+    "method": "PUT",
+    "url": "https://support.example/v1/reports/<opaque UUID>/upload"
+  }
+}
+```
+
+The public endpoint rate limits creates and uploads using a salted hash of
+`CF-Connecting-IP`; no raw IP address is persisted or logged. A shared-network
+user can receive `429` after the configured quota, which is intentional for
+this unauthenticated, abuse-bounded endpoint.
+
+### Upload and finalize
+
+`PUT /v1/reports/{report_id}/upload`
+
+Use the exact authorization and headers returned from creation. The successful
+`201` PUT is the atomic finalization step: the Worker writes the private R2
+object only after the bounded body matches the report's authorized size and
+SHA-256, then changes the Durable Object state to `uploaded`. A token cannot
+produce a second stored object; a replay returns `409 upload_consumed`.
+
+`GET /v1/reports/{report_id}/status` requires the returned short-lived status
+bearer token. It returns only the opaque report ID, upload state, and retention
+expiry; it does not return the bundle, support code, or metadata.
+
+### Maintainer retrieval and deletion
+
+Both routes require `Authorization: Bearer $SUPPORT_DIAGNOSTICS_TOKEN`, which
+is checked with fixed-length SHA-256 digests and a constant-time comparison.
+
+```text
+GET    /v1/maintainer/reports/{support_code}
+DELETE /v1/maintainer/reports/{support_code}
+```
+
+The GET response is the gzip archive with `X-Diagnostic-SHA256` and
+`X-Diagnostic-Schema-Version` headers. The DELETE response is `204 No Content`.
+Unknown support codes return `404` only after maintainer authentication. There
+is no public list endpoint, public object route, or support-code-only read
+route.
+
+## Retention and Storage
+
+Each object is stored under the private `reports/` prefix with `created_at`,
+`expires_at`, report ID, schema, checksum, and size as R2 custom metadata. The
+Worker deletes expired records from its Durable Object and R2 through both a
+Durable Object alarm and an hourly cron. `r2-lifecycle.json` defines a second
+30-day R2 lifecycle deletion rule (`2,592,000` seconds) for the same prefix.
+
+Keep the R2 bucket private: do not attach a public custom domain, do not
+configure a public bucket route, and do not grant anonymous R2 access. R2
+lifecycle deletion is asynchronous, so Worker expiry cleanup is intentionally
+the first enforcement layer; the lifecycle rule is the storage-layer backstop.
+
+## Maintainer CLI
+
+The repository-native CLI uses only Python's standard library. It reads its
+endpoint and bearer token exclusively from the environment; it never accepts a
+maintainer token on the command line.
+
+```sh
+export SUPPORT_DIAGNOSTICS_ENDPOINT='https://support.example'
+export SUPPORT_DIAGNOSTICS_TOKEN='<maintainer bearer token>'
+
+uv run python scripts/support_diagnostics.py fetch BDAVP-0123456789ABCDEF \
+  --output /secure/path/report.tar.gz
+uv run python scripts/support_diagnostics.py delete BDAVP-0123456789ABCDEF --yes
+```
+
+`fetch` refuses non-HTTPS endpoints, does not overwrite an existing file,
+streams at most 2 MiB from the response, verifies the response checksum/schema,
+validates the gzip tar archive without extracting it, and writes only a
+validated bundle. `delete` requires `--yes`.
+
+## Local Checks
+
+```sh
+cd support-diagnostics
+npm ci
+npm run check
+npm run deploy:dry-run
+
+cd ..
+uv run python -m unittest tests.test_support_diagnostics
+```
+
+The TypeScript tests use an in-memory R2 and Durable Object storage equivalent.
+They cover authorization replay, authorization expiry, support-code guessing,
+wrong content type/size/checksum, rate limits, public-read denial, maintainer
+authentication, deletion, expiry cleanup, and safe failure logging. The Python
+tests cover valid retrieval plus checksum, malformed archive, schema, delete,
+confirmation, and HTTP-failure handling.
+
+## Future Deployment
+
+No Cloudflare account, Wrangler authentication, R2 bucket, route/domain, or
+Worker secrets are provisioned by this repository. Before any deployment:
+
+1. Create a private R2 bucket named `bd-to-avp-support-diagnostics`, or update
+   `wrangler.jsonc` to the approved private bucket name.
+2. Reserve the two positive-integer rate-limit namespace IDs in
+   `wrangler.jsonc` so they are unique in the target Cloudflare account.
+3. Configure an HTTPS custom Worker route for the approved support domain while
+   leaving `workers_dev` disabled.
+4. Apply the 30-day `reports/` lifecycle rule represented by
+   `r2-lifecycle.json` through the Cloudflare dashboard/API or Wrangler's
+   `r2 bucket lifecycle add` command. For example:
+
+   ```sh
+   npx wrangler r2 bucket lifecycle add bd-to-avp-support-diagnostics \
+     expire-diagnostic-bundles reports/ --expire-days 30
+   ```
+
+5. Set the required Worker secrets without adding them to a file or command
+   history:
+
+   ```sh
+   npx wrangler secret put MAINTAINER_TOKEN
+   npx wrangler secret put RATE_LIMIT_SALT
+   ```
+
+6. Run `npm run deploy:dry-run`, review the route, binding, lifecycle, and
+   secret names, then deploy only with explicit Cloudflare authorization.
+
+The checked-in `wrangler.jsonc` declares a new SQLite Durable Object through
+the modern `exports` lifecycle block and two Worker Rate Limiting bindings.
+Rate-limit namespace IDs are positive integers represented as strings.

--- a/support-diagnostics/README.md
+++ b/support-diagnostics/README.md
@@ -13,18 +13,23 @@ bound abuse and storage exposure.
 
 ## Bundle Contract
 
-- Content type: `application/gzip`
+- Content type: `application/zip`
 - Maximum compressed size: `2 MiB` (`2,097,152` bytes)
-- Archive format: gzip-compressed tar archive
-- Required archive member: a regular top-level `diagnostic.json`
-- Required JSON field: `{"schema_version": 1, ...}`
+- Archive format: ZIP with raw-DEFLATE entries
+- Required top-level members: `manifest.json`, `events.jsonl`, `storage.json`,
+  and `tool-tail.txt`
+- Uncompressed limits: 64 KiB manifest, 320 KiB events, 160 KiB storage,
+  640 KiB tool tail, and 1,500,000 bytes total
+- Required schema field: integer `{"schema_version": 1, ...}` in the manifest,
+  storage document, and each event; the tool tail carries the matching header
 - The client declares the exact size, SHA-256, content type, and bundle schema
   before receiving upload authorization.
 
-The Worker validates size, content type, request checksum header, and the
-SHA-256 of the received bytes. It records the same checksum and expiry in R2
-metadata. The maintainer CLI validates those response headers, the downloaded
-checksum, archive safety, and the `diagnostic.json` schema before writing an
+The Worker validates size, content type, request checksum header, SHA-256,
+archive structure, exact member set, compression method, CRCs, decompressed
+limits, and schema markers before storage. It records the same checksum and
+expiry in R2 metadata. The maintainer CLI independently repeats the response,
+checksum, archive-safety, member, size, and schema validation before writing an
 archive to disk.
 
 ## HTTP Contract
@@ -39,7 +44,7 @@ no-store`; the Worker deliberately emits no CORS headers.
 ```json
 {
   "bundle_schema_version": 1,
-  "content_type": "application/gzip",
+  "content_type": "application/zip",
   "sha256": "<64-character lowercase SHA-256 hex>",
   "size_bytes": 12345
 }
@@ -68,7 +73,7 @@ maintainer; it never authorizes reads.
     "headers": {
       "Authorization": "Bearer <upload-token>",
       "Content-Length": "12345",
-      "Content-Type": "application/gzip",
+      "Content-Type": "application/zip",
       "X-Content-SHA256": "<64-character lowercase SHA-256 hex>"
     },
     "method": "PUT",
@@ -87,10 +92,12 @@ this unauthenticated, abuse-bounded endpoint.
 `PUT /v1/reports/{report_id}/upload`
 
 Use the exact authorization and headers returned from creation. The successful
-`201` PUT is the atomic finalization step: the Worker writes the private R2
-object only after the bounded body matches the report's authorized size and
-SHA-256, then changes the Durable Object state to `uploaded`. A token cannot
-produce a second stored object; a replay returns `409 upload_consumed`.
+`201` PUT is the finalization step. After headers match, the Worker atomically
+reserves the single-use authorization before reading the body, validates the
+bounded ZIP and its checksum, writes the private R2 object, and changes the
+Durable Object state to `uploaded`. Invalid body bytes fail the reserved report
+and require a fresh report; concurrent or later replays return
+`409 upload_consumed`.
 
 `GET /v1/reports/{report_id}/status` requires the returned short-lived status
 bearer token. It returns only the opaque report ID, upload state, and retention
@@ -106,7 +113,7 @@ GET    /v1/maintainer/reports/{support_code}
 DELETE /v1/maintainer/reports/{support_code}
 ```
 
-The GET response is the gzip archive with `X-Diagnostic-SHA256` and
+The GET response is the ZIP archive with `X-Diagnostic-SHA256` and
 `X-Diagnostic-Schema-Version` headers. The DELETE response is `204 No Content`.
 Unknown support codes return `404` only after maintainer authentication. There
 is no public list endpoint, public object route, or support-code-only read
@@ -136,13 +143,13 @@ export SUPPORT_DIAGNOSTICS_ENDPOINT='https://support.example'
 export SUPPORT_DIAGNOSTICS_TOKEN='<maintainer bearer token>'
 
 uv run python scripts/support_diagnostics.py fetch BDAVP-0123456789ABCDEF \
-  --output /secure/path/report.tar.gz
+  --output /secure/path/report.zip
 uv run python scripts/support_diagnostics.py delete BDAVP-0123456789ABCDEF --yes
 ```
 
 `fetch` refuses non-HTTPS endpoints, does not overwrite an existing file,
 streams at most 2 MiB from the response, verifies the response checksum/schema,
-validates the gzip tar archive without extracting it, and writes only a
+validates the ZIP archive without extracting it, and writes only a
 validated bundle. `delete` requires `--yes`.
 
 ## Local Checks

--- a/support-diagnostics/package-lock.json
+++ b/support-diagnostics/package-lock.json
@@ -1,0 +1,3169 @@
+{
+  "name": "bd-to-avp-support-diagnostics",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bd-to-avp-support-diagnostics",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "26.1.1",
+        "typescript": "7.0.2",
+        "vitest": "4.1.10",
+        "wrangler": "4.112.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
+      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
+      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
+      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260714.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
+      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260714.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
+      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260714.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
+        "@cloudflare/workerd-linux-64": "1.20260714.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
+        "@cloudflare/workerd-windows-64": "1.20260714.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.112.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
+      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260714.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260714.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260714.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/support-diagnostics/package.json
+++ b/support-diagnostics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bd-to-avp-support-diagnostics",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Private diagnostic bundle upload service for BD_to_AVP",
+  "type": "module",
+  "scripts": {
+    "check": "npm run typecheck && npm test",
+    "deploy:dry-run": "wrangler deploy --dry-run",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.1",
+    "typescript": "7.0.2",
+    "vitest": "4.1.10",
+    "wrangler": "4.112.0"
+  }
+}

--- a/support-diagnostics/r2-lifecycle.json
+++ b/support-diagnostics/r2-lifecycle.json
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "id": "expire-diagnostic-bundles-after-30-days",
+      "enabled": true,
+      "conditions": {
+        "prefix": "reports/"
+      },
+      "deleteObjectsTransition": {
+        "condition": {
+          "type": "Age",
+          "maxAge": 2592000
+        }
+      }
+    }
+  ]
+}

--- a/support-diagnostics/src/bundle.ts
+++ b/support-diagnostics/src/bundle.ts
@@ -1,0 +1,353 @@
+import { API_SCHEMA_VERSION, MAX_BUNDLE_BYTES } from "./protocol.js";
+
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const UTF8_FLAG = 0x0800;
+const DEFLATE_METHOD = 8;
+const MAX_UNCOMPRESSED_BUNDLE_BYTES = 1_500_000;
+const ENTRY_LIMITS = new Map<string, number>([
+  ["manifest.json", 64 * 1024],
+  ["events.jsonl", 320 * 1024],
+  ["storage.json", 160 * 1024],
+  ["tool-tail.txt", 640 * 1024],
+]);
+
+interface ZipEntry {
+  compressedSize: number;
+  crc32: number;
+  flags: number;
+  localHeaderOffset: number;
+  name: string;
+  uncompressedSize: number;
+}
+
+export class InvalidDiagnosticBundleError extends Error {
+  constructor() {
+    super("invalid_diagnostic_bundle");
+  }
+}
+
+function invalid(): never {
+  throw new InvalidDiagnosticBundleError();
+}
+
+function requireRange(bytes: Uint8Array, offset: number, length: number): void {
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(length) ||
+    offset < 0 ||
+    length < 0 ||
+    offset + length > bytes.byteLength
+  ) {
+    invalid();
+  }
+}
+
+function readUint16(bytes: Uint8Array, offset: number): number {
+  requireRange(bytes, offset, 2);
+  return bytes[offset]! | (bytes[offset + 1]! << 8);
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  requireRange(bytes, offset, 4);
+  return (
+    (bytes[offset]! |
+      (bytes[offset + 1]! << 8) |
+      (bytes[offset + 2]! << 16) |
+      (bytes[offset + 3]! << 24)) >>>
+    0
+  );
+}
+
+function decodeUTF8(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return invalid();
+  }
+}
+
+function validFlags(flags: number): boolean {
+  return flags === 0 || flags === UTF8_FLAG;
+}
+
+function findEndOfCentralDirectory(bytes: Uint8Array): number {
+  if (bytes.byteLength < 22 || bytes.byteLength > MAX_BUNDLE_BYTES) {
+    return invalid();
+  }
+  const earliestOffset = Math.max(0, bytes.byteLength - 65_557);
+  for (let offset = bytes.byteLength - 22; offset >= earliestOffset; offset -= 1) {
+    if (readUint32(bytes, offset) === END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+      return offset;
+    }
+  }
+  return invalid();
+}
+
+function parseCentralDirectory(bytes: Uint8Array): ZipEntry[] {
+  const endOffset = findEndOfCentralDirectory(bytes);
+  const diskNumber = readUint16(bytes, endOffset + 4);
+  const centralDirectoryDisk = readUint16(bytes, endOffset + 6);
+  const diskEntryCount = readUint16(bytes, endOffset + 8);
+  const entryCount = readUint16(bytes, endOffset + 10);
+  const centralDirectorySize = readUint32(bytes, endOffset + 12);
+  const centralDirectoryOffset = readUint32(bytes, endOffset + 16);
+  const commentLength = readUint16(bytes, endOffset + 20);
+  if (
+    diskNumber !== 0 ||
+    centralDirectoryDisk !== 0 ||
+    diskEntryCount !== ENTRY_LIMITS.size ||
+    entryCount !== ENTRY_LIMITS.size ||
+    commentLength !== 0 ||
+    endOffset + 22 !== bytes.byteLength ||
+    centralDirectoryOffset + centralDirectorySize !== endOffset
+  ) {
+    return invalid();
+  }
+
+  const entries: ZipEntry[] = [];
+  const names = new Set<string>();
+  let uncompressedBytes = 0;
+  let offset = centralDirectoryOffset;
+  while (offset < endOffset) {
+    requireRange(bytes, offset, 46);
+    if (readUint32(bytes, offset) !== CENTRAL_DIRECTORY_SIGNATURE) {
+      return invalid();
+    }
+    const versionNeeded = readUint16(bytes, offset + 6);
+    const flags = readUint16(bytes, offset + 8);
+    const method = readUint16(bytes, offset + 10);
+    const crc32 = readUint32(bytes, offset + 16);
+    const compressedSize = readUint32(bytes, offset + 20);
+    const uncompressedSize = readUint32(bytes, offset + 24);
+    const nameLength = readUint16(bytes, offset + 28);
+    const extraLength = readUint16(bytes, offset + 30);
+    const entryCommentLength = readUint16(bytes, offset + 32);
+    const diskStart = readUint16(bytes, offset + 34);
+    const localHeaderOffset = readUint32(bytes, offset + 42);
+    const variableLength = nameLength + extraLength + entryCommentLength;
+    requireRange(bytes, offset + 46, variableLength);
+    const name = decodeUTF8(bytes.subarray(offset + 46, offset + 46 + nameLength));
+    const entryLimit = ENTRY_LIMITS.get(name);
+    if (
+      versionNeeded !== 20 ||
+      !validFlags(flags) ||
+      method !== DEFLATE_METHOD ||
+      extraLength !== 0 ||
+      entryCommentLength !== 0 ||
+      diskStart !== 0 ||
+      entryLimit === undefined ||
+      names.has(name) ||
+      uncompressedSize > entryLimit
+    ) {
+      return invalid();
+    }
+    names.add(name);
+    uncompressedBytes += uncompressedSize;
+    if (uncompressedBytes > MAX_UNCOMPRESSED_BUNDLE_BYTES) {
+      return invalid();
+    }
+    entries.push({
+      compressedSize,
+      crc32,
+      flags,
+      localHeaderOffset,
+      name,
+      uncompressedSize,
+    });
+    offset += 46 + variableLength;
+  }
+  if (offset !== endOffset || entries.length !== ENTRY_LIMITS.size) {
+    return invalid();
+  }
+  return entries;
+}
+
+function compressedEntry(
+  bytes: Uint8Array,
+  entry: ZipEntry,
+  centralDirectoryOffset: number,
+): { bytes: Uint8Array; rangeEnd: number; rangeStart: number } {
+  const offset = entry.localHeaderOffset;
+  requireRange(bytes, offset, 30);
+  if (
+    readUint32(bytes, offset) !== LOCAL_FILE_HEADER_SIGNATURE ||
+    readUint16(bytes, offset + 4) !== 20 ||
+    readUint16(bytes, offset + 6) !== entry.flags ||
+    readUint16(bytes, offset + 8) !== DEFLATE_METHOD ||
+    readUint32(bytes, offset + 14) !== entry.crc32 ||
+    readUint32(bytes, offset + 18) !== entry.compressedSize ||
+    readUint32(bytes, offset + 22) !== entry.uncompressedSize
+  ) {
+    return invalid();
+  }
+  const nameLength = readUint16(bytes, offset + 26);
+  const extraLength = readUint16(bytes, offset + 28);
+  if (extraLength !== 0) {
+    return invalid();
+  }
+  requireRange(bytes, offset + 30, nameLength);
+  const name = decodeUTF8(bytes.subarray(offset + 30, offset + 30 + nameLength));
+  if (name !== entry.name) {
+    return invalid();
+  }
+  const dataOffset = offset + 30 + nameLength;
+  requireRange(bytes, dataOffset, entry.compressedSize);
+  const rangeEnd = dataOffset + entry.compressedSize;
+  if (rangeEnd > centralDirectoryOffset) {
+    return invalid();
+  }
+  return {
+    bytes: bytes.subarray(dataOffset, rangeEnd),
+    rangeEnd,
+    rangeStart: offset,
+  };
+}
+
+async function inflateRaw(
+  compressed: Uint8Array,
+  expectedSize: number,
+): Promise<Uint8Array> {
+  const copy = new Uint8Array(compressed.byteLength);
+  copy.set(compressed);
+  const stream = new Blob([copy.buffer])
+    .stream()
+    .pipeThrough(new DecompressionStream("deflate-raw"));
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      totalBytes += chunk.value.byteLength;
+      if (totalBytes > expectedSize) {
+        await reader.cancel();
+        return invalid();
+      }
+      chunks.push(chunk.value);
+    }
+  } catch {
+    return invalid();
+  } finally {
+    reader.releaseLock();
+  }
+  if (totalBytes !== expectedSize) {
+    return invalid();
+  }
+  const result = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+const CRC32_TABLE = new Uint32Array(256);
+for (let index = 0; index < CRC32_TABLE.length; index += 1) {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  CRC32_TABLE[index] = value >>> 0;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffffffff;
+  for (const byte of bytes) {
+    value = CRC32_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function requireSchemaDocument(
+  bytes: Uint8Array,
+  expectedSchemaVersion: number,
+): void {
+  let value: unknown;
+  try {
+    value = JSON.parse(decodeUTF8(bytes));
+  } catch (error) {
+    if (error instanceof InvalidDiagnosticBundleError) {
+      throw error;
+    }
+    return invalid();
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Number.isSafeInteger((value as Record<string, unknown>).schema_version) ||
+    (value as Record<string, unknown>).schema_version !== expectedSchemaVersion
+  ) {
+    return invalid();
+  }
+}
+
+function requireEventStream(
+  bytes: Uint8Array,
+  expectedSchemaVersion: number,
+): void {
+  const text = decodeUTF8(bytes);
+  for (const line of text.split("\n")) {
+    if (line.length === 0) {
+      continue;
+    }
+    requireSchemaDocument(new TextEncoder().encode(line), expectedSchemaVersion);
+  }
+}
+
+export async function validateDiagnosticBundle(
+  bytes: Uint8Array,
+  expectedSchemaVersion = API_SCHEMA_VERSION,
+): Promise<void> {
+  try {
+    const entries = parseCentralDirectory(bytes);
+    const endOffset = findEndOfCentralDirectory(bytes);
+    const centralDirectoryOffset = readUint32(bytes, endOffset + 16);
+    const ranges: Array<{ end: number; start: number }> = [];
+    const contents = new Map<string, Uint8Array>();
+    for (const entry of entries) {
+      const compressed = compressedEntry(bytes, entry, centralDirectoryOffset);
+      ranges.push({ end: compressed.rangeEnd, start: compressed.rangeStart });
+      const content = await inflateRaw(compressed.bytes, entry.uncompressedSize);
+      if (crc32(content) !== entry.crc32) {
+        return invalid();
+      }
+      contents.set(entry.name, content);
+    }
+    ranges.sort((left, right) => left.start - right.start);
+    if (
+      ranges[0]?.start !== 0 ||
+      ranges.at(-1)?.end !== centralDirectoryOffset
+    ) {
+      return invalid();
+    }
+    for (let index = 1; index < ranges.length; index += 1) {
+      if (ranges[index - 1]!.end !== ranges[index]!.start) {
+        return invalid();
+      }
+    }
+
+    requireSchemaDocument(contents.get("manifest.json")!, expectedSchemaVersion);
+    requireEventStream(contents.get("events.jsonl")!, expectedSchemaVersion);
+    requireSchemaDocument(contents.get("storage.json")!, expectedSchemaVersion);
+    const toolTail = decodeUTF8(contents.get("tool-tail.txt")!);
+    if (
+      !toolTail.startsWith(
+        `# bd_to_avp_support_tool_tail schema_version=${expectedSchemaVersion}\n`,
+      )
+    ) {
+      return invalid();
+    }
+  } catch (error) {
+    if (error instanceof InvalidDiagnosticBundleError) {
+      throw error;
+    }
+    throw new InvalidDiagnosticBundleError();
+  }
+}

--- a/support-diagnostics/src/crypto.ts
+++ b/support-diagnostics/src/crypto.ts
@@ -1,0 +1,88 @@
+const SUPPORT_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const textEncoder = new TextEncoder();
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+export async function sha256Bytes(
+  value: ArrayBuffer | Uint8Array | string,
+): Promise<Uint8Array> {
+  const source =
+    typeof value === "string"
+      ? textEncoder.encode(value).buffer
+      : value instanceof Uint8Array
+        ? (() => {
+            const copy = new Uint8Array(value.byteLength);
+            copy.set(value);
+            return copy.buffer;
+          })()
+        : value;
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", source));
+}
+
+export async function sha256Hex(
+  value: ArrayBuffer | Uint8Array | string,
+): Promise<string> {
+  return bytesToHex(await sha256Bytes(value));
+}
+
+export async function constantTimeTextEqual(
+  left: string,
+  right: string,
+): Promise<boolean> {
+  const [leftDigest, rightDigest] = await Promise.all([
+    sha256Bytes(left),
+    sha256Bytes(right),
+  ]);
+  let difference = 0;
+  for (let index = 0; index < leftDigest.length; index += 1) {
+    difference |= leftDigest[index]! ^ rightDigest[index]!;
+  }
+  return difference === 0;
+}
+
+export function generateToken(byteLength = 32): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return bytesToBase64Url(bytes);
+}
+
+export function generateSupportCode(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const code = Array.from(
+    bytes,
+    (byte) => SUPPORT_CODE_ALPHABET[byte & 31]!,
+  ).join("");
+  return `BDAVP-${code}`;
+}
+
+export function hexToArrayBuffer(value: string): ArrayBuffer {
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < value.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(value.slice(index, index + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+export function isSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+export function isSupportCode(value: string): boolean {
+  return /^BDAVP-[0-9ABCDEFGHJKMNPQRSTVWXYZ]{16}$/u.test(value);
+}

--- a/support-diagnostics/src/index.ts
+++ b/support-diagnostics/src/index.ts
@@ -1,0 +1,992 @@
+import {
+  API_SCHEMA_VERSION,
+  BUNDLE_CONTENT_TYPE,
+  BUNDLE_FILENAME_SUFFIX,
+  MAX_BUNDLE_BYTES,
+  MAX_CREATE_REQUEST_BYTES,
+  RETENTION_MS,
+  STATUS_AUTH_TTL_MS,
+  UPLOAD_AUTH_TTL_MS,
+  type CreateReportRecordInput,
+  type RegistryErrorCode,
+  RegistryError,
+  type ReportRecord,
+} from "./protocol.js";
+import {
+  constantTimeTextEqual,
+  generateSupportCode,
+  generateToken,
+  hexToArrayBuffer,
+  isSha256,
+  isSupportCode,
+  sha256Hex,
+} from "./crypto.js";
+import {
+  registryErrorCode,
+  type Registry,
+  ReportRegistryService,
+} from "./registry.js";
+import type {
+  DurableObjectState,
+  DurableObjectStub,
+  Env,
+  ExecutionContext,
+  ExportedHandler,
+  R2Bucket,
+  RateLimitBinding,
+  ServiceLogger,
+} from "./types.js";
+
+const INTERNAL_ORIGIN = "https://report-registry.internal";
+const REGISTRY_INSTANCE_NAME = "support-diagnostics-v1";
+const REPORT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+
+class PublicError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(code);
+  }
+}
+
+interface CreateReportRequest {
+  bundle_schema_version: number;
+  content_type: string;
+  sha256: string;
+  size_bytes: number;
+}
+
+interface ServiceDependencies {
+  bucket: R2Bucket;
+  clock?: () => number;
+  createRateLimiter: RateLimitBinding;
+  logger?: ServiceLogger;
+  maintainerToken: string;
+  rateLimitSalt: string;
+  registry: Registry;
+  serviceEnvironment: string;
+  uploadRateLimiter: RateLimitBinding;
+}
+
+interface RegistryOperationPayload {
+  input?: CreateReportRecordInput;
+  now: number;
+  reportId?: string;
+  statusTokenHash?: string;
+  supportCode?: string;
+  uploadTokenHash?: string;
+}
+
+interface RegistryOperationResponse {
+  error?: string;
+  result?: unknown;
+}
+
+function serviceLogger(): ServiceLogger {
+  return {
+    error(event, fields) {
+      console.error(JSON.stringify({ event, ...fields }));
+    },
+    info(event, fields) {
+      console.log(JSON.stringify({ event, ...fields }));
+    },
+  };
+}
+
+function secureHeaders(): Headers {
+  return new Headers({
+    "cache-control": "no-store",
+    "content-security-policy":
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+    "referrer-policy": "no-referrer",
+    "x-content-type-options": "nosniff",
+  });
+}
+
+function jsonResponse(
+  payload: Record<string, unknown>,
+  status = 200,
+): Response {
+  const headers = secureHeaders();
+  headers.set("content-type", "application/json; charset=utf-8");
+  return new Response(JSON.stringify(payload), { headers, status });
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { headers: secureHeaders(), status });
+}
+
+function errorResponse(error: PublicError): Response {
+  return jsonResponse({ error: error.code }, error.status);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nowFrom(dependencies: ServiceDependencies): number {
+  return dependencies.clock?.() ?? Date.now();
+}
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function requestContentType(request: Request): string {
+  return (
+    request.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase() ?? ""
+  );
+}
+
+function requireContentType(request: Request, expected: string): void {
+  if (requestContentType(request) !== expected) {
+    throw new PublicError("unsupported_content_type", 415);
+  }
+}
+
+function parseContentLength(request: Request): number | undefined {
+  const rawLength = request.headers.get("content-length");
+  if (rawLength === null) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/u.test(rawLength)) {
+    throw new PublicError("invalid_content_length", 400);
+  }
+  const length = Number(rawLength);
+  if (!Number.isSafeInteger(length)) {
+    throw new PublicError("invalid_content_length", 400);
+  }
+  return length;
+}
+
+async function readLimitedBody(
+  request: Request,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  const declaredLength = parseContentLength(request);
+  if (declaredLength !== undefined && declaredLength > maximumBytes) {
+    throw new PublicError("payload_too_large", 413);
+  }
+  if (request.body === null) {
+    return new Uint8Array();
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      totalBytes += chunk.value.byteLength;
+      if (totalBytes > maximumBytes) {
+        await reader.cancel();
+        throw new PublicError("payload_too_large", 413);
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function readCreateRequest(
+  request: Request,
+): Promise<CreateReportRequest> {
+  requireContentType(request, "application/json");
+  const bytes = await readLimitedBody(request, MAX_CREATE_REQUEST_BYTES);
+  let payload: unknown;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new PublicError("invalid_json", 400);
+  }
+  if (!isRecord(payload)) {
+    throw new PublicError("invalid_request", 400);
+  }
+
+  const keys = Object.keys(payload).sort();
+  const expectedKeys = [
+    "bundle_schema_version",
+    "content_type",
+    "sha256",
+    "size_bytes",
+  ];
+  if (
+    keys.length !== expectedKeys.length ||
+    keys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new PublicError("invalid_request", 400);
+  }
+
+  const sizeBytes = payload.size_bytes;
+  const bundleSchemaVersion = payload.bundle_schema_version;
+  const contentType = payload.content_type;
+  const sha256 = payload.sha256;
+  if (
+    typeof sizeBytes !== "number" ||
+    typeof bundleSchemaVersion !== "number" ||
+    typeof contentType !== "string" ||
+    !Number.isSafeInteger(sizeBytes) ||
+    sizeBytes <= 0 ||
+    sizeBytes > MAX_BUNDLE_BYTES ||
+    bundleSchemaVersion !== API_SCHEMA_VERSION ||
+    contentType !== BUNDLE_CONTENT_TYPE ||
+    !isSha256(sha256)
+  ) {
+    throw new PublicError("invalid_request", 400);
+  }
+
+  return {
+    bundle_schema_version: bundleSchemaVersion,
+    content_type: contentType,
+    sha256,
+    size_bytes: sizeBytes,
+  };
+}
+
+function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function bearerToken(request: Request): string | undefined {
+  const header = request.headers.get("authorization");
+  if (header === null) {
+    return undefined;
+  }
+  const match = /^Bearer ([^\s]{1,512})$/u.exec(header);
+  return match?.[1];
+}
+
+function requireReportId(value: string | undefined): string {
+  if (value === undefined || !REPORT_ID_PATTERN.test(value)) {
+    throw new PublicError("not_found", 404);
+  }
+  return value;
+}
+
+function requireSupportCode(value: string | undefined): string {
+  if (value === undefined || !isSupportCode(value)) {
+    throw new PublicError("not_found", 404);
+  }
+  return value;
+}
+
+function requireSecureTransport(
+  request: Request,
+  serviceEnvironment: string,
+): void {
+  const url = new URL(request.url);
+  if (url.protocol === "https:") {
+    return;
+  }
+  const localDevelopmentHost =
+    url.hostname === "127.0.0.1" || url.hostname === "localhost";
+  if (serviceEnvironment !== "production" && localDevelopmentHost) {
+    return;
+  }
+  throw new PublicError("https_required", 400);
+}
+
+async function clientFingerprint(
+  request: Request,
+  rateLimitSalt: string,
+): Promise<string> {
+  const clientAddress =
+    request.headers.get("cf-connecting-ip") ?? "unavailable";
+  return sha256Hex(`${rateLimitSalt}:${clientAddress}`);
+}
+
+async function applyRateLimit(
+  binding: RateLimitBinding,
+  key: string,
+): Promise<void> {
+  try {
+    if (!(await binding.limit({ key })).success) {
+      throw new PublicError("rate_limited", 429);
+    }
+  } catch (error) {
+    if (error instanceof PublicError) {
+      throw error;
+    }
+    throw new PublicError("service_unavailable", 503);
+  }
+}
+
+function registryPublicError(error: RegistryError): PublicError {
+  switch (error.code) {
+    case "client_daily_limit":
+      return new PublicError("rate_limited", 429);
+    case "not_found":
+      return new PublicError("not_found", 404);
+    case "total_capacity_reached":
+      return new PublicError("service_unavailable", 503);
+    case "upload_consumed":
+      return new PublicError("upload_consumed", 409);
+    case "upload_expired":
+      return new PublicError("upload_expired", 410);
+    case "support_code_collision":
+      return new PublicError("service_unavailable", 503);
+  }
+}
+
+function registryErrorResponse(error: unknown): PublicError | undefined {
+  return error instanceof RegistryError
+    ? registryPublicError(error)
+    : undefined;
+}
+
+function bundleHeaders(record: ReportRecord): Headers {
+  const headers = secureHeaders();
+  headers.set(
+    "content-disposition",
+    `attachment; filename="${record.supportCode}${BUNDLE_FILENAME_SUFFIX}"`,
+  );
+  headers.set("content-length", String(record.sizeBytes));
+  headers.set("content-type", record.contentType);
+  headers.set(
+    "x-diagnostic-schema-version",
+    String(record.bundleSchemaVersion),
+  );
+  headers.set("x-diagnostic-sha256", record.sha256);
+  return headers;
+}
+
+async function requireMaintainer(
+  request: Request,
+  dependencies: ServiceDependencies,
+): Promise<void> {
+  const token = bearerToken(request);
+  if (
+    token === undefined ||
+    dependencies.maintainerToken.length === 0 ||
+    !(await constantTimeTextEqual(token, dependencies.maintainerToken))
+  ) {
+    throw new PublicError("unauthorized", 401);
+  }
+}
+
+async function createReport(
+  request: Request,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  const payload = await readCreateRequest(request);
+  const now = nowFrom(dependencies);
+  const fingerprint = await clientFingerprint(
+    request,
+    dependencies.rateLimitSalt,
+  );
+  await applyRateLimit(dependencies.createRateLimiter, `create:${fingerprint}`);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const reportId = crypto.randomUUID();
+    const supportCode = generateSupportCode();
+    const uploadToken = generateToken();
+    const statusToken = generateToken();
+    const [uploadTokenHash, statusTokenHash] = await Promise.all([
+      sha256Hex(uploadToken),
+      sha256Hex(statusToken),
+    ]);
+    const uploadExpiresAt = now + UPLOAD_AUTH_TTL_MS;
+    const expiresAt = now + RETENTION_MS;
+    const input: CreateReportRecordInput = {
+      bundleSchemaVersion: payload.bundle_schema_version,
+      clientFingerprint: fingerprint,
+      contentType: payload.content_type,
+      createdAt: now,
+      expiresAt,
+      objectKey: `reports/${reportId}${BUNDLE_FILENAME_SUFFIX}`,
+      reportId,
+      sha256: payload.sha256,
+      sizeBytes: payload.size_bytes,
+      statusExpiresAt: now + STATUS_AUTH_TTL_MS,
+      statusTokenHash,
+      supportCode,
+      uploadExpiresAt,
+      uploadState: "pending",
+      uploadTokenHash,
+    };
+
+    try {
+      await dependencies.registry.create(input, now);
+    } catch (error) {
+      if (
+        error instanceof RegistryError &&
+        error.code === "support_code_collision"
+      ) {
+        continue;
+      }
+      throw error;
+    }
+
+    const url = new URL(request.url);
+    dependencies.logger?.info("report_created", {
+      outcome: "accepted",
+      report_id: reportId,
+    });
+    return jsonResponse(
+      {
+        expires_at: toIso(expiresAt),
+        report_id: reportId,
+        schema_version: API_SCHEMA_VERSION,
+        status: {
+          expires_at: toIso(now + STATUS_AUTH_TTL_MS),
+          headers: {
+            Authorization: `Bearer ${statusToken}`,
+          },
+          method: "GET",
+          url: `${url.origin}/v1/reports/${reportId}/status`,
+        },
+        support_code: supportCode,
+        upload: {
+          expires_at: toIso(uploadExpiresAt),
+          headers: {
+            Authorization: `Bearer ${uploadToken}`,
+            "Content-Length": String(payload.size_bytes),
+            "Content-Type": payload.content_type,
+            "X-Content-SHA256": payload.sha256,
+          },
+          method: "PUT",
+          url: `${url.origin}/v1/reports/${reportId}/upload`,
+        },
+      },
+      201,
+    );
+  }
+
+  throw new PublicError("service_unavailable", 503);
+}
+
+async function uploadBundle(
+  request: Request,
+  reportId: string,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  const uploadToken = bearerToken(request);
+  if (uploadToken === undefined) {
+    throw new PublicError("not_found", 404);
+  }
+  requireContentType(request, BUNDLE_CONTENT_TYPE);
+  const suppliedSha256 = request.headers.get("x-content-sha256");
+  if (!isSha256(suppliedSha256)) {
+    throw new PublicError("invalid_request", 400);
+  }
+
+  const now = nowFrom(dependencies);
+  const uploadTokenHash = await sha256Hex(uploadToken);
+  const authorized = await dependencies.registry.authorizeUpload(
+    reportId,
+    uploadTokenHash,
+    now,
+  );
+  const declaredLength = parseContentLength(request);
+  if (declaredLength === undefined || declaredLength !== authorized.sizeBytes) {
+    throw new PublicError("content_length_mismatch", 422);
+  }
+  if (suppliedSha256 !== authorized.sha256) {
+    throw new PublicError("checksum_mismatch", 422);
+  }
+
+  const bytes = await readLimitedBody(request, MAX_BUNDLE_BYTES);
+  if (bytes.byteLength !== authorized.sizeBytes) {
+    throw new PublicError("content_length_mismatch", 422);
+  }
+  if ((await sha256Hex(bytes)) !== authorized.sha256) {
+    throw new PublicError("checksum_mismatch", 422);
+  }
+
+  await applyRateLimit(
+    dependencies.uploadRateLimiter,
+    `upload:${authorized.clientFingerprint}`,
+  );
+  const record = await dependencies.registry.beginUpload(
+    reportId,
+    uploadTokenHash,
+    now,
+  );
+  try {
+    await dependencies.bucket.put(
+      record.objectKey,
+      arrayBufferFromBytes(bytes),
+      {
+        customMetadata: {
+          bundle_schema_version: String(record.bundleSchemaVersion),
+          created_at: toIso(record.createdAt),
+          expires_at: toIso(record.expiresAt),
+          report_id: record.reportId,
+          sha256: record.sha256,
+          size_bytes: String(record.sizeBytes),
+        },
+        httpMetadata: {
+          cacheControl: "no-store",
+          contentDisposition: `attachment; filename="${record.supportCode}${BUNDLE_FILENAME_SUFFIX}"`,
+          contentType: record.contentType,
+          expires: new Date(record.expiresAt),
+        },
+        sha256: hexToArrayBuffer(record.sha256),
+      },
+    );
+  } catch {
+    await dependencies.registry
+      .failUpload(reportId, now)
+      .catch(() => undefined);
+    dependencies.logger?.error("report_upload_failed", {
+      outcome: "storage_unavailable",
+      report_id: record.reportId,
+    });
+    throw new PublicError("service_unavailable", 503);
+  }
+
+  try {
+    const completed = await dependencies.registry.completeUpload(reportId, now);
+    dependencies.logger?.info("report_uploaded", {
+      outcome: "stored",
+      report_id: completed.reportId,
+    });
+    return jsonResponse(
+      {
+        expires_at: toIso(completed.expiresAt),
+        report_id: completed.reportId,
+        status: "uploaded",
+      },
+      201,
+    );
+  } catch (error) {
+    await dependencies.bucket.delete(record.objectKey).catch(() => undefined);
+    await dependencies.registry
+      .failUpload(reportId, now)
+      .catch(() => undefined);
+    dependencies.logger?.error("report_upload_failed", {
+      outcome: "finalization_unavailable",
+      report_id: record.reportId,
+    });
+    throw error;
+  }
+}
+
+async function getStatus(
+  request: Request,
+  reportId: string,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  const statusToken = bearerToken(request);
+  if (statusToken === undefined) {
+    throw new PublicError("not_found", 404);
+  }
+  const statusTokenHash = await sha256Hex(statusToken);
+  const result = await dependencies.registry.getStatus(
+    reportId,
+    statusTokenHash,
+    nowFrom(dependencies),
+  );
+  return jsonResponse({
+    expires_at: toIso(result.expiresAt),
+    report_id: result.reportId,
+    status: result.uploadState,
+  });
+}
+
+async function fetchForMaintainer(
+  request: Request,
+  supportCode: string,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  await requireMaintainer(request, dependencies);
+  const record = await dependencies.registry.getForMaintainer(
+    supportCode,
+    nowFrom(dependencies),
+  );
+  if (record.uploadState !== "uploaded") {
+    throw new PublicError("not_found", 404);
+  }
+
+  const object = await dependencies.bucket.get(record.objectKey);
+  if (
+    object === null ||
+    object.size !== record.sizeBytes ||
+    object.customMetadata?.sha256 !== record.sha256 ||
+    object.customMetadata.bundle_schema_version !==
+      String(record.bundleSchemaVersion)
+  ) {
+    dependencies.logger?.error("maintainer_fetch_failed", {
+      outcome: "object_unavailable",
+      report_id: record.reportId,
+    });
+    throw new PublicError("service_unavailable", 503);
+  }
+
+  dependencies.logger?.info("maintainer_fetch", {
+    outcome: "served",
+    report_id: record.reportId,
+  });
+  return new Response(object.body, {
+    headers: bundleHeaders(record),
+    status: 200,
+  });
+}
+
+async function deleteForMaintainer(
+  request: Request,
+  supportCode: string,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  await requireMaintainer(request, dependencies);
+  const now = nowFrom(dependencies);
+  const record = await dependencies.registry.getForMaintainer(supportCode, now);
+  try {
+    await dependencies.bucket.delete(record.objectKey);
+  } catch {
+    dependencies.logger?.error("maintainer_delete_failed", {
+      outcome: "storage_unavailable",
+      report_id: record.reportId,
+    });
+    throw new PublicError("service_unavailable", 503);
+  }
+  await dependencies.registry.deleteForMaintainer(supportCode, now);
+  dependencies.logger?.info("maintainer_delete", {
+    outcome: "deleted",
+    report_id: record.reportId,
+  });
+  return emptyResponse(204);
+}
+
+function route(request: Request): string[] {
+  return new URL(request.url).pathname.split("/").filter(Boolean);
+}
+
+async function handleRequest(
+  request: Request,
+  dependencies: ServiceDependencies,
+): Promise<Response> {
+  try {
+    requireSecureTransport(request, dependencies.serviceEnvironment);
+    const path = route(request);
+    if (
+      request.method === "POST" &&
+      path.length === 2 &&
+      path[0] === "v1" &&
+      path[1] === "reports"
+    ) {
+      return await createReport(request, dependencies);
+    }
+    if (
+      request.method === "PUT" &&
+      path.length === 4 &&
+      path[0] === "v1" &&
+      path[1] === "reports" &&
+      path[3] === "upload"
+    ) {
+      return await uploadBundle(
+        request,
+        requireReportId(path[2]),
+        dependencies,
+      );
+    }
+    if (
+      request.method === "GET" &&
+      path.length === 4 &&
+      path[0] === "v1" &&
+      path[1] === "reports" &&
+      path[3] === "status"
+    ) {
+      return await getStatus(request, requireReportId(path[2]), dependencies);
+    }
+    if (
+      request.method === "GET" &&
+      path.length === 4 &&
+      path[0] === "v1" &&
+      path[1] === "maintainer" &&
+      path[2] === "reports"
+    ) {
+      return await fetchForMaintainer(
+        request,
+        requireSupportCode(path[3]),
+        dependencies,
+      );
+    }
+    if (
+      request.method === "DELETE" &&
+      path.length === 4 &&
+      path[0] === "v1" &&
+      path[1] === "maintainer" &&
+      path[2] === "reports"
+    ) {
+      return await deleteForMaintainer(
+        request,
+        requireSupportCode(path[3]),
+        dependencies,
+      );
+    }
+    throw new PublicError("not_found", 404);
+  } catch (error) {
+    if (error instanceof PublicError) {
+      return errorResponse(error);
+    }
+    const registryError = registryErrorResponse(error);
+    if (registryError !== undefined) {
+      return errorResponse(registryError);
+    }
+    return errorResponse(new PublicError("service_unavailable", 503));
+  }
+}
+
+export function createDiagnosticService(dependencies: ServiceDependencies): {
+  fetch(request: Request): Promise<Response>;
+} {
+  const logger = dependencies.logger ?? serviceLogger();
+  return {
+    fetch(request) {
+      return handleRequest(request, { ...dependencies, logger });
+    },
+  };
+}
+
+class DurableObjectRegistryClient implements Registry {
+  constructor(private readonly stub: DurableObjectStub) {}
+
+  async create(input: CreateReportRecordInput, now: number): Promise<void> {
+    await this.call("create", { input, now });
+  }
+
+  async authorizeUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    return this.call("authorize-upload", { now, reportId, uploadTokenHash });
+  }
+
+  async beginUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    return this.call("begin-upload", { now, reportId, uploadTokenHash });
+  }
+
+  async completeUpload(reportId: string, now: number): Promise<ReportRecord> {
+    return this.call("complete-upload", { now, reportId });
+  }
+
+  async failUpload(reportId: string, now: number): Promise<void> {
+    await this.call("fail-upload", { now, reportId });
+  }
+
+  async getStatus(
+    reportId: string,
+    statusTokenHash: string,
+    now: number,
+  ): Promise<{
+    expiresAt: number;
+    reportId: string;
+    uploadState: ReportRecord["uploadState"];
+  }> {
+    return this.call("status", { now, reportId, statusTokenHash });
+  }
+
+  async getForMaintainer(
+    supportCode: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    return this.call("maintainer-get", { now, supportCode });
+  }
+
+  async deleteForMaintainer(
+    supportCode: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    return this.call("maintainer-delete", { now, supportCode });
+  }
+
+  async prune(now: number): Promise<string[]> {
+    return this.call("prune", { now });
+  }
+
+  private async call<Result>(
+    operation: string,
+    payload: RegistryOperationPayload,
+  ): Promise<Result> {
+    const response = await this.stub.fetch(`${INTERNAL_ORIGIN}/${operation}`, {
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    let body: RegistryOperationResponse;
+    try {
+      body = (await response.json()) as RegistryOperationResponse;
+    } catch {
+      throw new RegistryError("not_found");
+    }
+    const errorCode = registryErrorCode(body.error);
+    if (!response.ok || errorCode !== undefined) {
+      throw new RegistryError(errorCode ?? "not_found");
+    }
+    return body.result as Result;
+  }
+}
+
+function internalPayload(request: Request): Promise<RegistryOperationPayload> {
+  return request.json() as Promise<RegistryOperationPayload>;
+}
+
+function internalErrorResponse(error: unknown): Response {
+  if (error instanceof RegistryError) {
+    return jsonResponse({ error: error.code }, 400);
+  }
+  return jsonResponse({ error: "not_found" }, 400);
+}
+
+export class ReportRegistry {
+  private readonly service: ReportRegistryService;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    this.service = new ReportRegistryService(state.storage);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== "POST") {
+      return jsonResponse({ error: "not_found" }, 404);
+    }
+    const operation = new URL(request.url).pathname.slice(1);
+    try {
+      const payload = await internalPayload(request);
+      const now = payload.now;
+      if (!Number.isSafeInteger(now)) {
+        return jsonResponse({ error: "not_found" }, 400);
+      }
+      switch (operation) {
+        case "create":
+          await this.service.create(
+            payload.input as CreateReportRecordInput,
+            now,
+          );
+          return jsonResponse({ result: null });
+        case "authorize-upload":
+          return jsonResponse({
+            result: await this.service.authorizeUpload(
+              payload.reportId!,
+              payload.uploadTokenHash!,
+              now,
+            ),
+          });
+        case "begin-upload":
+          return jsonResponse({
+            result: await this.service.beginUpload(
+              payload.reportId!,
+              payload.uploadTokenHash!,
+              now,
+            ),
+          });
+        case "complete-upload":
+          return jsonResponse({
+            result: await this.service.completeUpload(payload.reportId!, now),
+          });
+        case "fail-upload":
+          await this.service.failUpload(payload.reportId!, now);
+          return jsonResponse({ result: null });
+        case "status":
+          return jsonResponse({
+            result: await this.service.getStatus(
+              payload.reportId!,
+              payload.statusTokenHash!,
+              now,
+            ),
+          });
+        case "maintainer-get":
+          return jsonResponse({
+            result: await this.service.getForMaintainer(
+              payload.supportCode!,
+              now,
+            ),
+          });
+        case "maintainer-delete":
+          return jsonResponse({
+            result: await this.service.deleteForMaintainer(
+              payload.supportCode!,
+              now,
+            ),
+          });
+        case "prune":
+          return jsonResponse({ result: await this.service.prune(now) });
+        default:
+          return jsonResponse({ error: "not_found" }, 404);
+      }
+    } catch (error) {
+      if (
+        error instanceof RegistryError &&
+        error.expiredObjectKey !== undefined
+      ) {
+        await this.env.DIAGNOSTIC_BUNDLES.delete(error.expiredObjectKey).catch(
+          () => undefined,
+        );
+      }
+      return internalErrorResponse(error);
+    }
+  }
+
+  async alarm(): Promise<void> {
+    const expiredObjectKeys = await this.service.prune(Date.now());
+    await Promise.all(
+      expiredObjectKeys.map((key) => this.env.DIAGNOSTIC_BUNDLES.delete(key)),
+    );
+  }
+}
+
+function runtimeDependencies(env: Env): ServiceDependencies {
+  const namespace = env.REPORT_REGISTRY;
+  const registry = new DurableObjectRegistryClient(
+    namespace.get(namespace.idFromName(REGISTRY_INSTANCE_NAME)),
+  );
+  return {
+    bucket: env.DIAGNOSTIC_BUNDLES,
+    createRateLimiter: env.CREATE_RATE_LIMITER,
+    maintainerToken: env.MAINTAINER_TOKEN,
+    rateLimitSalt: env.RATE_LIMIT_SALT,
+    registry,
+    serviceEnvironment: env.SERVICE_ENVIRONMENT,
+    uploadRateLimiter: env.UPLOAD_RATE_LIMITER,
+  };
+}
+
+const worker: ExportedHandler<Env> = {
+  async fetch(request, env) {
+    return createDiagnosticService(runtimeDependencies(env)).fetch(request);
+  },
+  async scheduled(controller, env, context) {
+    const registry = new DurableObjectRegistryClient(
+      env.REPORT_REGISTRY.get(
+        env.REPORT_REGISTRY.idFromName(REGISTRY_INSTANCE_NAME),
+      ),
+    );
+    const cleanup = registry
+      .prune(controller.scheduledTime)
+      .then((keys) =>
+        Promise.all(keys.map((key) => env.DIAGNOSTIC_BUNDLES.delete(key))),
+      )
+      .then(() => undefined);
+    context.waitUntil(cleanup);
+  },
+};
+
+export default worker;

--- a/support-diagnostics/src/index.ts
+++ b/support-diagnostics/src/index.ts
@@ -13,6 +13,10 @@ import {
   type ReportRecord,
 } from "./protocol.js";
 import {
+  InvalidDiagnosticBundleError,
+  validateDiagnosticBundle,
+} from "./bundle.js";
+import {
   constantTimeTextEqual,
   generateSupportCode,
   generateToken,
@@ -490,26 +494,17 @@ async function uploadBundle(
     throw new PublicError("invalid_request", 400);
   }
 
-  const now = nowFrom(dependencies);
   const uploadTokenHash = await sha256Hex(uploadToken);
   const authorized = await dependencies.registry.authorizeUpload(
     reportId,
     uploadTokenHash,
-    now,
+    nowFrom(dependencies),
   );
   const declaredLength = parseContentLength(request);
   if (declaredLength === undefined || declaredLength !== authorized.sizeBytes) {
     throw new PublicError("content_length_mismatch", 422);
   }
   if (suppliedSha256 !== authorized.sha256) {
-    throw new PublicError("checksum_mismatch", 422);
-  }
-
-  const bytes = await readLimitedBody(request, MAX_BUNDLE_BYTES);
-  if (bytes.byteLength !== authorized.sizeBytes) {
-    throw new PublicError("content_length_mismatch", 422);
-  }
-  if ((await sha256Hex(bytes)) !== authorized.sha256) {
     throw new PublicError("checksum_mismatch", 422);
   }
 
@@ -520,8 +515,38 @@ async function uploadBundle(
   const record = await dependencies.registry.beginUpload(
     reportId,
     uploadTokenHash,
-    now,
+    nowFrom(dependencies),
   );
+  let bytes: Uint8Array;
+  try {
+    bytes = await readLimitedBody(request, MAX_BUNDLE_BYTES);
+    if (bytes.byteLength !== authorized.sizeBytes) {
+      throw new PublicError("content_length_mismatch", 422);
+    }
+    if ((await sha256Hex(bytes)) !== authorized.sha256) {
+      throw new PublicError("checksum_mismatch", 422);
+    }
+    await validateDiagnosticBundle(bytes, record.bundleSchemaVersion);
+    if (record.uploadExpiresAt <= nowFrom(dependencies)) {
+      throw new PublicError("upload_expired", 410);
+    }
+  } catch (error) {
+    await dependencies.registry
+      .failUpload(reportId, nowFrom(dependencies))
+      .catch(() => undefined);
+    dependencies.logger?.error("report_upload_failed", {
+      outcome:
+        error instanceof InvalidDiagnosticBundleError
+          ? "invalid_bundle"
+          : "invalid_upload",
+      report_id: record.reportId,
+    });
+    if (error instanceof InvalidDiagnosticBundleError) {
+      throw new PublicError("invalid_bundle", 422);
+    }
+    throw error;
+  }
+
   try {
     await dependencies.bucket.put(
       record.objectKey,
@@ -539,14 +564,14 @@ async function uploadBundle(
           cacheControl: "no-store",
           contentDisposition: `attachment; filename="${record.supportCode}${BUNDLE_FILENAME_SUFFIX}"`,
           contentType: record.contentType,
-          expires: new Date(record.expiresAt),
+          cacheExpiry: new Date(record.expiresAt),
         },
         sha256: hexToArrayBuffer(record.sha256),
       },
     );
   } catch {
     await dependencies.registry
-      .failUpload(reportId, now)
+      .failUpload(reportId, nowFrom(dependencies))
       .catch(() => undefined);
     dependencies.logger?.error("report_upload_failed", {
       outcome: "storage_unavailable",
@@ -556,7 +581,10 @@ async function uploadBundle(
   }
 
   try {
-    const completed = await dependencies.registry.completeUpload(reportId, now);
+    const completed = await dependencies.registry.completeUpload(
+      reportId,
+      nowFrom(dependencies),
+    );
     dependencies.logger?.info("report_uploaded", {
       outcome: "stored",
       report_id: completed.reportId,
@@ -572,7 +600,7 @@ async function uploadBundle(
   } catch (error) {
     await dependencies.bucket.delete(record.objectKey).catch(() => undefined);
     await dependencies.registry
-      .failUpload(reportId, now)
+      .failUpload(reportId, nowFrom(dependencies))
       .catch(() => undefined);
     dependencies.logger?.error("report_upload_failed", {
       outcome: "finalization_unavailable",
@@ -759,7 +787,7 @@ export function createDiagnosticService(dependencies: ServiceDependencies): {
   };
 }
 
-class DurableObjectRegistryClient implements Registry {
+export class DurableObjectRegistryClient implements Registry {
   constructor(private readonly stub: DurableObjectStub) {}
 
   async create(input: CreateReportRecordInput, now: number): Promise<void> {
@@ -833,11 +861,18 @@ class DurableObjectRegistryClient implements Registry {
     try {
       body = (await response.json()) as RegistryOperationResponse;
     } catch {
-      throw new RegistryError("not_found");
+      throw new Error("registry_unavailable");
     }
     const errorCode = registryErrorCode(body.error);
-    if (!response.ok || errorCode !== undefined) {
-      throw new RegistryError(errorCode ?? "not_found");
+    if (errorCode !== undefined) {
+      throw new RegistryError(errorCode);
+    }
+    if (
+      !response.ok ||
+      body.error !== undefined ||
+      !Object.hasOwn(body, "result")
+    ) {
+      throw new Error("registry_unavailable");
     }
     return body.result as Result;
   }
@@ -851,7 +886,7 @@ function internalErrorResponse(error: unknown): Response {
   if (error instanceof RegistryError) {
     return jsonResponse({ error: error.code }, 400);
   }
-  return jsonResponse({ error: "not_found" }, 400);
+  return jsonResponse({ error: "internal_error" }, 500);
 }
 
 export class ReportRegistry {

--- a/support-diagnostics/src/protocol.ts
+++ b/support-diagnostics/src/protocol.ts
@@ -1,6 +1,6 @@
 export const API_SCHEMA_VERSION = 1;
-export const BUNDLE_CONTENT_TYPE = "application/gzip";
-export const BUNDLE_FILENAME_SUFFIX = ".tar.gz";
+export const BUNDLE_CONTENT_TYPE = "application/zip";
+export const BUNDLE_FILENAME_SUFFIX = ".zip";
 export const MAX_ACTIVE_REPORTS = 500;
 export const MAX_BUNDLE_BYTES = 2 * 1024 * 1024;
 export const MAX_CREATE_REQUEST_BYTES = 4 * 1024;

--- a/support-diagnostics/src/protocol.ts
+++ b/support-diagnostics/src/protocol.ts
@@ -1,0 +1,60 @@
+export const API_SCHEMA_VERSION = 1;
+export const BUNDLE_CONTENT_TYPE = "application/gzip";
+export const BUNDLE_FILENAME_SUFFIX = ".tar.gz";
+export const MAX_ACTIVE_REPORTS = 500;
+export const MAX_BUNDLE_BYTES = 2 * 1024 * 1024;
+export const MAX_CREATE_REQUEST_BYTES = 4 * 1024;
+export const MAX_DAILY_REPORTS_PER_CLIENT = 5;
+export const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+export const STATUS_AUTH_TTL_MS = 10 * 60 * 1000;
+export const UPLOAD_AUTH_TTL_MS = 10 * 60 * 1000;
+
+export type UploadState = "failed" | "pending" | "uploaded" | "uploading";
+
+export interface ReportRecord {
+  bundleSchemaVersion: number;
+  clientFingerprint: string;
+  contentType: string;
+  createdAt: number;
+  expiresAt: number;
+  objectKey: string;
+  reportId: string;
+  sha256: string;
+  sizeBytes: number;
+  statusExpiresAt: number;
+  statusTokenHash: string;
+  supportCode: string;
+  uploadExpiresAt: number;
+  uploadState: UploadState;
+  uploadTokenHash?: string;
+}
+
+export interface ClientUsage {
+  count: number;
+  windowStartedAt: number;
+}
+
+export interface CreateReportRecordInput extends ReportRecord {}
+
+export type RegistryErrorCode =
+  | "client_daily_limit"
+  | "not_found"
+  | "support_code_collision"
+  | "total_capacity_reached"
+  | "upload_consumed"
+  | "upload_expired";
+
+export class RegistryError extends Error {
+  constructor(
+    readonly code: RegistryErrorCode,
+    readonly expiredObjectKey?: string,
+  ) {
+    super(code);
+  }
+}
+
+export interface ReportStatus {
+  expiresAt: number;
+  reportId: string;
+  uploadState: UploadState;
+}

--- a/support-diagnostics/src/registry.ts
+++ b/support-diagnostics/src/registry.ts
@@ -1,0 +1,280 @@
+import {
+  MAX_ACTIVE_REPORTS,
+  MAX_DAILY_REPORTS_PER_CLIENT,
+  type ClientUsage,
+  type CreateReportRecordInput,
+  type RegistryErrorCode,
+  RegistryError,
+  type ReportRecord,
+  type ReportStatus,
+} from "./protocol.js";
+import type { DurableObjectStorage } from "./types.js";
+
+const CLIENT_USAGE_PREFIX = "client:";
+const REPORT_PREFIX = "report:";
+const SUPPORT_CODE_PREFIX = "support:";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function reportKey(reportId: string): string {
+  return `${REPORT_PREFIX}${reportId}`;
+}
+
+function supportCodeKey(supportCode: string): string {
+  return `${SUPPORT_CODE_PREFIX}${supportCode}`;
+}
+
+function clientUsageKey(clientFingerprint: string): string {
+  return `${CLIENT_USAGE_PREFIX}${clientFingerprint}`;
+}
+
+export interface Registry {
+  authorizeUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord>;
+  beginUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord>;
+  completeUpload(reportId: string, now: number): Promise<ReportRecord>;
+  create(input: CreateReportRecordInput, now: number): Promise<void>;
+  deleteForMaintainer(supportCode: string, now: number): Promise<ReportRecord>;
+  failUpload(reportId: string, now: number): Promise<void>;
+  getForMaintainer(supportCode: string, now: number): Promise<ReportRecord>;
+  getStatus(
+    reportId: string,
+    statusTokenHash: string,
+    now: number,
+  ): Promise<ReportStatus>;
+  prune(now: number): Promise<string[]>;
+}
+
+export class ReportRegistryService implements Registry {
+  constructor(private readonly storage: DurableObjectStorage) {}
+
+  async create(input: CreateReportRecordInput, now: number): Promise<void> {
+    const records = await this.storage.list<ReportRecord>({
+      prefix: REPORT_PREFIX,
+    });
+    const activeReports = Array.from(records.values()).filter(
+      (record) => record.expiresAt > now,
+    ).length;
+    if (activeReports >= MAX_ACTIVE_REPORTS) {
+      throw new RegistryError("total_capacity_reached");
+    }
+
+    const existingReport = await this.storage.get<ReportRecord>(
+      reportKey(input.reportId),
+    );
+    const existingSupportCode = await this.storage.get<string>(
+      supportCodeKey(input.supportCode),
+    );
+    if (existingReport !== undefined || existingSupportCode !== undefined) {
+      throw new RegistryError("support_code_collision");
+    }
+
+    await this.consumeClientQuota(input.clientFingerprint, now);
+    await this.storage.put(reportKey(input.reportId), input);
+    await this.storage.put(supportCodeKey(input.supportCode), input.reportId);
+    await this.scheduleNextExpiry();
+  }
+
+  async authorizeUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    const record = await this.getLiveReport(reportId, now);
+    this.assertUploadAuthorization(record, uploadTokenHash, now);
+    return record;
+  }
+
+  async beginUpload(
+    reportId: string,
+    uploadTokenHash: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    const record = await this.getLiveReport(reportId, now);
+    this.assertUploadAuthorization(record, uploadTokenHash, now);
+    record.uploadState = "uploading";
+    await this.storage.put(reportKey(record.reportId), record);
+    return record;
+  }
+
+  async completeUpload(reportId: string, now: number): Promise<ReportRecord> {
+    const record = await this.getLiveReport(reportId, now);
+    if (record.uploadState !== "uploading") {
+      throw new RegistryError("upload_consumed");
+    }
+    record.uploadState = "uploaded";
+    await this.storage.put(reportKey(record.reportId), record);
+    return record;
+  }
+
+  async failUpload(reportId: string, now: number): Promise<void> {
+    const record = await this.getLiveReport(reportId, now);
+    if (record.uploadState !== "uploading") {
+      return;
+    }
+    record.uploadState = "failed";
+    await this.storage.put(reportKey(record.reportId), record);
+  }
+
+  async getStatus(
+    reportId: string,
+    statusTokenHash: string,
+    now: number,
+  ): Promise<ReportStatus> {
+    const record = await this.getLiveReport(reportId, now);
+    if (
+      record.statusExpiresAt <= now ||
+      record.statusTokenHash !== statusTokenHash
+    ) {
+      throw new RegistryError("not_found");
+    }
+    return {
+      expiresAt: record.expiresAt,
+      reportId: record.reportId,
+      uploadState: record.uploadState,
+    };
+  }
+
+  async getForMaintainer(
+    supportCode: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    const reportId = await this.storage.get<string>(
+      supportCodeKey(supportCode),
+    );
+    if (reportId === undefined) {
+      throw new RegistryError("not_found");
+    }
+    return this.getLiveReport(reportId, now);
+  }
+
+  async deleteForMaintainer(
+    supportCode: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    const record = await this.getForMaintainer(supportCode, now);
+    await this.deleteRecord(record);
+    await this.scheduleNextExpiry();
+    return record;
+  }
+
+  async prune(now: number): Promise<string[]> {
+    const records = await this.storage.list<ReportRecord>({
+      prefix: REPORT_PREFIX,
+    });
+    const expiredObjectKeys: string[] = [];
+    for (const record of records.values()) {
+      if (record.expiresAt <= now) {
+        expiredObjectKeys.push(record.objectKey);
+        await this.deleteRecord(record);
+      }
+    }
+
+    const usages = await this.storage.list<ClientUsage>({
+      prefix: CLIENT_USAGE_PREFIX,
+    });
+    for (const [key, usage] of usages) {
+      if (usage.windowStartedAt + DAY_MS <= now) {
+        await this.storage.delete(key);
+      }
+    }
+
+    await this.scheduleNextExpiry();
+    return expiredObjectKeys;
+  }
+
+  private async consumeClientQuota(
+    clientFingerprint: string,
+    now: number,
+  ): Promise<void> {
+    const key = clientUsageKey(clientFingerprint);
+    const existing = await this.storage.get<ClientUsage>(key);
+    const usage =
+      existing === undefined || existing.windowStartedAt + DAY_MS <= now
+        ? { count: 0, windowStartedAt: now }
+        : existing;
+
+    if (usage.count >= MAX_DAILY_REPORTS_PER_CLIENT) {
+      throw new RegistryError("client_daily_limit");
+    }
+
+    usage.count += 1;
+    await this.storage.put(key, usage);
+  }
+
+  private assertUploadAuthorization(
+    record: ReportRecord,
+    uploadTokenHash: string,
+    now: number,
+  ): void {
+    if (record.uploadTokenHash !== uploadTokenHash) {
+      throw new RegistryError("not_found");
+    }
+    if (record.uploadExpiresAt <= now) {
+      throw new RegistryError("upload_expired");
+    }
+    if (record.uploadState !== "pending") {
+      throw new RegistryError("upload_consumed");
+    }
+  }
+
+  private async getLiveReport(
+    reportId: string,
+    now: number,
+  ): Promise<ReportRecord> {
+    const record = await this.storage.get<ReportRecord>(reportKey(reportId));
+    if (record === undefined) {
+      throw new RegistryError("not_found");
+    }
+    if (record.expiresAt <= now) {
+      await this.deleteRecord(record);
+      throw new RegistryError("not_found", record.objectKey);
+    }
+    return record;
+  }
+
+  private async deleteRecord(record: ReportRecord): Promise<void> {
+    await this.storage.delete(reportKey(record.reportId));
+    await this.storage.delete(supportCodeKey(record.supportCode));
+  }
+
+  private async scheduleNextExpiry(): Promise<void> {
+    const records = await this.storage.list<ReportRecord>({
+      prefix: REPORT_PREFIX,
+    });
+    let nextExpiry: number | undefined;
+    for (const record of records.values()) {
+      if (nextExpiry === undefined || record.expiresAt < nextExpiry) {
+        nextExpiry = record.expiresAt;
+      }
+    }
+    if (nextExpiry !== undefined) {
+      await this.storage.setAlarm(nextExpiry);
+    }
+  }
+}
+
+export function registryErrorCode(
+  value: unknown,
+): RegistryErrorCode | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const codes: readonly RegistryErrorCode[] = [
+    "client_daily_limit",
+    "not_found",
+    "support_code_collision",
+    "total_capacity_reached",
+    "upload_consumed",
+    "upload_expired",
+  ];
+  return codes.includes(value as RegistryErrorCode)
+    ? (value as RegistryErrorCode)
+    : undefined;
+}

--- a/support-diagnostics/src/registry.ts
+++ b/support-diagnostics/src/registry.ts
@@ -75,10 +75,16 @@ export class ReportRegistryService implements Registry {
       throw new RegistryError("support_code_collision");
     }
 
-    await this.consumeClientQuota(input.clientFingerprint, now);
-    await this.storage.put(reportKey(input.reportId), input);
-    await this.storage.put(supportCodeKey(input.supportCode), input.reportId);
-    await this.scheduleNextExpiry();
+    const [usageKey, usage] = await this.nextClientUsage(
+      input.clientFingerprint,
+      now,
+    );
+    await this.storage.put({
+      [usageKey]: usage,
+      [reportKey(input.reportId)]: input,
+      [supportCodeKey(input.supportCode)]: input.reportId,
+    });
+    await this.scheduleNextExpiry().catch(() => undefined);
   }
 
   async authorizeUpload(
@@ -107,6 +113,11 @@ export class ReportRegistryService implements Registry {
     const record = await this.getLiveReport(reportId, now);
     if (record.uploadState !== "uploading") {
       throw new RegistryError("upload_consumed");
+    }
+    if (record.uploadExpiresAt <= now) {
+      record.uploadState = "failed";
+      await this.storage.put(reportKey(record.reportId), record);
+      throw new RegistryError("upload_expired");
     }
     record.uploadState = "uploaded";
     await this.storage.put(reportKey(record.reportId), record);
@@ -160,7 +171,7 @@ export class ReportRegistryService implements Registry {
   ): Promise<ReportRecord> {
     const record = await this.getForMaintainer(supportCode, now);
     await this.deleteRecord(record);
-    await this.scheduleNextExpiry();
+    await this.scheduleNextExpiry().catch(() => undefined);
     return record;
   }
 
@@ -185,14 +196,14 @@ export class ReportRegistryService implements Registry {
       }
     }
 
-    await this.scheduleNextExpiry();
+    await this.scheduleNextExpiry().catch(() => undefined);
     return expiredObjectKeys;
   }
 
-  private async consumeClientQuota(
+  private async nextClientUsage(
     clientFingerprint: string,
     now: number,
-  ): Promise<void> {
+  ): Promise<readonly [string, ClientUsage]> {
     const key = clientUsageKey(clientFingerprint);
     const existing = await this.storage.get<ClientUsage>(key);
     const usage =
@@ -205,7 +216,7 @@ export class ReportRegistryService implements Registry {
     }
 
     usage.count += 1;
-    await this.storage.put(key, usage);
+    return [key, usage] as const;
   }
 
   private assertUploadAuthorization(
@@ -240,8 +251,10 @@ export class ReportRegistryService implements Registry {
   }
 
   private async deleteRecord(record: ReportRecord): Promise<void> {
-    await this.storage.delete(reportKey(record.reportId));
-    await this.storage.delete(supportCodeKey(record.supportCode));
+    await this.storage.delete([
+      reportKey(record.reportId),
+      supportCodeKey(record.supportCode),
+    ]);
   }
 
   private async scheduleNextExpiry(): Promise<void> {

--- a/support-diagnostics/src/types.ts
+++ b/support-diagnostics/src/types.ts
@@ -1,0 +1,94 @@
+export interface R2HttpMetadata {
+  cacheControl?: string;
+  contentDisposition?: string;
+  contentType?: string;
+  expires?: Date;
+}
+
+export interface R2PutOptions {
+  customMetadata?: Record<string, string>;
+  httpMetadata?: R2HttpMetadata;
+  sha256?: ArrayBuffer | string;
+}
+
+export interface R2ObjectBody {
+  body: ReadableStream<Uint8Array>;
+  customMetadata?: Record<string, string>;
+  key: string;
+  size: number;
+}
+
+export interface R2Bucket {
+  delete(key: string): Promise<void>;
+  get(key: string): Promise<R2ObjectBody | null>;
+  put(
+    key: string,
+    value: ArrayBuffer,
+    options?: R2PutOptions,
+  ): Promise<unknown>;
+}
+
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+export interface DurableObjectId {
+  toString(): string;
+}
+
+export interface DurableObjectStub {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+export interface DurableObjectNamespace {
+  get(id: DurableObjectId): DurableObjectStub;
+  idFromName(name: string): DurableObjectId;
+}
+
+export interface DurableObjectStorage {
+  delete(key: string): Promise<boolean>;
+  get<T>(key: string): Promise<T | undefined>;
+  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+  put<T>(key: string, value: T): Promise<void>;
+  setAlarm(scheduledTime: number): Promise<void>;
+}
+
+export interface DurableObjectState {
+  storage: DurableObjectStorage;
+}
+
+export interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export interface ScheduledController {
+  scheduledTime: number;
+}
+
+export interface Env {
+  CREATE_RATE_LIMITER: RateLimitBinding;
+  DIAGNOSTIC_BUNDLES: R2Bucket;
+  MAINTAINER_TOKEN: string;
+  RATE_LIMIT_SALT: string;
+  REPORT_REGISTRY: DurableObjectNamespace;
+  SERVICE_ENVIRONMENT: string;
+  UPLOAD_RATE_LIMITER: RateLimitBinding;
+}
+
+export interface ExportedHandler<Environment> {
+  fetch(
+    request: Request,
+    env: Environment,
+    context: ExecutionContext,
+  ): Promise<Response>;
+  scheduled?(
+    controller: ScheduledController,
+    env: Environment,
+    context: ExecutionContext,
+  ): Promise<void>;
+}
+
+export interface ServiceLogger {
+  error(event: string, fields: Record<string, string | number>): void;
+  info(event: string, fields: Record<string, string | number>): void;
+}

--- a/support-diagnostics/src/types.ts
+++ b/support-diagnostics/src/types.ts
@@ -1,8 +1,8 @@
 export interface R2HttpMetadata {
   cacheControl?: string;
+  cacheExpiry?: Date;
   contentDisposition?: string;
   contentType?: string;
-  expires?: Date;
 }
 
 export interface R2PutOptions {
@@ -46,9 +46,11 @@ export interface DurableObjectNamespace {
 }
 
 export interface DurableObjectStorage {
+  delete(keys: string[]): Promise<number>;
   delete(key: string): Promise<boolean>;
   get<T>(key: string): Promise<T | undefined>;
   list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+  put(entries: Record<string, unknown>): Promise<void>;
   put<T>(key: string, value: T): Promise<void>;
   setAlarm(scheduledTime: number): Promise<void>;
 }

--- a/support-diagnostics/test/diagnostic-service.test.ts
+++ b/support-diagnostics/test/diagnostic-service.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { deflateRawSync } from "node:zlib";
 
 import { sha256Hex } from "../src/crypto.js";
-import { createDiagnosticService } from "../src/index.js";
+import {
+  createDiagnosticService,
+  DurableObjectRegistryClient,
+} from "../src/index.js";
 import {
   API_SCHEMA_VERSION,
   BUNDLE_CONTENT_TYPE,
@@ -13,7 +17,9 @@ import {
 import { ReportRegistryService } from "../src/registry.js";
 import type {
   DurableObjectStorage,
+  DurableObjectStub,
   R2Bucket,
+  R2HttpMetadata,
   R2ObjectBody,
   R2PutOptions,
   RateLimitBinding,
@@ -44,8 +50,19 @@ class MemoryStorage implements DurableObjectStorage {
   readonly values = new Map<string, unknown>();
   alarm: number | undefined;
 
-  async delete(key: string): Promise<boolean> {
-    return this.values.delete(key);
+  async delete(keys: string[]): Promise<number>;
+  async delete(key: string): Promise<boolean>;
+  async delete(keyOrKeys: string | string[]): Promise<boolean | number> {
+    if (Array.isArray(keyOrKeys)) {
+      let count = 0;
+      for (const key of keyOrKeys) {
+        if (this.values.delete(key)) {
+          count += 1;
+        }
+      }
+      return count;
+    }
+    return this.values.delete(keyOrKeys);
   }
 
   async get<Value>(key: string): Promise<Value | undefined> {
@@ -64,8 +81,19 @@ class MemoryStorage implements DurableObjectStorage {
     return values;
   }
 
-  async put<Value>(key: string, value: Value): Promise<void> {
-    this.values.set(key, structuredClone(value));
+  async put(entries: Record<string, unknown>): Promise<void>;
+  async put<Value>(key: string, value: Value): Promise<void>;
+  async put<Value>(
+    keyOrEntries: string | Record<string, unknown>,
+    value?: Value,
+  ): Promise<void> {
+    if (typeof keyOrEntries === "string") {
+      this.values.set(keyOrEntries, structuredClone(value));
+      return;
+    }
+    for (const [key, entry] of Object.entries(keyOrEntries)) {
+      this.values.set(key, structuredClone(entry));
+    }
   }
 
   async setAlarm(scheduledTime: number): Promise<void> {
@@ -76,6 +104,7 @@ class MemoryStorage implements DurableObjectStorage {
 interface MemoryObject {
   bytes: Uint8Array;
   customMetadata?: Record<string, string>;
+  httpMetadata?: R2HttpMetadata;
 }
 
 class MemoryBucket implements R2Bucket {
@@ -123,8 +152,99 @@ class MemoryBucket implements R2Bucket {
     if (options?.customMetadata !== undefined) {
       object.customMetadata = options.customMetadata;
     }
+    if (options?.httpMetadata !== undefined) {
+      object.httpMetadata = options.httpMetadata;
+    }
     this.objects.set(key, object);
   }
+}
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffffffff;
+  for (const byte of bytes) {
+    value ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function makeDiagnosticBundle(
+  options: {
+    manifestSchemaVersion?: unknown;
+    toolTail?: string;
+    utf8Flag?: boolean;
+  } = {},
+): Uint8Array {
+  const schemaVersion = options.manifestSchemaVersion ?? API_SCHEMA_VERSION;
+  const entries = [
+    {
+      data: Buffer.from(JSON.stringify({ schema_version: schemaVersion })),
+      name: "manifest.json",
+    },
+    {
+      data: Buffer.from(
+        `${JSON.stringify({ schema_version: API_SCHEMA_VERSION, source: "client" })}\n`,
+      ),
+      name: "events.jsonl",
+    },
+    {
+      data: Buffer.from(
+        JSON.stringify({ schema_version: API_SCHEMA_VERSION, probes: [] }),
+      ),
+      name: "storage.json",
+    },
+    {
+      data: Buffer.from(
+        `# bd_to_avp_support_tool_tail schema_version=${API_SCHEMA_VERSION}\n${options.toolTail ?? ""}`,
+      ),
+      name: "tool-tail.txt",
+    },
+  ];
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  const flags = options.utf8Flag === false ? 0 : 0x0800;
+  let localOffset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name);
+    const compressed = deflateRawSync(entry.data);
+    const checksum = crc32(entry.data);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(flags, 6);
+    localHeader.writeUInt16LE(8, 8);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(compressed.byteLength, 18);
+    localHeader.writeUInt32LE(entry.data.byteLength, 22);
+    localHeader.writeUInt16LE(name.byteLength, 26);
+    localParts.push(localHeader, name, compressed);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(0x0314, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(flags, 8);
+    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(compressed.byteLength, 20);
+    centralHeader.writeUInt32LE(entry.data.byteLength, 24);
+    centralHeader.writeUInt16LE(name.byteLength, 28);
+    centralHeader.writeUInt32LE(localOffset, 42);
+    centralParts.push(centralHeader, name);
+    localOffset += localHeader.byteLength + name.byteLength + compressed.byteLength;
+  }
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.byteLength, 12);
+  end.writeUInt32LE(localOffset, 16);
+  return new Uint8Array(
+    Buffer.concat([...localParts, centralDirectory, end]),
+  );
 }
 
 class FixedRateLimiter implements RateLimitBinding {
@@ -228,9 +348,7 @@ function maintainerRequest(
 describe("private diagnostic service", () => {
   it("creates a bounded report, finalizes upload, and rejects replay", async () => {
     const harness = makeHarness();
-    const bytes = new TextEncoder().encode(
-      "small diagnostic archive placeholder",
-    );
+    const bytes = makeDiagnosticBundle();
     const report = await createReport(harness.service, bytes);
 
     expect(report.support_code).toMatch(
@@ -257,6 +375,9 @@ describe("private diagnostic service", () => {
       report_id: report.report_id,
       sha256: await sha256Hex(bytes),
     });
+    expect(object?.httpMetadata?.cacheExpiry).toEqual(
+      new Date(harness.clock.now + RETENTION_MS),
+    );
 
     const status = await harness.service.fetch(
       new Request(report.status.url, {
@@ -275,9 +396,9 @@ describe("private diagnostic service", () => {
     expect(await replay.json()).toEqual({ error: "upload_consumed" });
   });
 
-  it("rejects wrong content, size, and checksum without consuming authorization", async () => {
+  it("rejects wrong headers without consuming authorization", async () => {
     const harness = makeHarness();
-    const bytes = new TextEncoder().encode("diagnostic bytes");
+    const bytes = makeDiagnosticBundle();
     const report = await createReport(harness.service, bytes);
 
     const wrongContentType = await harness.service.fetch(
@@ -288,7 +409,9 @@ describe("private diagnostic service", () => {
     expect(wrongContentType.status).toBe(415);
 
     const wrongSize = await harness.service.fetch(
-      uploadRequest(report, new TextEncoder().encode("wrong bytes")),
+      uploadRequest(report, bytes, {
+        "Content-Length": String(bytes.byteLength - 1),
+      }),
     );
     expect(wrongSize.status).toBe(422);
     expect(await wrongSize.json()).toEqual({
@@ -305,9 +428,87 @@ describe("private diagnostic service", () => {
     expect(success.status).toBe(201);
   });
 
+  it("rejects malformed archives and consumes the reserved upload", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode("not a diagnostic ZIP");
+    const report = await createReport(harness.service, bytes);
+
+    const invalid = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(invalid.status).toBe(422);
+    expect(await invalid.json()).toEqual({ error: "invalid_bundle" });
+
+    const status = await harness.service.fetch(
+      new Request(report.status.url, {
+        headers: report.status.headers,
+        method: "GET",
+      }),
+    );
+    expect(await status.json()).toMatchObject({ status: "failed" });
+
+    const replay = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(replay.status).toBe(409);
+  });
+
+  it("reserves upload authorization before reading a streaming body", async () => {
+    const harness = makeHarness();
+    const bytes = makeDiagnosticBundle();
+    const report = await createReport(harness.service, bytes);
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+    const request = new Request(report.upload.url, {
+      body,
+      duplex: "half",
+      headers: report.upload.headers,
+      method: "PUT",
+    } as RequestInit & { duplex: "half" });
+    const inFlight = harness.service.fetch(request);
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const status = await harness.service.fetch(
+        new Request(report.status.url, {
+          headers: report.status.headers,
+          method: "GET",
+        }),
+      );
+      if ((await status.json() as { status: string }).status === "uploading") {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const replay = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(replay.status).toBe(409);
+    bodyController!.enqueue(bytes);
+    bodyController!.close();
+    expect((await inFlight).status).toBe(201);
+  });
+
+  it("rejects non-integer manifest schema values", async () => {
+    const harness = makeHarness();
+    const bytes = makeDiagnosticBundle({ manifestSchemaVersion: true });
+    const report = await createReport(harness.service, bytes);
+
+    const invalid = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(invalid.status).toBe(422);
+    expect(await invalid.json()).toEqual({ error: "invalid_bundle" });
+  });
+
+  it("accepts standard ASCII ZIP entries without the UTF-8 filename flag", async () => {
+    const harness = makeHarness();
+    const bytes = makeDiagnosticBundle({ utf8Flag: false });
+    const report = await createReport(harness.service, bytes);
+
+    const uploaded = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(uploaded.status).toBe(201);
+  });
+
   it("expires upload authorization and denies support-code guessing", async () => {
     const harness = makeHarness();
-    const bytes = new TextEncoder().encode("expiring diagnostic");
+    const bytes = makeDiagnosticBundle();
     const report = await createReport(harness.service, bytes);
     harness.clock.now += UPLOAD_AUTH_TTL_MS + 1;
 
@@ -373,7 +574,7 @@ describe("private diagnostic service", () => {
 
   it("requires the maintainer token to fetch and delete without public read routes", async () => {
     const harness = makeHarness();
-    const bytes = new TextEncoder().encode("maintainer-only diagnostic");
+    const bytes = makeDiagnosticBundle();
     const report = await createReport(harness.service, bytes);
     expect(
       (await harness.service.fetch(uploadRequest(report, bytes))).status,
@@ -430,9 +631,9 @@ describe("private diagnostic service", () => {
 
   it("records storage failure safely and exposes no token or bundle content in logs", async () => {
     const harness = makeHarness();
-    const bytes = new TextEncoder().encode(
-      "bundle content that must never be logged",
-    );
+    const bytes = makeDiagnosticBundle({
+      toolTail: "bundle content that must never be logged",
+    });
     const report = await createReport(harness.service, bytes);
     harness.bucket.failPuts = true;
 
@@ -463,7 +664,7 @@ describe("private diagnostic service", () => {
       contentType: BUNDLE_CONTENT_TYPE,
       createdAt: harness.clock.now,
       expiresAt: harness.clock.now + 1,
-      objectKey: "reports/expired.tar.gz",
+      objectKey: "reports/expired.zip",
       reportId: "00000000-0000-4000-8000-000000000000",
       sha256: "b".repeat(64),
       sizeBytes: 1,
@@ -486,5 +687,77 @@ describe("private diagnostic service", () => {
     ).rejects.toMatchObject({
       code: "not_found",
     });
+  });
+
+  it("rejects finalization after the upload authorization expires", async () => {
+    const harness = makeHarness();
+    const record: CreateReportRecordInput = {
+      bundleSchemaVersion: API_SCHEMA_VERSION,
+      clientFingerprint: "client",
+      contentType: BUNDLE_CONTENT_TYPE,
+      createdAt: harness.clock.now,
+      expiresAt: harness.clock.now + RETENTION_MS,
+      objectKey: "reports/late.zip",
+      reportId: "00000000-0000-4000-8000-000000000001",
+      sha256: "c".repeat(64),
+      sizeBytes: 1,
+      statusExpiresAt: harness.clock.now + RETENTION_MS,
+      statusTokenHash: "status",
+      supportCode: "BDAVP-1123456789ABCDEF",
+      uploadExpiresAt: harness.clock.now + UPLOAD_AUTH_TTL_MS,
+      uploadState: "pending",
+      uploadTokenHash: "upload",
+    };
+    await harness.registry.create(record, harness.clock.now);
+    await harness.registry.beginUpload(
+      record.reportId,
+      record.uploadTokenHash!,
+      harness.clock.now,
+    );
+
+    await expect(
+      harness.registry.completeUpload(
+        record.reportId,
+        record.uploadExpiresAt,
+      ),
+    ).rejects.toMatchObject({ code: "upload_expired" });
+    await expect(
+      harness.registry.getStatus(
+        record.reportId,
+        record.statusTokenHash,
+        record.uploadExpiresAt,
+      ),
+    ).resolves.toMatchObject({ uploadState: "failed" });
+  });
+
+  it("maps registry transport and serialization failures to service unavailable", async () => {
+    const stub: DurableObjectStub = {
+      async fetch() {
+        return new Response("not JSON", { status: 500 });
+      },
+    };
+    const harness = makeHarness();
+    const service = createDiagnosticService({
+      bucket: harness.bucket,
+      clock: () => harness.clock.now,
+      createRateLimiter: new FixedRateLimiter(),
+      maintainerToken: "maintainer-token-with-at-least-thirty-two-characters",
+      rateLimitSalt: "test-rate-limit-salt",
+      registry: new DurableObjectRegistryClient(stub),
+      serviceEnvironment: "test",
+      uploadRateLimiter: new FixedRateLimiter(),
+    });
+
+    const response = await service.fetch(
+      new Request(
+        "https://diagnostics.example.test/v1/reports/00000000-0000-4000-8000-000000000000/status",
+        {
+          headers: { authorization: "Bearer status-token" },
+          method: "GET",
+        },
+      ),
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "service_unavailable" });
   });
 });

--- a/support-diagnostics/test/diagnostic-service.test.ts
+++ b/support-diagnostics/test/diagnostic-service.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, it } from "vitest";
+
+import { sha256Hex } from "../src/crypto.js";
+import { createDiagnosticService } from "../src/index.js";
+import {
+  API_SCHEMA_VERSION,
+  BUNDLE_CONTENT_TYPE,
+  MAX_DAILY_REPORTS_PER_CLIENT,
+  RETENTION_MS,
+  UPLOAD_AUTH_TTL_MS,
+  type CreateReportRecordInput,
+} from "../src/protocol.js";
+import { ReportRegistryService } from "../src/registry.js";
+import type {
+  DurableObjectStorage,
+  R2Bucket,
+  R2ObjectBody,
+  R2PutOptions,
+  RateLimitBinding,
+  ServiceLogger,
+} from "../src/types.js";
+
+interface CreatedReport {
+  report_id: string;
+  status: {
+    headers: {
+      Authorization: string;
+    };
+    url: string;
+  };
+  support_code: string;
+  upload: {
+    headers: {
+      Authorization: string;
+      "Content-Length": string;
+      "Content-Type": string;
+      "X-Content-SHA256": string;
+    };
+    url: string;
+  };
+}
+
+class MemoryStorage implements DurableObjectStorage {
+  readonly values = new Map<string, unknown>();
+  alarm: number | undefined;
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async get<Value>(key: string): Promise<Value | undefined> {
+    return this.values.get(key) as Value | undefined;
+  }
+
+  async list<Value>(options?: {
+    prefix?: string;
+  }): Promise<Map<string, Value>> {
+    const values = new Map<string, Value>();
+    for (const [key, value] of this.values) {
+      if (options?.prefix === undefined || key.startsWith(options.prefix)) {
+        values.set(key, value as Value);
+      }
+    }
+    return values;
+  }
+
+  async put<Value>(key: string, value: Value): Promise<void> {
+    this.values.set(key, structuredClone(value));
+  }
+
+  async setAlarm(scheduledTime: number): Promise<void> {
+    this.alarm = scheduledTime;
+  }
+}
+
+interface MemoryObject {
+  bytes: Uint8Array;
+  customMetadata?: Record<string, string>;
+}
+
+class MemoryBucket implements R2Bucket {
+  readonly objects = new Map<string, MemoryObject>();
+  failPuts = false;
+  failDeletes = false;
+
+  async delete(key: string): Promise<void> {
+    if (this.failDeletes) {
+      throw new Error("delete failed");
+    }
+    this.objects.delete(key);
+  }
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    const object = this.objects.get(key);
+    if (object === undefined) {
+      return null;
+    }
+    const response: R2ObjectBody = {
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(object.bytes);
+          controller.close();
+        },
+      }),
+      key,
+      size: object.bytes.byteLength,
+    };
+    if (object.customMetadata !== undefined) {
+      response.customMetadata = object.customMetadata;
+    }
+    return response;
+  }
+
+  async put(
+    key: string,
+    value: ArrayBuffer,
+    options?: R2PutOptions,
+  ): Promise<void> {
+    if (this.failPuts) {
+      throw new Error("put failed");
+    }
+    const object: MemoryObject = { bytes: new Uint8Array(value.slice(0)) };
+    if (options?.customMetadata !== undefined) {
+      object.customMetadata = options.customMetadata;
+    }
+    this.objects.set(key, object);
+  }
+}
+
+class FixedRateLimiter implements RateLimitBinding {
+  constructor(private readonly allowed = true) {}
+
+  async limit(): Promise<{ success: boolean }> {
+    return { success: this.allowed };
+  }
+}
+
+interface TestHarness {
+  bucket: MemoryBucket;
+  clock: { now: number };
+  logs: Array<{ event: string; fields: Record<string, string | number> }>;
+  registry: ReportRegistryService;
+  service: ReturnType<typeof createDiagnosticService>;
+  storage: MemoryStorage;
+}
+
+function makeHarness(
+  options: { createAllowed?: boolean; uploadAllowed?: boolean } = {},
+): TestHarness {
+  const clock = { now: 1_700_000_000_000 };
+  const bucket = new MemoryBucket();
+  const storage = new MemoryStorage();
+  const registry = new ReportRegistryService(storage);
+  const logs: Array<{
+    event: string;
+    fields: Record<string, string | number>;
+  }> = [];
+  const logger: ServiceLogger = {
+    error(event, fields) {
+      logs.push({ event, fields });
+    },
+    info(event, fields) {
+      logs.push({ event, fields });
+    },
+  };
+  const service = createDiagnosticService({
+    bucket,
+    clock: () => clock.now,
+    createRateLimiter: new FixedRateLimiter(options.createAllowed),
+    logger,
+    maintainerToken: "maintainer-token-with-at-least-thirty-two-characters",
+    rateLimitSalt: "test-rate-limit-salt",
+    registry,
+    serviceEnvironment: "test",
+    uploadRateLimiter: new FixedRateLimiter(options.uploadAllowed),
+  });
+  return { bucket, clock, logs, registry, service, storage };
+}
+
+async function createReport(
+  service: ReturnType<typeof createDiagnosticService>,
+  bytes: Uint8Array,
+): Promise<CreatedReport> {
+  const response = await service.fetch(
+    new Request("https://diagnostics.example.test/v1/reports", {
+      body: JSON.stringify({
+        bundle_schema_version: API_SCHEMA_VERSION,
+        content_type: BUNDLE_CONTENT_TYPE,
+        sha256: await sha256Hex(bytes),
+        size_bytes: bytes.byteLength,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }),
+  );
+  expect(response.status).toBe(201);
+  return (await response.json()) as CreatedReport;
+}
+
+function uploadRequest(
+  report: CreatedReport,
+  bytes: Uint8Array,
+  headers: Record<string, string> = {},
+): Request {
+  const body = new Uint8Array(bytes.byteLength);
+  body.set(bytes);
+  return new Request(report.upload.url, {
+    body: body.buffer,
+    headers: { ...report.upload.headers, ...headers },
+    method: "PUT",
+  });
+}
+
+function maintainerRequest(
+  method: "DELETE" | "GET",
+  report: CreatedReport,
+  token?: string,
+): Request {
+  return new Request(
+    `https://diagnostics.example.test/v1/maintainer/reports/${report.support_code}`,
+    {
+      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+      method,
+    },
+  );
+}
+
+describe("private diagnostic service", () => {
+  it("creates a bounded report, finalizes upload, and rejects replay", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode(
+      "small diagnostic archive placeholder",
+    );
+    const report = await createReport(harness.service, bytes);
+
+    expect(report.support_code).toMatch(
+      /^BDAVP-[0-9ABCDEFGHJKMNPQRSTVWXYZ]{16}$/u,
+    );
+    expect(report.upload.headers["Content-Length"]).toBe(
+      String(bytes.byteLength),
+    );
+    expect(JSON.stringify(harness.logs)).not.toContain(
+      report.upload.headers.Authorization,
+    );
+
+    const uploaded = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(uploaded.status).toBe(201);
+    expect(await uploaded.json()).toMatchObject({
+      report_id: report.report_id,
+      status: "uploaded",
+    });
+
+    const object = [...harness.bucket.objects.values()][0];
+    expect(object?.customMetadata).toMatchObject({
+      bundle_schema_version: "1",
+      expires_at: new Date(harness.clock.now + RETENTION_MS).toISOString(),
+      report_id: report.report_id,
+      sha256: await sha256Hex(bytes),
+    });
+
+    const status = await harness.service.fetch(
+      new Request(report.status.url, {
+        headers: report.status.headers,
+        method: "GET",
+      }),
+    );
+    expect(status.status).toBe(200);
+    expect(await status.json()).toMatchObject({
+      report_id: report.report_id,
+      status: "uploaded",
+    });
+
+    const replay = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(replay.status).toBe(409);
+    expect(await replay.json()).toEqual({ error: "upload_consumed" });
+  });
+
+  it("rejects wrong content, size, and checksum without consuming authorization", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode("diagnostic bytes");
+    const report = await createReport(harness.service, bytes);
+
+    const wrongContentType = await harness.service.fetch(
+      uploadRequest(report, bytes, {
+        "Content-Type": "application/octet-stream",
+      }),
+    );
+    expect(wrongContentType.status).toBe(415);
+
+    const wrongSize = await harness.service.fetch(
+      uploadRequest(report, new TextEncoder().encode("wrong bytes")),
+    );
+    expect(wrongSize.status).toBe(422);
+    expect(await wrongSize.json()).toEqual({
+      error: "content_length_mismatch",
+    });
+
+    const wrongChecksum = await harness.service.fetch(
+      uploadRequest(report, bytes, { "X-Content-SHA256": "a".repeat(64) }),
+    );
+    expect(wrongChecksum.status).toBe(422);
+    expect(await wrongChecksum.json()).toEqual({ error: "checksum_mismatch" });
+
+    const success = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(success.status).toBe(201);
+  });
+
+  it("expires upload authorization and denies support-code guessing", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode("expiring diagnostic");
+    const report = await createReport(harness.service, bytes);
+    harness.clock.now += UPLOAD_AUTH_TTL_MS + 1;
+
+    const expired = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(expired.status).toBe(410);
+    expect(await expired.json()).toEqual({ error: "upload_expired" });
+
+    const guessed = await harness.service.fetch(
+      new Request(
+        "https://diagnostics.example.test/v1/maintainer/reports/BDAVP-0123456789ABCDEF",
+        {
+          headers: {
+            authorization:
+              "Bearer maintainer-token-with-at-least-thirty-two-characters",
+          },
+          method: "GET",
+        },
+      ),
+    );
+    expect(guessed.status).toBe(404);
+
+    const withoutToken = await harness.service.fetch(
+      maintainerRequest("GET", report),
+    );
+    expect(withoutToken.status).toBe(401);
+  });
+
+  it("uses both the configured rate-limit binding and daily client quota", async () => {
+    const limitedHarness = makeHarness({ createAllowed: false });
+    const bytes = new TextEncoder().encode("rate limit");
+    const limited = await limitedHarness.service.fetch(
+      new Request("https://diagnostics.example.test/v1/reports", {
+        body: JSON.stringify({
+          bundle_schema_version: API_SCHEMA_VERSION,
+          content_type: BUNDLE_CONTENT_TYPE,
+          sha256: await sha256Hex(bytes),
+          size_bytes: bytes.byteLength,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    expect(limited.status).toBe(429);
+
+    const harness = makeHarness();
+    for (let index = 0; index < MAX_DAILY_REPORTS_PER_CLIENT; index += 1) {
+      await createReport(harness.service, bytes);
+    }
+    const excess = await harness.service.fetch(
+      new Request("https://diagnostics.example.test/v1/reports", {
+        body: JSON.stringify({
+          bundle_schema_version: API_SCHEMA_VERSION,
+          content_type: BUNDLE_CONTENT_TYPE,
+          sha256: await sha256Hex(bytes),
+          size_bytes: bytes.byteLength,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    expect(excess.status).toBe(429);
+  });
+
+  it("requires the maintainer token to fetch and delete without public read routes", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode("maintainer-only diagnostic");
+    const report = await createReport(harness.service, bytes);
+    expect(
+      (await harness.service.fetch(uploadRequest(report, bytes))).status,
+    ).toBe(201);
+
+    const publicRead = await harness.service.fetch(
+      new Request(
+        `https://diagnostics.example.test/v1/reports/${report.report_id}/bundle`,
+        { method: "GET" },
+      ),
+    );
+    expect(publicRead.status).toBe(404);
+
+    const wrongToken = await harness.service.fetch(
+      maintainerRequest(
+        "GET",
+        report,
+        "wrong-maintainer-token-with-at-least-thirty-two",
+      ),
+    );
+    expect(wrongToken.status).toBe(401);
+
+    const fetched = await harness.service.fetch(
+      maintainerRequest(
+        "GET",
+        report,
+        "maintainer-token-with-at-least-thirty-two-characters",
+      ),
+    );
+    expect(fetched.status).toBe(200);
+    expect(new Uint8Array(await fetched.arrayBuffer())).toEqual(bytes);
+    expect(fetched.headers.get("x-diagnostic-sha256")).toBe(
+      await sha256Hex(bytes),
+    );
+
+    const deleted = await harness.service.fetch(
+      maintainerRequest(
+        "DELETE",
+        report,
+        "maintainer-token-with-at-least-thirty-two-characters",
+      ),
+    );
+    expect(deleted.status).toBe(204);
+
+    const afterDelete = await harness.service.fetch(
+      maintainerRequest(
+        "GET",
+        report,
+        "maintainer-token-with-at-least-thirty-two-characters",
+      ),
+    );
+    expect(afterDelete.status).toBe(404);
+  });
+
+  it("records storage failure safely and exposes no token or bundle content in logs", async () => {
+    const harness = makeHarness();
+    const bytes = new TextEncoder().encode(
+      "bundle content that must never be logged",
+    );
+    const report = await createReport(harness.service, bytes);
+    harness.bucket.failPuts = true;
+
+    const failed = await harness.service.fetch(uploadRequest(report, bytes));
+    expect(failed.status).toBe(503);
+    expect(await failed.json()).toEqual({ error: "service_unavailable" });
+
+    const status = await harness.service.fetch(
+      new Request(report.status.url, {
+        headers: report.status.headers,
+        method: "GET",
+      }),
+    );
+    expect(await status.json()).toMatchObject({ status: "failed" });
+    const serializedLogs = JSON.stringify(harness.logs);
+    expect(serializedLogs).toContain(report.report_id);
+    expect(serializedLogs).not.toContain(report.upload.headers.Authorization);
+    expect(serializedLogs).not.toContain(
+      "bundle content that must never be logged",
+    );
+  });
+
+  it("prunes expired report metadata and identifies the private object for deletion", async () => {
+    const harness = makeHarness();
+    const record: CreateReportRecordInput = {
+      bundleSchemaVersion: API_SCHEMA_VERSION,
+      clientFingerprint: "client",
+      contentType: BUNDLE_CONTENT_TYPE,
+      createdAt: harness.clock.now,
+      expiresAt: harness.clock.now + 1,
+      objectKey: "reports/expired.tar.gz",
+      reportId: "00000000-0000-4000-8000-000000000000",
+      sha256: "b".repeat(64),
+      sizeBytes: 1,
+      statusExpiresAt: harness.clock.now + 1,
+      statusTokenHash: "status",
+      supportCode: "BDAVP-0123456789ABCDEF",
+      uploadExpiresAt: harness.clock.now + 1,
+      uploadState: "uploaded",
+      uploadTokenHash: "upload",
+    };
+    await harness.registry.create(record, harness.clock.now);
+    expect(await harness.registry.prune(harness.clock.now + 1)).toEqual([
+      record.objectKey,
+    ]);
+    await expect(
+      harness.registry.getForMaintainer(
+        record.supportCode,
+        harness.clock.now + 1,
+      ),
+    ).rejects.toMatchObject({
+      code: "not_found",
+    });
+  });
+});

--- a/support-diagnostics/tsconfig.json
+++ b/support-diagnostics/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/support-diagnostics/vitest.config.ts
+++ b/support-diagnostics/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    restoreMocks: true,
+  },
+});

--- a/support-diagnostics/wrangler.jsonc
+++ b/support-diagnostics/wrangler.jsonc
@@ -1,0 +1,51 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "bd-to-avp-support-diagnostics",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-18",
+  "workers_dev": false,
+  "r2_buckets": [
+    {
+      "binding": "DIAGNOSTIC_BUNDLES",
+      "bucket_name": "bd-to-avp-support-diagnostics",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "REPORT_REGISTRY",
+        "class_name": "ReportRegistry",
+      },
+    ],
+  },
+  "exports": {
+    "ReportRegistry": {
+      "type": "durable-object",
+      "storage": "sqlite",
+    },
+  },
+  "ratelimits": [
+    {
+      "name": "CREATE_RATE_LIMITER",
+      "namespace_id": "26601",
+      "simple": {
+        "limit": 3,
+        "period": 60,
+      },
+    },
+    {
+      "name": "UPLOAD_RATE_LIMITER",
+      "namespace_id": "26602",
+      "simple": {
+        "limit": 6,
+        "period": 60,
+      },
+    },
+  ],
+  "triggers": {
+    "crons": ["0 * * * *"],
+  },
+  "vars": {
+    "SERVICE_ENVIRONMENT": "production",
+  },
+}

--- a/tests/test_support_diagnostics.py
+++ b/tests/test_support_diagnostics.py
@@ -5,11 +5,11 @@ import email.message
 import hashlib
 import io
 import json
-import tarfile
 import tempfile
 import unittest
 import urllib.error
 import urllib.request
+import zipfile
 
 from pathlib import Path
 
@@ -56,20 +56,20 @@ class CapturingOpener:
         return self.response
 
 
-def make_bundle(schema_version: int = 1) -> bytes:
+def make_bundle(schema_version: object = 1) -> bytes:
     contents = io.BytesIO()
-    payload = json.dumps({"schema_version": schema_version, "state": "complete"}).encode("utf-8")
-    with tarfile.open(fileobj=contents, mode="w:gz") as archive:
-        member = tarfile.TarInfo("diagnostic.json")
-        member.size = len(payload)
-        archive.addfile(member, io.BytesIO(payload))
+    with zipfile.ZipFile(contents, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps({"schema_version": schema_version, "state": "complete"}))
+        archive.writestr("events.jsonl", json.dumps({"schema_version": 1, "source": "client"}) + "\n")
+        archive.writestr("storage.json", json.dumps({"schema_version": 1, "probes": []}))
+        archive.writestr("tool-tail.txt", "# bd_to_avp_support_tool_tail schema_version=1\n")
     return contents.getvalue()
 
 
 def bundle_headers(bundle: bytes, schema_version: int = 1) -> dict[str, str]:
     return {
         "Content-Length": str(len(bundle)),
-        "Content-Type": "application/gzip",
+        "Content-Type": "application/zip",
         "X-Diagnostic-Schema-Version": str(schema_version),
         "X-Diagnostic-SHA256": hashlib.sha256(bundle).hexdigest(),
     }
@@ -83,7 +83,7 @@ class SupportDiagnosticsCliTests(unittest.TestCase):
         bundle = make_bundle()
         opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
         with tempfile.TemporaryDirectory() as temporary_directory:
-            output = Path(temporary_directory) / "bundle.tar.gz"
+            output = Path(temporary_directory) / "bundle.zip"
             result = fetch_report(self.configuration, SUPPORT_CODE, output, opener)
 
             self.assertEqual(output.read_bytes(), bundle)
@@ -104,17 +104,29 @@ class SupportDiagnosticsCliTests(unittest.TestCase):
         headers["X-Diagnostic-SHA256"] = "0" * 64
         opener = CapturingOpener(FakeResponse(bundle, headers))
         with tempfile.TemporaryDirectory() as temporary_directory:
-            output = Path(temporary_directory) / "bundle.tar.gz"
+            output = Path(temporary_directory) / "bundle.zip"
             with self.assertRaisesRegex(SupportDiagnosticsError, "checksum"):
                 fetch_report(self.configuration, SUPPORT_CODE, output, opener)
             self.assertFalse(output.exists())
 
     def test_fetch_rejects_malformed_archive_without_writing_output(self) -> None:
-        bundle = b"not-a-gzip-tar"
+        bundle = b"not-a-zip"
         opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
         with tempfile.TemporaryDirectory() as temporary_directory:
-            output = Path(temporary_directory) / "bundle.tar.gz"
-            with self.assertRaisesRegex(SupportDiagnosticsError, "valid gzip tar"):
+            output = Path(temporary_directory) / "bundle.zip"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "valid ZIP"):
+                fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+            self.assertFalse(output.exists())
+
+    def test_fetch_rejects_local_and_central_header_mismatch(self) -> None:
+        bundle = bytearray(make_bundle())
+        compressed_size = int.from_bytes(bundle[18:22], "little")
+        bundle[18:22] = (compressed_size + 1).to_bytes(4, "little")
+        headers = bundle_headers(bundle)
+        opener = CapturingOpener(FakeResponse(bytes(bundle), headers))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.zip"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "invalid archive entry"):
                 fetch_report(self.configuration, SUPPORT_CODE, output, opener)
             self.assertFalse(output.exists())
 
@@ -122,7 +134,16 @@ class SupportDiagnosticsCliTests(unittest.TestCase):
         bundle = make_bundle(schema_version=2)
         opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
         with tempfile.TemporaryDirectory() as temporary_directory:
-            output = Path(temporary_directory) / "bundle.tar.gz"
+            output = Path(temporary_directory) / "bundle.zip"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "schema verification"):
+                fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+            self.assertFalse(output.exists())
+
+    def test_fetch_rejects_boolean_schema_without_writing_output(self) -> None:
+        bundle = make_bundle(schema_version=True)
+        opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.zip"
             with self.assertRaisesRegex(SupportDiagnosticsError, "schema verification"):
                 fetch_report(self.configuration, SUPPORT_CODE, output, opener)
             self.assertFalse(output.exists())

--- a/tests/test_support_diagnostics.py
+++ b/tests/test_support_diagnostics.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import contextlib
+import email.message
+import hashlib
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+
+from pathlib import Path
+
+from scripts.support_diagnostics import (
+    ClientConfiguration,
+    SupportDiagnosticsError,
+    delete_report,
+    fetch_report,
+    main,
+)
+
+
+SUPPORT_CODE = "BDAVP-0123456789ABCDEF"
+TOKEN = "maintainer-token-with-at-least-thirty-two-characters"
+
+
+class FakeResponse:
+    def __init__(self, data: bytes = b"", headers: dict[str, str] | None = None, status: int = 200) -> None:
+        self.data = data
+        self.headers = headers or {}
+        self.status = status
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        return None
+
+    def read(self, amount: int = -1) -> bytes:
+        self.read_sizes.append(amount)
+        return self.data if amount < 0 else self.data[:amount]
+
+
+class CapturingOpener:
+    def __init__(self, response: FakeResponse | Exception) -> None:
+        self.response = response
+        self.requests: list[tuple[urllib.request.Request, int]] = []
+
+    def __call__(self, request: urllib.request.Request, timeout: int) -> FakeResponse:
+        self.requests.append((request, timeout))
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def make_bundle(schema_version: int = 1) -> bytes:
+    contents = io.BytesIO()
+    payload = json.dumps({"schema_version": schema_version, "state": "complete"}).encode("utf-8")
+    with tarfile.open(fileobj=contents, mode="w:gz") as archive:
+        member = tarfile.TarInfo("diagnostic.json")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+    return contents.getvalue()
+
+
+def bundle_headers(bundle: bytes, schema_version: int = 1) -> dict[str, str]:
+    return {
+        "Content-Length": str(len(bundle)),
+        "Content-Type": "application/gzip",
+        "X-Diagnostic-Schema-Version": str(schema_version),
+        "X-Diagnostic-SHA256": hashlib.sha256(bundle).hexdigest(),
+    }
+
+
+class SupportDiagnosticsCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.configuration = ClientConfiguration(endpoint="https://diagnostics.example.test/private", token=TOKEN)
+
+    def test_fetch_writes_checksum_and_schema_validated_bundle(self) -> None:
+        bundle = make_bundle()
+        opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.tar.gz"
+            result = fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+
+            self.assertEqual(output.read_bytes(), bundle)
+            self.assertEqual(result.sha256, hashlib.sha256(bundle).hexdigest())
+            self.assertEqual(result.schema_version, 1)
+
+        request, timeout = opener.requests[0]
+        self.assertEqual(timeout, 30)
+        self.assertEqual(request.get_method(), "GET")
+        self.assertEqual(
+            request.full_url, f"https://diagnostics.example.test/private/v1/maintainer/reports/{SUPPORT_CODE}"
+        )
+        self.assertEqual(request.get_header("Authorization"), f"Bearer {TOKEN}")
+
+    def test_fetch_rejects_checksum_mismatch_without_writing_output(self) -> None:
+        bundle = make_bundle()
+        headers = bundle_headers(bundle)
+        headers["X-Diagnostic-SHA256"] = "0" * 64
+        opener = CapturingOpener(FakeResponse(bundle, headers))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.tar.gz"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "checksum"):
+                fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+            self.assertFalse(output.exists())
+
+    def test_fetch_rejects_malformed_archive_without_writing_output(self) -> None:
+        bundle = b"not-a-gzip-tar"
+        opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.tar.gz"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "valid gzip tar"):
+                fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+            self.assertFalse(output.exists())
+
+    def test_fetch_rejects_schema_mismatch_without_writing_output(self) -> None:
+        bundle = make_bundle(schema_version=2)
+        opener = CapturingOpener(FakeResponse(bundle, bundle_headers(bundle)))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "bundle.tar.gz"
+            with self.assertRaisesRegex(SupportDiagnosticsError, "schema verification"):
+                fetch_report(self.configuration, SUPPORT_CODE, output, opener)
+            self.assertFalse(output.exists())
+
+    def test_delete_uses_maintainer_authorization(self) -> None:
+        opener = CapturingOpener(FakeResponse(status=204))
+        delete_report(self.configuration, SUPPORT_CODE, opener)
+
+        request, timeout = opener.requests[0]
+        self.assertEqual(timeout, 30)
+        self.assertEqual(request.get_method(), "DELETE")
+        self.assertEqual(request.get_header("Authorization"), f"Bearer {TOKEN}")
+
+    def test_main_requires_delete_confirmation(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = main(
+                ["delete", SUPPORT_CODE],
+                {
+                    "SUPPORT_DIAGNOSTICS_ENDPOINT": "https://diagnostics.example.test",
+                    "SUPPORT_DIAGNOSTICS_TOKEN": TOKEN,
+                },
+            )
+
+        self.assertEqual(result, 1)
+        self.assertIn("Deletion requires --yes", stderr.getvalue())
+
+    def test_main_redacts_service_failure_body_and_token(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://diagnostics.example.test/v1/maintainer/reports/example",
+            503,
+            "Service unavailable",
+            email.message.Message(),
+            io.BytesIO(b"sensitive response content"),
+        )
+        opener = CapturingOpener(error)
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = main(
+                ["fetch", SUPPORT_CODE],
+                {
+                    "SUPPORT_DIAGNOSTICS_ENDPOINT": "https://diagnostics.example.test",
+                    "SUPPORT_DIAGNOSTICS_TOKEN": TOKEN,
+                },
+                opener,
+            )
+
+        self.assertEqual(result, 1)
+        self.assertIn("HTTP 503", stderr.getvalue())
+        self.assertNotIn("sensitive response content", stderr.getvalue())
+        self.assertNotIn(TOKEN, stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a private Cloudflare Worker/R2 diagnostic upload service with single-use upload authorization, rate limits, retention, and maintainer-only retrieval/deletion
- enforce the native v1 ZIP contract, checksums, strict archive bounds, upload race/expiry handling, and atomic Durable Object metadata writes
- add a standard-library maintainer CLI, deployment dry-run CI coverage, and focused TypeScript/Python tests

## Validation
- `npm run check` (13 tests)
- `npm run deploy:dry-run`
- `uv run python -m unittest tests.test_support_diagnostics` (9 tests)
- `uv run python -m unittest discover -s tests -t .` (582 tests, 2 skipped)
- `uv run ruff format --check scripts/support_diagnostics.py tests/test_support_diagnostics.py`
- `uv run ruff check --no-fix scripts/support_diagnostics.py tests/test_support_diagnostics.py`
- `actionlint .github/workflows/ci.yml`

Closes #266
Relates to #264 and #267