### PR TITLE
Route FFmpeg and ffprobe through structured process runner

### DIFF
--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -17,6 +18,11 @@ from bd_to_avp.process_runner import (
     ChildProcessRunner,
     DEFAULT_CAPTURE_LIMIT_BYTES,
     ProcessArtifactProbe,
+    ProcessCancelled,
+    ProcessExecutionError,
+    ProcessOutputSnapshot,
+    ProcessResult,
+    ProcessRunnerError,
     ProcessSpec,
 )
 from bd_to_avp.runtime import RunContext
@@ -99,6 +105,16 @@ def normalize_command_elements(command: list[Any]) -> list[str | Path | bytes]:
     return [str(item) if not isinstance(item, (str, bytes, Path)) else item for item in command if item is not None]
 
 
+def command_line_options(options: dict[str, object]) -> list[str]:
+    arguments: list[str] = []
+    for key in sorted(options):
+        arguments.append(f"-{key}")
+        value = options[key]
+        if value is not None:
+            arguments.append(str(value))
+    return arguments
+
+
 def run_command(
     commands: list[Any],
     command_name: str = "",
@@ -170,13 +186,154 @@ def default_tool_id(command: str | Path | bytes) -> str:
     return normalized
 
 
-def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, **kwargs) -> None:
-    kwargs["quiet"] = quiet
-    if config.output_commands:
-        output_commands_quoted = add_quotes_to_path_if_space(
-            ffmpeg.compile(stream_spec, cmd=config.FFMPEG_PATH.as_posix())
+def run_process_capture(
+    commands: list[Any],
+    command_name: str,
+    *,
+    tool_id: str,
+    merge_stderr: bool = False,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+    timeout_seconds: float | None = None,
+    capture_limit_bytes: int = DEFAULT_CAPTURE_LIMIT_BYTES,
+    capture_overflow: CaptureOverflowPolicy = CaptureOverflowPolicy.FAIL,
+    show_command: bool = True,
+) -> ProcessResult:
+    normalized_commands = normalize_command_elements(commands)
+    if show_command and config.output_commands:
+        print("Running command:\n" + " ".join(add_quotes_to_path_if_space(normalized_commands)))
+    return ChildProcessRunner().run(
+        ProcessSpec(
+            argv=tuple(normalized_commands),
+            tool_id=tool_id,
+            display_name=command_name,
+            env=os.environ.copy(),
+            merge_stderr=merge_stderr,
+            event_context=observability_context or ObservabilityContext(),
+            timeout_seconds=timeout_seconds,
+            capture_limit_bytes=capture_limit_bytes,
+            capture_overflow=capture_overflow,
+        ),
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+    )
+
+
+def ffmpeg_diagnostic_output(snapshot: ProcessOutputSnapshot | None) -> bytes:
+    if snapshot is None:
+        return b""
+    if not snapshot.truncated:
+        return snapshot.capture
+    return snapshot.capture + b"\n[... output truncated; final output follows ...]\n" + snapshot.tail
+
+
+def ffmpeg_called_process_error(error: subprocess.CalledProcessError, executable: str) -> ffmpeg.Error:
+    if isinstance(error, ProcessExecutionError):
+        stdout = ffmpeg_diagnostic_output(error.stdout_snapshot)
+        stderr = ffmpeg_diagnostic_output(error.stderr_snapshot)
+    else:
+        stdout = error.output.encode("utf-8", errors="replace") if isinstance(error.output, str) else error.output
+        stderr = error.stderr.encode("utf-8", errors="replace") if isinstance(error.stderr, str) else error.stderr
+    return ffmpeg.Error(executable, stdout or b"", stderr or b"")
+
+
+def ffmpeg_runner_error(error: ProcessRunnerError, executable: str) -> ffmpeg.Error:
+    stdout = ffmpeg_diagnostic_output(error.stdout_snapshot)
+    stderr = ffmpeg_diagnostic_output(error.stderr_snapshot)
+    message = str(error).encode("utf-8", errors="replace")
+    stderr = stderr + (b"\n" if stderr else b"") + message
+    return ffmpeg.Error(executable, stdout, stderr)
+
+
+def run_ffmpeg_capture(
+    stream_spec: Any,
+    *,
+    overwrite_output: bool = False,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> tuple[bytes, bytes]:
+    command = ffmpeg.compile(
+        stream_spec,
+        cmd=config.FFMPEG_PATH.as_posix(),
+        overwrite_output=overwrite_output,
+    )
+    try:
+        result = run_process_capture(
+            command,
+            "FFmpeg",
+            tool_id="ffmpeg",
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
         )
-        output_commands_str = " ".join(output_commands_quoted)
+    except subprocess.CalledProcessError as error:
+        raise ffmpeg_called_process_error(error, "ffmpeg") from error
+    except ProcessCancelled:
+        raise
+    except ProcessRunnerError as error:
+        raise ffmpeg_runner_error(error, "ffmpeg") from error
+    return result.stdout.capture, result.stderr.capture
+
+
+def run_ffprobe(
+    input_path: str | Path,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+    **kwargs: object,
+) -> dict[str, Any]:
+    command: list[Any] = [
+        config.FFPROBE_PATH,
+        "-show_format",
+        "-show_streams",
+        "-of",
+        "json",
+        *command_line_options(kwargs),
+        input_path,
+    ]
+    try:
+        result = run_process_capture(
+            command,
+            "FFprobe",
+            tool_id="ffprobe",
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+        )
+    except subprocess.CalledProcessError as error:
+        raise ffmpeg_called_process_error(error, "ffprobe") from error
+    except ProcessCancelled:
+        raise
+    except ProcessRunnerError as error:
+        raise ffmpeg_runner_error(error, "ffprobe") from error
+    return cast(dict[str, Any], json.loads(result.stdout.capture.decode("utf-8")))
+
+
+def run_ffmpeg_print_errors(
+    stream_spec: Any,
+    message: str,
+    quiet: bool = True,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+    **kwargs: object,
+) -> None:
+    del quiet
+    overwrite_output = bool(kwargs.pop("overwrite_output", False))
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(f"Unsupported FFmpeg execution options: {unexpected}")
+    command = ffmpeg.compile(
+        stream_spec,
+        cmd=config.FFMPEG_PATH.as_posix(),
+        overwrite_output=overwrite_output,
+    )
+    if config.output_commands:
+        output_commands_str = " ".join(add_quotes_to_path_if_space(command))
 
         print(f"Running command:\n{output_commands_str}")
     spinner = Spinner(message)
@@ -184,11 +341,27 @@ def run_ffmpeg_print_errors(stream_spec: Any, message: str, quiet: bool = True, 
     spinner_thread = threading.Thread(target=spinner.start, args=(spinner_update_func,))
     spinner_thread.start()
     try:
-        ffmpeg.run(stream_spec, cmd=config.FFMPEG_PATH.as_posix(), **kwargs)
+        try:
+            run_process_capture(
+                command,
+                message,
+                tool_id="ffmpeg",
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                show_command=False,
+            )
+        except subprocess.CalledProcessError as error:
+            raise ffmpeg_called_process_error(error, "ffmpeg") from error
+        except ProcessCancelled:
+            raise
+        except ProcessRunnerError as error:
+            raise ffmpeg_runner_error(error, "ffmpeg") from error
     except ffmpeg.Error as e:
         print("FFmpeg Error:")
-        print("STDOUT:", e.stdout.decode("utf-8") if e.stdout else "")
-        print("STDERR:", e.stderr.decode("utf-8") if e.stderr else "")
+        print("STDOUT:", e.stdout.decode("utf-8", errors="replace") if e.stdout else "")
+        print("STDERR:", e.stderr.decode("utf-8", errors="replace") if e.stderr else "")
         raise
     finally:
         spinner.stop(spinner_update_func)

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -9,7 +9,7 @@ from bd_to_avp.modules.config import (
     is_audio_m4a_preparation_enabled,
     is_direct_mvc_stream_enabled,
 )
-from bd_to_avp.modules.command import run_command, run_ffmpeg_print_errors
+from bd_to_avp.modules.command import run_command, run_ffmpeg_print_errors, run_ffprobe
 from bd_to_avp.modules.languages import language_name, normalize_source_language
 from bd_to_avp.modules.util import sorted_files_by_creation_filtered_on_suffix
 from bd_to_avp.modules.video_mode import VideoMode
@@ -201,7 +201,7 @@ def normalize_track_language(language_code: object) -> tuple[str, str]:
 
 
 def get_audio_stream_data(file_path: Path) -> list[dict[str, Any]]:
-    probe = ffmpeg.probe(str(file_path), cmd=config.FFPROBE_PATH.as_posix())
+    probe = run_ffprobe(file_path)
     if not probe or "streams" not in probe:
         return []
     audio_streams = [stream for stream in probe["streams"] if stream["codec_type"] == "audio"]

--- a/bd_to_avp/modules/disc.py
+++ b/bd_to_avp/modules/disc.py
@@ -5,12 +5,10 @@ from pathlib import Path
 from threading import Event
 from typing import Callable
 
-import ffmpeg
-
 from bd_to_avp.observability import ObservabilityProgress
 from bd_to_avp.modules.config import config, is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.file import find_largest_file_with_extensions, sanitize_filename
-from bd_to_avp.modules.command import run_command
+from bd_to_avp.modules.command import run_command, run_ffprobe
 from bd_to_avp.process_runner import CaptureOverflowPolicy, ProcessArtifactProbe
 from bd_to_avp.runtime import RunContext
 
@@ -186,7 +184,11 @@ def get_disc_and_mvc_video_info(
         filename = source_path.stem
         disc_info = DiscInfo(name=filename)
 
-        probe = ffmpeg.probe(source_path.as_posix(), cmd=config.FFPROBE_PATH.as_posix())
+        probe = run_ffprobe(
+            source_path,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+        )
         streams = probe.get("streams", [])
         ffmpeg_probe_output = next((stream for stream in streams if stream.get("codec_type") == "video"), None)
         if ffmpeg_probe_output is None:

--- a/bd_to_avp/modules/preview.py
+++ b/bd_to_avp/modules/preview.py
@@ -3,9 +3,7 @@ import math
 from dataclasses import dataclass
 from pathlib import Path
 
-import ffmpeg
-
-from bd_to_avp.modules.command import run_command
+from bd_to_avp.modules.command import run_command, run_ffprobe
 from bd_to_avp.modules.config import config
 from bd_to_avp.modules.preview_range import PreviewRange
 
@@ -125,9 +123,8 @@ def create_bounded_preview_source(
 
 
 def probe_media_timing(input_path: Path) -> MediaTiming:
-    probe = ffmpeg.probe(
-        input_path.as_posix(),
-        cmd=config.FFPROBE_PATH.as_posix(),
+    probe = run_ffprobe(
+        input_path,
         show_entries="format=start_time,duration:stream=codec_type,start_time",
     )
     format_data = probe.get("format", {})

--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -4,13 +4,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-import ffmpeg
 from babelfish import Language
 from bd_to_avp.vendor.pgsrip import Mkv, Options, pgsrip
 from bd_to_avp.vendor.pgsrip.mkv import MkvPgs
 
 from bd_to_avp.modules.config import config, Stage
-from bd_to_avp.modules.command import get_spinner_update_func, Spinner
+from bd_to_avp.modules.command import get_spinner_update_func, run_ffprobe, Spinner
 from bd_to_avp.modules.languages import (
     language_alpha2,
     language_name,
@@ -200,8 +199,8 @@ def subtitle_language_alpha2(language_code: str) -> str | None:
 
 
 def get_languages_in_mkv(mkv_path: Path) -> None | list[dict[str, Any]]:
-    mkv_info = ffmpeg.probe(str(mkv_path), cmd=config.FFPROBE_PATH.as_posix())
-    streams = mkv_info["streams"]
+    mkv_info = run_ffprobe(mkv_path)
+    streams = mkv_info.get("streams") or []
     subtitle_streams = [
         stream
         for stream in streams

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import signal
@@ -10,8 +11,8 @@ import ffmpeg
 
 from bd_to_avp.modules.config import Stage, config, is_direct_mvc_stream_enabled
 from bd_to_avp.modules.disc import DiscInfo
-from bd_to_avp.modules.command import cleanup_process, run_command
-from bd_to_avp.process_runner import CaptureOverflowPolicy
+from bd_to_avp.modules.command import cleanup_process, run_command, run_ffmpeg_capture, run_ffprobe
+from bd_to_avp.process_runner import CaptureOverflowPolicy, ProcessRunnerError
 
 
 def has_native_mvc_splitter() -> bool:
@@ -671,16 +672,11 @@ def detect_crop_parameters(
     )
 
     try:
-        _, stdout = ffmpeg.run(
-            stream,
-            cmd=config.FFMPEG_PATH.as_posix(),
-            capture_stdout=True,
-            capture_stderr=True,
-        )
-        output = stdout.decode("utf-8").split("\n")
+        _, stderr = run_ffmpeg_capture(stream)
+        output = stderr.decode("utf-8", errors="replace").splitlines()
     except ffmpeg.Error as e:
         print("FFmpeg Error:")
-        print(e.stderr.decode("utf-8"))
+        print(e.stderr.decode("utf-8", errors="replace"))
         raise
 
     crop_params: list[tuple[int, int, int, int]] = []
@@ -752,9 +748,8 @@ def create_av1_sbs_file(
 
 def get_video_color_depth(input_path: Path) -> int:
     try:
-        probe = ffmpeg.probe(
-            str(input_path),
-            cmd=config.FFPROBE_PATH.as_posix(),
+        probe = run_ffprobe(
+            input_path,
             select_streams="v:0",
             show_entries="stream=pix_fmt",
         )
@@ -764,7 +759,7 @@ def get_video_color_depth(input_path: Path) -> int:
             if "10le" in pix_fmt or "10be" in pix_fmt:
                 return 10
             return DiscInfo.color_depth
-    except ffmpeg.Error:
+    except (ffmpeg.Error, json.JSONDecodeError, ProcessRunnerError):
         print(f"Error getting video color depth, using default of {DiscInfo.color_depth}")
     return DiscInfo.color_depth
 

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -759,7 +759,7 @@ def get_video_color_depth(input_path: Path) -> int:
             if "10le" in pix_fmt or "10be" in pix_fmt:
                 return 10
             return DiscInfo.color_depth
-    except (ffmpeg.Error, json.JSONDecodeError, ProcessRunnerError):
+    except (ffmpeg.Error, json.JSONDecodeError, ProcessRunnerError, UnicodeDecodeError):
         print(f"Error getting video color depth, using default of {DiscInfo.color_depth}")
     return DiscInfo.color_depth
 

--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -1,10 +1,13 @@
 import os
 import stat
 from pathlib import Path
+from subprocess import SubprocessError
 
 from bd_to_avp.vendor.pgsrip.ocr import AppleVisionOcr, OcrError
+from bd_to_avp.modules.command import run_process_capture
 from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.process_runner import ProcessRunnerError
 
 
 class DependencyPreflightError(RuntimeError):
@@ -138,24 +141,20 @@ def verify_av1_encoder_ready() -> None:
     if config.video_mode is not VideoMode.AV1_SBS or config.start_stage.value > Stage.CREATE_LEFT_RIGHT_FILES.value:
         return
 
-    import subprocess
-
     try:
-        encoders = subprocess.run(
+        encoders = run_process_capture(
             [config.FFMPEG_PATH, "-hide_banner", "-encoders"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        ).stdout
-        bitstream_filters = subprocess.run(
+            "Verify FFmpeg AV1 encoders",
+            tool_id="ffmpeg",
+            timeout_seconds=10,
+        ).stdout.text()
+        bitstream_filters = run_process_capture(
             [config.FFMPEG_PATH, "-hide_banner", "-bsfs"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        ).stdout
-    except (OSError, subprocess.SubprocessError) as error:
+            "Verify FFmpeg AV1 bitstream filters",
+            tool_id="ffmpeg",
+            timeout_seconds=10,
+        ).stdout.text()
+    except (OSError, SubprocessError, ProcessRunnerError) as error:
         raise DependencyPreflightError("FFmpeg could not verify the required AV1 encoding support.") from error
     if "libsvtav1" not in encoders:
         raise DependencyPreflightError(

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -59,7 +59,18 @@ class CaptureOverflowPolicy(StrEnum):
 
 
 class ProcessRunnerError(RuntimeError):
-    pass
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.stdout_snapshot: ProcessOutputSnapshot | None = None
+        self.stderr_snapshot: ProcessOutputSnapshot | None = None
+
+    def attach_output(
+        self,
+        stdout_snapshot: ProcessOutputSnapshot,
+        stderr_snapshot: ProcessOutputSnapshot,
+    ) -> None:
+        self.stdout_snapshot = stdout_snapshot
+        self.stderr_snapshot = stderr_snapshot
 
 
 class ProcessCancelled(ProcessRunnerError):
@@ -180,6 +191,24 @@ class ProcessOutputSnapshot:
 
     def tail_text(self) -> str:
         return self.tail.decode("utf-8", errors="replace")
+
+
+class ProcessExecutionError(subprocess.CalledProcessError):
+    def __init__(
+        self,
+        returncode: int,
+        command: list[str | bytes],
+        stdout_snapshot: ProcessOutputSnapshot,
+        stderr_snapshot: ProcessOutputSnapshot,
+    ) -> None:
+        super().__init__(
+            returncode,
+            command,
+            output=stdout_snapshot.text(),
+            stderr=stderr_snapshot.text(),
+        )
+        self.stdout_snapshot = stdout_snapshot
+        self.stderr_snapshot = stderr_snapshot
 
 
 @dataclass(frozen=True)
@@ -832,6 +861,8 @@ class ChildProcessRunner:
                 terminal=True,
             )
             emitter.close()
+            if isinstance(pending_error, ProcessRunnerError):
+                pending_error.attach_output(stdout_snapshot, stderr_snapshot)
             raise pending_error
 
         if returncode != 0:
@@ -846,11 +877,11 @@ class ChildProcessRunner:
                 terminal=True,
             )
             emitter.close()
-            raise subprocess.CalledProcessError(
+            raise ProcessExecutionError(
                 returncode,
                 [os.fspath(argument) for argument in spec.argv],
-                output=stdout_snapshot.text(),
-                stderr=None if spec.merge_stderr else stderr_snapshot.text(),
+                stdout_snapshot,
+                stderr_snapshot,
             )
 
         emitter.emit("tool.completed", context=final_context, data=final_data, terminal=True)

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -200,12 +200,14 @@ class ProcessExecutionError(subprocess.CalledProcessError):
         command: list[str | bytes],
         stdout_snapshot: ProcessOutputSnapshot,
         stderr_snapshot: ProcessOutputSnapshot,
+        *,
+        merge_stderr: bool = False,
     ) -> None:
         super().__init__(
             returncode,
             command,
             output=stdout_snapshot.text(),
-            stderr=stderr_snapshot.text(),
+            stderr=None if merge_stderr else stderr_snapshot.text(),
         )
         self.stdout_snapshot = stdout_snapshot
         self.stderr_snapshot = stderr_snapshot
@@ -882,6 +884,7 @@ class ChildProcessRunner:
                 [os.fspath(argument) for argument in spec.argv],
                 stdout_snapshot,
                 stderr_snapshot,
+                merge_stderr=spec.merge_stderr,
             )
 
         emitter.emit("tool.completed", context=final_context, data=final_data, terminal=True)

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -10,6 +10,7 @@ from trakit.api import trakit
 from bd_to_avp.vendor.pgsrip.media import Media, Pgs
 from bd_to_avp.vendor.pgsrip.media_path import MediaPath
 from bd_to_avp.vendor.pgsrip.options import Options
+from bd_to_avp.modules.command import run_ffprobe
 from bd_to_avp.modules.config import config
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ class MkvTrack:
 class Mkv(Media):
     def __init__(self, path: str):
         try:
-            metadata = ffmpeg.probe(path, cmd=config.FFPROBE_PATH.as_posix())
+            metadata = run_ffprobe(path)
         except ffmpeg.Error as error:
             raise subprocess.CalledProcessError(
                 returncode=1,

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -1,6 +1,7 @@
+import json
 import logging
-import typing
 import subprocess
+import typing
 
 import ffmpeg
 from babelfish import Language
@@ -128,6 +129,12 @@ class Mkv(Media):
                 cmd=[config.FFPROBE_PATH, path],
                 output=error.stdout,
                 stderr=error.stderr,
+            ) from error
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=[config.FFPROBE_PATH, path],
+                stderr=str(error).encode("utf-8", errors="replace"),
             ) from error
         tracks = [MkvTrack.from_ffprobe_stream(t) for t in metadata.get("streams", [])]
         super().__init__(MediaPath(path), languages={t.language for t in tracks if t.type == "subtitles"})

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -91,8 +91,9 @@ single `stream_id`.
 1. Add the shared models, sinks, fixtures, and runtime context without changing
    conversion behavior.
 2. Replace fragmented child execution with one binary-safe streaming runner.
-   The ordinary command path and MakeMKV are migrated; FFmpeg probes and the
-   native MVC binary pipeline remain in the active child-tool workstream.
+   The ordinary command path, MakeMKV, FFmpeg graph execution, FFprobe metadata,
+   and FFmpeg capability checks are migrated. Binary subtitle extraction and
+   the native MVC linear pipeline remain in the active child-tool workstream.
 3. Project semantic runner activity into the worker protocol and bounded raw
    output into the diagnostic channel.
 4. Make the native diagnostic recorder and support bundle consume the shared

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,9 +1,18 @@
 import sys
+import threading
 import unittest
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 from bd_to_avp.modules import command
-from bd_to_avp.process_runner import ProcessOutputSnapshot, ProcessResult, ProcessStream
+from bd_to_avp.process_runner import (
+    ProcessCancelled,
+    ProcessExecutionError,
+    ProcessOutputLimitError,
+    ProcessOutputSnapshot,
+    ProcessResult,
+    ProcessStream,
+)
 
 
 class RunCommandTests(unittest.TestCase):
@@ -74,6 +83,153 @@ class RunCommandTests(unittest.TestCase):
             )
 
         self.assertEqual(len(output), 4096)
+
+    def test_ffprobe_uses_configured_binary_and_keyword_options(self) -> None:
+        result = ProcessResult(
+            tool_run_id="run-id",
+            returncode=0,
+            elapsed_ms=10,
+            stdout=ProcessOutputSnapshot(b'{"streams": []}', b"", 15, 15, 0, 0),
+            stderr=ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0),
+        )
+        with (
+            patch.object(command.config, "FFPROBE_PATH", Path("/tools/ffprobe")),
+            patch.object(command, "run_process_capture", return_value=result) as run,
+        ):
+            metadata = command.run_ffprobe("movie.mkv", select_streams="v:0")
+
+        self.assertEqual(metadata, {"streams": []})
+        process_command = run.call_args.args[0]
+        self.assertEqual(process_command[0], Path("/tools/ffprobe"))
+        self.assertIn("-select_streams", process_command)
+        self.assertIn("v:0", process_command)
+        self.assertEqual(process_command[-1], "movie.mkv")
+        self.assertEqual(run.call_args.kwargs["tool_id"], "ffprobe")
+
+    def test_ffprobe_preserves_ffmpeg_error_contract(self) -> None:
+        error = command.subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["ffprobe"],
+            output="out",
+            stderr="err",
+        )
+        with (
+            patch.object(command, "run_process_capture", side_effect=error),
+            self.assertRaises(command.ffmpeg.Error) as raised,
+        ):
+            command.run_ffprobe("movie.mkv")
+
+        self.assertEqual(raised.exception.stdout, b"out")
+        self.assertEqual(raised.exception.stderr, b"err")
+
+    def test_ffprobe_rejects_invalid_utf8(self) -> None:
+        result = ProcessResult(
+            tool_run_id="run-id",
+            returncode=0,
+            elapsed_ms=10,
+            stdout=ProcessOutputSnapshot(b"\xff", b"", 1, 1, 0, 1),
+            stderr=ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0),
+        )
+        with (
+            patch.object(command, "run_process_capture", return_value=result),
+            self.assertRaises(UnicodeDecodeError),
+        ):
+            command.run_ffprobe("movie.mkv")
+
+    def test_ffprobe_translates_runner_failures_but_preserves_cancellation(self) -> None:
+        runner_error = ProcessOutputLimitError("FFprobe exceeded its output capture limit")
+        runner_error.attach_output(
+            ProcessOutputSnapshot(b"partial", b"", 7, 7, 0, 0),
+            ProcessOutputSnapshot(b"details", b"", 7, 7, 0, 0),
+        )
+        with (
+            patch.object(command, "run_process_capture", side_effect=runner_error),
+            self.assertRaises(command.ffmpeg.Error) as raised,
+        ):
+            command.run_ffprobe("movie.mkv")
+
+        self.assertEqual(raised.exception.stdout, b"partial")
+        self.assertIn(b"details", raised.exception.stderr)
+        self.assertIn(b"capture limit", raised.exception.stderr)
+
+        cancellation = ProcessCancelled("cancelled")
+        with (
+            patch.object(command, "run_process_capture", side_effect=cancellation),
+            self.assertRaises(ProcessCancelled) as cancelled,
+        ):
+            command.run_ffprobe("movie.mkv")
+
+        self.assertIs(cancelled.exception, cancellation)
+
+    def test_ffmpeg_error_includes_truncated_prefix_and_final_tail(self) -> None:
+        error = ProcessExecutionError(
+            1,
+            ["ffmpeg"],
+            ProcessOutputSnapshot(b"out", b"", 3, 3, 0, 0),
+            ProcessOutputSnapshot(b"prefix", b"terminal error", 100, 6, 94, 0),
+        )
+        with (
+            patch.object(command.ffmpeg, "compile", return_value=["ffmpeg"]),
+            patch.object(command, "run_process_capture", side_effect=error),
+            self.assertRaises(command.ffmpeg.Error) as raised,
+        ):
+            command.run_ffmpeg_capture("stream")
+
+        self.assertEqual(raised.exception.stdout, b"out")
+        self.assertIn(b"output truncated", raised.exception.stderr)
+        self.assertTrue(raised.exception.stderr.endswith(b"terminal error"))
+
+    def test_ffmpeg_capture_uses_compiled_command_and_separate_streams(self) -> None:
+        result = ProcessResult(
+            tool_run_id="run-id",
+            returncode=0,
+            elapsed_ms=10,
+            stdout=ProcessOutputSnapshot(b"out", b"", 3, 3, 0, 0),
+            stderr=ProcessOutputSnapshot(b"err", b"", 3, 3, 0, 0),
+        )
+        compiled = ["/tools/ffmpeg", "-i", "movie.mkv", "null"]
+        with (
+            patch.object(command.ffmpeg, "compile", return_value=compiled) as compile_command,
+            patch.object(command, "run_process_capture", return_value=result) as run,
+        ):
+            stdout, stderr = command.run_ffmpeg_capture("stream", overwrite_output=True)
+
+        self.assertEqual((stdout, stderr), (b"out", b"err"))
+        compile_command.assert_called_once_with(
+            "stream",
+            cmd=command.config.FFMPEG_PATH.as_posix(),
+            overwrite_output=True,
+        )
+        self.assertEqual(run.call_args.args[0], compiled)
+        self.assertEqual(run.call_args.kwargs["tool_id"], "ffmpeg")
+
+    def test_ffmpeg_spinner_wrapper_forwards_runtime_context(self) -> None:
+        result = ProcessResult(
+            tool_run_id="run-id",
+            returncode=0,
+            elapsed_ms=10,
+            stdout=ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0),
+            stderr=ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0),
+        )
+        compiled = ["/tools/ffmpeg", "-i", "movie.mkv", "out.mov"]
+        run_context = Mock()
+        cancellation_event = threading.Event()
+        with (
+            patch.object(command.ffmpeg, "compile", return_value=compiled),
+            patch.object(command, "run_process_capture", return_value=result) as run,
+            patch.object(command.Spinner, "start"),
+            patch.object(command.Spinner, "stop"),
+        ):
+            command.run_ffmpeg_print_errors(
+                "stream",
+                "encode",
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                overwrite_output=True,
+            )
+
+        self.assertIs(run.call_args.kwargs["run_context"], run_context)
+        self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,9 +1,8 @@
 import sys
-import subprocess
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from bd_to_avp import preflight
 from bd_to_avp.modules.config import Stage
@@ -169,14 +168,10 @@ class DependencyPreflightTests(unittest.TestCase):
             patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
             patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
             patch(
-                "subprocess.run",
+                "bd_to_avp.preflight.run_process_capture",
                 side_effect=[
-                    subprocess.CompletedProcess(
-                        args=[],
-                        returncode=0,
-                        stdout=" V..... libsvtav1 SVT-AV1 encoder\n",
-                    ),
-                    subprocess.CompletedProcess(args=[], returncode=0, stdout="av1_metadata\n"),
+                    Mock(stdout=Mock(text=Mock(return_value=" V..... libsvtav1 SVT-AV1 encoder\n"))),
+                    Mock(stdout=Mock(text=Mock(return_value="av1_metadata\n"))),
                 ],
             ) as run,
         ):
@@ -190,8 +185,8 @@ class DependencyPreflightTests(unittest.TestCase):
             patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
             patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
             patch(
-                "subprocess.run",
-                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=" V..... libaom-av1\n"),
+                "bd_to_avp.preflight.run_process_capture",
+                return_value=Mock(stdout=Mock(text=Mock(return_value=" V..... libaom-av1\n"))),
             ),
             self.assertRaisesRegex(preflight.DependencyPreflightError, "libsvtav1"),
         ):
@@ -203,10 +198,10 @@ class DependencyPreflightTests(unittest.TestCase):
             patch.object(preflight.config, "start_stage", Stage.CREATE_LEFT_RIGHT_FILES),
             patch.object(preflight.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
             patch(
-                "subprocess.run",
+                "bd_to_avp.preflight.run_process_capture",
                 side_effect=[
-                    subprocess.CompletedProcess(args=[], returncode=0, stdout=" V..... libsvtav1\n"),
-                    subprocess.CompletedProcess(args=[], returncode=0, stdout="extract_extradata\n"),
+                    Mock(stdout=Mock(text=Mock(return_value=" V..... libsvtav1\n"))),
+                    Mock(stdout=Mock(text=Mock(return_value="extract_extradata\n"))),
                 ],
             ),
             self.assertRaisesRegex(preflight.DependencyPreflightError, "av1_metadata"),

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -53,7 +53,7 @@ class PreviewSourceTests(unittest.TestCase):
             with (
                 patch("bd_to_avp.modules.preview.run_command", side_effect=run),
                 patch(
-                    "bd_to_avp.modules.preview.ffmpeg.probe",
+                    "bd_to_avp.modules.preview.run_ffprobe",
                     side_effect=[
                         {
                             "format": {"start_time": "0", "duration": "7200"},

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -121,6 +121,13 @@ class ChildProcessRunnerTests(unittest.TestCase):
         self.assertTrue(raised.exception.stderr_snapshot.truncated)
         self.assertTrue(raised.exception.stderr_snapshot.tail.endswith(b"END"))
 
+    def test_nonzero_merged_output_preserves_called_process_error_contract(self) -> None:
+        with self.assertRaises(ProcessExecutionError) as raised:
+            ChildProcessRunner().run(self.spec("import sys; print('error', file=sys.stderr); sys.exit(2)"))
+
+        self.assertIn("error", raised.exception.output)
+        self.assertIsNone(raised.exception.stderr)
+
     def test_rejects_unmanaged_stdin_pipe(self) -> None:
         with self.assertRaisesRegex(ValueError, "stdin=subprocess.PIPE"):
             self.spec("pass", stdin=-1)

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -13,6 +13,7 @@ from bd_to_avp.process_runner import (
     ChildProcessRunner,
     ProcessArtifactProbe,
     ProcessCancelled,
+    ProcessExecutionError,
     ProcessOutputLimitError,
     ProcessPipeDrainError,
     ProcessRunnerError,
@@ -91,13 +92,34 @@ class ChildProcessRunnerTests(unittest.TestCase):
         self.assertEqual(lines, ["first", "second"])
 
     def test_capture_limit_fails_without_unbounded_memory(self) -> None:
-        with self.assertRaises(ProcessOutputLimitError):
+        with self.assertRaises(ProcessOutputLimitError) as raised:
             ChildProcessRunner().run(
                 self.spec(
                     "import os; os.write(1, b'x' * 200000)",
                     capture_limit_bytes=32 * 1024,
                 )
             )
+
+        self.assertIsNotNone(raised.exception.stdout_snapshot)
+        assert raised.exception.stdout_snapshot is not None
+        self.assertTrue(raised.exception.stdout_snapshot.truncated)
+
+    def test_nonzero_exit_preserves_raw_bounded_output_snapshots(self) -> None:
+        with self.assertRaises(ProcessExecutionError) as raised:
+            ChildProcessRunner().run(
+                self.spec(
+                    "import os, sys; os.write(2, b'\\xff' + b'x' * 10000 + b'END'); sys.exit(2)",
+                    merge_stderr=False,
+                    capture_limit_bytes=4096,
+                    tail_limit_bytes=1024,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            )
+
+        self.assertEqual(raised.exception.returncode, 2)
+        self.assertEqual(raised.exception.stderr_snapshot.capture[:1], b"\xff")
+        self.assertTrue(raised.exception.stderr_snapshot.truncated)
+        self.assertTrue(raised.exception.stderr_snapshot.tail.endswith(b"END"))
 
     def test_rejects_unmanaged_stdin_pipe(self) -> None:
         with self.assertRaisesRegex(ValueError, "stdin=subprocess.PIPE"):

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -149,6 +149,12 @@ class SubtitleRipOptionsTests(unittest.TestCase):
 
 
 class SubtitleStreamDetectionTests(unittest.TestCase):
+    def test_missing_streams_returns_no_subtitles(self) -> None:
+        with patch.object(sub, "run_ffprobe", return_value={}):
+            tracks = get_languages_in_mkv(Path("movie.mkv"))
+
+        self.assertIsNone(tracks)
+
     def test_language_detection_uses_only_pgs_streams(self) -> None:
         probe = {
             "streams": [
@@ -169,7 +175,7 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
             ]
         }
 
-        with patch.object(sub.ffmpeg, "probe", return_value=probe):
+        with patch.object(sub, "run_ffprobe", return_value=probe):
             tracks = get_languages_in_mkv(Path("movie.mkv"))
 
         self.assertEqual(tracks, [{"index": 3, "language": "eng", "default": 0, "forced": 1}])
@@ -187,7 +193,7 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
             ]
         }
 
-        with patch.object(sub.ffmpeg, "probe", return_value=probe):
+        with patch.object(sub, "run_ffprobe", return_value=probe):
             tracks = get_languages_in_mkv(Path("movie.mkv"))
 
         self.assertEqual(tracks, [{"index": 3, "language": "deu", "default": 0, "forced": 0}])
@@ -218,7 +224,7 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
             ]
         }
 
-        with patch.object(sub.ffmpeg, "probe", return_value=probe):
+        with patch.object(sub, "run_ffprobe", return_value=probe):
             tracks = get_languages_in_mkv(Path("movie.mkv"))
 
         self.assertEqual([track["language"] for track in tracks or []], ["und", "und", "und"])

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -94,13 +94,10 @@ class ToolResolutionTests(unittest.TestCase):
 class MkvToolPathTests(unittest.TestCase):
     def test_mkv_metadata_uses_configured_ffprobe_path(self) -> None:
         metadata: dict[str, object] = {"streams": []}
-        with (
-            patch.object(mkv.config, "FFPROBE_PATH", Path("/tools/ffprobe")),
-            patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata) as probe,
-        ):
+        with patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", return_value=metadata) as probe:
             mkv.Mkv("movie.mkv")
 
-        probe.assert_called_once_with("movie.mkv", cmd="/tools/ffprobe")
+        probe.assert_called_once_with("movie.mkv")
 
     def test_mkv_metadata_maps_ffprobe_pgs_streams_to_existing_track_model(self) -> None:
         metadata = {
@@ -116,7 +113,7 @@ class MkvToolPathTests(unittest.TestCase):
             ]
         }
 
-        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+        with patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", return_value=metadata):
             movie = mkv.Mkv("movie.mkv")
 
         video_track, subtitle_track = movie.tracks
@@ -162,7 +159,7 @@ class MkvToolPathTests(unittest.TestCase):
             ]
         }
 
-        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+        with patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", return_value=metadata):
             movie = mkv.Mkv("movie.mkv")
 
         selected = list(movie.get_selected_pgs_tracks(mkv.Options(overwrite=True, one_per_lang=False)))
@@ -173,7 +170,7 @@ class MkvToolPathTests(unittest.TestCase):
         error = mkv.ffmpeg.Error("ffprobe", b"out", b"err")
         with (
             patch.object(mkv.config, "FFPROBE_PATH", Path("/tools/ffprobe")),
-            patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", side_effect=error),
+            patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", side_effect=error),
             self.assertRaises(subprocess.CalledProcessError) as raised,
         ):
             mkv.Mkv("movie.mkv")
@@ -201,7 +198,7 @@ class MkvToolPathTests(unittest.TestCase):
             ]
         }
 
-        with patch("bd_to_avp.vendor.pgsrip.mkv.ffmpeg.probe", return_value=metadata):
+        with patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", return_value=metadata):
             movie = mkv.Mkv("movie.mkv")
 
         selected = list(movie.get_selected_pgs_tracks(mkv.Options(overwrite=True, one_per_lang=False)))

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import tempfile
@@ -177,6 +178,21 @@ class MkvToolPathTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.cmd, [Path("/tools/ffprobe"), "movie.mkv"])
         self.assertEqual(raised.exception.stderr, b"err")
+
+    def test_mkv_metadata_wraps_malformed_ffprobe_output_as_called_process_error(self) -> None:
+        errors = [
+            json.JSONDecodeError("bad metadata", "", 0),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad metadata"),
+        ]
+        for error in errors:
+            with (
+                self.subTest(error=type(error).__name__),
+                patch("bd_to_avp.vendor.pgsrip.mkv.run_ffprobe", side_effect=error),
+                self.assertRaises(subprocess.CalledProcessError) as raised,
+            ):
+                mkv.Mkv("movie.mkv")
+
+            self.assertIn(b"bad metadata", raised.exception.stderr)
 
     def test_pgs_selection_ignores_non_pgs_subtitle_streams(self) -> None:
         metadata = {

--- a/tests/test_video_helpers.py
+++ b/tests/test_video_helpers.py
@@ -15,6 +15,12 @@ class VideoProbeTests(unittest.TestCase):
 
         self.assertEqual(color_depth, video.DiscInfo.color_depth)
 
+    def test_invalid_ffprobe_utf8_uses_default_color_depth(self) -> None:
+        with patch.object(video, "run_ffprobe", side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")):
+            color_depth = video.get_video_color_depth(Path("movie.mkv"))
+
+        self.assertEqual(color_depth, video.DiscInfo.color_depth)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_video_helpers.py
+++ b/tests/test_video_helpers.py
@@ -1,0 +1,20 @@
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import video
+
+
+class VideoProbeTests(unittest.TestCase):
+    def test_malformed_ffprobe_output_uses_default_color_depth(self) -> None:
+        malformed = json.JSONDecodeError("bad metadata", "", 0)
+
+        with patch.object(video, "run_ffprobe", side_effect=malformed):
+            color_depth = video.get_video_color_depth(Path("movie.mkv"))
+
+        self.assertEqual(color_depth, video.DiscInfo.color_depth)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route runtime FFmpeg, ffprobe, crop detection, subtitle metadata, and capability probes through the shared bounded process runner
- preserve cancellation and FFmpeg error contracts while retaining raw bounded prefix/tail diagnostics on failures
- add strict metadata decoding, malformed-output fallbacks, and focused regression coverage

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/release.py validate`
- `uv run python -m unittest discover -s tests -t .` (648 passed, 2 skipped)
- `uv run python scripts/native_app.py test` (194 passed)

Part of #276. The remaining child-tool slice is binary PGS extraction plus the native MVC linear pipeline.