### PR TITLE
Add resilient child-tool observability runner

### DIFF
--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -9,13 +9,23 @@ from typing import Any, Callable, ClassVar, cast
 
 import ffmpeg
 
+from bd_to_avp.observability import ObservabilityContext, ObservabilityProgress
 from bd_to_avp.modules.config import config
 from bd_to_avp.modules.util import formatted_time_elapsed
+from bd_to_avp.process_runner import (
+    CaptureOverflowPolicy,
+    ChildProcessRunner,
+    DEFAULT_CAPTURE_LIMIT_BYTES,
+    ProcessArtifactProbe,
+    ProcessSpec,
+)
+from bd_to_avp.runtime import RunContext
 
 
 SpinnerUpdate = Callable[[str], object]
 LineHandler = Callable[[str], object]
-PROCESS_TERMINATION_TIMEOUT_SECONDS = 5.0
+ProgressParser = Callable[[str], ObservabilityProgress | None]
+OutputObserver = Callable[[bytes], object]
 
 
 def get_spinner_update_func() -> SpinnerUpdate | None:
@@ -95,6 +105,15 @@ def run_command(
     env: dict[str, str] | None = None,
     *,
     line_handler: LineHandler | None = None,
+    progress_parser: ProgressParser | None = None,
+    output_observer: OutputObserver | None = None,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    tool_id: str | None = None,
+    observability_context: ObservabilityContext | None = None,
+    artifacts: tuple[ProcessArtifactProbe, ...] = (),
+    capture_limit_bytes: int | None = None,
+    capture_overflow: CaptureOverflowPolicy = CaptureOverflowPolicy.TRUNCATE,
 ) -> str:
     commands = normalize_command_elements(commands)
     if not command_name:
@@ -104,62 +123,51 @@ def run_command(
         commands_to_print = add_quotes_to_path_if_space(commands)
         print(f"Running command:\n{' '.join(str(command) for command in commands_to_print)}")
 
-    env = env if env else os.environ.copy()
-    output_lines = []
     spinner = Spinner(command_name)
     spinner_update_func = get_spinner_update_func()
     spinner_thread = threading.Thread(target=spinner.start, args=(spinner_update_func,))
     spinner_thread.start()
-    process = None
     try:
-        process = subprocess.Popen(
-            commands,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            env=env,
+        result = ChildProcessRunner().run(
+            ProcessSpec(
+                argv=tuple(commands),
+                tool_id=tool_id or default_tool_id(commands[0]),
+                display_name=command_name,
+                env=env if env is not None else os.environ.copy(),
+                event_context=observability_context or ObservabilityContext(),
+                artifacts=artifacts,
+                capture_limit_bytes=(
+                    DEFAULT_CAPTURE_LIMIT_BYTES if capture_limit_bytes is None else capture_limit_bytes
+                ),
+                capture_overflow=capture_overflow,
+            ),
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            line_handler=(None if line_handler is None else lambda _stream, line: line_handler(line)),
+            output_observer=(None if output_observer is None else lambda _stream, payload: output_observer(payload)),
+            progress_parser=(None if progress_parser is None else lambda _stream, line: progress_parser(line)),
         )
-        while True and process and process.stdout:
-            line = process.stdout.readline()
-            if not line:
-                break
-            output_lines.append(line)
-            if line_handler:
-                line_handler(line.rstrip("\r\n"))
-
-        process.wait()
-        if process.returncode != 0:
-            print("Error running command:", command_name)
-            print("\n".join(output_lines))
-            raise subprocess.CalledProcessError(process.returncode, commands, output="".join(output_lines))
+        return result.stdout.text()
+    except subprocess.CalledProcessError as error:
+        print("Error running command:", command_name)
+        if error.output:
+            print(error.output)
+        raise
     except KeyboardInterrupt:
         print("\nCommand interrupted.")
-        if process:
-            terminate_and_wait(process)
         raise
-    except BaseException:
-        if process:
-            terminate_and_wait(process)
-        raise
-
     finally:
         spinner.stop(spinner_update_func)
         spinner_thread.join()
-    return "".join(output_lines)
 
 
-def terminate_and_wait(
-    process: subprocess.Popen,
-    timeout: float = PROCESS_TERMINATION_TIMEOUT_SECONDS,
-) -> None:
-    if process.poll() is not None:
-        return
-    process.terminate()
-    try:
-        process.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait()
+def default_tool_id(command: str | Path | bytes) -> str:
+    decoded = os.fsdecode(command)
+    name = Path(decoded).name.strip().lower()
+    normalized = "".join(character if character.isalnum() else "_" for character in name).strip("_")
+    if not normalized or len(normalized.encode("utf-8")) > 128:
+        return "external_tool"
+    return normalized
 
 
 def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, **kwargs) -> None:

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -2,13 +2,17 @@ import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Event
 from typing import Callable
 
 import ffmpeg
 
+from bd_to_avp.observability import ObservabilityProgress
 from bd_to_avp.modules.config import config, is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.file import find_largest_file_with_extensions, sanitize_filename
 from bd_to_avp.modules.command import run_command
+from bd_to_avp.process_runner import CaptureOverflowPolicy, ProcessArtifactProbe
+from bd_to_avp.runtime import RunContext
 
 
 class MKVCreationError(Exception):
@@ -65,6 +69,19 @@ def parse_makemkv_progress(line: str) -> tuple[int, int] | None:
     if maximum_progress <= 0:
         return None
     return min(max(total_progress, 0), maximum_progress), maximum_progress
+
+
+def parse_makemkv_observability_progress(line: str) -> ObservabilityProgress | None:
+    progress = parse_makemkv_progress(line)
+    if progress is None:
+        return None
+    completed, total = progress
+    return ObservabilityProgress(
+        fraction=completed / total,
+        completed_units=completed,
+        total_units=total,
+        unit="makemkv_progress",
+    )
 
 
 def parse_makemkv_output(output: str) -> tuple[str, list[TitleInfo]]:
@@ -155,7 +172,12 @@ def select_disc_title(titles: tuple[DiscTitleInfo, ...], title_id: str | None) -
     raise DiscTitleSelectionError("The selected 3D video is no longer available. Analyze the source again.")
 
 
-def get_disc_and_mvc_video_info(selected_title_id: str | None = None) -> DiscInfo:
+def get_disc_and_mvc_video_info(
+    selected_title_id: str | None = None,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: Event | None = None,
+) -> DiscInfo:
     source_path = config.source_path
     source = source_path.as_posix() if source_path else config.source_str
     if not source:
@@ -190,7 +212,14 @@ def get_disc_and_mvc_video_info(selected_title_id: str | None = None) -> DiscInf
         "info",
         source,
     ]
-    output = run_command(command, "Get disc and MVC video properties")
+    output = run_command(
+        command,
+        "Get disc and MVC video properties",
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        tool_id="makemkvcon",
+        capture_overflow=CaptureOverflowPolicy.FAIL,
+    )
 
     disc_name, raw_titles = parse_makemkv_output(output)
     try:
@@ -217,6 +246,9 @@ def rip_disc_to_mkv(
     output_folder: Path,
     disc_info: DiscInfo,
     progress_callback: ProgressCallback | None = None,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: Event | None = None,
 ) -> None:
     custom_profile_path = output_folder / "custom_profile.mmcp.xml"
     create_custom_makemkv_profile(custom_profile_path)
@@ -242,7 +274,40 @@ def rip_disc_to_mkv(
         if progress is not None:
             progress_callback(*progress)
 
-    mkv_output = run_command(command, "Rip disc to MKV file.", line_handler=report_progress)
+    baseline: dict[Path, tuple[int, int]] = {}
+    for candidate in output_folder.glob("*.mkv"):
+        try:
+            status = candidate.stat()
+        except OSError:
+            continue
+        if candidate.is_file():
+            baseline[candidate] = (status.st_size, status.st_mtime_ns)
+
+    def active_mkv() -> Path | None:
+        candidates: list[tuple[int, Path]] = []
+        for candidate in output_folder.glob("*.mkv"):
+            try:
+                status = candidate.stat()
+            except OSError:
+                continue
+            previous = baseline.get(candidate)
+            if previous is None or previous != (status.st_size, status.st_mtime_ns):
+                candidates.append((status.st_mtime_ns, candidate))
+        if not candidates:
+            return None
+        return max(candidates)[1]
+
+    mkv_output = run_command(
+        command,
+        "Rip disc to MKV file.",
+        line_handler=report_progress,
+        progress_parser=parse_makemkv_observability_progress,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        tool_id="makemkvcon",
+        artifacts=(ProcessArtifactProbe("intermediate_mkv", resolver=active_mkv),),
+        capture_overflow=CaptureOverflowPolicy.FAIL,
+    )
     if config.continue_on_error or all(error not in mkv_output for error in config.MKV_ERROR_CODES):
         return
     filtered_output = filter_lines_from_output(mkv_output, config.MKV_ERROR_FILTERS)
@@ -289,6 +354,9 @@ def create_mkv_file(
     output_folder: Path,
     disc_info: DiscInfo,
     progress_callback: ProgressCallback | None = None,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: Event | None = None,
 ) -> Path:
     if config.source_path and config.source_path.suffix.lower() in [*config.MTS_EXTENSIONS, ".mkv"]:
         if not config.source_path.is_file():
@@ -304,7 +372,13 @@ def create_mkv_file(
             return mkv_file
 
     if config.start_stage.value <= Stage.CREATE_MKV.value:
-        rip_disc_to_mkv(output_folder, disc_info, progress_callback)
+        rip_disc_to_mkv(
+            output_folder,
+            disc_info,
+            progress_callback,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+        )
 
     if mkv_file := find_largest_file_with_extensions(output_folder, [".mkv"]):
         return mkv_file

--- a/bd_to_avp/modules/file.py
+++ b/bd_to_avp/modules/file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.command import run_command
+from bd_to_avp.process_runner import CaptureOverflowPolicy
 
 
 def normalize_name(name: str) -> str:
@@ -98,7 +99,11 @@ def move_file_to_output_root_folder(muxed_output_path: Path) -> Path:
 def mounted_image(image_path: Path):
     mount_point = None
     existing_mounts_command = ["hdiutil", "info"]
-    existing_mounts_output = run_command(existing_mounts_command, "Check mounted images")
+    existing_mounts_output = run_command(
+        existing_mounts_command,
+        "Check mounted images",
+        capture_overflow=CaptureOverflowPolicy.FAIL,
+    )
     try:
         for line in existing_mounts_output.split("\n"):
             if str(image_path) in line:
@@ -111,7 +116,11 @@ def mounted_image(image_path: Path):
 
         if not mount_point:
             mount_command = ["hdiutil", "attach", image_path]
-            mount_output = run_command(mount_command, "Mount image")
+            mount_output = run_command(
+                mount_command,
+                "Mount image",
+                capture_overflow=CaptureOverflowPolicy.FAIL,
+            )
             for line in mount_output.split("\n"):
                 if "/Volumes/" in line:
                     mount_point = line.split("\t")[-1]

--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -31,6 +31,8 @@ from bd_to_avp.modules.video import (
     create_upscaled_file,
     get_video_color_depth,
 )
+from bd_to_avp.process_runner import ProcessCancelled
+from bd_to_avp.runtime import RunContext
 
 
 class ProcessingCancelled(Exception):
@@ -65,6 +67,18 @@ class ActivityReporter(Protocol):
 def raise_if_cancelled(cancellation_event: Event | None) -> None:
     if cancellation_event is not None and cancellation_event.is_set():
         raise ProcessingCancelled("Processing was cancelled.")
+
+
+def normalized_cancellation_event(
+    cancellation_event: Event | None,
+    run_context: RunContext | None,
+) -> Event | None:
+    if run_context is None:
+        return cancellation_event
+    context_event = run_context.cancellation.event
+    if cancellation_event is not None and cancellation_event is not context_event:
+        raise ValueError("run_context and cancellation_event must share the same event")
+    return context_event
 
 
 def find_batch_sources(source_folder_path: Path) -> tuple[Path, ...]:
@@ -123,7 +137,9 @@ def process(
     batch_start_stage: Stage | None = None,
     batch_sources: tuple[Path, ...] | None = None,
     activity: ActivityReporter | None = None,
+    run_context: RunContext | None = None,
 ) -> Path | None:
+    cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     raise_if_cancelled(cancellation_event)
     batch_start_stage = batch_start_stage or gui_start_stage
     waiting_for_resume = resume_source_path is not None
@@ -142,9 +158,9 @@ def process(
             config.start_stage = gui_start_stage if is_resume_source else batch_start_stage
             try:
                 final_output_path = (
-                    process_each(cancellation_event, activity=activity)
+                    process_each(cancellation_event, activity=activity, run_context=run_context)
                     if activity
-                    else process_each(cancellation_event)
+                    else process_each(cancellation_event, run_context=run_context)
                 )
                 raise_if_cancelled(cancellation_event)
             except preflight.DependencyPreflightError:
@@ -153,6 +169,8 @@ def process(
                 raise BatchProcessingError(source, error, batch_sources) from error
             except FileExistsError:
                 continue
+            except ProcessCancelled as error:
+                raise ProcessingCancelled("Processing was cancelled.") from error
             except (RuntimeError, ValueError, subprocess.CalledProcessError):
                 raise_if_cancelled(cancellation_event)
                 if is_resume_source:
@@ -168,13 +186,24 @@ def process(
     else:
         if selected_title_id is None:
             final_output_path = (
-                process_each(cancellation_event, activity=activity) if activity else process_each(cancellation_event)
+                process_each(cancellation_event, activity=activity, run_context=run_context)
+                if activity
+                else process_each(cancellation_event, run_context=run_context)
             )
         else:
             final_output_path = (
-                process_each(cancellation_event, activity=activity, selected_title_id=selected_title_id)
+                process_each(
+                    cancellation_event,
+                    activity=activity,
+                    selected_title_id=selected_title_id,
+                    run_context=run_context,
+                )
                 if activity
-                else process_each(cancellation_event, selected_title_id=selected_title_id)
+                else process_each(
+                    cancellation_event,
+                    selected_title_id=selected_title_id,
+                    run_context=run_context,
+                )
             )
 
     return final_output_path
@@ -185,7 +214,9 @@ def process_each(
     activity: ActivityReporter | None = None,
     *,
     selected_title_id: str | None = None,
+    run_context: RunContext | None = None,
 ) -> Path:
+    cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     raise_if_cancelled(cancellation_event)
     if config.video_mode is VideoMode.AV1_SBS and config.fx_upscale:
         raise ValueError("AV1 stereo export does not support AI FX upscale.")
@@ -211,7 +242,11 @@ def process_each(
     raise_if_cancelled(cancellation_event)
     if activity:
         activity.stage_started("inspect_source", "Reading video metadata")
-    disc_info = get_disc_and_mvc_video_info(selected_title_id)
+    disc_info = get_disc_and_mvc_video_info(
+        selected_title_id,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+    )
     raise_if_cancelled(cancellation_event)
     if activity:
         activity.log("Source metadata loaded", stage="inspect_source", name=disc_info.name)
@@ -239,6 +274,8 @@ def process_each(
         output_folder,
         disc_info,
         progress_callback=activity.stage_progress if activity else None,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
     )
     if config.preview_range is not None:
         raise_if_cancelled(cancellation_event)
@@ -387,28 +424,35 @@ def start_process(
     batch_start_stage: Stage | None = None,
     batch_sources: tuple[Path, ...] | None = None,
     activity: ActivityReporter | None = None,
+    run_context: RunContext | None = None,
 ) -> Path | None:
+    cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     gui_start_stage = gui_start_stage or config.start_stage
-    if config.keep_awake:
-        with keep.running():
-            return process(
-                gui_start_stage,
-                cancellation_event,
-                selected_title_id=selected_title_id,
-                resume_source_path=resume_source_path,
-                batch_start_stage=batch_start_stage,
-                batch_sources=batch_sources,
-                activity=activity,
-            )
-    return process(
-        gui_start_stage,
-        cancellation_event,
-        selected_title_id=selected_title_id,
-        resume_source_path=resume_source_path,
-        batch_start_stage=batch_start_stage,
-        batch_sources=batch_sources,
-        activity=activity,
-    )
+    try:
+        if config.keep_awake:
+            with keep.running():
+                return process(
+                    gui_start_stage,
+                    cancellation_event,
+                    selected_title_id=selected_title_id,
+                    resume_source_path=resume_source_path,
+                    batch_start_stage=batch_start_stage,
+                    batch_sources=batch_sources,
+                    activity=activity,
+                    run_context=run_context,
+                )
+        return process(
+            gui_start_stage,
+            cancellation_event,
+            selected_title_id=selected_title_id,
+            resume_source_path=resume_source_path,
+            batch_start_stage=batch_start_stage,
+            batch_sources=batch_sources,
+            activity=activity,
+            run_context=run_context,
+        )
+    except ProcessCancelled as error:
+        raise ProcessingCancelled("Processing was cancelled.") from error
 
 
 if __name__ == "__main__":

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -11,6 +11,7 @@ import ffmpeg
 from bd_to_avp.modules.config import Stage, config, is_direct_mvc_stream_enabled
 from bd_to_avp.modules.disc import DiscInfo
 from bd_to_avp.modules.command import cleanup_process, run_command
+from bd_to_avp.process_runner import CaptureOverflowPolicy
 
 
 def has_native_mvc_splitter() -> bool:
@@ -633,7 +634,11 @@ def combine_to_mv_hevc(
         "--output-file",
         output_path,
     ]
-    output = run_command(command, "combine stereo HEVC streams to MV-HEVC.")
+    output = run_command(
+        command,
+        "combine stereo HEVC streams to MV-HEVC.",
+        capture_overflow=CaptureOverflowPolicy.FAIL,
+    )
     if "left and right input resolutions do not match. aborting!" in output:
         raise RuntimeError("Left and right input resolutions do not match.")
     elif "aborting!" in output:

--- a/bd_to_avp/observability.py
+++ b/bd_to_avp/observability.py
@@ -316,6 +316,14 @@ class ObservabilityCounters:
 
 
 @dataclass(frozen=True)
+class ObservabilityActivity:
+    last_output_age_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_int(self.last_output_age_seconds, "activity.last_output_age_seconds")
+
+
+@dataclass(frozen=True)
 class ObservabilityData:
     message: ObservabilityText | None = None
     detail: ObservabilityText | None = None
@@ -325,6 +333,7 @@ class ObservabilityData:
     failure: ObservabilityFailure | None = None
     cancellation: ObservabilityCancellation | None = None
     counters: ObservabilityCounters | None = None
+    activity: ObservabilityActivity | None = None
 
     def __post_init__(self) -> None:
         for name, value, expected_type in (
@@ -336,6 +345,7 @@ class ObservabilityData:
             ("data.failure", self.failure, ObservabilityFailure),
             ("data.cancellation", self.cancellation, ObservabilityCancellation),
             ("data.counters", self.counters, ObservabilityCounters),
+            ("data.activity", self.activity, ObservabilityActivity),
         ):
             if value is not None and not isinstance(value, expected_type):
                 raise TypeError(f"{name} has an invalid type")
@@ -431,6 +441,7 @@ class ObservabilityEvent:
                 failure=_optional_dataclass(ObservabilityFailure, data_value.get("failure")),
                 cancellation=_optional_dataclass(ObservabilityCancellation, data_value.get("cancellation")),
                 counters=_optional_dataclass(ObservabilityCounters, data_value.get("counters")),
+                activity=_optional_dataclass(ObservabilityActivity, data_value.get("activity")),
             ),
         )
 

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -523,7 +523,7 @@ class ChildProcessRunner:
             expected_streams.add(ProcessStream.STDERR)
         closed_streams: set[ProcessStream] = set()
         framers = {stream: _LineFramer(spec.line_limit_bytes) for stream in expected_streams}
-        artifact_states = [_ArtifactState() for _probe in spec.artifacts]
+        artifact_states = [_ArtifactState(path=probe.path) for probe in spec.artifacts]
 
         pending_error: BaseException | None = None
         failure_code: str | None = None
@@ -561,13 +561,12 @@ class ChildProcessRunner:
                                 line_handler,
                                 progress_parser,
                             )
-                    except BaseException as error:
-                        if isinstance(error, KeyboardInterrupt):
-                            keyboard_interrupt = error
-                            cancelled = True
-                        else:
-                            pending_error = error
-                            failure_code = "output_handler_failed"
+                    except KeyboardInterrupt as error:
+                        keyboard_interrupt = error
+                        cancelled = True
+                    except (Exception, SystemExit) as error:
+                        pending_error = error
+                        failure_code = "output_handler_failed"
                 elif isinstance(item, _StreamClosed):
                     closed_streams.add(item.stream)
                     if pending_error is None:
@@ -581,13 +580,12 @@ class ChildProcessRunner:
                                     line_handler,
                                     progress_parser,
                                 )
-                        except BaseException as error:
-                            if isinstance(error, KeyboardInterrupt):
-                                keyboard_interrupt = error
-                                cancelled = True
-                            else:
-                                pending_error = error
-                                failure_code = "output_handler_failed"
+                        except KeyboardInterrupt as error:
+                            keyboard_interrupt = error
+                            cancelled = True
+                        except (Exception, SystemExit) as error:
+                            pending_error = error
+                            failure_code = "output_handler_failed"
 
                 if dispatch_overflow.is_set() and pending_error is None:
                     pending_error = ProcessOutputDispatchError(
@@ -733,13 +731,25 @@ class ChildProcessRunner:
                     break
 
             returncode = process.wait(timeout=spec.kill_wait_seconds)
-        except BaseException as error:
-            if isinstance(error, KeyboardInterrupt):
-                keyboard_interrupt = error
-                cancelled = True
-            else:
-                pending_error = error
-                failure_code = failure_code or "runner_interrupted"
+        except KeyboardInterrupt as error:
+            keyboard_interrupt = error
+            cancelled = True
+            forced_termination = (
+                self._terminate_process_group(
+                    process,
+                    process.pid,
+                    spec.termination_grace_seconds,
+                    spec.kill_wait_seconds,
+                )
+                or forced_termination
+            )
+            returncode = process.poll()
+            if returncode is None:
+                process.kill()
+                returncode = process.wait()
+        except (Exception, SystemExit) as error:
+            pending_error = error
+            failure_code = failure_code or "runner_interrupted"
             forced_termination = (
                 self._terminate_process_group(
                     process,

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -1,0 +1,1127 @@
+from __future__ import annotations
+
+import codecs
+import os
+import queue
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import BinaryIO, cast
+from uuid import uuid4
+
+from bd_to_avp.observability import (
+    MAX_DETAIL_BYTES,
+    ObservabilityActivity,
+    ObservabilityArtifact,
+    ObservabilityCancellation,
+    ObservabilityContext,
+    ObservabilityCounters,
+    ObservabilityData,
+    ObservabilityFailure,
+    ObservabilityPrivacy,
+    ObservabilityProcess,
+    ObservabilityProgress,
+    ObservabilitySeverity,
+    ObservabilityText,
+    ObservabilityTool,
+)
+from bd_to_avp.runtime import RunContext
+
+DEFAULT_CAPTURE_LIMIT_BYTES = 16 * 1024 * 1024
+DEFAULT_TAIL_LIMIT_BYTES = 64 * 1024
+DEFAULT_LINE_LIMIT_BYTES = 16 * 1024
+DEFAULT_QUEUE_CHUNKS = 128
+DEFAULT_ACTIVITY_INTERVAL_SECONDS = 5.0
+DEFAULT_ARTIFACT_INTERVAL_SECONDS = 2.0
+DEFAULT_TERMINATION_GRACE_SECONDS = 5.0
+DEFAULT_KILL_WAIT_SECONDS = 5.0
+DEFAULT_PIPE_DRAIN_TIMEOUT_SECONDS = 5.0
+READ_CHUNK_BYTES = 32 * 1024
+ARTIFACT_SIZE_QUANTUM_BYTES = 64 * 1024
+ARTIFACT_AGE_QUANTUM_SECONDS = 5
+EVENT_QUEUE_LIMIT = 128
+EVENT_FLUSH_TIMEOUT_SECONDS = 1.0
+
+
+class ProcessStream(StrEnum):
+    STDOUT = "stdout"
+    STDERR = "stderr"
+
+
+class CaptureOverflowPolicy(StrEnum):
+    FAIL = "fail"
+    TRUNCATE = "truncate"
+
+
+class ProcessRunnerError(RuntimeError):
+    pass
+
+
+class ProcessCancelled(ProcessRunnerError):
+    pass
+
+
+class ProcessOutputLimitError(ProcessRunnerError):
+    pass
+
+
+class ProcessOutputDispatchError(ProcessRunnerError):
+    pass
+
+
+class ProcessTimeoutError(ProcessRunnerError):
+    pass
+
+
+class ProcessPipeDrainError(ProcessRunnerError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProcessArtifactProbe:
+    role: str
+    path: Path | None = None
+    resolver: Callable[[], Path | None] | None = field(default=None, compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.role:
+            raise ValueError("artifact role must not be empty")
+        if (self.path is None) == (self.resolver is None):
+            raise ValueError("artifact probe requires exactly one path source")
+        ObservabilityArtifact(role=self.role, state="registered")
+
+    def resolve_path(self) -> Path | None:
+        if self.path is not None:
+            return self.path
+        assert self.resolver is not None
+        return self.resolver()
+
+
+@dataclass(frozen=True)
+class ProcessSpec:
+    argv: tuple[str | bytes | Path, ...]
+    tool_id: str
+    display_name: str
+    env: Mapping[str, str] | None = None
+    cwd: Path | None = None
+    stdin: int | BinaryIO | None = None
+    merge_stderr: bool = True
+    event_context: ObservabilityContext = field(default_factory=ObservabilityContext)
+    tool_version: str | None = None
+    artifacts: tuple[ProcessArtifactProbe, ...] = ()
+    capture_limit_bytes: int = DEFAULT_CAPTURE_LIMIT_BYTES
+    tail_limit_bytes: int = DEFAULT_TAIL_LIMIT_BYTES
+    line_limit_bytes: int = DEFAULT_LINE_LIMIT_BYTES
+    queue_chunks: int = DEFAULT_QUEUE_CHUNKS
+    capture_overflow: CaptureOverflowPolicy = CaptureOverflowPolicy.FAIL
+    activity_interval_seconds: float = DEFAULT_ACTIVITY_INTERVAL_SECONDS
+    artifact_interval_seconds: float = DEFAULT_ARTIFACT_INTERVAL_SECONDS
+    timeout_seconds: float | None = None
+    termination_grace_seconds: float = DEFAULT_TERMINATION_GRACE_SECONDS
+    kill_wait_seconds: float = DEFAULT_KILL_WAIT_SECONDS
+    pipe_drain_timeout_seconds: float = DEFAULT_PIPE_DRAIN_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        if not self.argv:
+            raise ValueError("process argv must not be empty")
+        if not self.tool_id:
+            raise ValueError("process tool_id must not be empty")
+        if not self.display_name:
+            raise ValueError("process display_name must not be empty")
+        if not isinstance(self.event_context, ObservabilityContext):
+            raise TypeError("event_context must be an ObservabilityContext")
+        if not isinstance(self.capture_overflow, CaptureOverflowPolicy):
+            raise TypeError("capture_overflow must be a CaptureOverflowPolicy")
+        if any(not isinstance(probe, ProcessArtifactProbe) for probe in self.artifacts):
+            raise TypeError("artifacts must contain ProcessArtifactProbe values")
+        if isinstance(self.stdin, int) and self.stdin == subprocess.PIPE:
+            raise ValueError("stdin=subprocess.PIPE requires an input writer and is not supported")
+        for integer_name, integer_value in (
+            ("capture_limit_bytes", self.capture_limit_bytes),
+            ("tail_limit_bytes", self.tail_limit_bytes),
+            ("line_limit_bytes", self.line_limit_bytes),
+            ("queue_chunks", self.queue_chunks),
+        ):
+            if type(integer_value) is not int or integer_value <= 0:
+                raise ValueError(f"{integer_name} must be a positive integer")
+        for duration_name, duration_value in (
+            ("activity_interval_seconds", self.activity_interval_seconds),
+            ("artifact_interval_seconds", self.artifact_interval_seconds),
+            ("termination_grace_seconds", self.termination_grace_seconds),
+            ("kill_wait_seconds", self.kill_wait_seconds),
+            ("pipe_drain_timeout_seconds", self.pipe_drain_timeout_seconds),
+        ):
+            if duration_value <= 0:
+                raise ValueError(f"{duration_name} must be positive")
+        if self.timeout_seconds is not None and self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+
+
+@dataclass(frozen=True)
+class ProcessOutputSnapshot:
+    capture: bytes
+    tail: bytes
+    total_bytes: int
+    retained_bytes: int
+    dropped_bytes: int
+    decode_replacements: int
+
+    @property
+    def truncated(self) -> bool:
+        return self.dropped_bytes > 0
+
+    def text(self) -> str:
+        return self.capture.decode("utf-8", errors="replace")
+
+    def tail_text(self) -> str:
+        return self.tail.decode("utf-8", errors="replace")
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    tool_run_id: str
+    returncode: int
+    elapsed_ms: int
+    stdout: ProcessOutputSnapshot
+    stderr: ProcessOutputSnapshot
+    forced_termination: bool = False
+
+
+LineHandler = Callable[[ProcessStream, str], object]
+OutputObserver = Callable[[ProcessStream, bytes], object]
+ProgressParser = Callable[[ProcessStream, str], ObservabilityProgress | None]
+
+
+@dataclass(frozen=True)
+class _OutputChunk:
+    stream: ProcessStream
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class _StreamClosed:
+    stream: ProcessStream
+
+
+@dataclass(frozen=True)
+class _PendingEvent:
+    kind: str
+    severity: ObservabilitySeverity
+    context: ObservabilityContext
+    data: ObservabilityData
+
+
+class _AsyncRunEmitter:
+    def __init__(self, run_context: RunContext | None) -> None:
+        self._run_context = run_context
+        self._queue: queue.Queue[_PendingEvent] = queue.Queue(maxsize=EVENT_QUEUE_LIMIT)
+        self._closing = threading.Event()
+        self._dropped = 0
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        if run_context is not None:
+            self._thread = threading.Thread(target=self._run, name="observability-emitter", daemon=True)
+            self._thread.start()
+
+    @property
+    def dropped_count(self) -> int:
+        with self._lock:
+            return self._dropped
+
+    def emit(
+        self,
+        kind: str,
+        *,
+        severity: ObservabilitySeverity = ObservabilitySeverity.INFO,
+        context: ObservabilityContext,
+        data: ObservabilityData | None = None,
+        terminal: bool = False,
+    ) -> None:
+        if self._run_context is None:
+            return
+        pending_event = _PendingEvent(
+            kind=kind,
+            severity=severity,
+            context=context,
+            data=data or ObservabilityData(),
+        )
+        try:
+            self._queue.put_nowait(pending_event)
+        except queue.Full:
+            if terminal:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    pass
+                else:
+                    with self._lock:
+                        self._dropped += 1
+                try:
+                    self._queue.put_nowait(pending_event)
+                    return
+                except queue.Full:
+                    pass
+            with self._lock:
+                self._dropped += 1
+
+    def close(self) -> None:
+        if self._thread is None:
+            return
+        self._closing.set()
+        self._thread.join(timeout=EVENT_FLUSH_TIMEOUT_SECONDS)
+
+    def _run(self) -> None:
+        assert self._run_context is not None
+        while not self._closing.is_set() or not self._queue.empty():
+            try:
+                event = self._queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            self._run_context.emit(
+                event.kind,
+                severity=event.severity,
+                privacy=ObservabilityPrivacy.PRIVATE,
+                context=event.context,
+                data=event.data,
+            )
+
+
+class _StreamState:
+    def __init__(self, capture_limit_bytes: int, tail_limit_bytes: int) -> None:
+        self._capture_limit_bytes = capture_limit_bytes
+        self._tail_limit_bytes = tail_limit_bytes
+        self._capture = bytearray()
+        self._tail = bytearray()
+        self._total_bytes = 0
+        self._decode_replacements = 0
+        self._last_output_at: float | None = None
+        self._overflowed = False
+        self._closed = False
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        self._lock = threading.Lock()
+
+    @property
+    def overflowed(self) -> bool:
+        with self._lock:
+            return self._overflowed
+
+    @property
+    def last_output_at(self) -> float | None:
+        with self._lock:
+            return self._last_output_at
+
+    def record(self, payload: bytes, observed_at: float) -> None:
+        decoded = self._decoder.decode(payload, final=False)
+        with self._lock:
+            self._total_bytes += len(payload)
+            self._last_output_at = observed_at
+            self._decode_replacements += decoded.count("\ufffd")
+            available = self._capture_limit_bytes - len(self._capture)
+            if available > 0:
+                self._capture.extend(payload[:available])
+            if len(payload) > available:
+                self._overflowed = True
+            if len(payload) >= self._tail_limit_bytes:
+                self._tail[:] = payload[-self._tail_limit_bytes :]
+            else:
+                self._tail.extend(payload)
+                excess = len(self._tail) - self._tail_limit_bytes
+                if excess > 0:
+                    del self._tail[:excess]
+
+    def close(self) -> None:
+        decoded = self._decoder.decode(b"", final=True)
+        with self._lock:
+            self._decode_replacements += decoded.count("\ufffd")
+            self._closed = True
+
+    def snapshot(self) -> ProcessOutputSnapshot:
+        with self._lock:
+            retained_bytes = len(self._capture)
+            return ProcessOutputSnapshot(
+                capture=bytes(self._capture),
+                tail=bytes(self._tail),
+                total_bytes=self._total_bytes,
+                retained_bytes=retained_bytes,
+                dropped_bytes=self._total_bytes - retained_bytes,
+                decode_replacements=self._decode_replacements,
+            )
+
+
+class _LineFramer:
+    def __init__(self, maximum_bytes: int) -> None:
+        self._maximum_bytes = maximum_bytes
+        self._pending = bytearray()
+
+    def feed(self, payload: bytes) -> list[bytes]:
+        self._pending.extend(payload)
+        return self._extract_records(final=False)
+
+    def flush(self) -> list[bytes]:
+        return self._extract_records(final=True)
+
+    def _extract_records(self, *, final: bool) -> list[bytes]:
+        records: list[bytes] = []
+        while self._pending:
+            delimiter = self._find_delimiter(final=final)
+            if delimiter is not None:
+                delimiter_index, delimiter_size = delimiter
+                record = bytes(self._pending[:delimiter_index])
+                del self._pending[: delimiter_index + delimiter_size]
+                records.extend(self._split_record(record))
+                continue
+            if len(self._pending) > self._maximum_bytes:
+                prefix_length = self._safe_prefix_length(self._pending, self._maximum_bytes)
+                records.append(bytes(self._pending[:prefix_length]))
+                del self._pending[:prefix_length]
+                continue
+            if final:
+                record = bytes(self._pending)
+                self._pending.clear()
+                records.extend(self._split_record(record))
+            break
+        return records
+
+    def _find_delimiter(self, *, final: bool) -> tuple[int, int] | None:
+        for index, value in enumerate(self._pending):
+            if value == ord("\n"):
+                return index, 1
+            if value != ord("\r"):
+                continue
+            if index + 1 < len(self._pending):
+                return index, 2 if self._pending[index + 1] == ord("\n") else 1
+            if final:
+                return index, 1
+            return None
+        return None
+
+    def _split_record(self, record: bytes) -> list[bytes]:
+        if not record:
+            return [b""]
+        records: list[bytes] = []
+        remaining = record
+        while remaining:
+            prefix_length = self._safe_prefix_length(remaining, self._maximum_bytes)
+            records.append(remaining[:prefix_length])
+            remaining = remaining[prefix_length:]
+        return records
+
+    @staticmethod
+    def _safe_prefix_length(value: bytes | bytearray, maximum_bytes: int) -> int:
+        end = min(len(value), maximum_bytes)
+        if end == len(value):
+            return end
+        lead_index = end - 1
+        while lead_index >= 0 and value[lead_index] & 0xC0 == 0x80:
+            lead_index -= 1
+        if lead_index < 0:
+            return end
+        lead = value[lead_index]
+        expected_bytes = 4 if lead & 0xF8 == 0xF0 else 3 if lead & 0xF0 == 0xE0 else 2 if lead & 0xE0 == 0xC0 else 1
+        if expected_bytes > end - lead_index and lead_index > 0:
+            return lead_index
+        return end
+
+
+@dataclass
+class _ArtifactState:
+    path: Path | None = None
+    size_bytes: int | None = None
+    observed_at: float | None = None
+    resolver_failed: bool = False
+
+
+class ChildProcessRunner:
+    def __init__(
+        self,
+        *,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._monotonic_clock = monotonic_clock
+        self._wall_clock = wall_clock
+
+    def run(
+        self,
+        spec: ProcessSpec,
+        *,
+        run_context: RunContext | None = None,
+        cancellation_event: threading.Event | None = None,
+        line_handler: LineHandler | None = None,
+        output_observer: OutputObserver | None = None,
+        progress_parser: ProgressParser | None = None,
+    ) -> ProcessResult:
+        started_at = self._monotonic_clock()
+        tool_run_id = str(uuid4())
+        tool_context = replace(
+            spec.event_context,
+            tool=ObservabilityTool(id=spec.tool_id, run_id=tool_run_id, version=spec.tool_version),
+            process=None,
+        )
+        emitter = _AsyncRunEmitter(run_context)
+        if self._is_cancelled(run_context, cancellation_event):
+            emitter.emit(
+                "tool.cancelled",
+                context=tool_context,
+                data=ObservabilityData(cancellation=ObservabilityCancellation(requested=True, forced=False)),
+                terminal=True,
+            )
+            emitter.close()
+            raise ProcessCancelled(f"{spec.display_name} was cancelled before it started")
+
+        try:
+            process = subprocess.Popen(
+                [os.fspath(argument) for argument in spec.argv],
+                stdin=spec.stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if spec.merge_stderr else subprocess.PIPE,
+                env=dict(spec.env) if spec.env is not None else None,
+                cwd=spec.cwd,
+                bufsize=0,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except OSError:
+            emitter.emit(
+                "tool.failed",
+                severity=ObservabilitySeverity.ERROR,
+                context=tool_context,
+                data=ObservabilityData(failure=ObservabilityFailure(code="spawn_failed", retryable=False)),
+                terminal=True,
+            )
+            emitter.close()
+            raise
+
+        process_context = replace(
+            tool_context,
+            process=ObservabilityProcess(pid=process.pid, process_group_id=process.pid),
+        )
+        emitter.emit("tool.started", context=process_context)
+
+        stream_queue: queue.Queue[_OutputChunk | _StreamClosed] = queue.Queue(maxsize=spec.queue_chunks)
+        dispatch_overflow = threading.Event()
+        reader_stop = threading.Event()
+        stream_states = {
+            ProcessStream.STDOUT: _StreamState(spec.capture_limit_bytes, spec.tail_limit_bytes),
+            ProcessStream.STDERR: _StreamState(spec.capture_limit_bytes, spec.tail_limit_bytes),
+        }
+        readers = self._start_readers(
+            process,
+            spec,
+            stream_states,
+            stream_queue,
+            dispatch_overflow,
+            reader_stop,
+        )
+        expected_streams = {ProcessStream.STDOUT}
+        if not spec.merge_stderr:
+            expected_streams.add(ProcessStream.STDERR)
+        closed_streams: set[ProcessStream] = set()
+        framers = {stream: _LineFramer(spec.line_limit_bytes) for stream in expected_streams}
+        artifact_states = [_ArtifactState() for _probe in spec.artifacts]
+
+        pending_error: BaseException | None = None
+        failure_code: str | None = None
+        cancelled = False
+        keyboard_interrupt: KeyboardInterrupt | None = None
+        termination_requested_at: float | None = None
+        kill_requested_at: float | None = None
+        forced_termination = False
+        process_exited_at: float | None = None
+        last_activity_event_at = started_at
+        last_artifact_event_at = started_at
+
+        try:
+            while True:
+                now = self._monotonic_clock()
+                try:
+                    item = stream_queue.get(timeout=0.05)
+                except queue.Empty:
+                    item = None
+                except KeyboardInterrupt as error:
+                    keyboard_interrupt = error
+                    cancelled = True
+                    item = None
+
+                if isinstance(item, _OutputChunk) and pending_error is None:
+                    try:
+                        if output_observer is not None:
+                            output_observer(item.stream, item.payload)
+                        for record in framers[item.stream].feed(item.payload):
+                            self._handle_line(
+                                record,
+                                item.stream,
+                                process_context,
+                                emitter,
+                                line_handler,
+                                progress_parser,
+                            )
+                    except BaseException as error:
+                        if isinstance(error, KeyboardInterrupt):
+                            keyboard_interrupt = error
+                            cancelled = True
+                        else:
+                            pending_error = error
+                            failure_code = "output_handler_failed"
+                elif isinstance(item, _StreamClosed):
+                    closed_streams.add(item.stream)
+                    if pending_error is None:
+                        try:
+                            for record in framers[item.stream].flush():
+                                self._handle_line(
+                                    record,
+                                    item.stream,
+                                    process_context,
+                                    emitter,
+                                    line_handler,
+                                    progress_parser,
+                                )
+                        except BaseException as error:
+                            if isinstance(error, KeyboardInterrupt):
+                                keyboard_interrupt = error
+                                cancelled = True
+                            else:
+                                pending_error = error
+                                failure_code = "output_handler_failed"
+
+                if dispatch_overflow.is_set() and pending_error is None:
+                    pending_error = ProcessOutputDispatchError(
+                        f"{spec.display_name} produced output faster than it could be processed"
+                    )
+                    failure_code = "output_dispatch_overflow"
+
+                if spec.capture_overflow is CaptureOverflowPolicy.FAIL and pending_error is None:
+                    if any(stream_states[stream].overflowed for stream in expected_streams):
+                        pending_error = ProcessOutputLimitError(
+                            f"{spec.display_name} exceeded the {spec.capture_limit_bytes}-byte output capture limit"
+                        )
+                        failure_code = "output_limit_exceeded"
+
+                if self._is_cancelled(run_context, cancellation_event) or keyboard_interrupt is not None:
+                    if not cancelled:
+                        cancelled = True
+                    if termination_requested_at is None:
+                        emitter.emit(
+                            "tool.cancellation_requested",
+                            context=process_context,
+                            data=ObservabilityData(cancellation=ObservabilityCancellation(requested=True)),
+                        )
+
+                if spec.timeout_seconds is not None and now - started_at >= spec.timeout_seconds:
+                    if pending_error is None:
+                        pending_error = ProcessTimeoutError(
+                            f"{spec.display_name} exceeded its {spec.timeout_seconds:g}-second timeout"
+                        )
+                        failure_code = "timeout"
+
+                if (cancelled or pending_error is not None) and termination_requested_at is None:
+                    self._signal_process_group(process, process.pid, signal.SIGTERM)
+                    termination_requested_at = now
+
+                if (
+                    termination_requested_at is not None
+                    and (process.poll() is None or self._process_group_exists(process.pid))
+                    and kill_requested_at is None
+                    and now - termination_requested_at >= spec.termination_grace_seconds
+                ):
+                    self._signal_process_group(process, process.pid, signal.SIGKILL)
+                    kill_requested_at = now
+                    forced_termination = True
+
+                returncode = process.poll()
+                if returncode is not None and process_exited_at is None:
+                    process_exited_at = now
+
+                if (
+                    process_exited_at is not None
+                    and closed_streams != expected_streams
+                    and now - process_exited_at >= spec.pipe_drain_timeout_seconds
+                ):
+                    if pending_error is None:
+                        pending_error = ProcessPipeDrainError(
+                            f"{spec.display_name} exited while a descendant kept its output stream open"
+                        )
+                        failure_code = "pipe_drain_timeout"
+                    if termination_requested_at is None:
+                        self._signal_process_group(process, process.pid, signal.SIGTERM)
+                        termination_requested_at = now
+                    elif kill_requested_at is None and now - termination_requested_at >= spec.termination_grace_seconds:
+                        self._signal_process_group(process, process.pid, signal.SIGKILL)
+                        kill_requested_at = now
+                        forced_termination = True
+
+                if (
+                    returncode is not None
+                    and closed_streams == expected_streams
+                    and stream_queue.empty()
+                    and self._process_group_exists(process.pid)
+                ):
+                    if pending_error is None:
+                        pending_error = ProcessRunnerError(
+                            f"{spec.display_name} exited while a descendant remained running"
+                        )
+                        failure_code = "descendant_survived"
+                    if termination_requested_at is None:
+                        self._signal_process_group(process, process.pid, signal.SIGTERM)
+                        termination_requested_at = now
+
+                if (
+                    process_exited_at is not None
+                    and closed_streams != expected_streams
+                    and kill_requested_at is not None
+                    and now - kill_requested_at >= spec.kill_wait_seconds
+                ):
+                    reader_stop.set()
+                    self._close_process_streams(process)
+                    break
+
+                if now - last_activity_event_at >= spec.activity_interval_seconds:
+                    emitter.emit(
+                        "tool.heartbeat",
+                        context=self._process_context(process_context, process.poll()),
+                        data=ObservabilityData(
+                            activity=ObservabilityActivity(
+                                last_output_age_seconds=self._last_output_age_seconds(
+                                    stream_states,
+                                    expected_streams,
+                                    started_at,
+                                    now,
+                                )
+                            ),
+                            counters=self._counters(stream_states, expected_streams),
+                        ),
+                    )
+                    last_activity_event_at = now
+
+                if spec.artifacts and now - last_artifact_event_at >= spec.artifact_interval_seconds:
+                    self._emit_artifacts(
+                        spec,
+                        artifact_states,
+                        process_context,
+                        emitter,
+                        state="growing",
+                        now=now,
+                    )
+                    last_artifact_event_at = now
+
+                if (
+                    returncode is not None
+                    and closed_streams == expected_streams
+                    and stream_queue.empty()
+                    and not self._process_group_exists(process.pid)
+                ):
+                    break
+
+                if (
+                    kill_requested_at is not None
+                    and returncode is None
+                    and now - kill_requested_at >= spec.kill_wait_seconds
+                ):
+                    process.kill()
+
+                if (
+                    kill_requested_at is not None
+                    and returncode is not None
+                    and closed_streams == expected_streams
+                    and now - kill_requested_at >= spec.kill_wait_seconds
+                ):
+                    break
+
+            returncode = process.wait(timeout=spec.kill_wait_seconds)
+        except BaseException as error:
+            if isinstance(error, KeyboardInterrupt):
+                keyboard_interrupt = error
+                cancelled = True
+            else:
+                pending_error = error
+                failure_code = failure_code or "runner_interrupted"
+            forced_termination = (
+                self._terminate_process_group(
+                    process,
+                    process.pid,
+                    spec.termination_grace_seconds,
+                    spec.kill_wait_seconds,
+                )
+                or forced_termination
+            )
+            returncode = process.poll()
+            if returncode is None:
+                process.kill()
+                returncode = process.wait()
+        finally:
+            reader_stop.set()
+            self._close_process_streams(process)
+            for reader in readers:
+                reader.join(timeout=1.0)
+
+        elapsed_ms = max(0, int((self._monotonic_clock() - started_at) * 1000))
+        stdout_snapshot = stream_states[ProcessStream.STDOUT].snapshot()
+        stderr_snapshot = (
+            ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+            if spec.merge_stderr
+            else stream_states[ProcessStream.STDERR].snapshot()
+        )
+        result = ProcessResult(
+            tool_run_id=tool_run_id,
+            returncode=returncode,
+            elapsed_ms=elapsed_ms,
+            stdout=stdout_snapshot,
+            stderr=stderr_snapshot,
+            forced_termination=forced_termination,
+        )
+        final_context = self._process_context(process_context, returncode)
+        final_data = ObservabilityData(
+            activity=ObservabilityActivity(
+                last_output_age_seconds=self._last_output_age_seconds(
+                    stream_states,
+                    expected_streams,
+                    started_at,
+                    self._monotonic_clock(),
+                )
+            ),
+            counters=self._counters(stream_states, expected_streams),
+        )
+        self._emit_artifacts(
+            spec,
+            artifact_states,
+            final_context,
+            emitter,
+            state="complete" if returncode == 0 and pending_error is None and not cancelled else "incomplete",
+            now=self._monotonic_clock(),
+        )
+
+        if cancelled:
+            emitter.emit(
+                "tool.cancelled",
+                context=final_context,
+                data=replace(
+                    final_data,
+                    cancellation=ObservabilityCancellation(requested=True, forced=forced_termination),
+                ),
+                terminal=True,
+            )
+            emitter.close()
+            if keyboard_interrupt is not None:
+                raise keyboard_interrupt
+            raise ProcessCancelled(f"{spec.display_name} was cancelled")
+
+        if pending_error is not None:
+            emitter.emit(
+                "tool.failed",
+                severity=ObservabilitySeverity.ERROR,
+                context=final_context,
+                data=replace(
+                    final_data,
+                    failure=ObservabilityFailure(code=failure_code or "runner_failed", retryable=False),
+                ),
+                terminal=True,
+            )
+            emitter.close()
+            raise pending_error
+
+        if returncode != 0:
+            emitter.emit(
+                "tool.failed",
+                severity=ObservabilitySeverity.ERROR,
+                context=final_context,
+                data=replace(
+                    final_data,
+                    failure=ObservabilityFailure(code="nonzero_exit", retryable=False),
+                ),
+                terminal=True,
+            )
+            emitter.close()
+            raise subprocess.CalledProcessError(
+                returncode,
+                [os.fspath(argument) for argument in spec.argv],
+                output=stdout_snapshot.text(),
+                stderr=None if spec.merge_stderr else stderr_snapshot.text(),
+            )
+
+        emitter.emit("tool.completed", context=final_context, data=final_data, terminal=True)
+        emitter.close()
+        return result
+
+    def _start_readers(
+        self,
+        process: subprocess.Popen[bytes],
+        spec: ProcessSpec,
+        stream_states: dict[ProcessStream, _StreamState],
+        stream_queue: queue.Queue[_OutputChunk | _StreamClosed],
+        dispatch_overflow: threading.Event,
+        reader_stop: threading.Event,
+    ) -> list[threading.Thread]:
+        readers: list[threading.Thread] = []
+        assert process.stdout is not None
+        readers.append(
+            self._start_reader(
+                cast(BinaryIO, process.stdout),
+                ProcessStream.STDOUT,
+                stream_states[ProcessStream.STDOUT],
+                stream_queue,
+                dispatch_overflow,
+                reader_stop,
+            )
+        )
+        if not spec.merge_stderr:
+            assert process.stderr is not None
+            readers.append(
+                self._start_reader(
+                    cast(BinaryIO, process.stderr),
+                    ProcessStream.STDERR,
+                    stream_states[ProcessStream.STDERR],
+                    stream_queue,
+                    dispatch_overflow,
+                    reader_stop,
+                )
+            )
+        return readers
+
+    def _start_reader(
+        self,
+        pipe: BinaryIO,
+        stream: ProcessStream,
+        state: _StreamState,
+        stream_queue: queue.Queue[_OutputChunk | _StreamClosed],
+        dispatch_overflow: threading.Event,
+        reader_stop: threading.Event,
+    ) -> threading.Thread:
+        def read() -> None:
+            try:
+                while not reader_stop.is_set():
+                    try:
+                        payload = pipe.read(READ_CHUNK_BYTES)
+                    except (OSError, ValueError):
+                        break
+                    if not payload:
+                        break
+                    state.record(payload, self._monotonic_clock())
+                    try:
+                        stream_queue.put_nowait(_OutputChunk(stream, payload))
+                    except queue.Full:
+                        dispatch_overflow.set()
+            finally:
+                state.close()
+                while not reader_stop.is_set():
+                    try:
+                        stream_queue.put(_StreamClosed(stream), timeout=0.05)
+                        break
+                    except queue.Full:
+                        continue
+
+        reader = threading.Thread(target=read, name=f"{stream}-reader", daemon=True)
+        reader.start()
+        return reader
+
+    @staticmethod
+    def _handle_line(
+        record: bytes,
+        stream: ProcessStream,
+        process_context: ObservabilityContext,
+        emitter: _AsyncRunEmitter,
+        line_handler: LineHandler | None,
+        progress_parser: ProgressParser | None,
+    ) -> None:
+        line = record.decode("utf-8", errors="replace").removesuffix("\r")
+        if line_handler is not None:
+            line_handler(stream, line)
+        if progress_parser is not None:
+            progress = progress_parser(stream, line)
+            if progress is not None:
+                emitter.emit(
+                    "tool.progress",
+                    context=process_context,
+                    data=ObservabilityData(progress=progress),
+                )
+
+    @staticmethod
+    def _is_cancelled(run_context: RunContext | None, cancellation_event: threading.Event | None) -> bool:
+        return bool(
+            (run_context is not None and run_context.cancellation.is_cancelled)
+            or (cancellation_event is not None and cancellation_event.is_set())
+        )
+
+    @staticmethod
+    def _signal_process_group(
+        process: subprocess.Popen[bytes],
+        process_group_id: int,
+        requested_signal: signal.Signals,
+    ) -> None:
+        try:
+            os.killpg(process_group_id, requested_signal)
+        except (ProcessLookupError, PermissionError):
+            if process.poll() is None:
+                try:
+                    process.send_signal(requested_signal)
+                except ProcessLookupError:
+                    return
+
+    @staticmethod
+    def _process_group_exists(process_group_id: int) -> bool:
+        try:
+            os.killpg(process_group_id, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def _terminate_process_group(
+        self,
+        process: subprocess.Popen[bytes],
+        process_group_id: int,
+        termination_grace_seconds: float,
+        kill_wait_seconds: float,
+    ) -> bool:
+        self._signal_process_group(process, process_group_id, signal.SIGTERM)
+        deadline = self._monotonic_clock() + termination_grace_seconds
+        while self._monotonic_clock() < deadline:
+            if process.poll() is not None and not self._process_group_exists(process_group_id):
+                return False
+            time.sleep(0.01)
+
+        self._signal_process_group(process, process_group_id, signal.SIGKILL)
+        deadline = self._monotonic_clock() + kill_wait_seconds
+        while self._monotonic_clock() < deadline:
+            if process.poll() is not None and not self._process_group_exists(process_group_id):
+                return True
+            time.sleep(0.01)
+        return True
+
+    @staticmethod
+    def _close_process_streams(process: subprocess.Popen[bytes]) -> None:
+        for pipe in (process.stdin, process.stdout, process.stderr):
+            if pipe is not None:
+                try:
+                    pipe.close()
+                except (OSError, ValueError):
+                    continue
+
+    @staticmethod
+    def _process_context(context: ObservabilityContext, returncode: int | None) -> ObservabilityContext:
+        current = context.process
+        if current is None or returncode is None:
+            return context
+        return replace(
+            context,
+            process=replace(
+                current,
+                exit_code=returncode if returncode >= 0 else None,
+                signal=-returncode if returncode < 0 else None,
+            ),
+        )
+
+    @staticmethod
+    def _last_output_age_seconds(
+        states: dict[ProcessStream, _StreamState],
+        streams: set[ProcessStream],
+        started_at: float,
+        now: float,
+    ) -> int:
+        last_output_at = max((states[stream].last_output_at or started_at for stream in streams), default=started_at)
+        return max(0, int(now - last_output_at))
+
+    @staticmethod
+    def _counters(
+        states: dict[ProcessStream, _StreamState],
+        streams: set[ProcessStream],
+    ) -> ObservabilityCounters:
+        snapshots = [states[stream].snapshot() for stream in streams]
+        return ObservabilityCounters(
+            total_bytes=sum(snapshot.total_bytes for snapshot in snapshots),
+            retained_bytes=sum(snapshot.retained_bytes for snapshot in snapshots),
+            dropped_bytes=sum(snapshot.dropped_bytes for snapshot in snapshots),
+            decode_replacements=sum(snapshot.decode_replacements for snapshot in snapshots),
+        )
+
+    def _emit_artifacts(
+        self,
+        spec: ProcessSpec,
+        artifact_states: list[_ArtifactState],
+        context: ObservabilityContext,
+        emitter: _AsyncRunEmitter,
+        *,
+        state: str,
+        now: float,
+    ) -> None:
+        for probe, artifact_state in zip(spec.artifacts, artifact_states, strict=True):
+            try:
+                path = probe.resolve_path()
+            except Exception:
+                if not artifact_state.resolver_failed:
+                    emitter.emit(
+                        "tool.artifact_probe_failed",
+                        severity=ObservabilitySeverity.WARNING,
+                        context=context,
+                        data=ObservabilityData(
+                            failure=ObservabilityFailure(code="artifact_resolver_failed", retryable=False)
+                        ),
+                    )
+                    artifact_state.resolver_failed = True
+                path = None
+            if artifact_state.path != path:
+                artifact_state.path = path
+                artifact_state.size_bytes = None
+                artifact_state.observed_at = None
+            if path is None:
+                artifact = ObservabilityArtifact(role=probe.role, state="missing")
+                emitter.emit(
+                    "tool.artifact",
+                    context=context,
+                    data=ObservabilityData(artifact=artifact),
+                )
+                continue
+            try:
+                status = path.stat()
+            except OSError:
+                artifact = ObservabilityArtifact(
+                    role=probe.role,
+                    state="missing",
+                    location=self._artifact_location(path),
+                )
+            else:
+                growth = None
+                if artifact_state.size_bytes is not None and artifact_state.observed_at is not None:
+                    elapsed = now - artifact_state.observed_at
+                    if elapsed > 0:
+                        growth = max(0, int((status.st_size - artifact_state.size_bytes) / elapsed))
+                artifact_state.size_bytes = status.st_size
+                artifact_state.observed_at = now
+                artifact = ObservabilityArtifact(
+                    role=probe.role,
+                    state=state,
+                    location=self._artifact_location(path),
+                    size_bytes=self._round_down(status.st_size, ARTIFACT_SIZE_QUANTUM_BYTES),
+                    modification_age_seconds=self._round_down(
+                        max(0, int(self._wall_clock() - status.st_mtime)),
+                        ARTIFACT_AGE_QUANTUM_SECONDS,
+                    ),
+                    growth_bytes_per_second=(
+                        None if growth is None else self._round_down(growth, ARTIFACT_SIZE_QUANTUM_BYTES)
+                    ),
+                )
+            emitter.emit(
+                "tool.artifact",
+                context=context,
+                data=ObservabilityData(artifact=artifact),
+            )
+
+    @staticmethod
+    def _artifact_location(path: Path) -> ObservabilityText | None:
+        try:
+            return ObservabilityText.bounded(
+                path.as_posix(),
+                privacy=ObservabilityPrivacy.PRIVATE,
+                maximum_bytes=MAX_DETAIL_BYTES,
+            )
+        except (TypeError, ValueError, UnicodeError):
+            return None
+
+    @staticmethod
+    def _round_down(value: int, quantum: int) -> int:
+        return value - (value % quantum)

--- a/bd_to_avp/worker/ownership.py
+++ b/bd_to_avp/worker/ownership.py
@@ -18,6 +18,8 @@ class WorkerProcessOwner:
     def __init__(self) -> None:
         self.cancellation_event = threading.Event()
         self._cleanup_lock = threading.Lock()
+        self._signal_cleanup_lock = threading.Lock()
+        self._signal_cleanup_started = False
 
     def establish_session(self) -> int:
         if os.getpgrp() != os.getpid():
@@ -30,6 +32,16 @@ class WorkerProcessOwner:
 
     def _handle_signal(self, _signum: int, _frame: FrameType | None) -> None:
         self.cancellation_event.set()
+        with self._signal_cleanup_lock:
+            if self._signal_cleanup_started:
+                return
+            self._signal_cleanup_started = True
+        threading.Thread(
+            target=self.terminate_descendants,
+            kwargs={"timeout": 0.5},
+            name="worker-descendant-cleanup",
+            daemon=True,
+        ).start()
 
     def request_cancel(self) -> None:
         self.cancellation_event.set()

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,6 +38,33 @@ protocol events. Structured events identify the active tool, stage, recent
 activity, process outcome, and active artifact while the bounded diagnostic tail
 retains recent raw evidence.
 
+## Child Processes
+
+`ChildProcessRunner` is the only supported path for ordinary conversion helper
+processes. It launches each helper in a new process group, drains binary stdout
+and stderr concurrently, applies incremental UTF-8 replacement for diagnostic
+views, and retains bounded captures and tails. Output capture overflow fails the
+tool by default rather than silently parsing incomplete MakeMKV or probe data;
+callers that only need a diagnostic prefix may explicitly select bounded
+truncation.
+
+When a caller supplies a `RunContext`, the runner emits low-volume lifecycle,
+heartbeat, progress, cancellation, failure, and active-artifact events through
+a bounded asynchronous delivery queue. Raw command arguments, environment
+values, and child output are never copied into those semantic events. A blocked
+or failed event sink cannot block pipe draining or process cancellation.
+
+Line, progress, raw-output, and artifact resolver hooks are internal producer
+boundaries and must return promptly without performing unbounded I/O. Pipe
+readers remain independent from those hooks, and bounded dispatch overflow
+fails the tool rather than silently dropping parser input.
+
+The legacy `run_command` API is a compatibility adapter over the shared runner.
+MakeMKV inspection and ripping identify the tool explicitly, emit parsed robot
+progress, sample the actively growing MKV, and honor cancellation while the tool
+is running. Compatibility calls that ignore output retain a bounded prefix and
+continue; callers that parse complete output explicitly fail on truncation.
+
 ## Privacy
 
 Every event declares its maximum privacy level and redaction state. Secrets are
@@ -64,6 +91,8 @@ single `stream_id`.
 1. Add the shared models, sinks, fixtures, and runtime context without changing
    conversion behavior.
 2. Replace fragmented child execution with one binary-safe streaming runner.
+   The ordinary command path and MakeMKV are migrated; FFmpeg probes and the
+   native MVC binary pipeline remain in the active child-tool workstream.
 3. Project semantic runner activity into the worker protocol and bounded raw
    output into the diagnostic channel.
 4. Make the native diagnostic recorder and support bundle consume the shared

--- a/macos/BluRayToVisionPro/Models/ObservabilityEvent.swift
+++ b/macos/BluRayToVisionPro/Models/ObservabilityEvent.swift
@@ -168,6 +168,7 @@ struct ObservabilityEventData: Codable, Equatable, Sendable {
     let failure: ObservabilityFailure?
     let cancellation: ObservabilityCancellation?
     let counters: ObservabilityCounters?
+    let activity: ObservabilityActivity?
 }
 
 struct ObservabilityText: Codable, Equatable, Sendable {
@@ -280,5 +281,25 @@ struct ObservabilityCounters: Codable, Equatable, Sendable {
         case retainedBytes = "retained_bytes"
         case droppedBytes = "dropped_bytes"
         case decodeReplacements = "decode_replacements"
+    }
+}
+
+struct ObservabilityActivity: Codable, Equatable, Sendable {
+    let lastOutputAgeSeconds: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case lastOutputAgeSeconds = "last_output_age_seconds"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        lastOutputAgeSeconds = try container.decodeIfPresent(Int64.self, forKey: .lastOutputAgeSeconds)
+        if let lastOutputAgeSeconds, lastOutputAgeSeconds < 0 {
+            throw DecodingError.dataCorruptedError(
+                forKey: .lastOutputAgeSeconds,
+                in: container,
+                debugDescription: "Observability output age must be non-negative"
+            )
+        }
     }
 }

--- a/macos/BluRayToVisionProTests/ObservabilityEventTests.swift
+++ b/macos/BluRayToVisionProTests/ObservabilityEventTests.swift
@@ -65,6 +65,16 @@ final class ObservabilityEventTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode(ObservabilityEvent.self, from: oversizedMessage))
     }
 
+    func testNegativeOutputAgeIsRejected() throws {
+        var fixture = try XCTUnwrap(try jsonObject(try sharedFixtureData()) as? [String: Any])
+        var data = try XCTUnwrap(fixture["data"] as? [String: Any])
+        data["activity"] = ["last_output_age_seconds": -1]
+        fixture["data"] = data
+        let negativeAge = try JSONSerialization.data(withJSONObject: fixture)
+
+        XCTAssertThrowsError(try JSONDecoder().decode(ObservabilityEvent.self, from: negativeAge))
+    }
+
     private func sharedFixtureData() throws -> Data {
         let fixtureURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/tests/fixtures/observability_event_v1.json
+++ b/tests/fixtures/observability_event_v1.json
@@ -58,6 +58,9 @@
       "retained_bytes": 32768,
       "dropped_bytes": 0,
       "decode_replacements": 0
+    },
+    "activity": {
+      "last_output_age_seconds": 3
     }
   }
 }

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,20 +1,28 @@
-import io
+import sys
 import unittest
-
-from unittest.mock import Mock, call, patch
+from unittest.mock import patch
 
 from bd_to_avp.modules import command
+from bd_to_avp.process_runner import ProcessOutputSnapshot, ProcessResult, ProcessStream
 
 
 class RunCommandTests(unittest.TestCase):
     def test_line_handler_receives_streamed_output(self) -> None:
-        process = Mock()
-        process.stdout = io.StringIO("first\nsecond\r\n")
-        process.returncode = 0
         lines: list[str] = []
 
+        def run(_runner, _spec, **kwargs):
+            kwargs["line_handler"](ProcessStream.STDOUT, "first")
+            kwargs["line_handler"](ProcessStream.STDOUT, "second")
+            return ProcessResult(
+                tool_run_id="run-id",
+                returncode=0,
+                elapsed_ms=10,
+                stdout=ProcessOutputSnapshot(b"first\nsecond\r\n", b"", 14, 14, 0, 0),
+                stderr=ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0),
+            )
+
         with (
-            patch.object(command.subprocess, "Popen", return_value=process),
+            patch.object(command.ChildProcessRunner, "run", autospec=True, side_effect=run),
             patch.object(command.Spinner, "start"),
             patch.object(command.Spinner, "stop"),
         ):
@@ -22,75 +30,50 @@ class RunCommandTests(unittest.TestCase):
 
         self.assertEqual(lines, ["first", "second"])
         self.assertEqual(output, "first\nsecond\r\n")
-        process.wait.assert_called_once_with()
 
     def test_line_handler_failure_terminates_running_process(self) -> None:
-        process = Mock()
-        process.stdout = io.StringIO("progress\n")
-        process.poll.return_value = None
-
         def fail(_line: str) -> None:
             raise RuntimeError("bad progress parser")
 
         with (
-            patch.object(command.subprocess, "Popen", return_value=process),
             patch.object(command.Spinner, "start"),
             patch.object(command.Spinner, "stop"),
             self.assertRaisesRegex(RuntimeError, "bad progress parser"),
         ):
-            command.run_command(["tool"], line_handler=fail)
+            command.run_command(
+                [sys.executable, "-c", "import time; print('progress', flush=True); time.sleep(30)"],
+                line_handler=fail,
+            )
 
-        process.terminate.assert_called_once_with()
-        process.wait.assert_called_once_with(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS)
-
-    def test_line_handler_failure_kills_process_after_termination_timeout(self) -> None:
-        process = Mock()
-        process.stdout = io.StringIO("progress\n")
-        process.poll.return_value = None
-        process.wait.side_effect = [
-            command.subprocess.TimeoutExpired(cmd="tool", timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS),
-            None,
-        ]
-
-        def fail(_line: str) -> None:
-            raise RuntimeError("bad progress parser")
-
-        with (
-            patch.object(command.subprocess, "Popen", return_value=process),
-            patch.object(command.Spinner, "start"),
-            patch.object(command.Spinner, "stop"),
-            self.assertRaisesRegex(RuntimeError, "bad progress parser"),
-        ):
-            command.run_command(["tool"], line_handler=fail)
-
-        process.terminate.assert_called_once_with()
-        process.kill.assert_called_once_with()
-        self.assertEqual(
-            process.wait.call_args_list,
-            [
-                call(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS),
-                call(),
-            ],
-        )
-
-    def test_keyboard_interrupt_terminates_running_process(self) -> None:
-        process = Mock()
-        process.stdout = io.StringIO("progress\n")
-        process.poll.return_value = None
-
+    def test_keyboard_interrupt_from_line_handler_terminates_process(self) -> None:
         def interrupt(_line: str) -> None:
             raise KeyboardInterrupt
 
         with (
-            patch.object(command.subprocess, "Popen", return_value=process),
             patch.object(command.Spinner, "start"),
             patch.object(command.Spinner, "stop"),
             self.assertRaises(KeyboardInterrupt),
         ):
-            command.run_command(["tool"], line_handler=interrupt)
+            command.run_command(
+                [sys.executable, "-c", "import time; print('progress', flush=True); time.sleep(30)"],
+                line_handler=interrupt,
+            )
 
-        process.terminate.assert_called_once_with()
-        process.wait.assert_called_once_with(timeout=command.PROCESS_TERMINATION_TIMEOUT_SECONDS)
+    def test_default_tool_id_uses_executable_name_without_path(self) -> None:
+        self.assertEqual(command.default_tool_id("/Applications/Tool Suite/bin/MakeMKVCon"), "makemkvcon")
+        self.assertEqual(command.default_tool_id("***"), "external_tool")
+
+    def test_large_ignored_output_is_truncated_without_failing_command(self) -> None:
+        with (
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+        ):
+            output = command.run_command(
+                [sys.executable, "-c", "import os; os.write(1, b'x' * 100000)"],
+                capture_limit_bytes=4096,
+            )
+
+        self.assertEqual(len(output), 4096)
 
 
 if __name__ == "__main__":

--- a/tests/test_disc.py
+++ b/tests/test_disc.py
@@ -28,6 +28,11 @@ class DiscStageArtifactTests(unittest.TestCase):
         self.assertIsNone(disc.parse_makemkv_progress("PRGV:5,25,0"))
         self.assertIsNone(disc.parse_makemkv_progress("MSG:1005,0,1,Finished"))
 
+        structured = disc.parse_makemkv_observability_progress("PRGV:5,25,100")
+        self.assertEqual(structured.fraction, 0.25)
+        self.assertEqual(structured.completed_units, 25)
+        self.assertEqual(structured.total_units, 100)
+
     def test_rip_requests_progress_and_reports_robot_updates(self) -> None:
         progress_updates: list[tuple[float, float]] = []
 
@@ -36,6 +41,7 @@ class DiscStageArtifactTests(unittest.TestCase):
             _name: str,
             *,
             line_handler: object,
+            **kwargs: object,
         ) -> str:
             assert callable(line_handler)
             line_handler("PRGV:5,25,100")
@@ -43,6 +49,10 @@ class DiscStageArtifactTests(unittest.TestCase):
             line_handler("PRGV:5,100,100")
             self.assertIn("--robot", command)
             self.assertIn("--progress=-same", command)
+            self.assertEqual(kwargs["tool_id"], "makemkvcon")
+            self.assertTrue(callable(kwargs["progress_parser"]))
+            self.assertEqual(len(kwargs["artifacts"]), 1)
+            self.assertEqual(kwargs["capture_overflow"], disc.CaptureOverflowPolicy.FAIL)
             return ""
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -212,17 +222,10 @@ class DiscStageArtifactTests(unittest.TestCase):
             result = disc.get_disc_and_mvc_video_info()
 
         self.assertEqual(result.name, "Physical 3D")
-        self.assertEqual(
-            run_command.call_args.args[0],
-            [
-                Path("/Applications/MakeMKV/makemkvcon"),
-                "--robot",
-                "--minlength=0",
-                None,
-                "info",
-                "dev:/dev/disk9",
-            ],
-        )
+        command = run_command.call_args.args[0]
+        self.assertNotIn("--noscan", command)
+        self.assertIn("info", command)
+        self.assertIn("dev:/dev/disk9", command)
 
     def test_disc_rip_disables_makemkv_minimum_title_length(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -1295,6 +1295,7 @@ class SourceConversionTests(unittest.TestCase):
                 _output_folder: Path,
                 _disc_info: DiscInfo,
                 progress_callback: object | None = None,
+                **_kwargs: object,
             ) -> Path:
                 self.assertTrue(callable(progress_callback))
                 progress_callback(50, 100)
@@ -1557,7 +1558,11 @@ class SourceConversionTests(unittest.TestCase):
             activity = WorkerActivityReporter(emitter)
             observed: dict[str, object] = {}
 
-            def fake_process_each(_cancellation_event: object, activity: object | None = None) -> Path:
+            def fake_process_each(
+                _cancellation_event: object,
+                activity: object | None = None,
+                **_kwargs: object,
+            ) -> Path:
                 observed.update(
                     {
                         "source_path": config.source_path,
@@ -1636,7 +1641,11 @@ class SourceConversionTests(unittest.TestCase):
             activity = WorkerActivityReporter(emitter)
             owner = WorkerProcessOwner()
 
-            def cancel(_cancellation_event: object, activity: object | None = None) -> Path:
+            def cancel(
+                _cancellation_event: object,
+                activity: object | None = None,
+                **_kwargs: object,
+            ) -> Path:
                 owner.request_cancel()
                 from bd_to_avp.modules.process import ProcessingCancelled
 
@@ -1703,9 +1712,8 @@ class WorkerProcessOwnerTests(unittest.TestCase):
             owner._handle_signal(signal.SIGTERM, None)
 
             self.assertTrue(owner.cancellation_event.is_set())
-            self.assertIsNone(child.poll())
-            owner.terminate_descendants(timeout=0.1)
             child.wait(timeout=3)
+            self.assertIsNotNone(child.returncode)
         finally:
             if child.poll() is None:
                 child.kill()

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -15,6 +15,8 @@ from bd_to_avp.modules.file import (
     prepare_output_folder_for_source,
     remove_output_folder_if_safe,
 )
+from bd_to_avp.observability import ObservabilityEmitter
+from bd_to_avp.runtime import CancellationToken, ObservabilityStream, RunContext
 
 
 class ProcessPreflightTests(unittest.TestCase):
@@ -124,7 +126,10 @@ class ProcessPreflightTests(unittest.TestCase):
         cancellation_event = threading.Event()
         processed_sources: list[Path | None] = []
 
-        def cancel_after_first_source(_cancellation_event: threading.Event | None = None) -> None:
+        def cancel_after_first_source(
+            _cancellation_event: threading.Event | None = None,
+            **_kwargs: object,
+        ) -> None:
             processed_sources.append(process.config.source_path)
             cancellation_event.set()
 
@@ -142,10 +147,33 @@ class ProcessPreflightTests(unittest.TestCase):
 
         self.assertEqual(len(processed_sources), 1)
 
+    def test_batch_processing_propagates_run_context_cancellation(self) -> None:
+        cancellation = CancellationToken()
+        run_context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER), cancellation)
+
+        def cancel_from_context(*_args: object, **_kwargs: object) -> None:
+            cancellation.cancel()
+            raise process.ProcessCancelled("stop")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_folder = Path(temp_dir)
+            (source_folder / "first.m2ts").touch()
+            (source_folder / "second.m2ts").touch()
+
+            with (
+                patch.object(process.config, "source_folder_path", source_folder),
+                patch.object(process, "process_each", side_effect=cancel_from_context),
+                self.assertRaises(process.ProcessingCancelled),
+            ):
+                process.process(Stage.CREATE_MKV, run_context=run_context)
+
     def test_batch_resume_stage_only_applies_to_failed_source(self) -> None:
         processed_sources: list[tuple[Path | None, Stage]] = []
 
-        def record_source(_cancellation_event: threading.Event | None = None) -> None:
+        def record_source(
+            _cancellation_event: threading.Event | None = None,
+            **_kwargs: object,
+        ) -> None:
             processed_sources.append((process.config.source_path, process.config.start_stage))
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -334,7 +334,7 @@ class ChildProcessRunnerTests(unittest.TestCase):
             try:
                 os.kill(escaped_pid, signal.SIGKILL)
             except ProcessLookupError:
-                pass
+                return
 
     def test_same_group_descendant_is_terminated_after_leader_exit(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -1,0 +1,461 @@
+import os
+import signal
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+from bd_to_avp.observability import BoundedEventSink, ObservabilityEmitter, ObservabilityProgress
+from bd_to_avp.process_runner import (
+    CaptureOverflowPolicy,
+    ChildProcessRunner,
+    ProcessArtifactProbe,
+    ProcessCancelled,
+    ProcessOutputLimitError,
+    ProcessPipeDrainError,
+    ProcessRunnerError,
+    ProcessSpec,
+    ProcessStream,
+)
+from bd_to_avp.runtime import CancellationToken, ObservabilityStream, RunContext
+
+
+class ChildProcessRunnerTests(unittest.TestCase):
+    def test_streams_output_and_emits_lifecycle_events(self) -> None:
+        sink = BoundedEventSink(maximum_events=50, maximum_bytes=100_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        lines: list[tuple[ProcessStream, str]] = []
+
+        result = ChildProcessRunner().run(
+            self.spec(
+                "import sys; print('out'); print('err', file=sys.stderr)",
+                merge_stderr=False,
+            ),
+            run_context=context,
+            line_handler=lambda stream, line: lines.append((stream, line)),
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.text(), "out\n")
+        self.assertEqual(result.stderr.text(), "err\n")
+        self.assertCountEqual(
+            lines,
+            [
+                (ProcessStream.STDOUT, "out"),
+                (ProcessStream.STDERR, "err"),
+            ],
+        )
+        events = sink.snapshot().events
+        self.assertEqual(events[0].kind, "tool.started")
+        self.assertEqual(events[-1].kind, "tool.completed")
+        self.assertEqual(events[-1].context.process.exit_code, 0)
+
+    def test_invalid_utf8_is_replaced_and_counted(self) -> None:
+        result = ChildProcessRunner().run(self.spec("import os; os.write(1, b'valid \\xff text\\n')"))
+
+        self.assertEqual(result.stdout.text(), "valid � text\n")
+        self.assertEqual(result.stdout.decode_replacements, 1)
+
+    def test_multibyte_utf8_split_across_writes_is_preserved(self) -> None:
+        result = ChildProcessRunner().run(
+            self.spec("import os, time; os.write(1, b'\\xe2'); time.sleep(0.05); os.write(1, b'\\x82\\xac\\n')")
+        )
+
+        self.assertEqual(result.stdout.text(), "€\n")
+        self.assertEqual(result.stdout.decode_replacements, 0)
+
+    def test_line_limit_does_not_split_multibyte_utf8(self) -> None:
+        lines: list[str] = []
+
+        ChildProcessRunner().run(
+            self.spec(
+                "print('a' * 15 + '€')",
+                line_limit_bytes=16,
+            ),
+            line_handler=lambda _stream, line: lines.append(line),
+        )
+
+        self.assertEqual("".join(lines), "a" * 15 + "€")
+        self.assertNotIn("�", "".join(lines))
+
+    def test_carriage_return_only_progress_is_framed(self) -> None:
+        lines: list[str] = []
+
+        ChildProcessRunner().run(
+            self.spec("import os; os.write(1, b'first\\rsecond\\r')"),
+            line_handler=lambda _stream, line: lines.append(line),
+        )
+
+        self.assertEqual(lines, ["first", "second"])
+
+    def test_capture_limit_fails_without_unbounded_memory(self) -> None:
+        with self.assertRaises(ProcessOutputLimitError):
+            ChildProcessRunner().run(
+                self.spec(
+                    "import os; os.write(1, b'x' * 200000)",
+                    capture_limit_bytes=32 * 1024,
+                )
+            )
+
+    def test_rejects_unmanaged_stdin_pipe(self) -> None:
+        with self.assertRaisesRegex(ValueError, "stdin=subprocess.PIPE"):
+            self.spec("pass", stdin=-1)
+
+    def test_truncation_policy_returns_bounded_prefix_and_tail(self) -> None:
+        result = ChildProcessRunner().run(
+            self.spec(
+                "import os; os.write(1, b'a' * 100000 + b'END')",
+                capture_limit_bytes=4096,
+                tail_limit_bytes=1024,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            )
+        )
+
+        self.assertEqual(len(result.stdout.capture), 4096)
+        self.assertEqual(len(result.stdout.tail), 1024)
+        self.assertTrue(result.stdout.tail.endswith(b"END"))
+        self.assertEqual(result.stdout.total_bytes, 100003)
+        self.assertEqual(result.stdout.dropped_bytes, 100003 - 4096)
+
+    def test_silent_process_emits_heartbeat_with_output_age(self) -> None:
+        sink = BoundedEventSink(maximum_events=50, maximum_bytes=100_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+
+        ChildProcessRunner().run(
+            self.spec(
+                "import time; time.sleep(0.18)",
+                activity_interval_seconds=0.05,
+            ),
+            run_context=context,
+        )
+
+        heartbeats = [event for event in sink.snapshot().events if event.kind == "tool.heartbeat"]
+        self.assertGreaterEqual(len(heartbeats), 2)
+        self.assertIsNotNone(heartbeats[-1].data.activity)
+        self.assertGreaterEqual(heartbeats[-1].data.activity.last_output_age_seconds, 0)
+
+    def test_progress_parser_emits_structured_progress(self) -> None:
+        sink = BoundedEventSink(maximum_events=50, maximum_bytes=100_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+
+        def parse_progress(_stream: ProcessStream, line: str) -> ObservabilityProgress | None:
+            if not line.startswith("progress="):
+                return None
+            completed = float(line.partition("=")[2])
+            return ObservabilityProgress(completed_units=completed, total_units=10, unit="items")
+
+        ChildProcessRunner().run(
+            self.spec("print('progress=4')"),
+            run_context=context,
+            progress_parser=parse_progress,
+        )
+
+        progress_events = [event for event in sink.snapshot().events if event.kind == "tool.progress"]
+        self.assertEqual(len(progress_events), 1)
+        self.assertEqual(progress_events[0].data.progress.completed_units, 4)
+
+    def test_cancellation_terminates_process_group(self) -> None:
+        cancellation_event = threading.Event()
+        timer = threading.Timer(0.1, cancellation_event.set)
+        timer.start()
+        started = time.monotonic()
+        try:
+            with self.assertRaises(ProcessCancelled):
+                ChildProcessRunner().run(
+                    self.spec("import time; time.sleep(30)", termination_grace_seconds=0.1),
+                    cancellation_event=cancellation_event,
+                )
+        finally:
+            timer.cancel()
+
+        self.assertLess(time.monotonic() - started, 3)
+
+    def test_cancellation_escalates_when_process_ignores_sigterm(self) -> None:
+        sink = BoundedEventSink(maximum_events=50, maximum_bytes=100_000)
+        cancellation = CancellationToken()
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink), cancellation)
+        timer = threading.Timer(0.1, cancellation.cancel)
+        timer.start()
+        try:
+            with self.assertRaises(ProcessCancelled):
+                ChildProcessRunner().run(
+                    self.spec(
+                        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
+                        termination_grace_seconds=0.1,
+                    ),
+                    run_context=context,
+                )
+        finally:
+            timer.cancel()
+
+        cancelled = [event for event in sink.snapshot().events if event.kind == "tool.cancelled"]
+        self.assertEqual(len(cancelled), 1)
+        self.assertTrue(cancelled[0].data.cancellation.forced)
+        self.assertEqual(cancelled[0].context.process.signal, signal.SIGKILL)
+
+    def test_stdout_and_stderr_floods_are_drained_concurrently(self) -> None:
+        result = ChildProcessRunner().run(
+            self.spec(
+                "import os, threading; "
+                "threads = [threading.Thread(target=lambda fd=fd: os.write(fd, b'x' * 500000)) "
+                "for fd in (1, 2)]; [thread.start() for thread in threads]; "
+                "[thread.join() for thread in threads]",
+                merge_stderr=False,
+                capture_limit_bytes=600000,
+            )
+        )
+
+        self.assertEqual(result.stdout.total_bytes, 500000)
+        self.assertEqual(result.stderr.total_bytes, 500000)
+
+    def test_artifact_growth_is_sampled_without_affecting_process(self) -> None:
+        sink = BoundedEventSink(maximum_events=100, maximum_bytes=200_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            ChildProcessRunner().run(
+                self.spec(
+                    "import pathlib, sys, time; path = pathlib.Path(sys.argv[1]); "
+                    "path.write_bytes(b'x' * 70000); time.sleep(0.08); "
+                    "path.write_bytes(b'x' * 150000); time.sleep(0.08)",
+                    artifact,
+                    artifacts=(ProcessArtifactProbe("intermediate", artifact),),
+                    artifact_interval_seconds=0.04,
+                ),
+                run_context=context,
+            )
+
+        artifact_events = [event for event in sink.snapshot().events if event.kind == "tool.artifact"]
+        self.assertGreaterEqual(len(artifact_events), 2)
+        self.assertEqual(artifact_events[-1].data.artifact.state, "complete")
+        self.assertEqual(artifact_events[-1].data.artifact.size_bytes, 131072)
+
+    def test_blocked_event_sink_does_not_block_output_draining(self) -> None:
+        release_sink = threading.Event()
+
+        class BlockingSink:
+            def emit(self, _event: object) -> None:
+                release_sink.wait(timeout=5)
+
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, BlockingSink()))
+        started = time.monotonic()
+        try:
+            result = ChildProcessRunner().run(
+                self.spec(
+                    "import os; os.write(1, b'x' * 500000)",
+                    capture_limit_bytes=600000,
+                ),
+                run_context=context,
+            )
+        finally:
+            release_sink.set()
+
+        self.assertEqual(result.stdout.total_bytes, 500000)
+        self.assertLess(time.monotonic() - started, 2)
+
+    def test_terminal_event_survives_saturated_async_queue(self) -> None:
+        release_sink = threading.Event()
+        events: list[object] = []
+
+        class BlockingRecordingSink:
+            def emit(self, event: object) -> None:
+                events.append(event)
+                if len(events) == 1:
+                    release_sink.wait(timeout=5)
+
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, BlockingRecordingSink()))
+        try:
+            ChildProcessRunner().run(
+                self.spec("for index in range(300): print(index)"),
+                run_context=context,
+                progress_parser=lambda _stream, _line: ObservabilityProgress(
+                    completed_units=1,
+                    total_units=1,
+                    unit="items",
+                ),
+            )
+        finally:
+            release_sink.set()
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not any(
+            getattr(event, "kind", None) == "tool.completed" for event in events
+        ):
+            time.sleep(0.01)
+        self.assertTrue(any(getattr(event, "kind", None) == "tool.completed" for event in events))
+
+    def test_output_observer_failure_terminates_and_reraises(self) -> None:
+        def fail(_stream: ProcessStream, _payload: bytes) -> None:
+            raise RuntimeError("observer failed")
+
+        started = time.monotonic()
+        with self.assertRaisesRegex(RuntimeError, "observer failed"):
+            ChildProcessRunner().run(
+                self.spec("import time; print('data', flush=True); time.sleep(30)"),
+                output_observer=fail,
+            )
+        self.assertLess(time.monotonic() - started, 3)
+
+    def test_progress_parser_failure_terminates_and_reraises(self) -> None:
+        def fail(_stream: ProcessStream, _line: str) -> ObservabilityProgress | None:
+            raise RuntimeError("progress failed")
+
+        started = time.monotonic()
+        with self.assertRaisesRegex(RuntimeError, "progress failed"):
+            ChildProcessRunner().run(
+                self.spec("import time; print('data', flush=True); time.sleep(30)"),
+                progress_parser=fail,
+            )
+        self.assertLess(time.monotonic() - started, 3)
+
+    def test_escaped_descendant_cannot_hold_output_pipe_forever(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pid_path = Path(directory) / "escaped.pid"
+            started = time.monotonic()
+            with self.assertRaises(ProcessPipeDrainError):
+                ChildProcessRunner().run(
+                    self.spec(
+                        "import os, pathlib, sys, time; pid = os.fork(); "
+                        "(os.setsid(), pathlib.Path(sys.argv[1]).write_text(str(os.getpid())), "
+                        "time.sleep(30), os._exit(0)) if pid == 0 else os._exit(0)",
+                        pid_path,
+                        pipe_drain_timeout_seconds=0.1,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                )
+            self.assertLess(time.monotonic() - started, 3)
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline and not pid_path.exists():
+                time.sleep(0.01)
+            escaped_pid = int(pid_path.read_text(encoding="utf-8"))
+            try:
+                os.kill(escaped_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    def test_same_group_descendant_is_terminated_after_leader_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pid_path = Path(directory) / "descendant.pid"
+            with self.assertRaisesRegex(ProcessRunnerError, "descendant remained running"):
+                ChildProcessRunner().run(
+                    self.spec(
+                        "import os, pathlib, sys, time; pid = os.fork(); "
+                        "(os.close(1), os.close(2), pathlib.Path(sys.argv[1]).write_text(str(os.getpid())), "
+                        "time.sleep(30), os._exit(0)) if pid == 0 else os._exit(0)",
+                        pid_path,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                )
+            deadline = time.monotonic() + 1
+            descendant_text = ""
+            while time.monotonic() < deadline:
+                try:
+                    descendant_text = pid_path.read_text(encoding="utf-8").strip()
+                except FileNotFoundError:
+                    descendant_text = ""
+                if descendant_text:
+                    break
+                time.sleep(0.01)
+            if descendant_text:
+                descendant_pid = int(descendant_text)
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(descendant_pid, 0)
+
+    def test_artifact_resolver_failure_emits_one_warning(self) -> None:
+        sink = BoundedEventSink(maximum_events=50, maximum_bytes=100_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+
+        def fail() -> Path | None:
+            raise RuntimeError("probe failed")
+
+        ChildProcessRunner().run(
+            self.spec(
+                "import time; time.sleep(0.08)",
+                artifacts=(ProcessArtifactProbe("intermediate", resolver=fail),),
+                artifact_interval_seconds=0.02,
+            ),
+            run_context=context,
+        )
+
+        failures = [event for event in sink.snapshot().events if event.kind == "tool.artifact_probe_failed"]
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].data.failure.code, "artifact_resolver_failed")
+
+    def test_keyboard_interrupt_during_artifact_probe_terminates_child(self) -> None:
+        def interrupt() -> Path | None:
+            raise KeyboardInterrupt
+
+        started = time.monotonic()
+        with self.assertRaises(KeyboardInterrupt):
+            ChildProcessRunner().run(
+                self.spec(
+                    "import time; time.sleep(30)",
+                    artifacts=(ProcessArtifactProbe("intermediate", resolver=interrupt),),
+                    artifact_interval_seconds=0.02,
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            )
+        self.assertLess(time.monotonic() - started, 3)
+
+    def test_artifact_growth_resets_when_resolver_switches_files(self) -> None:
+        sink = BoundedEventSink(maximum_events=100, maximum_bytes=200_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first.bin"
+            second = Path(directory) / "second.bin"
+            first.write_bytes(b"x" * 100000)
+            second.write_bytes(b"x" * 200000)
+            calls = 0
+
+            def resolve() -> Path:
+                nonlocal calls
+                calls += 1
+                return first if calls == 1 else second
+
+            ChildProcessRunner().run(
+                self.spec(
+                    "import time; time.sleep(0.08)",
+                    artifacts=(ProcessArtifactProbe("intermediate", resolver=resolve),),
+                    artifact_interval_seconds=0.02,
+                ),
+                run_context=context,
+            )
+
+        second_events = [
+            event
+            for event in sink.snapshot().events
+            if event.kind == "tool.artifact" and event.data.artifact.location.value.endswith("second.bin")
+        ]
+        self.assertGreaterEqual(len(second_events), 1)
+        self.assertIsNone(second_events[0].data.artifact.growth_bytes_per_second)
+
+    def test_precancelled_context_does_not_spawn(self) -> None:
+        cancellation = CancellationToken()
+        cancellation.cancel()
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER), cancellation)
+
+        with self.assertRaises(ProcessCancelled):
+            ChildProcessRunner().run(self.spec("raise SystemExit(99)"), run_context=context)
+
+    @staticmethod
+    def spec(
+        source: str,
+        *arguments: object,
+        **overrides: object,
+    ) -> ProcessSpec:
+        values = {
+            "argv": (sys.executable, "-c", source, *(os.fspath(argument) for argument in arguments)),
+            "tool_id": "python-test-tool",
+            "display_name": "test tool",
+        }
+        values.update(overrides)
+        return ProcessSpec(**values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add one binary-safe child-process runner with concurrent stdout/stderr draining, bounded capture/tails, universal line framing, process-group teardown, cancellation escalation, silent heartbeats, progress, artifact growth, and terminal lifecycle events
- migrate the ordinary `run_command` path and MakeMKV inspection/ripping to the runner, including parsed robot progress, active MKV sampling, truncation policy, and in-flight cancellation
- extend the shared Python/Swift schema with last-output age and harden worker descendant cleanup so forced app cancellation does not orphan isolated helper groups
- document the migration boundary; FFmpeg probes, native MVC pipelines, worker event projection/raw diagnostic wiring, and legacy-log removal remain active follow-up work in #276/#277/#278

## Safety
- semantic events never include argv, environment values, or raw child output
- output, callback, and event queues are bounded; terminal events displace nonterminal events under saturation
- escaped or surviving descendants cannot hold a conversion pipe indefinitely
- compatibility callers that ignore output truncate safely; complete-output parsers opt into fail-on-truncation

## Validation
- `uv run python -m unittest discover -s tests -t .` — 635 passed, 2 skipped
- `uv run python scripts/native_app.py test` — 194 passed
- `uv run ruff format --check ...` — passed
- `uv run ruff check ...` — passed
- `uv run mypy ...` — passed
- JetBrains changed-files inspection — GREEN, 0 findings
- independent concurrency/privacy/API reviews completed and findings reconciled

Advances #276.