### PR TITLE
Supervise native MVC and PGS binary pipelines

### DIFF
--- a/bd_to_avp/modules/command.py
+++ b/bd_to_avp/modules/command.py
@@ -6,7 +6,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, ClassVar, cast
+from typing import Any, BinaryIO, Callable, ClassVar, cast
 
 import ffmpeg
 
@@ -196,6 +196,8 @@ def run_process_capture(
     cancellation_event: threading.Event | None = None,
     observability_context: ObservabilityContext | None = None,
     timeout_seconds: float | None = None,
+    stdout: int | BinaryIO = subprocess.PIPE,
+    artifacts: tuple[ProcessArtifactProbe, ...] = (),
     capture_limit_bytes: int = DEFAULT_CAPTURE_LIMIT_BYTES,
     capture_overflow: CaptureOverflowPolicy = CaptureOverflowPolicy.FAIL,
     show_command: bool = True,
@@ -210,7 +212,9 @@ def run_process_capture(
             display_name=command_name,
             env=os.environ.copy(),
             merge_stderr=merge_stderr,
+            stdout=stdout,
             event_context=observability_context or ObservabilityContext(),
+            artifacts=artifacts,
             timeout_seconds=timeout_seconds,
             capture_limit_bytes=capture_limit_bytes,
             capture_overflow=capture_overflow,

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -5,14 +5,28 @@ import signal
 import stat
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 import ffmpeg
 
+from bd_to_avp.observability import ObservabilityContext
 from bd_to_avp.modules.config import Stage, config, is_direct_mvc_stream_enabled
 from bd_to_avp.modules.disc import DiscInfo
-from bd_to_avp.modules.command import cleanup_process, run_command, run_ffmpeg_capture, run_ffprobe
-from bd_to_avp.process_runner import CaptureOverflowPolicy, ProcessRunnerError
+from bd_to_avp.modules.command import run_command, run_ffmpeg_capture, run_ffprobe
+from bd_to_avp.process_runner import (
+    CaptureOverflowPolicy,
+    ChildProcessRunner,
+    ProcessArtifactProbe,
+    ProcessExecutionError,
+    ProcessPipelineError,
+    ProcessPipelineRunner,
+    ProcessPipelineStage,
+    ProcessRunnerError,
+    ProcessSpec,
+    ProcessTimeoutError,
+)
+from bd_to_avp.runtime import RunContext
 
 
 def has_native_mvc_splitter() -> bool:
@@ -51,7 +65,6 @@ class NativeMvcSplitError(RuntimeError):
 
 
 NATIVE_MVC_PROBE_TIMEOUT_SECONDS = 30
-NATIVE_MVC_PROCESS_EXIT_TIMEOUT_SECONDS = 5
 NATIVE_MVC_RETRY_SIGNALS = {
     signal.SIGABRT,
     signal.SIGBUS,
@@ -234,9 +247,20 @@ def split_mvc_to_stereo_native(
     right_output_path: Path,
     disc_info: DiscInfo,
     crop_params: str,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
 ) -> tuple[Path, Path]:
     ffmpeg_command = generate_native_mvc_ffmpeg_command(left_output_path, right_output_path, disc_info, crop_params)
-    run_native_mvc_encoding(video_input_path, (left_output_path, right_output_path), ffmpeg_command)
+    run_native_mvc_encoding(
+        video_input_path,
+        (left_output_path, right_output_path),
+        ffmpeg_command,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        observability_context=observability_context,
+    )
     return left_output_path, right_output_path
 
 
@@ -245,9 +269,20 @@ def encode_mvc_to_av1_sbs_native(
     output_path: Path,
     disc_info: DiscInfo,
     crop_params: str,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
 ) -> Path:
     ffmpeg_command = generate_native_mvc_av1_command(output_path, disc_info, crop_params)
-    run_native_mvc_encoding(video_input_path, (output_path,), ffmpeg_command)
+    run_native_mvc_encoding(
+        video_input_path,
+        (output_path,),
+        ffmpeg_command,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        observability_context=observability_context,
+    )
     return output_path
 
 
@@ -255,21 +290,23 @@ def run_native_mvc_encoding(
     video_input_path: Path,
     output_paths: tuple[Path, ...],
     ffmpeg_command: list[str],
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
 ) -> None:
-    primary_output_path = output_paths[0]
     stream_from_container = should_stream_mvc_from_container(video_input_path)
     producer_command = generate_mvc_annex_b_stream_command(video_input_path) if stream_from_container else None
     native_input_path = Path("-") if stream_from_container else prepare_native_mvc_input(video_input_path)
-    splitter_log_path = primary_output_path.with_suffix(".native_mvc.log")
-    ffmpeg_log_path = primary_output_path.with_suffix(".native_ffmpeg.log")
-    producer_log_path = primary_output_path.with_suffix(".mvc_extract.log")
     try:
         skip_multithreaded_attempt = False
         if not stream_from_container and should_probe_native_multithread_splitter():
             print("Checking native MVC splitter with a short multi-threaded probe.")
             skip_multithreaded_attempt = native_multithread_splitter_probe_crashed(
                 native_input_path,
-                splitter_log_path,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
             )
             if not skip_multithreaded_attempt:
                 print("Native MVC splitter probe passed; proceeding with multi-threaded mode.")
@@ -280,21 +317,23 @@ def run_native_mvc_encoding(
                 run_native_mvc_split_attempt(
                     native_input_path,
                     ffmpeg_command,
-                    ffmpeg_log_path,
-                    splitter_log_path,
+                    output_paths,
                     producer_command=producer_command,
-                    producer_log_path=producer_log_path,
                     single_threaded=True,
+                    run_context=run_context,
+                    cancellation_event=cancellation_event,
+                    observability_context=observability_context,
                 )
             else:
                 run_native_mvc_split_attempt(
                     native_input_path,
                     ffmpeg_command,
-                    ffmpeg_log_path,
-                    splitter_log_path,
+                    output_paths,
                     producer_command=producer_command,
-                    producer_log_path=producer_log_path,
                     single_threaded=False,
+                    run_context=run_context,
+                    cancellation_event=cancellation_event,
+                    observability_context=observability_context,
                 )
         except subprocess.CalledProcessError as error:
             if not native_splitter_died_by_signal(error):
@@ -306,70 +345,65 @@ def run_native_mvc_encoding(
             run_native_mvc_split_attempt(
                 native_input_path,
                 ffmpeg_command,
-                ffmpeg_log_path,
-                splitter_log_path,
+                output_paths,
                 producer_command=producer_command,
-                producer_log_path=producer_log_path,
                 single_threaded=True,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
             )
     except subprocess.CalledProcessError as error:
         if native_splitter_should_report_crash(error):
-            raise NativeMvcSplitError(build_native_splitter_failure_message(error, splitter_log_path)) from error
+            raise NativeMvcSplitError(build_native_splitter_failure_message(error)) from error
         raise
     finally:
         if not stream_from_container and native_input_path != video_input_path:
             native_input_path.unlink(missing_ok=True)
 
 
-def native_multithread_splitter_probe_crashed(native_input_path: Path, splitter_log_path: Path) -> bool:
+def native_multithread_splitter_probe_crashed(
+    native_input_path: Path,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> bool:
     splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=False)
-    splitter_process = None
-    with open(splitter_log_path, "ab") as splitter_log:
-        splitter_log.write(b"\n--- Native MVC split probe: multi-threaded ---\n")
-        try:
-            splitter_process = subprocess.Popen(
-                splitter_command,
+    try:
+        ChildProcessRunner().run(
+            ProcessSpec(
+                argv=tuple(splitter_command),
+                tool_id="edge264",
+                display_name="Native MVC splitter probe",
+                env=os.environ.copy(),
                 stdout=subprocess.DEVNULL,
-                stderr=splitter_log,
-            )
-            splitter_process.wait(timeout=NATIVE_MVC_PROBE_TIMEOUT_SECONDS)
-        except subprocess.TimeoutExpired:
-            splitter_log.write(b"\n--- Probe timed out; process stayed alive, continuing multi-threaded ---\n")
-            if splitter_process:
-                cleanup_process(splitter_process)
-                try:
-                    splitter_process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    splitter_process.kill()
-                    splitter_process.wait(timeout=2)
-            return False
-
-    if splitter_process.returncode == 0:
-        return False
-    if splitter_process.returncode < 0:
-        if native_splitter_returncode_is_retry_signal(splitter_process.returncode):
-            return True
-        raise subprocess.CalledProcessError(
-            splitter_process.returncode,
-            splitter_command,
-            output=splitter_log_path.read_text(errors="replace"),
+                merge_stderr=False,
+                event_context=observability_context or ObservabilityContext(),
+                timeout_seconds=NATIVE_MVC_PROBE_TIMEOUT_SECONDS,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            ),
+            run_context=run_context,
+            cancellation_event=cancellation_event,
         )
-    raise subprocess.CalledProcessError(
-        splitter_process.returncode,
-        splitter_command,
-        output=splitter_log_path.read_text(errors="replace"),
-    )
+    except ProcessTimeoutError:
+        return False
+    except ProcessExecutionError as error:
+        if native_splitter_returncode_is_retry_signal(error.returncode):
+            return True
+        raise
+    return False
 
 
 def run_native_mvc_split_attempt(
     native_input_path: Path,
     ffmpeg_command: list[str],
-    ffmpeg_log_path: Path,
-    splitter_log_path: Path,
+    output_paths: tuple[Path, ...],
     *,
     producer_command: list[str | Path] | None = None,
-    producer_log_path: Path | None = None,
     single_threaded: bool,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
 ) -> None:
     splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=single_threaded)
     attempt_name = "single-threaded" if single_threaded else "multi-threaded"
@@ -384,120 +418,100 @@ def run_native_mvc_split_attempt(
             command_text = f"{producer_command_text} | {command_text}"
         print(f"Running command:\n{command_text}")
 
-    producer_process = None
-    splitter_process = None
-    ffmpeg_process = None
-    try:
-        producer_log_context = (
-            open(producer_log_path, "a") if producer_command and producer_log_path else open(os.devnull, "w")
-        )
-        with (
-            open(ffmpeg_log_path, "a") as ffmpeg_log,
-            open(splitter_log_path, "ab") as splitter_log,
-            producer_log_context as producer_log,
-        ):
-            ffmpeg_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n")
-            splitter_log.write(f"\n--- Native MVC split attempt: {attempt_name} ---\n".encode())
-            if producer_command:
-                producer_log.write(f"\n--- MVC extraction stream attempt: {attempt_name} ---\n")
-                producer_process = subprocess.Popen(
-                    producer_command,
-                    stdout=subprocess.PIPE,
-                    stderr=producer_log,
+    event_context = observability_context or ObservabilityContext()
+    stages: list[ProcessPipelineStage] = []
+    if producer_command:
+        stages.append(
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(producer_command),
+                    tool_id="ffmpeg",
+                    display_name=f"Extract MVC stream ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
                 )
-            splitter_process = subprocess.Popen(
-                splitter_command,
-                stdin=producer_process.stdout if producer_process else None,
-                stdout=subprocess.PIPE,
-                stderr=splitter_log,
             )
-
-            if producer_process and producer_process.stdout:
-                producer_process.stdout.close()
-            ffmpeg_process = subprocess.Popen(
-                ffmpeg_command,
-                stdin=splitter_process.stdout,
-                stdout=ffmpeg_log,
-                stderr=subprocess.STDOUT,
-                text=False,
-            )
-
-            if splitter_process.stdout:
-                splitter_process.stdout.close()
-
-            ffmpeg_process.wait()
-            splitter_failed_before_cleanup = splitter_process.poll() is not None
-            producer_exited_before_cleanup = producer_process is not None and producer_process.poll() is not None
-            if ffmpeg_process.returncode != 0:
-                terminate_native_pipeline_process(splitter_process)
-                if producer_process:
-                    terminate_native_pipeline_process(producer_process)
-            else:
-                wait_for_native_pipeline_process(splitter_process)
-            if producer_process:
-                wait_for_native_pipeline_process(producer_process)
-
-        if (
-            splitter_process.returncode != 0
-            and splitter_failed_before_cleanup
-            and native_splitter_returncode_is_retry_signal(splitter_process.returncode)
-        ):
-            raise subprocess.CalledProcessError(
-                splitter_process.returncode,
-                splitter_command,
-                output=splitter_log_path.read_text(errors="replace"),
-            )
-        if (
-            producer_process
-            and producer_process.returncode != 0
-            and producer_exited_before_cleanup
-            and producer_process.returncode != -signal.SIGPIPE
-        ):
-            assert producer_command is not None
-            raise subprocess.CalledProcessError(
-                producer_process.returncode,
-                producer_command,
-                output=producer_log_path.read_text(errors="replace") if producer_log_path else "",
-            )
-        if ffmpeg_process.returncode != 0:
-            raise subprocess.CalledProcessError(ffmpeg_process.returncode, ffmpeg_command)
-        if splitter_process.returncode != 0:
-            raise subprocess.CalledProcessError(
-                splitter_process.returncode,
-                splitter_command,
-                output=splitter_log_path.read_text(errors="replace"),
-            )
-        if producer_process and producer_process.returncode != 0:
-            assert producer_command is not None
-            raise subprocess.CalledProcessError(
-                producer_process.returncode,
-                producer_command,
-                output=producer_log_path.read_text(errors="replace") if producer_log_path else "",
-            )
-    finally:
-        if producer_process:
-            terminate_native_pipeline_process(producer_process)
-        if splitter_process:
-            terminate_native_pipeline_process(splitter_process)
-        if ffmpeg_process:
-            terminate_native_pipeline_process(ffmpeg_process)
-
-
-def wait_for_native_pipeline_process(process: subprocess.Popen) -> None:
+        )
+    stages.extend(
+        (
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(splitter_command),
+                    tool_id="edge264",
+                    display_name=f"Split native MVC stream ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            ),
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(ffmpeg_command),
+                    tool_id="ffmpeg",
+                    display_name=f"Encode stereo video ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    artifacts=tuple(
+                        ProcessArtifactProbe(f"video_output_{index}", path=output_path)
+                        for index, output_path in enumerate(output_paths, start=1)
+                    ),
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            ),
+        )
+    )
     try:
-        process.wait(timeout=NATIVE_MVC_PROCESS_EXIT_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        terminate_native_pipeline_process(process)
+        ProcessPipelineRunner(exit_grace_seconds=5).run(
+            tuple(stages),
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+        )
+    except ProcessPipelineError as error:
+        selected_error = select_native_pipeline_error(error, producer_present=producer_command is not None)
+        if selected_error is not None:
+            raise selected_error from error
 
 
-def terminate_native_pipeline_process(process: subprocess.Popen) -> None:
-    if process.poll() is None:
-        process.terminate()
-    try:
-        process.wait(timeout=NATIVE_MVC_PROCESS_EXIT_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait(timeout=NATIVE_MVC_PROCESS_EXIT_TIMEOUT_SECONDS)
+def select_native_pipeline_error(
+    pipeline_error: ProcessPipelineError,
+    *,
+    producer_present: bool,
+) -> BaseException | None:
+    stages = pipeline_error.result.stages
+    producer_index = 0 if producer_present else None
+    splitter_index = 1 if producer_present else 0
+    ffmpeg_index = 2 if producer_present else 1
+    producer_stage = stages[producer_index] if producer_index is not None else None
+    splitter_stage = stages[splitter_index]
+    ffmpeg_stage = stages[ffmpeg_index]
+
+    if (
+        isinstance(splitter_stage.error, subprocess.CalledProcessError)
+        and splitter_stage.completed_before_final
+        and native_splitter_died_by_signal(splitter_stage.error)
+    ):
+        return splitter_stage.error
+    if (
+        producer_stage is not None
+        and producer_stage.completed_before_final
+        and producer_stage.error is not None
+        and not process_error_is_sigpipe(producer_stage.error)
+    ):
+        return producer_stage.error
+    if ffmpeg_stage.error is not None:
+        return ffmpeg_stage.error
+    if splitter_stage.error is not None:
+        return splitter_stage.error
+    if producer_stage is not None and producer_stage.error is not None:
+        if process_error_is_sigpipe(producer_stage.error):
+            return None
+        return producer_stage.error
+    return None
+
+
+def process_error_is_sigpipe(error: BaseException) -> bool:
+    return isinstance(error, subprocess.CalledProcessError) and error.returncode == -signal.SIGPIPE
 
 
 def native_splitter_died_by_signal(error: subprocess.CalledProcessError) -> bool:
@@ -521,7 +535,7 @@ def native_splitter_should_report_crash(error: subprocess.CalledProcessError) ->
     return error.returncode > 0 or native_splitter_died_by_signal(error)
 
 
-def build_native_splitter_failure_message(error: subprocess.CalledProcessError, splitter_log_path: Path) -> str:
+def build_native_splitter_failure_message(error: subprocess.CalledProcessError) -> str:
     if error.returncode >= 0:
         signal_name = f"exit code {error.returncode}"
     else:
@@ -533,7 +547,7 @@ def build_native_splitter_failure_message(error: subprocess.CalledProcessError, 
         "The native MVC splitter crashed while decoding this MVC video stream "
         f"({signal_name}). This usually means the bundled native decoder hit a Blu-ray MVC bitstream it does not "
         "currently support. The source may need a splitter update or a future fallback path. "
-        f"Details were written to {splitter_log_path}."
+        "Please submit a diagnostic report so the bounded splitter and encoder evidence can be reviewed."
     )
 
 
@@ -553,9 +567,6 @@ def split_mvc_to_stereo(
             crop_params,
         )
         if not config.keep_files:
-            left_output_path.with_suffix(".native_ffmpeg.log").unlink(missing_ok=True)
-            left_output_path.with_suffix(".native_mvc.log").unlink(missing_ok=True)
-            left_output_path.with_suffix(".mvc_extract.log").unlink(missing_ok=True)
             if not should_stream_mvc_from_container(video_input_path):
                 video_input_path.unlink(missing_ok=True)
         return result
@@ -572,9 +583,6 @@ def encode_mvc_to_av1_sbs(
     if can_use_native_mvc_splitter(disc_info):
         result = encode_mvc_to_av1_sbs_native(video_input_path, output_path, disc_info, crop_params)
         if not config.keep_files:
-            output_path.with_suffix(".native_ffmpeg.log").unlink(missing_ok=True)
-            output_path.with_suffix(".native_mvc.log").unlink(missing_ok=True)
-            output_path.with_suffix(".mvc_extract.log").unlink(missing_ok=True)
             if not should_stream_mvc_from_container(video_input_path):
                 video_input_path.unlink(missing_ok=True)
         return result

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import BinaryIO, cast
+from typing import BinaryIO, Protocol, cast
 from uuid import uuid4
 
 from bd_to_avp.observability import (
@@ -41,6 +41,7 @@ DEFAULT_ARTIFACT_INTERVAL_SECONDS = 2.0
 DEFAULT_TERMINATION_GRACE_SECONDS = 5.0
 DEFAULT_KILL_WAIT_SECONDS = 5.0
 DEFAULT_PIPE_DRAIN_TIMEOUT_SECONDS = 5.0
+DEFAULT_PIPELINE_EXIT_GRACE_SECONDS = 5.0
 READ_CHUNK_BYTES = 32 * 1024
 ARTIFACT_SIZE_QUANTUM_BYTES = 64 * 1024
 ARTIFACT_AGE_QUANTUM_SECONDS = 5
@@ -56,6 +57,10 @@ class ProcessStream(StrEnum):
 class CaptureOverflowPolicy(StrEnum):
     FAIL = "fail"
     TRUNCATE = "truncate"
+
+
+class CancellationSignal(Protocol):
+    def is_set(self) -> bool: ...
 
 
 class ProcessRunnerError(RuntimeError):
@@ -121,6 +126,7 @@ class ProcessSpec:
     env: Mapping[str, str] | None = None
     cwd: Path | None = None
     stdin: int | BinaryIO | None = None
+    stdout: int | BinaryIO = subprocess.PIPE
     merge_stderr: bool = True
     event_context: ObservabilityContext = field(default_factory=ObservabilityContext)
     tool_version: str | None = None
@@ -152,6 +158,8 @@ class ProcessSpec:
             raise TypeError("artifacts must contain ProcessArtifactProbe values")
         if isinstance(self.stdin, int) and self.stdin == subprocess.PIPE:
             raise ValueError("stdin=subprocess.PIPE requires an input writer and is not supported")
+        if self.stdout != subprocess.PIPE and self.merge_stderr:
+            raise ValueError("redirected stdout requires merge_stderr=False so diagnostics remain separate")
         for integer_name, integer_value in (
             ("capture_limit_bytes", self.capture_limit_bytes),
             ("tail_limit_bytes", self.tail_limit_bytes),
@@ -229,6 +237,34 @@ ProgressParser = Callable[[ProcessStream, str], ObservabilityProgress | None]
 
 
 @dataclass(frozen=True)
+class ProcessPipelineStage:
+    spec: ProcessSpec
+    line_handler: LineHandler | None = field(default=None, compare=False, repr=False)
+    output_observer: OutputObserver | None = field(default=None, compare=False, repr=False)
+    progress_parser: ProgressParser | None = field(default=None, compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class ProcessPipelineStageResult:
+    tool_id: str
+    result: ProcessResult | None
+    error: BaseException | None = field(default=None, compare=False, repr=False)
+    completed_before_final: bool = False
+
+
+@dataclass(frozen=True)
+class ProcessPipelineResult:
+    stages: tuple[ProcessPipelineStageResult, ...]
+    forced_cleanup: bool = False
+
+
+class ProcessPipelineError(ProcessRunnerError):
+    def __init__(self, result: ProcessPipelineResult) -> None:
+        super().__init__("one or more child processes in the pipeline failed")
+        self.result = result
+
+
+@dataclass(frozen=True)
 class _OutputChunk:
     stream: ProcessStream
     payload: bytes
@@ -245,6 +281,26 @@ class _PendingEvent:
     severity: ObservabilitySeverity
     context: ObservabilityContext
     data: ObservabilityData
+
+
+@dataclass
+class _PipelineStageState:
+    stage: ProcessPipelineStage
+    started: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+    result: ProcessResult | None = None
+    error: BaseException | None = None
+    completed_at: float | None = None
+    thread: threading.Thread | None = None
+
+
+class _CombinedCancellationSignal:
+    def __init__(self, internal: threading.Event, external: CancellationSignal | None) -> None:
+        self._internal = internal
+        self._external = external
+
+    def is_set(self) -> bool:
+        return self._internal.is_set() or (self._external is not None and self._external.is_set())
 
 
 class _AsyncRunEmitter:
@@ -482,7 +538,8 @@ class ChildProcessRunner:
         spec: ProcessSpec,
         *,
         run_context: RunContext | None = None,
-        cancellation_event: threading.Event | None = None,
+        cancellation_event: CancellationSignal | None = None,
+        started_event: threading.Event | None = None,
         line_handler: LineHandler | None = None,
         output_observer: OutputObserver | None = None,
         progress_parser: ProgressParser | None = None,
@@ -503,13 +560,15 @@ class ChildProcessRunner:
                 terminal=True,
             )
             emitter.close()
+            if started_event is not None:
+                started_event.set()
             raise ProcessCancelled(f"{spec.display_name} was cancelled before it started")
 
         try:
             process = subprocess.Popen(
                 [os.fspath(argument) for argument in spec.argv],
                 stdin=spec.stdin,
-                stdout=subprocess.PIPE,
+                stdout=spec.stdout,
                 stderr=subprocess.STDOUT if spec.merge_stderr else subprocess.PIPE,
                 env=dict(spec.env) if spec.env is not None else None,
                 cwd=spec.cwd,
@@ -526,6 +585,8 @@ class ChildProcessRunner:
                 terminal=True,
             )
             emitter.close()
+            if started_event is not None:
+                started_event.set()
             raise
 
         process_context = replace(
@@ -533,6 +594,8 @@ class ChildProcessRunner:
             process=ObservabilityProcess(pid=process.pid, process_group_id=process.pid),
         )
         emitter.emit("tool.started", context=process_context)
+        if started_event is not None:
+            started_event.set()
 
         stream_queue: queue.Queue[_OutputChunk | _StreamClosed] = queue.Queue(maxsize=spec.queue_chunks)
         dispatch_overflow = threading.Event()
@@ -549,7 +612,9 @@ class ChildProcessRunner:
             dispatch_overflow,
             reader_stop,
         )
-        expected_streams = {ProcessStream.STDOUT}
+        expected_streams: set[ProcessStream] = set()
+        if spec.stdout == subprocess.PIPE:
+            expected_streams.add(ProcessStream.STDOUT)
         if not spec.merge_stderr:
             expected_streams.add(ProcessStream.STDERR)
         closed_streams: set[ProcessStream] = set()
@@ -901,17 +966,18 @@ class ChildProcessRunner:
         reader_stop: threading.Event,
     ) -> list[threading.Thread]:
         readers: list[threading.Thread] = []
-        assert process.stdout is not None
-        readers.append(
-            self._start_reader(
-                cast(BinaryIO, process.stdout),
-                ProcessStream.STDOUT,
-                stream_states[ProcessStream.STDOUT],
-                stream_queue,
-                dispatch_overflow,
-                reader_stop,
+        if spec.stdout == subprocess.PIPE:
+            assert process.stdout is not None
+            readers.append(
+                self._start_reader(
+                    cast(BinaryIO, process.stdout),
+                    ProcessStream.STDOUT,
+                    stream_states[ProcessStream.STDOUT],
+                    stream_queue,
+                    dispatch_overflow,
+                    reader_stop,
+                )
             )
-        )
         if not spec.merge_stderr:
             assert process.stderr is not None
             readers.append(
@@ -984,7 +1050,7 @@ class ChildProcessRunner:
                 )
 
     @staticmethod
-    def _is_cancelled(run_context: RunContext | None, cancellation_event: threading.Event | None) -> bool:
+    def _is_cancelled(run_context: RunContext | None, cancellation_event: CancellationSignal | None) -> bool:
         return bool(
             (run_context is not None and run_context.cancellation.is_cancelled)
             or (cancellation_event is not None and cancellation_event.is_set())
@@ -1169,3 +1235,232 @@ class ChildProcessRunner:
     @staticmethod
     def _round_down(value: int, quantum: int) -> int:
         return value - (value % quantum)
+
+
+class ProcessPipelineRunner:
+    def __init__(
+        self,
+        *,
+        runner_factory: Callable[[], ChildProcessRunner] = ChildProcessRunner,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        exit_grace_seconds: float = DEFAULT_PIPELINE_EXIT_GRACE_SECONDS,
+    ) -> None:
+        if exit_grace_seconds <= 0:
+            raise ValueError("exit_grace_seconds must be positive")
+        self._runner_factory = runner_factory
+        self._monotonic_clock = monotonic_clock
+        self._exit_grace_seconds = exit_grace_seconds
+
+    def run(
+        self,
+        stages: tuple[ProcessPipelineStage, ...],
+        *,
+        run_context: RunContext | None = None,
+        cancellation_event: CancellationSignal | None = None,
+    ) -> ProcessPipelineResult:
+        if len(stages) < 2:
+            raise ValueError("a process pipeline requires at least two stages")
+        if any(not isinstance(stage, ProcessPipelineStage) for stage in stages):
+            raise TypeError("stages must contain ProcessPipelineStage values")
+
+        pipe_files = self._open_pipes(len(stages) - 1)
+        try:
+            connected_stages = self._connect_stages(stages, pipe_files)
+        except BaseException:
+            self._close_pipe_files(pipe_files)
+            raise
+        internal_cancellation = threading.Event()
+        combined_cancellation = _CombinedCancellationSignal(internal_cancellation, cancellation_event)
+        states = [_PipelineStageState(stage) for stage in connected_stages]
+        startup_error: BaseException | None = None
+
+        try:
+            for state in reversed(states):
+                state.thread = threading.Thread(
+                    target=self._run_stage,
+                    args=(state, run_context, combined_cancellation),
+                    name=f"{state.stage.spec.tool_id}-pipeline-monitor",
+                    daemon=True,
+                )
+                state.thread.start()
+                self._wait_for_stage_start(state)
+                if state.error is not None:
+                    startup_error = state.error
+                    internal_cancellation.set()
+                    break
+        finally:
+            self._close_pipe_files(pipe_files)
+
+        if startup_error is not None:
+            self._join_started_stages(states, internal_cancellation)
+            raise startup_error
+
+        final_state = states[-1]
+        upstream_failure_deadline: float | None = None
+        while not final_state.done.wait(0.05):
+            if self._externally_cancelled(run_context, cancellation_event):
+                internal_cancellation.set()
+            if upstream_failure_deadline is None and any(
+                state.done.is_set() and self._is_substantive_error(state.error) for state in states[:-1]
+            ):
+                upstream_failure_deadline = self._monotonic_clock() + self._exit_grace_seconds
+            if upstream_failure_deadline is not None and self._monotonic_clock() >= upstream_failure_deadline:
+                internal_cancellation.set()
+
+        final_completed_at = final_state.completed_at or self._monotonic_clock()
+        completed_before_final = tuple(
+            state.completed_at is not None and state.completed_at <= final_completed_at for state in states
+        )
+        if self._is_substantive_error(final_state.error) or any(
+            self._is_substantive_error(state.error) for state in states[:-1]
+        ):
+            internal_cancellation.set()
+
+        forced_cleanup = self._join_upstream_stages(states[:-1], internal_cancellation)
+        result = ProcessPipelineResult(
+            stages=tuple(
+                ProcessPipelineStageResult(
+                    tool_id=state.stage.spec.tool_id,
+                    result=state.result,
+                    error=state.error,
+                    completed_before_final=completed_before_final[index],
+                )
+                for index, state in enumerate(states)
+            ),
+            forced_cleanup=forced_cleanup,
+        )
+
+        if self._externally_cancelled(run_context, cancellation_event):
+            cancellation_error = next(
+                (stage.error for stage in result.stages if isinstance(stage.error, ProcessCancelled)),
+                None,
+            )
+            if cancellation_error is not None:
+                raise cancellation_error
+            raise ProcessCancelled("process pipeline was cancelled")
+        if any(self._is_substantive_error(stage.error) for stage in result.stages):
+            raise ProcessPipelineError(result)
+        if final_state.result is None:
+            raise ProcessRunnerError("process pipeline ended without a final-stage result")
+        return result
+
+    def _run_stage(
+        self,
+        state: _PipelineStageState,
+        run_context: RunContext | None,
+        cancellation_event: CancellationSignal,
+    ) -> None:
+        try:
+            state.result = self._runner_factory().run(
+                state.stage.spec,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                started_event=state.started,
+                line_handler=state.stage.line_handler,
+                output_observer=state.stage.output_observer,
+                progress_parser=state.stage.progress_parser,
+            )
+        except BaseException as error:
+            state.error = error
+        finally:
+            state.completed_at = self._monotonic_clock()
+            state.done.set()
+
+    @staticmethod
+    def _open_pipes(count: int) -> list[tuple[BinaryIO, BinaryIO]]:
+        pipes: list[tuple[BinaryIO, BinaryIO]] = []
+        try:
+            for _ in range(count):
+                read_descriptor, write_descriptor = os.pipe()
+                pipes.append(
+                    (
+                        os.fdopen(read_descriptor, "rb", buffering=0),
+                        os.fdopen(write_descriptor, "wb", buffering=0),
+                    )
+                )
+        except BaseException:
+            ProcessPipelineRunner._close_pipe_files(pipes)
+            raise
+        return pipes
+
+    @staticmethod
+    def _connect_stages(
+        stages: tuple[ProcessPipelineStage, ...],
+        pipe_files: list[tuple[BinaryIO, BinaryIO]],
+    ) -> tuple[ProcessPipelineStage, ...]:
+        connected: list[ProcessPipelineStage] = []
+        for index, stage in enumerate(stages):
+            spec = stage.spec
+            if index > 0:
+                if spec.stdin is not None:
+                    raise ValueError("only the first pipeline stage may define stdin")
+                spec = replace(spec, stdin=pipe_files[index - 1][0])
+            if index < len(stages) - 1:
+                if spec.stdout != subprocess.PIPE:
+                    raise ValueError("only the final pipeline stage may redirect stdout")
+                spec = replace(spec, stdout=pipe_files[index][1], merge_stderr=False)
+            connected.append(replace(stage, spec=spec))
+        return tuple(connected)
+
+    @staticmethod
+    def _wait_for_stage_start(state: _PipelineStageState) -> None:
+        while not state.started.wait(0.01):
+            if state.done.is_set():
+                return
+
+    def _join_started_stages(
+        self,
+        states: list[_PipelineStageState],
+        internal_cancellation: threading.Event,
+    ) -> None:
+        internal_cancellation.set()
+        self._join_threads(states, self._exit_grace_seconds * 3)
+
+    def _join_upstream_stages(
+        self,
+        states: list[_PipelineStageState],
+        internal_cancellation: threading.Event,
+    ) -> bool:
+        deadline = self._monotonic_clock() + self._exit_grace_seconds
+        for state in states:
+            if state.thread is None:
+                continue
+            state.thread.join(max(0.0, deadline - self._monotonic_clock()))
+        running = [state for state in states if state.thread is not None and state.thread.is_alive()]
+        if not running:
+            return False
+        internal_cancellation.set()
+        self._join_threads(running, self._exit_grace_seconds * 3)
+        return True
+
+    def _join_threads(self, states: list[_PipelineStageState], timeout_seconds: float) -> None:
+        deadline = self._monotonic_clock() + timeout_seconds
+        for state in states:
+            if state.thread is None:
+                continue
+            state.thread.join(max(0.0, deadline - self._monotonic_clock()))
+        if any(state.thread is not None and state.thread.is_alive() for state in states):
+            raise ProcessRunnerError("a process pipeline monitor did not stop after cancellation")
+
+    @staticmethod
+    def _close_pipe_files(pipe_files: list[tuple[BinaryIO, BinaryIO]]) -> None:
+        for read_file, write_file in pipe_files:
+            for pipe_file in (read_file, write_file):
+                try:
+                    pipe_file.close()
+                except (OSError, ValueError):
+                    continue
+
+    @staticmethod
+    def _is_substantive_error(error: BaseException | None) -> bool:
+        return error is not None and not isinstance(error, ProcessCancelled)
+
+    @staticmethod
+    def _externally_cancelled(
+        run_context: RunContext | None,
+        cancellation_event: CancellationSignal | None,
+    ) -> bool:
+        return bool(
+            (run_context is not None and run_context.cancellation.is_cancelled)
+            or (cancellation_event is not None and cancellation_event.is_set())
+        )

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -60,7 +60,8 @@ class CaptureOverflowPolicy(StrEnum):
 
 
 class CancellationSignal(Protocol):
-    def is_set(self) -> bool: ...
+    def is_set(self) -> bool:
+        raise NotImplementedError
 
 
 class ProcessRunnerError(RuntimeError):
@@ -1266,7 +1267,7 @@ class ProcessPipelineRunner:
         pipe_files = self._open_pipes(len(stages) - 1)
         try:
             connected_stages = self._connect_stages(stages, pipe_files)
-        except BaseException:
+        except (Exception, KeyboardInterrupt, SystemExit):
             self._close_pipe_files(pipe_files)
             raise
         internal_cancellation = threading.Event()
@@ -1360,7 +1361,7 @@ class ProcessPipelineRunner:
                 output_observer=state.stage.output_observer,
                 progress_parser=state.stage.progress_parser,
             )
-        except BaseException as error:
+        except (Exception, KeyboardInterrupt, SystemExit) as error:
             state.error = error
         finally:
             state.completed_at = self._monotonic_clock()
@@ -1378,7 +1379,7 @@ class ProcessPipelineRunner:
                         os.fdopen(write_descriptor, "wb", buffering=0),
                     )
                 )
-        except BaseException:
+        except (Exception, KeyboardInterrupt, SystemExit):
             ProcessPipelineRunner._close_pipe_files(pipes)
             raise
         return pipes

--- a/bd_to_avp/vendor/pgsrip/mkv.py
+++ b/bd_to_avp/vendor/pgsrip/mkv.py
@@ -2,6 +2,7 @@ import json
 import logging
 import subprocess
 import typing
+from pathlib import Path
 
 import ffmpeg
 from babelfish import Language
@@ -11,8 +12,9 @@ from trakit.api import trakit
 from bd_to_avp.vendor.pgsrip.media import Media, Pgs
 from bd_to_avp.vendor.pgsrip.media_path import MediaPath
 from bd_to_avp.vendor.pgsrip.options import Options
-from bd_to_avp.modules.command import run_ffprobe
+from bd_to_avp.modules.command import run_ffprobe, run_process_capture
 from bd_to_avp.modules.config import config
+from bd_to_avp.process_runner import ProcessArtifactProbe
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +42,16 @@ class MkvPgs(Pgs):
             "sup",
             "pipe:1",
         ]
-        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        return result.stdout
+        output_path = Path(temp_folder) / f"track-{track_id}.sup"
+        with output_path.open("wb") as output_file:
+            run_process_capture(
+                command,
+                "Extract PGS subtitle stream",
+                tool_id="ffmpeg",
+                stdout=output_file,
+                artifacts=(ProcessArtifactProbe("subtitle_payload", path=output_path),),
+            )
+        return output_path.read_bytes()
 
     def __init__(self, media_path: MediaPath, track_id: int, language: Language, number: int, options: Options):
         temp_folder = media_path.create_temp_folder()

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -59,6 +59,13 @@ boundaries and must return promptly without performing unbounded I/O. Pipe
 readers remain independent from those hooks, and bounded dispatch overflow
 fails the tool rather than silently dropping parser input.
 
+`ProcessPipelineRunner` connects linear helper graphs with native OS pipes while
+using `ChildProcessRunner` to supervise every stage independently. Intermediate
+binary payloads are never decoded or retained as diagnostics; bounded stderr,
+heartbeats, exit state, cancellation, and final output artifact growth remain
+observable for the producer, MVC splitter, and encoder. Parent pipe handles are
+closed after launch so EOF and backpressure remain correct.
+
 The legacy `run_command` API is a compatibility adapter over the shared runner.
 MakeMKV inspection and ripping identify the tool explicitly, emit parsed robot
 progress, sample the actively growing MKV, and honor cancellation while the tool
@@ -92,8 +99,9 @@ single `stream_id`.
    conversion behavior.
 2. Replace fragmented child execution with one binary-safe streaming runner.
    The ordinary command path, MakeMKV, FFmpeg graph execution, FFprobe metadata,
-   and FFmpeg capability checks are migrated. Binary subtitle extraction and
-   the native MVC linear pipeline remain in the active child-tool workstream.
+   FFmpeg capability checks, binary subtitle extraction, and the native MVC
+   linear pipeline are migrated. Binary payloads are redirected to artifacts or
+   native pipes rather than entering diagnostic capture.
 3. Project semantic runner activity into the worker protocol and bounded raw
    output into the diagnostic channel.
 4. Make the native diagnostic recorder and support bundle consume the shared

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -1,14 +1,26 @@
+import signal
 import subprocess
 import tempfile
+import threading
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import cast
 from unittest.mock import Mock, patch
 
-from bd_to_avp.modules.disc import DiscInfo
 from bd_to_avp.modules import video
+from bd_to_avp.modules.disc import DiscInfo
+from bd_to_avp.observability import ObservabilityContext
+from bd_to_avp.process_runner import (
+    ProcessCancelled,
+    ProcessExecutionError,
+    ProcessOutputSnapshot,
+    ProcessPipelineError,
+    ProcessPipelineResult,
+    ProcessPipelineStageResult,
+    ProcessResult,
+    ProcessTimeoutError,
+)
 
 
 class NativeMvcCommandTests(unittest.TestCase):
@@ -83,11 +95,9 @@ class NativeMvcCommandTests(unittest.TestCase):
         ):
             command = video.generate_native_mvc_ffmpeg_command(Path("left.mov"), Path("right.mov"), self.disc_info, "")
 
-        self.assertEqual(Path(command[0]), Path(video.config.FFMPEG_PATH))
         filter_graph = command[command.index("-filter_complex") + 1]
         map_labels = [command[index + 1] for index, value in enumerate(command) if value == "-map"]
         left_label, right_label = map_labels
-
         self.assertIn(f"crop=1920:1080:1920:0{left_label}", filter_graph)
         self.assertIn(f"crop=1920:1080:0:0{right_label}", filter_graph)
 
@@ -115,13 +125,11 @@ class NativeMvcCommandTests(unittest.TestCase):
 class NativeMvcSelectionTests(unittest.TestCase):
     def test_direct_pipeline_keeps_streamed_source_file(self) -> None:
         disc_info = DiscInfo(name="Sample")
-
         with tempfile.TemporaryDirectory() as temp_dir:
             source_path = Path(temp_dir) / "source.mkv"
             source_path.touch()
             helper_path = Path(temp_dir) / "edge264_test"
             helper_path.touch(mode=0o755)
-
             with (
                 patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
                 patch.object(video.config, "keep_files", False),
@@ -137,15 +145,12 @@ class NativeMvcSelectionTests(unittest.TestCase):
 
     def test_split_uses_native_helper_when_present_for_extracted_mvc(self) -> None:
         disc_info = DiscInfo(name="Sample")
-
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o755)
-
             with (
                 patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
                 patch.object(video.config, "source_path", Path("source.mkv")),
-                patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
                 patch.object(video.config, "keep_files", True),
                 patch(
                     "bd_to_avp.modules.video.split_mvc_to_stereo_native",
@@ -157,15 +162,13 @@ class NativeMvcSelectionTests(unittest.TestCase):
                 )
 
         self.assertEqual(result, (Path("left.mov"), Path("right.mov")))
-        native_split.assert_called_once()
+        native_split.assert_called_once_with(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
 
     def test_split_uses_native_helper_for_mts_sources_when_present(self) -> None:
         disc_info = DiscInfo(name="Sample")
-
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o755)
-
             with (
                 patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
                 patch.object(video.config, "source_path", Path("source.m2ts")),
@@ -181,40 +184,32 @@ class NativeMvcSelectionTests(unittest.TestCase):
                 )
 
         self.assertEqual(result, (Path("left.mov"), Path("right.mov")))
-        native_split.assert_called_once_with(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
+        native_split.assert_called_once()
 
     def test_split_rejects_10_bit_sources(self) -> None:
         disc_info = DiscInfo(name="Sample", color_depth=10)
-
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o755)
-
             with (
                 patch.object(video.config, "EDGE264_TEST_PATH", helper_path),
                 patch.object(video.config, "source_path", Path("source.mkv")),
-                patch.object(video.config, "keep_files", True),
                 patch("bd_to_avp.modules.video.split_mvc_to_stereo_native") as native_split,
+                self.assertRaisesRegex(RuntimeError, "8-bit Blu-ray 3D MVC sources only"),
             ):
-                with self.assertRaisesRegex(RuntimeError, "8-bit Blu-ray 3D MVC sources only"):
-                    video.split_mvc_to_stereo(
-                        Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, ""
-                    )
+                video.split_mvc_to_stereo(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
 
         native_split.assert_not_called()
 
     def test_split_rejects_sources_when_native_helper_is_missing(self) -> None:
         disc_info = DiscInfo(name="Sample")
-
         with (
             patch.object(video.config, "EDGE264_TEST_PATH", Path("/missing/edge264_test")),
             patch.object(video.config, "source_path", Path("source.m2ts")),
-            patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-            patch.object(video.config, "keep_files", True),
             patch("bd_to_avp.modules.video.split_mvc_to_stereo_native") as native_split,
+            self.assertRaisesRegex(RuntimeError, "native MVC splitter is missing"),
         ):
-            with self.assertRaisesRegex(RuntimeError, "native MVC splitter is missing"):
-                video.split_mvc_to_stereo(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
+            video.split_mvc_to_stereo(Path("movie_mvc.h264"), Path("left.mov"), Path("right.mov"), disc_info, "")
 
         native_split.assert_not_called()
 
@@ -222,471 +217,318 @@ class NativeMvcSelectionTests(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as helper_file:
             helper_path = Path(helper_file.name)
             helper_path.chmod(0o644)
-
             with patch.object(video.config, "EDGE264_TEST_PATH", helper_path):
                 self.assertTrue(video.has_native_mvc_splitter())
-
             self.assertTrue(helper_path.stat().st_mode & 0o111)
 
-    def test_native_split_raises_when_ffmpeg_fails(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[None])
-        ffmpeg_process = _FakeProcess(returncode=1, stdout=None, stderr=None)
-
+    def test_streaming_pipeline_registers_producer_splitter_encoder_and_outputs(self) -> None:
+        left_output = Path("left.mov")
+        right_output = Path("right.mov")
+        run_context = Mock()
+        cancellation_event = threading.Event()
+        event_context = ObservabilityContext()
         with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter, ffmpeg_process]),
-        ):
-            with self.assertRaises(subprocess.CalledProcessError):
-                video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
-
-        splitter.terminate.assert_called_once()
-
-    def test_streaming_split_connects_producer_splitter_and_encoder(self) -> None:
-        producer_stdout = Mock()
-        splitter_stdout = Mock()
-        producer = _FakeProcess(returncode=None, stdout=producer_stdout, returncode_after_wait=0, poll_results=[0])
-        splitter = _FakeProcess(returncode=None, stdout=splitter_stdout, returncode_after_wait=0, poll_results=[0])
-        ffmpeg_process = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "keep_files", False),
-            patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-            patch("bd_to_avp.modules.video.prepare_native_mvc_input") as prepare_input,
-            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed") as probe,
-            patch(
-                "bd_to_avp.modules.video.generate_mvc_annex_b_stream_command",
-                return_value=["source-ffmpeg"],
-            ),
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                return_value=["edge264_test", "-", "-Omk"],
-            ),
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["encode-ffmpeg"]),
-            patch(
-                "bd_to_avp.modules.video.subprocess.Popen",
-                side_effect=[producer, splitter, ffmpeg_process],
-            ) as popen,
-            patch("pathlib.Path.unlink") as unlink,
+            patch.object(video, "should_stream_mvc_from_container", return_value=True),
+            patch.object(video, "generate_mvc_annex_b_stream_command", return_value=["source-ffmpeg"]),
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test", "-", "-Omk"]),
+            patch.object(video, "generate_native_mvc_ffmpeg_command", return_value=["encode-ffmpeg"]),
+            patch.object(video.ProcessPipelineRunner, "run", return_value=pipeline_success(True)) as run,
         ):
             result = video.split_mvc_to_stereo_native(
-                Path("source.mkv"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+                Path("source.mkv"),
+                left_output,
+                right_output,
+                DiscInfo(),
+                "",
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=event_context,
             )
 
-        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
-        prepare_input.assert_not_called()
-        probe.assert_not_called()
-        self.assertEqual(popen.call_args_list[1].kwargs["stdin"], producer_stdout)
-        self.assertEqual(popen.call_args_list[2].kwargs["stdin"], splitter_stdout)
-        producer_stdout.close.assert_called_once()
-        splitter_stdout.close.assert_called_once()
-        unlink.assert_not_called()
+        self.assertEqual(result, (left_output, right_output))
+        stages = run.call_args.args[0]
+        self.assertEqual([stage.spec.tool_id for stage in stages], ["ffmpeg", "edge264", "ffmpeg"])
+        self.assertEqual([stage.spec.argv[0] for stage in stages], ["source-ffmpeg", "edge264_test", "encode-ffmpeg"])
+        self.assertEqual([probe.path for probe in stages[-1].spec.artifacts], [left_output, right_output])
+        self.assertTrue(all(stage.spec.event_context is event_context for stage in stages))
+        self.assertIs(run.call_args.kwargs["run_context"], run_context)
+        self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
 
-    def test_streaming_split_restarts_producer_for_single_threaded_retry(self) -> None:
-        first_producer = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-13, poll_results=[-13])
-        first_splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
-        first_ffmpeg = _FakeProcess(returncode=1, stdout=None, stderr=None)
-        retry_producer = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        retry_splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        retry_ffmpeg = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
+    def test_extracted_mvc_pipeline_has_splitter_and_encoder_stages(self) -> None:
         with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "keep_files", False),
-            patch.object(video.config, "MTS_EXTENSIONS", [".mts", ".m2ts"]),
-            patch(
-                "bd_to_avp.modules.video.generate_mvc_annex_b_stream_command",
-                return_value=["source-ffmpeg"],
-            ),
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                side_effect=[["edge264_test", "-", "-Omk"], ["edge264_test", "-", "-Osk"]],
-            ),
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["encode-ffmpeg"]),
-            patch(
-                "bd_to_avp.modules.video.subprocess.Popen",
-                side_effect=[
-                    first_producer,
-                    first_splitter,
-                    first_ffmpeg,
-                    retry_producer,
-                    retry_splitter,
-                    retry_ffmpeg,
-                ],
-            ) as popen,
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test", "movie.264"]),
+            patch.object(video.ProcessPipelineRunner, "run", return_value=pipeline_success(False)) as run,
         ):
-            result = video.split_mvc_to_stereo_native(
-                Path("source.mkv"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
+            video.run_native_mvc_split_attempt(
+                Path("movie.264"),
+                ["encode-ffmpeg"],
+                (Path("output.mov"),),
+                single_threaded=False,
             )
 
-        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
-        self.assertEqual(popen.call_args_list[0].args[0], ["source-ffmpeg"])
-        self.assertEqual(popen.call_args_list[3].args[0], ["source-ffmpeg"])
+        stages = run.call_args.args[0]
+        self.assertEqual([stage.spec.tool_id for stage in stages], ["edge264", "ffmpeg"])
 
-    def test_streaming_split_reports_producer_failure_before_pipe_cascade(self) -> None:
-        producer = _FakeProcess(returncode=254, stdout=Mock(), poll_results=[254])
-        splitter = _FakeProcess(returncode=1, stdout=Mock(), poll_results=[1])
-        ffmpeg_process = _FakeProcess(returncode=234, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[producer, splitter, ffmpeg_process]),
-        ):
-            with self.assertRaises(subprocess.CalledProcessError) as raised:
-                video.run_native_mvc_split_attempt(
-                    Path("-"),
-                    ["encode-ffmpeg"],
-                    Path(temp_dir) / "encode.log",
-                    Path(temp_dir) / "split.log",
-                    producer_command=["source-ffmpeg"],
-                    producer_log_path=Path(temp_dir) / "extract.log",
-                    single_threaded=False,
-                )
-
-        self.assertEqual(raised.exception.cmd, ["source-ffmpeg"])
-
-    def test_streaming_split_reports_encoder_failure_when_upstream_gets_sigpipe(self) -> None:
-        producer = _FakeProcess(returncode=-13, stdout=Mock(), poll_results=[-13])
-        splitter = _FakeProcess(returncode=-13, stdout=Mock(), poll_results=[-13])
-        ffmpeg_process = _FakeProcess(returncode=234, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[producer, splitter, ffmpeg_process]),
-        ):
-            with self.assertRaises(subprocess.CalledProcessError) as raised:
-                video.run_native_mvc_split_attempt(
-                    Path("-"),
-                    ["encode-ffmpeg"],
-                    Path(temp_dir) / "encode.log",
-                    Path(temp_dir) / "split.log",
-                    producer_command=["source-ffmpeg"],
-                    producer_log_path=Path(temp_dir) / "extract.log",
-                    single_threaded=False,
-                )
-
-        self.assertEqual(raised.exception.cmd, ["encode-ffmpeg"])
-
-    def test_streaming_split_terminates_upstream_processes_when_encoder_fails(self) -> None:
-        producer = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[None])
-        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[None])
-        ffmpeg_process = _FakeProcess(returncode=1, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[producer, splitter, ffmpeg_process]),
-        ):
-            with self.assertRaises(subprocess.CalledProcessError):
-                video.run_native_mvc_split_attempt(
-                    Path("-"),
-                    ["encode-ffmpeg"],
-                    Path(temp_dir) / "encode.log",
-                    Path(temp_dir) / "split.log",
-                    producer_command=["source-ffmpeg"],
-                    producer_log_path=Path(temp_dir) / "extract.log",
-                    single_threaded=False,
-                )
-
-        producer.terminate.assert_called_once()
-        splitter.terminate.assert_called_once()
-
-    def test_pipeline_cleanup_kills_process_when_termination_stalls(self) -> None:
-        process = _FakeProcess(
-            returncode=None,
-            stdout=None,
-            returncode_after_wait=-9,
-            raises_timeout_count=1,
+    def test_pipeline_reports_producer_failure_before_pipe_cascade(self) -> None:
+        producer_error = process_error(2, ["source-ffmpeg"])
+        error = pipeline_failure(
+            producer_present=True,
+            producer_error=producer_error,
+            splitter_error=process_error(-signal.SIGPIPE, ["edge264_test"]),
+            ffmpeg_error=process_error(1, ["encode-ffmpeg"]),
         )
-
-        video.terminate_native_pipeline_process(cast(subprocess.Popen, process))
-
-        process.terminate.assert_called_once()
-        process.kill.assert_called_once()
-
-    def test_native_split_retries_single_threaded_when_splitter_sigaborts(self) -> None:
-        splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
-        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
-        splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        ffmpeg_retry = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
         with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                side_effect=[
-                    ["edge264_test", "-Omk"],
-                    ["edge264_test", "-Osk"],
-                ],
-            ) as splitter_command,
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch(
-                "bd_to_avp.modules.video.subprocess.Popen",
-                side_effect=[splitter_crash, ffmpeg_broken_pipe, splitter_retry, ffmpeg_retry],
-            ),
-        ):
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                result = video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
-
-        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
-        self.assertEqual(
-            [command_call.kwargs for command_call in splitter_command.call_args_list],
-            [{"single_threaded": False}, {"single_threaded": True}],
-        )
-        self.assertIn("Running native MVC split and encode (multi-threaded).", stdout.getvalue())
-        self.assertIn("Native MVC splitter crashed; retrying once in single-threaded mode.", stdout.getvalue())
-        self.assertIn("Running native MVC split and encode (single-threaded).", stdout.getvalue())
-
-    def test_native_split_does_not_retry_when_splitter_is_cancelled(self) -> None:
-        splitter_cancelled = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-15, poll_results=[-15])
-        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch(
-                "bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_cancelled, ffmpeg_broken_pipe]
-            ) as popen,
-        ):
-            with self.assertRaises(subprocess.CalledProcessError):
-                video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
-
-        self.assertEqual(popen.call_count, 2)
-
-    def test_native_split_probes_iso_sources_and_skips_doomed_multithread_attempt(self) -> None:
-        splitter_retry = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        ffmpeg_retry = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "source_path", Path("movie.iso")),
-            patch.object(video.config, "IMAGE_EXTENSIONS", [".iso"]),
-            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed", return_value=True) as probe,
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                return_value=["edge264_test", "-Osk"],
-            ) as splitter_command,
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter_retry, ffmpeg_retry]),
-        ):
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                result = video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
-
-        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
-        probe.assert_called_once()
-        self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": True}])
-        self.assertIn("Checking native MVC splitter with a short multi-threaded probe.", stdout.getvalue())
-        self.assertIn("Native MVC splitter probe crashed; using slower single-threaded mode.", stdout.getvalue())
-        self.assertIn("Running native MVC split and encode (single-threaded).", stdout.getvalue())
-
-    def test_native_split_probes_iso_sources_and_uses_multithreaded_when_probe_passes(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        ffmpeg_process = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "source_path", Path("movie.iso")),
-            patch.object(video.config, "IMAGE_EXTENSIONS", [".iso"]),
-            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed", return_value=False) as probe,
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                return_value=["edge264_test", "-Omk"],
-            ) as splitter_command,
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter, ffmpeg_process]),
-        ):
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                result = video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
-
-        self.assertEqual(result, (Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov"))
-        probe.assert_called_once()
-        self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": False}])
-        self.assertIn("Checking native MVC splitter with a short multi-threaded probe.", stdout.getvalue())
-        self.assertIn("Native MVC splitter probe passed; proceeding with multi-threaded mode.", stdout.getvalue())
-        self.assertIn("Running native MVC split and encode (multi-threaded).", stdout.getvalue())
-
-    def test_native_split_does_not_probe_mkv_sources(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=0, poll_results=[0])
-        ffmpeg_process = _FakeProcess(returncode=0, stdout=None, stderr=None)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "source_path", Path("movie.mkv")),
-            patch.object(video.config, "IMAGE_EXTENSIONS", [".iso"]),
-            patch("bd_to_avp.modules.video.native_multithread_splitter_probe_crashed") as probe,
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                return_value=["edge264_test", "-Omk"],
-            ) as splitter_command,
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", side_effect=[splitter, ffmpeg_process]),
-        ):
-            video.split_mvc_to_stereo_native(
-                Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-            )
-
-        probe.assert_not_called()
-        self.assertEqual([call.kwargs for call in splitter_command.call_args_list], [{"single_threaded": False}])
-
-    def test_native_multithread_probe_returns_true_when_splitter_dies_by_signal(self) -> None:
-        splitter_crash = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-6)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter_crash),
-        ):
-            result = video.native_multithread_splitter_probe_crashed(
-                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
-            )
-
-        self.assertTrue(result)
-
-    def test_native_multithread_probe_does_not_treat_sigterm_as_crash(self) -> None:
-        splitter_cancelled = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-15)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter_cancelled),
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=error),
             self.assertRaises(subprocess.CalledProcessError) as raised,
         ):
-            video.native_multithread_splitter_probe_crashed(
-                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+            video.run_native_mvc_split_attempt(
+                Path("-"),
+                ["encode-ffmpeg"],
+                (Path("output.mov"),),
+                producer_command=["source-ffmpeg"],
+                single_threaded=False,
             )
 
-        self.assertEqual(raised.exception.returncode, -15)
+        self.assertIs(raised.exception, producer_error)
+
+    def test_pipeline_reports_encoder_failure_when_upstream_gets_sigpipe(self) -> None:
+        ffmpeg_error = process_error(1, ["encode-ffmpeg"])
+        error = pipeline_failure(
+            producer_present=True,
+            producer_error=process_error(-signal.SIGPIPE, ["source-ffmpeg"]),
+            splitter_error=process_error(-signal.SIGPIPE, ["edge264_test"]),
+            ffmpeg_error=ffmpeg_error,
+        )
+        with (
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=error),
+            self.assertRaises(subprocess.CalledProcessError) as raised,
+        ):
+            video.run_native_mvc_split_attempt(
+                Path("-"),
+                ["encode-ffmpeg"],
+                (Path("output.mov"),),
+                producer_command=["source-ffmpeg"],
+                single_threaded=False,
+            )
+
+        self.assertIs(raised.exception, ffmpeg_error)
+
+    def test_pipeline_ignores_producer_sigpipe_after_successful_downstream_completion(self) -> None:
+        error = pipeline_failure(
+            producer_present=True,
+            producer_error=process_error(-signal.SIGPIPE, ["source-ffmpeg"]),
+        )
+        with (
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=error),
+        ):
+            video.run_native_mvc_split_attempt(
+                Path("-"),
+                ["encode-ffmpeg"],
+                (Path("output.mov"),),
+                producer_command=["source-ffmpeg"],
+                single_threaded=False,
+            )
+
+    def test_native_split_retries_single_threaded_when_splitter_sigaborts(self) -> None:
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
+            patch.object(
+                video.ProcessPipelineRunner,
+                "run",
+                side_effect=[
+                    pipeline_failure(
+                        splitter_error=process_error(-signal.SIGABRT, ["edge264_test"]),
+                        ffmpeg_error=process_error(1, ["encode-ffmpeg"]),
+                    ),
+                    pipeline_success(False),
+                ],
+            ) as run,
+            redirect_stdout(StringIO()),
+        ):
+            video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
+
+        self.assertEqual(run.call_count, 2)
+        first_stages = run.call_args_list[0].args[0]
+        second_stages = run.call_args_list[1].args[0]
+        self.assertEqual(first_stages[0].spec.argv[-1], "-Omk")
+        self.assertEqual(second_stages[0].spec.argv[-1], "-Osk")
+
+    def test_native_split_does_not_retry_when_pipeline_is_cancelled(self) -> None:
+        cancellation = ProcessCancelled("cancelled")
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=cancellation) as run,
+            self.assertRaises(ProcessCancelled),
+        ):
+            video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
+
+        run.assert_called_once()
+
+    def test_native_split_probe_crash_skips_multithreaded_attempt(self) -> None:
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video, "should_probe_native_multithread_splitter", return_value=True),
+            patch.object(video, "native_multithread_splitter_probe_crashed", return_value=True),
+            patch.object(video, "run_native_mvc_split_attempt") as run_attempt,
+            redirect_stdout(StringIO()),
+        ):
+            video.run_native_mvc_encoding(Path("movie.264"), (Path("output.mov"),), ["encode-ffmpeg"])
+
+        run_attempt.assert_called_once()
+        self.assertTrue(run_attempt.call_args.kwargs["single_threaded"])
+
+    def test_native_split_probe_pass_uses_multithreaded_attempt(self) -> None:
+        stdout = StringIO()
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video, "should_probe_native_multithread_splitter", return_value=True),
+            patch.object(video, "native_multithread_splitter_probe_crashed", return_value=False),
+            patch.object(video, "run_native_mvc_split_attempt") as run_attempt,
+            redirect_stdout(stdout),
+        ):
+            video.run_native_mvc_encoding(Path("movie.264"), (Path("output.mov"),), ["encode-ffmpeg"])
+
+        self.assertFalse(run_attempt.call_args.kwargs["single_threaded"])
+        self.assertIn("Native MVC splitter probe passed", stdout.getvalue())
+
+    def test_native_split_does_not_probe_mkv_sources(self) -> None:
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=True),
+            patch.object(video, "native_multithread_splitter_probe_crashed") as probe,
+            patch.object(video, "run_native_mvc_split_attempt"),
+        ):
+            video.run_native_mvc_encoding(Path("movie.mkv"), (Path("output.mov"),), ["encode-ffmpeg"])
+
+        probe.assert_not_called()
+
+    def test_native_multithread_probe_returns_true_when_splitter_dies_by_signal(self) -> None:
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(
+                video.ChildProcessRunner,
+                "run",
+                side_effect=process_error(-signal.SIGABRT, ["edge264_test"]),
+            ),
+        ):
+            self.assertTrue(video.native_multithread_splitter_probe_crashed(Path("movie.264")))
+
+    def test_native_multithread_probe_does_not_treat_sigterm_as_crash(self) -> None:
+        error = process_error(-signal.SIGTERM, ["edge264_test"])
+        with (
+            patch.object(video.ChildProcessRunner, "run", side_effect=error),
+            self.assertRaises(ProcessExecutionError) as raised,
+        ):
+            video.native_multithread_splitter_probe_crashed(Path("movie.264"))
+
+        self.assertIs(raised.exception, error)
 
     def test_native_multithread_probe_returns_false_after_timeout(self) -> None:
-        splitter = _FakeProcess(returncode=None, stdout=None, returncode_after_wait=-15, raises_timeout_once=True)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter),
+        with patch.object(
+            video.ChildProcessRunner,
+            "run",
+            side_effect=ProcessTimeoutError("probe timed out"),
         ):
-            log_path = Path(temp_dir) / "split.native_mvc.log"
-            result = video.native_multithread_splitter_probe_crashed(Path("movie_mvc.264"), log_path)
-            log_text = log_path.read_text(encoding="utf-8")
+            self.assertFalse(video.native_multithread_splitter_probe_crashed(Path("movie.264")))
 
-        self.assertFalse(result)
-        splitter.terminate.assert_called_once()
-        splitter.kill.assert_not_called()
-        self.assertIn(
-            "Probe timed out; process stayed alive, continuing multi-threaded",
-            log_text,
-        )
-
-    def test_native_multithread_probe_kills_splitter_when_timeout_cleanup_stalls(self) -> None:
-        splitter = _FakeProcess(
-            returncode=None,
-            stdout=None,
-            returncode_after_wait=-9,
-            raises_timeout_count=2,
-        )
-
+    def test_native_multithread_probe_uses_bounded_runner_contract(self) -> None:
+        run_context = Mock()
+        cancellation_event = threading.Event()
+        event_context = ObservabilityContext()
         with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch("bd_to_avp.modules.video.generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch("bd_to_avp.modules.video.subprocess.Popen", return_value=splitter),
+            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test"]),
+            patch.object(video.ChildProcessRunner, "run", return_value=process_result("edge264")) as run,
         ):
             result = video.native_multithread_splitter_probe_crashed(
-                Path("movie_mvc.264"), Path(temp_dir) / "split.native_mvc.log"
+                Path("movie.264"),
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=event_context,
             )
 
         self.assertFalse(result)
-        splitter.terminate.assert_called_once()
-        splitter.kill.assert_called_once()
+        spec = run.call_args.args[0]
+        self.assertEqual(spec.stdout, subprocess.DEVNULL)
+        self.assertFalse(spec.merge_stderr)
+        self.assertEqual(spec.timeout_seconds, video.NATIVE_MVC_PROBE_TIMEOUT_SECONDS)
+        self.assertIs(spec.event_context, event_context)
+        self.assertIs(run.call_args.kwargs["run_context"], run_context)
+        self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
 
     def test_native_split_raises_clear_error_when_single_thread_retry_sigaborts(self) -> None:
-        splitter_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
-        ffmpeg_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
-        splitter_retry_crash = _FakeProcess(returncode=None, stdout=Mock(), returncode_after_wait=-6, poll_results=[-6])
-        ffmpeg_retry_broken_pipe = _FakeProcess(returncode=1, stdout=None, stderr=None)
-
+        crash = pipeline_failure(
+            splitter_error=process_error(-signal.SIGABRT, ["edge264_test"]),
+            ffmpeg_error=process_error(1, ["encode-ffmpeg"]),
+        )
         with (
-            tempfile.TemporaryDirectory() as temp_dir,
             patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
-            patch(
-                "bd_to_avp.modules.video.generate_native_mvc_splitter_command",
-                side_effect=[
-                    ["edge264_test", "-Omk"],
-                    ["edge264_test", "-Osk"],
-                ],
-            ),
-            patch("bd_to_avp.modules.video.generate_native_mvc_ffmpeg_command", return_value=["ffmpeg"]),
-            patch(
-                "bd_to_avp.modules.video.subprocess.Popen",
-                side_effect=[splitter_crash, ffmpeg_broken_pipe, splitter_retry_crash, ffmpeg_retry_broken_pipe],
-            ),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=[crash, crash]),
+            self.assertRaisesRegex(video.NativeMvcSplitError, "SIGABRT.*diagnostic report"),
         ):
-            with self.assertRaisesRegex(video.NativeMvcSplitError, "SIGABRT"):
-                video.split_mvc_to_stereo_native(
-                    Path("movie_mvc.h264"), Path(temp_dir) / "left.mov", Path(temp_dir) / "right.mov", DiscInfo(), ""
-                )
+            video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
 
 
-class _FakeProcess:
-    def __init__(
-        self,
-        returncode: int | None,
-        stdout,
-        stderr=None,
-        returncode_after_wait: int | None = None,
-        poll_results: list[int | None] | None = None,
-        raises_timeout: bool = False,
-        raises_timeout_once: bool = False,
-        raises_timeout_count: int = 0,
-    ) -> None:
-        self.returncode = returncode
-        self.returncode_after_wait = returncode_after_wait if returncode_after_wait is not None else returncode
-        self.poll_results = poll_results or []
-        self.raises_timeout = raises_timeout
-        self.raises_timeout_once = raises_timeout_once
-        self.raises_timeout_count = raises_timeout_count
-        self.stdout = stdout
-        self.stderr = stderr
-        self.terminate = Mock()
-        self.kill = Mock()
+def process_result(tool_id: str) -> ProcessResult:
+    empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+    return ProcessResult(tool_run_id=f"{tool_id}-run", returncode=0, elapsed_ms=1, stdout=empty, stderr=empty)
 
-    def wait(self, timeout=None) -> int:
-        if self.raises_timeout:
-            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
-        if self.raises_timeout_count > 0:
-            self.raises_timeout_count -= 1
-            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
-        if self.raises_timeout_once:
-            self.raises_timeout_once = False
-            raise subprocess.TimeoutExpired("edge264_test", timeout or 0)
-        self.returncode = self.returncode_after_wait
-        if self.returncode is None:
-            raise AssertionError("test fake process still running after wait")
-        return self.returncode
 
-    def poll(self) -> int | None:
-        if self.poll_results:
-            return self.poll_results.pop(0)
-        return self.returncode
+def process_error(returncode: int, command: list[str]) -> ProcessExecutionError:
+    empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+    return ProcessExecutionError(returncode, command, empty, empty)
+
+
+def pipeline_success(producer_present: bool) -> ProcessPipelineResult:
+    tool_ids = ["ffmpeg", "edge264", "ffmpeg"] if producer_present else ["edge264", "ffmpeg"]
+    return ProcessPipelineResult(
+        stages=tuple(
+            ProcessPipelineStageResult(tool_id, process_result(tool_id), completed_before_final=True)
+            for tool_id in tool_ids
+        )
+    )
+
+
+def pipeline_failure(
+    *,
+    producer_present: bool = False,
+    producer_error: BaseException | None = None,
+    splitter_error: BaseException | None = None,
+    ffmpeg_error: BaseException | None = None,
+) -> ProcessPipelineError:
+    stages: list[ProcessPipelineStageResult] = []
+    if producer_present:
+        stages.append(
+            ProcessPipelineStageResult(
+                "ffmpeg",
+                None if producer_error else process_result("producer"),
+                producer_error,
+                completed_before_final=producer_error is not None,
+            )
+        )
+    stages.extend(
+        (
+            ProcessPipelineStageResult(
+                "edge264",
+                None if splitter_error else process_result("splitter"),
+                splitter_error,
+                completed_before_final=splitter_error is not None,
+            ),
+            ProcessPipelineStageResult(
+                "ffmpeg",
+                None if ffmpeg_error else process_result("encoder"),
+                ffmpeg_error,
+                completed_before_final=True,
+            ),
+        )
+    )
+    return ProcessPipelineError(ProcessPipelineResult(tuple(stages)))
 
 
 if __name__ == "__main__":

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import subprocess
 import sys
 import tempfile
 import threading
@@ -15,6 +16,9 @@ from bd_to_avp.process_runner import (
     ProcessCancelled,
     ProcessExecutionError,
     ProcessOutputLimitError,
+    ProcessPipelineError,
+    ProcessPipelineRunner,
+    ProcessPipelineStage,
     ProcessPipeDrainError,
     ProcessRunnerError,
     ProcessSpec,
@@ -131,6 +135,150 @@ class ChildProcessRunnerTests(unittest.TestCase):
     def test_rejects_unmanaged_stdin_pipe(self) -> None:
         with self.assertRaisesRegex(ValueError, "stdin=subprocess.PIPE"):
             self.spec("pass", stdin=-1)
+
+    def test_redirected_stdout_keeps_binary_payload_out_of_log_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "payload.bin"
+            with output_path.open("wb") as output_file:
+                result = ChildProcessRunner().run(
+                    self.spec(
+                        "import os; os.write(1, b'\\xffpayload'); os.write(2, b'diagnostic\\n')",
+                        stdout=output_file,
+                        merge_stderr=False,
+                    )
+                )
+
+            self.assertEqual(output_path.read_bytes(), b"\xffpayload")
+            self.assertEqual(result.stdout.total_bytes, 0)
+            self.assertEqual(result.stderr.text(), "diagnostic\n")
+
+    def test_redirected_stdout_requires_separate_stderr(self) -> None:
+        with tempfile.TemporaryFile("wb") as output_file:
+            with self.assertRaisesRegex(ValueError, "merge_stderr=False"):
+                self.spec("pass", stdout=output_file)
+
+    def test_pipeline_streams_high_volume_binary_output_with_backpressure(self) -> None:
+        sink = BoundedEventSink(maximum_events=100, maximum_bytes=200_000)
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        payload_size = 5 * 1024 * 1024
+        stages = (
+            ProcessPipelineStage(
+                self.spec(
+                    f"import os; os.write(1, b'x' * {payload_size})",
+                    tool_id="producer",
+                    display_name="producer",
+                )
+            ),
+            ProcessPipelineStage(
+                self.spec(
+                    "import sys; data = sys.stdin.buffer.read(); print(len(data))",
+                    tool_id="consumer",
+                    display_name="consumer",
+                )
+            ),
+        )
+
+        result = ProcessPipelineRunner(exit_grace_seconds=0.2).run(stages, run_context=context)
+
+        self.assertEqual(result.stages[-1].result.stdout.text(), f"{payload_size}\n")
+        self.assertEqual(result.stages[0].result.stdout.total_bytes, 0)
+        events = sink.snapshot().events
+        self.assertEqual(sum(event.kind == "tool.started" for event in events), 2)
+        self.assertEqual(sum(event.kind == "tool.completed" for event in events), 2)
+
+    def test_pipeline_upstream_failure_cancels_stalled_final_stage(self) -> None:
+        stages = (
+            ProcessPipelineStage(
+                self.spec(
+                    "raise SystemExit(3)",
+                    tool_id="producer",
+                    display_name="producer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+            ProcessPipelineStage(
+                self.spec(
+                    "import sys, time; sys.stdin.buffer.read(); time.sleep(30)",
+                    tool_id="consumer",
+                    display_name="consumer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+        )
+
+        started = time.monotonic()
+        with self.assertRaises(ProcessPipelineError) as raised:
+            ProcessPipelineRunner(exit_grace_seconds=0.1).run(stages)
+
+        self.assertLess(time.monotonic() - started, 3)
+        self.assertIsInstance(raised.exception.result.stages[0].error, subprocess.CalledProcessError)
+        self.assertIsInstance(raised.exception.result.stages[1].error, ProcessCancelled)
+
+    def test_pipeline_final_failure_cancels_blocked_producer(self) -> None:
+        stages = (
+            ProcessPipelineStage(
+                self.spec(
+                    "import os\nwhile True: os.write(1, b'x' * 65536)",
+                    tool_id="producer",
+                    display_name="producer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+            ProcessPipelineStage(
+                self.spec(
+                    "raise SystemExit(4)",
+                    tool_id="consumer",
+                    display_name="consumer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+        )
+
+        with self.assertRaises(ProcessPipelineError) as raised:
+            ProcessPipelineRunner(exit_grace_seconds=0.1).run(stages)
+
+        self.assertIsInstance(raised.exception.result.stages[0].error, ProcessCancelled)
+        final_error = raised.exception.result.stages[1].error
+        self.assertIsInstance(final_error, subprocess.CalledProcessError)
+        self.assertEqual(final_error.returncode, 4)
+
+    def test_pipeline_external_cancellation_stops_all_stages(self) -> None:
+        cancellation_event = threading.Event()
+        timer = threading.Timer(0.1, cancellation_event.set)
+        timer.start()
+        stages = (
+            ProcessPipelineStage(
+                self.spec(
+                    "import time; time.sleep(30)",
+                    tool_id="producer",
+                    display_name="producer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+            ProcessPipelineStage(
+                self.spec(
+                    "import sys; sys.stdin.buffer.read()",
+                    tool_id="consumer",
+                    display_name="consumer",
+                    termination_grace_seconds=0.1,
+                    kill_wait_seconds=0.1,
+                )
+            ),
+        )
+
+        try:
+            with self.assertRaises(ProcessCancelled):
+                ProcessPipelineRunner(exit_grace_seconds=0.1).run(
+                    stages,
+                    cancellation_event=cancellation_event,
+                )
+        finally:
+            timer.cancel()
 
     def test_truncation_policy_returns_bounded_prefix_and_tail(self) -> None:
         result = ChildProcessRunner().run(

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -227,15 +227,14 @@ class MkvToolPathTests(unittest.TestCase):
 
             with (
                 patch.object(mkv.config, "FFMPEG_PATH", Path("/tools/ffmpeg")),
-                patch(
-                    "bd_to_avp.vendor.pgsrip.mkv.subprocess.run",
-                    return_value=mkv.subprocess.CompletedProcess(args=[], returncode=0, stdout=b"pgs", stderr=b""),
-                ) as run,
+                patch("bd_to_avp.vendor.pgsrip.mkv.run_process_capture") as run,
             ):
+                run.side_effect = lambda *_args, **kwargs: kwargs["stdout"].write(b"pgs")
                 data = mkv.MkvPgs.read_data(media_path, 3, temp_dir)
 
         self.assertEqual(data, b"pgs")
-        run.assert_called_once_with(
+        self.assertEqual(
+            run.call_args.args[0],
             [
                 Path("/tools/ffmpeg"),
                 "-hide_banner",
@@ -252,10 +251,11 @@ class MkvToolPathTests(unittest.TestCase):
                 "sup",
                 "pipe:1",
             ],
-            stdout=mkv.subprocess.PIPE,
-            stderr=mkv.subprocess.PIPE,
-            check=True,
         )
+        self.assertEqual(run.call_args.kwargs["tool_id"], "ffmpeg")
+        artifact = run.call_args.kwargs["artifacts"][0]
+        self.assertEqual(artifact.role, "subtitle_payload")
+        self.assertEqual(artifact.path, Path(temp_dir) / "track-3.sup")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an OS-pipe `ProcessPipelineRunner` that supervises every stage with bounded diagnostics, lifecycle events, process-group cancellation, and failure classification
- migrate native MVC producer → edge264 splitter → FFmpeg encoding, preserve single-thread retry semantics, and replace sidecar log files with structured evidence plus active output artifacts
- redirect binary PGS extraction into a tracked temporary `.sup` artifact so payload bytes never enter UTF-8 diagnostic capture

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` (652 passed, 2 skipped)
- `uv run python scripts/native_app.py test` (194 passed)

Completes the remaining child-tool migration in #276.