### PR TITLE
Persist native observability events

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -96,6 +96,9 @@ Local raw records may contain private paths needed for active-file sampling.
 User-created support bundles apply a second redaction boundary that replaces
 paths and job identifiers with bundle-scoped tokens, removes process IDs and
 command details, redacts credential-like text, and coarsens sizes.
+Public and private classifications are retained in exported event metadata;
+private text is eligible for export only after that second redaction pass.
+Events marked `redaction=omitted` never project their message or detail text.
 
 ## Retention
 
@@ -105,6 +108,18 @@ written through an owner-only directory, use inter-process locking, reject
 symlinks, and are created with mode `0600`. Sink failures and retention limits
 must never fail or block a conversion. Sequence order is authoritative within a
 single `stream_id`.
+
+The macOS app persists canonical events under its Application Support container
+in an owner-only `Observability` directory. It retains at most three `4 MiB`
+JSONL segments (`12 MiB` total) and bounds pending writes to `4 MiB`; when that
+queue is full, the oldest pending records are dropped so recent failure evidence
+survives. Writes run on a utility queue and use a nonblocking inter-process lock.
+Directory and file ACLs are cleared in addition to enforcing modes `0700` and
+`0600`. Startup writes repair crash-truncated JSONL tails and remove segments
+outside the current retention policy. Normal app termination gives pending
+writes a bounded drain window. Raw local segments are never copied into support
+bundles. Bundles include only the existing redacted event projection plus
+path-free retention counters.
 
 ## Migration
 

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -5,6 +5,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     nonisolated static let startupSmokeArgument = "--startup-smoke"
 
     weak var workCoordinator: AppWorkCoordinator?
+    var observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared
     private weak var managedWindow: NSWindow?
     private var originalWindowDelegate: NSWindowDelegate?
     private var allowManagedWindowClose = false
@@ -68,7 +69,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return .terminateLater
         }
         guard let workCoordinator, workCoordinator.hasActiveWorker else {
-            return .terminateNow
+            isStoppingForTermination = true
+            Task {
+                await flushObservabilityStoreWithDeadline()
+                sender.reply(toApplicationShouldTerminate: true)
+            }
+            return .terminateLater
         }
 
         let alert = stopAlert(action: "quit", buttonTitle: "Stop and Quit")
@@ -80,6 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         isStoppingForTermination = true
         Task {
             await workCoordinator.stopForQuit()
+            await flushObservabilityStoreWithDeadline()
             sender.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
@@ -93,6 +100,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         alert.addButton(withTitle: buttonTitle)
         alert.addButton(withTitle: "Cancel")
         return alert
+    }
+
+    private func flushObservabilityStoreWithDeadline() async {
+        let store = observabilityEventStore
+        let completions = AsyncStream<Void> { continuation in
+            Task {
+                await store.flush()
+                continuation.yield()
+                continuation.finish()
+            }
+            Task {
+                try? await Task.sleep(for: .milliseconds(250))
+                continuation.yield()
+                continuation.finish()
+            }
+        }
+        for await _ in completions {
+            return
+        }
     }
 
     override func responds(to selector: Selector!) -> Bool {

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -16,10 +16,12 @@ struct BluRayToVisionProApp: App {
 
     private let capabilities = AppCapabilities.current
     private let workCoordinator: AppWorkCoordinator
+    private let observabilityEventStore: any ObservabilityEventPersisting
 
     init() {
-        let viewModel = ConversionViewModel()
-        let previewViewModel = PreviewViewModel()
+        let observabilityEventStore = ObservabilityEventStore.automatic()
+        let viewModel = ConversionViewModel(observabilityEventStore: observabilityEventStore)
+        let previewViewModel = PreviewViewModel(observabilityEventStore: observabilityEventStore)
         let diagnosticConfiguration = DiagnosticServiceConfiguration.configured()
         let diagnosticUploader = diagnosticConfiguration.map {
             DiagnosticReportClient(configuration: $0)
@@ -36,6 +38,8 @@ struct BluRayToVisionProApp: App {
         _diagnosticReportViewModel = StateObject(wrappedValue: diagnosticReportViewModel)
         _updater = StateObject(wrappedValue: UpdateController(installPostponer: workCoordinator))
         self.workCoordinator = workCoordinator
+        self.observabilityEventStore = observabilityEventStore
+        appDelegate.observabilityEventStore = observabilityEventStore
     }
 
     var body: some Scene {

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
@@ -105,6 +105,7 @@ struct DiagnosticRuntimeMetadata: Equatable {
 private enum DiagnosticSizeRounding {
     static let fileSizeQuantumBytes: Int64 = 256 * 1_024 * 1_024
     static let volumeCapacityQuantumBytes: Int64 = 16 * 1_024 * 1_024 * 1_024
+    static let byteRateQuantum: Int64 = 1 * 1_024 * 1_024
 
     static func fileSize(_ bytes: Int64?) -> Int64? {
         roundedDown(bytes, quantum: fileSizeQuantumBytes)
@@ -112,6 +113,10 @@ private enum DiagnosticSizeRounding {
 
     static func volumeCapacity(_ bytes: Int64?) -> Int64? {
         roundedDown(bytes, quantum: volumeCapacityQuantumBytes)
+    }
+
+    static func byteRate(_ bytes: Int64?) -> Int64? {
+        roundedDown(bytes, quantum: byteRateQuantum)
     }
 
     private static func roundedDown(_ bytes: Int64?, quantum: Int64) -> Int64? {
@@ -526,6 +531,9 @@ final class DiagnosticBundleBuilder: Sendable {
             ),
             job: job,
             batch: snapshot.batchSummary.map(BundleBatch.init),
+            localObservabilityStore: BundleLocalObservabilityStore(
+                snapshot.observabilityPersistence
+            ),
             files: [
                 BundleFile(
                     name: "events.jsonl",
@@ -644,14 +652,16 @@ final class DiagnosticBundleBuilder: Sendable {
     }
 
     private static let privacyManifest = BundlePrivacy(
-        rulesVersion: 2,
+        rulesVersion: 3,
         pathTokenScope: "bundle",
         sizeRoundingMode: "down",
         fileSizeQuantumBytes: DiagnosticSizeRounding.fileSizeQuantumBytes,
         volumeCapacityQuantumBytes: DiagnosticSizeRounding.volumeCapacityQuantumBytes,
+        byteRateQuantumBytesPerSecond: DiagnosticSizeRounding.byteRateQuantum,
         included: [
             "app/build and worker protocol versions",
             "worker lifecycle, stage, heartbeat, progress, warnings, and terminal state",
+            "path-free active tool, process state, last-output age, and coarsened artifact growth",
             "selected non-identifying conversion settings",
             "source kind and per-bundle path correlation tokens",
             "coarsely rounded destination capacity and artifact size, accessibility, and modification age",
@@ -665,6 +675,7 @@ final class DiagnosticBundleBuilder: Sendable {
             "raw job requests and command arguments",
             "environment variables and credentials",
             "raw process identifiers",
+            "raw local observability JSONL segments",
             "hardware serial numbers and reusable file hashes",
         ]
     )
@@ -700,6 +711,7 @@ private struct BundleManifest: Encodable {
     let lifecycle: BundleLifecycle
     let job: BundleJob?
     let batch: BundleBatch?
+    let localObservabilityStore: BundleLocalObservabilityStore
     let files: [BundleFile]
     let truncation: BundleTruncation
     let privacy: BundlePrivacy
@@ -786,6 +798,32 @@ private struct BundleBatch: Encodable {
     }
 }
 
+private struct BundleLocalObservabilityStore: Encodable {
+    let enabled: Bool
+    let maximumFileBytes: Int
+    let maximumTotalBytes: Int
+    let maximumPendingBytes: Int
+    let pendingBytes: Int
+    let writtenEvents: Int
+    let writtenBytes: Int
+    let droppedEvents: Int
+    let droppedBytes: Int
+    let failureCount: Int
+
+    init(_ snapshot: ObservabilityEventPersistenceSnapshot) {
+        enabled = snapshot.enabled
+        maximumFileBytes = snapshot.maximumFileBytes
+        maximumTotalBytes = snapshot.maximumTotalBytes
+        maximumPendingBytes = snapshot.maximumPendingBytes
+        pendingBytes = snapshot.pendingBytes
+        writtenEvents = snapshot.writtenEvents
+        writtenBytes = snapshot.writtenBytes
+        droppedEvents = snapshot.droppedEvents
+        droppedBytes = snapshot.droppedBytes
+        failureCount = snapshot.failureCount
+    }
+}
+
 private struct BundleFile: Encodable {
     let name: String
     let uncompressedBytes: Int
@@ -830,6 +868,7 @@ private struct BundlePrivacy: Encodable {
     let sizeRoundingMode: String
     let fileSizeQuantumBytes: Int64
     let volumeCapacityQuantumBytes: Int64
+    let byteRateQuantumBytesPerSecond: Int64
     let included: [String]
     let excluded: [String]
 }
@@ -845,6 +884,18 @@ private struct BundleEvent: Encodable {
     let operation: String?
     let activeMode: String?
     let stage: String?
+    let tool: String?
+    let processState: String?
+    let lastOutputAgeSeconds: Int64?
+    let artifactRole: String?
+    let artifactState: String?
+    let artifactSizeRoundedBytes: Int64?
+    let artifactModificationAgeSeconds: Int64?
+    let artifactGrowthRoundedBytesPerSecond: Int64?
+    let privacy: String?
+    let redaction: String?
+    let messagePrivacy: String?
+    let detailsPrivacy: String?
     let message: String?
     let details: String?
     let level: String?
@@ -882,6 +933,20 @@ private struct BundleEvent: Encodable {
         operation = bounded(event.operation, maximumBytes: 256)
         activeMode = bounded(event.activeMode, maximumBytes: 256)
         stage = bounded(event.stage, maximumBytes: 1_024)
+        tool = bounded(event.tool, maximumBytes: 512)
+        processState = bounded(event.processState, maximumBytes: 128)
+        lastOutputAgeSeconds = event.lastOutputAgeSeconds
+        artifactRole = bounded(event.artifactRole, maximumBytes: 512)
+        artifactState = bounded(event.artifactState, maximumBytes: 128)
+        artifactSizeRoundedBytes = DiagnosticSizeRounding.fileSize(event.artifactSizeBytes)
+        artifactModificationAgeSeconds = event.artifactModificationAgeSeconds
+        artifactGrowthRoundedBytesPerSecond = DiagnosticSizeRounding.byteRate(
+            event.artifactGrowthBytesPerSecond
+        )
+        privacy = bounded(event.privacy, maximumBytes: 128)
+        redaction = bounded(event.redaction, maximumBytes: 128)
+        messagePrivacy = bounded(event.messagePrivacy, maximumBytes: 128)
+        detailsPrivacy = bounded(event.detailsPrivacy, maximumBytes: 128)
         message = bounded(event.message, maximumBytes: 4_096)
         details = bounded(event.details, maximumBytes: 8_192)
         level = bounded(event.level, maximumBytes: 128)

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
@@ -490,6 +490,18 @@ struct DiagnosticEventRecord: Equatable, Sendable {
     let operation: String?
     let activeMode: String?
     let stage: String?
+    let tool: String?
+    let processState: String?
+    let lastOutputAgeSeconds: Int64?
+    let artifactRole: String?
+    let artifactState: String?
+    let artifactSizeBytes: Int64?
+    let artifactModificationAgeSeconds: Int64?
+    let artifactGrowthBytesPerSecond: Int64?
+    let privacy: String?
+    let redaction: String?
+    let messagePrivacy: String?
+    let detailsPrivacy: String?
     let message: String?
     let details: String?
     let level: String?
@@ -511,6 +523,14 @@ struct DiagnosticEventRecord: Equatable, Sendable {
             operation,
             activeMode,
             stage,
+            tool,
+            processState,
+            artifactRole,
+            artifactState,
+            privacy,
+            redaction,
+            messagePrivacy,
+            detailsPrivacy,
             message,
             details,
             level,
@@ -532,6 +552,14 @@ struct DiagnosticEventRecord: Equatable, Sendable {
                 + String($0.totalStages).utf8.count
                 + ($0.stageFraction.map { String($0).utf8.count } ?? 0)
         } ?? 0
+        let observabilityNumericBytes = [
+            lastOutputAgeSeconds,
+            artifactSizeBytes,
+            artifactModificationAgeSeconds,
+            artifactGrowthBytesPerSecond,
+        ]
+        .compactMap { $0 }
+        .reduce(0) { $0 + String($1).utf8.count }
         let resultSizeBytes = resultSizeBytes.map { String($0).utf8.count } ?? 0
         let exitStatusBytes = exitStatus.map { String($0).utf8.count } ?? 0
         let fixedValueBytes = (jobID == nil ? 0 : 38)
@@ -541,6 +569,7 @@ struct DiagnosticEventRecord: Equatable, Sendable {
             + strings
             + choicesBytes
             + numericBytes
+            + observabilityNumericBytes
             + progressBytes
             + resultSizeBytes
             + exitStatusBytes
@@ -622,6 +651,7 @@ struct DiagnosticCaptureSnapshot: @unchecked Sendable {
     let storageSamples: [RawDiagnosticStorageSample]
     let totalStorageSamples: Int
     let droppedStorageSamples: Int
+    let observabilityPersistence: ObservabilityEventPersistenceSnapshot
 }
 
 final class DiagnosticSessionRecorder {
@@ -704,6 +734,7 @@ final class DiagnosticSessionRecorder {
         recordedAt: Date
     ) {
         let observabilityEvent = event.payload.observabilityEvent
+        let observabilityTextIsOmitted = observabilityEvent?.redaction == "omitted"
         let terminalPhase: String?
         switch event.type {
         case .jobCompleted:
@@ -731,13 +762,27 @@ final class DiagnosticSessionRecorder {
             operation: event.payload.operation ?? context(for: event.jobID)?.operation,
             activeMode: activeMode,
             stage: event.payload.stage ?? observabilityEvent?.context.stage?.id,
+            tool: observabilityEvent?.context.tool?.id,
+            processState: observabilityEvent.flatMap {
+                LiveObservabilityStatus.processState(for: $0)?.rawValue
+            },
+            lastOutputAgeSeconds: observabilityEvent?.data.activity?.lastOutputAgeSeconds,
+            artifactRole: observabilityEvent?.data.artifact?.role,
+            artifactState: observabilityEvent?.data.artifact?.state,
+            artifactSizeBytes: observabilityEvent?.data.artifact?.sizeBytes,
+            artifactModificationAgeSeconds: observabilityEvent?.data.artifact?.modificationAgeSeconds,
+            artifactGrowthBytesPerSecond: observabilityEvent?.data.artifact?.growthBytesPerSecond,
+            privacy: observabilityEvent?.privacy,
+            redaction: observabilityEvent?.redaction,
+            messagePrivacy: observabilityEvent?.data.message?.privacy,
+            detailsPrivacy: observabilityEvent?.data.detail?.privacy,
             message: event.payload.message
                 ?? event.payload.error?.message
                 ?? event.payload.decision?.prompt
-                ?? observabilityEvent?.data.message?.value,
+                ?? (observabilityTextIsOmitted ? nil : observabilityEvent?.data.message?.value),
             details: event.payload.error?.details
                 ?? event.payload.decision?.details
-                ?? observabilityEvent?.data.detail?.value,
+                ?? (observabilityTextIsOmitted ? nil : observabilityEvent?.data.detail?.value),
             level: event.payload.level ?? observabilityEvent?.severity,
             elapsedSeconds: event.payload.elapsedSeconds,
             progress: event.payload.progress.map(DiagnosticProgressSnapshot.init),
@@ -780,6 +825,18 @@ final class DiagnosticSessionRecorder {
                 operation: jobContext?.operation,
                 activeMode: activeMode,
                 stage: lifecycle.stageMessage,
+                tool: nil,
+                processState: nil,
+                lastOutputAgeSeconds: nil,
+                artifactRole: nil,
+                artifactState: nil,
+                artifactSizeBytes: nil,
+                artifactModificationAgeSeconds: nil,
+                artifactGrowthBytesPerSecond: nil,
+                privacy: nil,
+                redaction: nil,
+                messagePrivacy: nil,
+                detailsPrivacy: nil,
                 message: message,
                 details: details,
                 level: nil,
@@ -858,7 +915,8 @@ final class DiagnosticSessionRecorder {
         lifecycle: WorkerLifecycleState,
         activeMode: String?,
         batchSummary: DiagnosticBatchSummary?,
-        process: WorkerProcessDiagnosticSnapshot
+        process: WorkerProcessDiagnosticSnapshot,
+        observabilityPersistence: ObservabilityEventPersistenceSnapshot = .disabled
     ) -> DiagnosticCaptureSnapshot {
         let meaningfulLifecycle = lifecycle.phase == .empty ? latestLifecycle ?? lifecycle : lifecycle
         return DiagnosticCaptureSnapshot(
@@ -874,7 +932,8 @@ final class DiagnosticSessionRecorder {
             events: history.snapshot(),
             storageSamples: storageSamples,
             totalStorageSamples: storageSamples.count + droppedStorageSamples,
-            droppedStorageSamples: droppedStorageSamples
+            droppedStorageSamples: droppedStorageSamples,
+            observabilityPersistence: observabilityPersistence
         )
     }
 

--- a/macos/BluRayToVisionPro/Diagnostics/ObservabilityEventStore.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/ObservabilityEventStore.swift
@@ -1,0 +1,774 @@
+import Darwin
+import Dispatch
+import Foundation
+
+struct ObservabilityEventPersistenceSnapshot: Equatable, Sendable {
+    let enabled: Bool
+    let maximumFileBytes: Int
+    let maximumTotalBytes: Int
+    let maximumPendingBytes: Int
+    let pendingBytes: Int
+    let writtenEvents: Int
+    let writtenBytes: Int
+    let droppedEvents: Int
+    let droppedBytes: Int
+    let failureCount: Int
+
+    static let disabled = ObservabilityEventPersistenceSnapshot(
+        enabled: false,
+        maximumFileBytes: 0,
+        maximumTotalBytes: 0,
+        maximumPendingBytes: 0,
+        pendingBytes: 0,
+        writtenEvents: 0,
+        writtenBytes: 0,
+        droppedEvents: 0,
+        droppedBytes: 0,
+        failureCount: 0
+    )
+}
+
+protocol ObservabilityEventPersisting: Sendable {
+    func append(_ event: ObservabilityEvent)
+    func snapshot() -> ObservabilityEventPersistenceSnapshot
+    func flush() async
+}
+
+extension ObservabilityEventPersisting {
+    func flush() async {}
+}
+
+final class NullObservabilityEventStore: ObservabilityEventPersisting, @unchecked Sendable {
+    static let shared = NullObservabilityEventStore()
+
+    private init() {}
+
+    func append(_: ObservabilityEvent) {}
+
+    func snapshot() -> ObservabilityEventPersistenceSnapshot {
+        .disabled
+    }
+}
+
+protocol ObservabilityEventWriting: AnyObject {
+    func append(_ line: Data) throws
+}
+
+final class ObservabilityEventStore: ObservabilityEventPersisting, @unchecked Sendable {
+    struct Configuration: Sendable {
+        let directoryURL: URL
+        let maximumFileBytes: Int
+        let maximumTotalBytes: Int
+        let maximumPendingBytes: Int
+
+        init(
+            directoryURL: URL,
+            maximumFileBytes: Int = 4 * 1_024 * 1_024,
+            maximumTotalBytes: Int = 12 * 1_024 * 1_024,
+            maximumPendingBytes: Int = 4 * 1_024 * 1_024
+        ) {
+            precondition(maximumFileBytes > 0)
+            precondition(maximumTotalBytes >= maximumFileBytes)
+            precondition(maximumPendingBytes > 0)
+            self.directoryURL = directoryURL
+            self.maximumFileBytes = maximumFileBytes
+            self.maximumTotalBytes = maximumTotalBytes
+            self.maximumPendingBytes = maximumPendingBytes
+        }
+    }
+
+    typealias WriterFactory = () throws -> any ObservabilityEventWriting
+
+    private struct State {
+        var pendingLines: [Data] = []
+        var pendingIndex = 0
+        var pendingBytes = 0
+        var drainScheduled = false
+        var writtenEvents = 0
+        var writtenBytes = 0
+        var droppedEvents = 0
+        var droppedBytes = 0
+        var failureCount = 0
+        var lastFailureDescription: String?
+    }
+
+    private let configuration: Configuration
+    private let writerFactory: WriterFactory
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "com.shinycomputers.bd-to-avp.observability-store", qos: .utility)
+    private var state = State()
+    private var writer: (any ObservabilityEventWriting)?
+
+    init(
+        configuration: Configuration,
+        writerFactory: WriterFactory? = nil
+    ) {
+        self.configuration = configuration
+        self.writerFactory = writerFactory ?? {
+            try SecureRotatingJSONLWriter(configuration: configuration)
+        }
+    }
+
+    static func automatic(
+        fileManager: FileManager = .default,
+        bundle: Bundle = .main
+    ) -> any ObservabilityEventPersisting {
+        guard let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return NullObservabilityEventStore.shared
+        }
+        let identifier = bundle.bundleIdentifier ?? "com.shinycomputers.bd-to-avp"
+        let directoryURL = applicationSupport
+            .appendingPathComponent(identifier, isDirectory: true)
+            .appendingPathComponent("Observability", isDirectory: true)
+        return ObservabilityEventStore(configuration: Configuration(directoryURL: directoryURL))
+    }
+
+    func append(_ event: ObservabilityEvent) {
+        let line: Data
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+            var encoded = try encoder.encode(event)
+            encoded.append(0x0A)
+            line = encoded
+        } catch {
+            lock.withObservabilityLock {
+                state.droppedEvents += 1
+                state.failureCount += 1
+                state.lastFailureDescription = String(describing: error)
+            }
+            return
+        }
+
+        var shouldScheduleDrain = false
+        lock.withObservabilityLock {
+            guard line.count <= configuration.maximumFileBytes,
+                  line.count <= configuration.maximumPendingBytes
+            else {
+                state.droppedEvents += 1
+                state.droppedBytes += line.count
+                return
+            }
+            while state.pendingBytes + line.count > configuration.maximumPendingBytes {
+                guard let dropped = dequeuePendingLine() else {
+                    break
+                }
+                state.droppedEvents += 1
+                state.droppedBytes += dropped.count
+            }
+            state.pendingLines.append(line)
+            state.pendingBytes += line.count
+            if !state.drainScheduled {
+                state.drainScheduled = true
+                shouldScheduleDrain = true
+            }
+        }
+        if shouldScheduleDrain {
+            queue.async { [self] in
+                drain()
+            }
+        }
+    }
+
+    func snapshot() -> ObservabilityEventPersistenceSnapshot {
+        lock.withObservabilityLock {
+            ObservabilityEventPersistenceSnapshot(
+                enabled: true,
+                maximumFileBytes: configuration.maximumFileBytes,
+                maximumTotalBytes: configuration.maximumTotalBytes,
+                maximumPendingBytes: configuration.maximumPendingBytes,
+                pendingBytes: state.pendingBytes,
+                writtenEvents: state.writtenEvents,
+                writtenBytes: state.writtenBytes,
+                droppedEvents: state.droppedEvents,
+                droppedBytes: state.droppedBytes,
+                failureCount: state.failureCount
+            )
+        }
+    }
+
+    func flushForTesting() {
+        queue.sync {}
+    }
+
+    func failureDescriptionForTesting() -> String? {
+        lock.withObservabilityLock { state.lastFailureDescription }
+    }
+
+    func flush() async {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                drain()
+                continuation.resume()
+            }
+        }
+    }
+
+    private func drain() {
+        while true {
+            let line = lock.withObservabilityLock { () -> Data? in
+                guard let line = dequeuePendingLine() else {
+                    state.drainScheduled = false
+                    return nil
+                }
+                return line
+            }
+            guard let line else {
+                return
+            }
+            do {
+                if writer == nil {
+                    writer = try writerFactory()
+                }
+                try writer?.append(line)
+                lock.withObservabilityLock {
+                    state.writtenEvents += 1
+                    state.writtenBytes += line.count
+                }
+            } catch {
+                writer = nil
+                lock.withObservabilityLock {
+                    state.droppedEvents += 1
+                    state.droppedBytes += line.count
+                    state.failureCount += 1
+                    state.lastFailureDescription = String(describing: error)
+                }
+            }
+        }
+    }
+
+    private func dequeuePendingLine() -> Data? {
+        guard state.pendingIndex < state.pendingLines.count else {
+            state.pendingLines.removeAll(keepingCapacity: true)
+            state.pendingIndex = 0
+            state.pendingBytes = 0
+            return nil
+        }
+        let line = state.pendingLines[state.pendingIndex]
+        state.pendingLines[state.pendingIndex] = Data()
+        state.pendingIndex += 1
+        state.pendingBytes -= line.count
+        if state.pendingIndex == state.pendingLines.count {
+            state.pendingLines.removeAll(keepingCapacity: true)
+            state.pendingIndex = 0
+        } else if state.pendingIndex >= 128,
+                  state.pendingIndex * 2 >= state.pendingLines.count
+        {
+            state.pendingLines.removeFirst(state.pendingIndex)
+            state.pendingIndex = 0
+        }
+        return line
+    }
+}
+
+private enum SecureJSONLWriterError: Error {
+    case invalidDirectory
+    case invalidEntry(String)
+    case systemCall(String, Int32)
+}
+
+private final class SecureRotatingJSONLWriter: ObservabilityEventWriting {
+    private static let currentFilename = "events.jsonl"
+    private static let lockFilename = ".events.jsonl.lock"
+
+    private let directoryFileDescriptor: Int32
+    private let maximumFileBytes: Int
+    private let segmentCount: Int
+
+    init(configuration: ObservabilityEventStore.Configuration) throws {
+        maximumFileBytes = configuration.maximumFileBytes
+        segmentCount = max(1, configuration.maximumTotalBytes / configuration.maximumFileBytes)
+        directoryFileDescriptor = try Self.openPrivateDirectory(at: configuration.directoryURL)
+    }
+
+    deinit {
+        close(directoryFileDescriptor)
+    }
+
+    func append(_ line: Data) throws {
+        guard !line.isEmpty, line.count <= maximumFileBytes else {
+            throw SecureJSONLWriterError.invalidEntry(Self.currentFilename)
+        }
+        let lockFileDescriptor = try openValidatedFile(
+            named: Self.lockFilename,
+            flags: O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW
+        )
+        defer { close(lockFileDescriptor) }
+        guard flock(lockFileDescriptor, LOCK_EX | LOCK_NB) == 0 else {
+            throw SecureJSONLWriterError.systemCall("flock", errno)
+        }
+        defer { _ = flock(lockFileDescriptor, LOCK_UN) }
+
+        try removeOutOfRangeSegments()
+        try normalizeAndRemoveOversizedSegments()
+        var eventFileDescriptor = try openValidatedFile(
+            named: Self.currentFilename,
+            flags: O_RDWR | O_APPEND | O_CREAT | O_CLOEXEC | O_NOFOLLOW
+        )
+        defer {
+            if eventFileDescriptor >= 0 {
+                close(eventFileDescriptor)
+            }
+        }
+        var metadata = try repairPartialTail(
+            fileDescriptor: eventFileDescriptor,
+            metadata: fileMetadata(eventFileDescriptor, named: Self.currentFilename)
+        )
+        if metadata.st_size + off_t(line.count) > off_t(maximumFileBytes) {
+            close(eventFileDescriptor)
+            eventFileDescriptor = -1
+            try rotate()
+            eventFileDescriptor = try openValidatedFile(
+                named: Self.currentFilename,
+                flags: O_RDWR | O_APPEND | O_CREAT | O_CLOEXEC | O_NOFOLLOW
+            )
+            metadata = try fileMetadata(eventFileDescriptor, named: Self.currentFilename)
+        }
+        let originalSize = metadata.st_size
+        do {
+            try writeAll(line, to: eventFileDescriptor)
+        } catch {
+            guard ftruncate(eventFileDescriptor, originalSize) == 0 else {
+                throw SecureJSONLWriterError.systemCall("ftruncate(rollback)", errno)
+            }
+            throw error
+        }
+    }
+
+    private func rotate() throws {
+        try compactRotatedSegments()
+        for index in stride(from: segmentCount - 1, through: 1, by: -1) {
+            let destination = filename(for: index)
+            let source = filename(for: index - 1)
+            if try validatedEntryExists(named: source) {
+                _ = try validatedEntryMetadata(named: destination)
+                try rename(source, to: destination)
+            }
+        }
+        if segmentCount == 1,
+           try validatedEntryExists(named: Self.currentFilename)
+        {
+            try unlink(named: Self.currentFilename)
+        }
+    }
+
+    private func compactRotatedSegments() throws {
+        var destinationIndex = 1
+        for sourceIndex in 1 ..< segmentCount {
+            let source = filename(for: sourceIndex)
+            guard try recoverableRotatedEntryExists(named: source) else {
+                continue
+            }
+            if sourceIndex != destinationIndex {
+                let destination = filename(for: destinationIndex)
+                guard try validatedEntryMetadata(named: destination) == nil else {
+                    throw SecureJSONLWriterError.invalidEntry(destination)
+                }
+                try rename(source, to: destination)
+            }
+            destinationIndex += 1
+        }
+    }
+
+    private func normalizeAndRemoveOversizedSegments() throws {
+        for index in 0 ..< segmentCount {
+            let name = filename(for: index)
+            let exists = if index == 0 {
+                try validatedEntryExists(named: name)
+            } else {
+                try recoverableRotatedEntryExists(named: name)
+            }
+            guard exists else {
+                continue
+            }
+            let descriptor = try openValidatedFile(
+                named: name,
+                flags: O_RDWR | O_CLOEXEC | O_NOFOLLOW
+            )
+            defer { close(descriptor) }
+            let metadata = try fileMetadata(descriptor, named: name)
+            if metadata.st_size > off_t(maximumFileBytes) {
+                try unlink(named: name)
+            }
+        }
+    }
+
+    private func removeOutOfRangeSegments() throws {
+        let scanDescriptor = ".".withCString {
+            openat(
+                directoryFileDescriptor,
+                $0,
+                O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+            )
+        }
+        guard scanDescriptor >= 0 else {
+            throw SecureJSONLWriterError.systemCall("openat(directory)", errno)
+        }
+        guard let directory = fdopendir(scanDescriptor) else {
+            close(scanDescriptor)
+            throw SecureJSONLWriterError.systemCall("fdopendir", errno)
+        }
+        defer { closedir(directory) }
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) { pointer in
+                pointer.withMemoryRebound(
+                    to: CChar.self,
+                    capacity: Int(MAXNAMLEN) + 1
+                ) {
+                    String(cString: $0)
+                }
+            }
+            guard let index = segmentIndex(from: name), index >= segmentCount else {
+                continue
+            }
+            if try recoverableRotatedEntryExists(named: name) {
+                try unlink(named: name)
+            }
+        }
+    }
+
+    private func segmentIndex(from name: String) -> Int? {
+        guard name.hasPrefix("events."), name.hasSuffix(".jsonl") else {
+            return nil
+        }
+        let start = name.index(name.startIndex, offsetBy: "events.".count)
+        let end = name.index(name.endIndex, offsetBy: -".jsonl".count)
+        guard start < end,
+              let index = Int(name[start ..< end]),
+              index > 0
+        else {
+            return nil
+        }
+        return index
+    }
+
+    private func filename(for index: Int) -> String {
+        index == 0 ? Self.currentFilename : "events.\(index).jsonl"
+    }
+
+    private func openValidatedFile(named name: String, flags: Int32) throws -> Int32 {
+        let descriptor = name.withCString {
+            openat(directoryFileDescriptor, $0, flags | O_NONBLOCK, mode_t(0o600))
+        }
+        guard descriptor >= 0 else {
+            throw SecureJSONLWriterError.systemCall("openat(\(name))", errno)
+        }
+        do {
+            _ = try fileMetadata(descriptor, named: name)
+            guard fchmod(descriptor, mode_t(0o600)) == 0 else {
+                throw SecureJSONLWriterError.systemCall("fchmod(\(name))", errno)
+            }
+            try Self.removeExtendedACL(from: descriptor, name: name)
+            return descriptor
+        } catch {
+            close(descriptor)
+            throw error
+        }
+    }
+
+    private func fileMetadata(_ descriptor: Int32, named name: String) throws -> stat {
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0 else {
+            throw SecureJSONLWriterError.systemCall("fstat(\(name))", errno)
+        }
+        guard metadata.st_mode & S_IFMT == S_IFREG,
+              metadata.st_uid == geteuid(),
+              metadata.st_nlink == 1
+        else {
+            throw SecureJSONLWriterError.invalidEntry(name)
+        }
+        return metadata
+    }
+
+    private func validatedEntryExists(named name: String) throws -> Bool {
+        try validatedEntryMetadata(named: name) != nil
+    }
+
+    private func recoverableRotatedEntryExists(named name: String) throws -> Bool {
+        do {
+            return try validatedEntryExists(named: name)
+        } catch SecureJSONLWriterError.invalidEntry {
+            try unlink(named: name)
+            return false
+        }
+    }
+
+    private func validatedEntryMetadata(named name: String) throws -> stat? {
+        var metadata = stat()
+        let result = name.withCString {
+            fstatat(directoryFileDescriptor, $0, &metadata, AT_SYMLINK_NOFOLLOW)
+        }
+        if result != 0 {
+            if errno == ENOENT {
+                return nil
+            }
+            throw SecureJSONLWriterError.systemCall("fstatat(\(name))", errno)
+        }
+        guard metadata.st_mode & S_IFMT == S_IFREG,
+              metadata.st_uid == geteuid(),
+              metadata.st_nlink == 1
+        else {
+            throw SecureJSONLWriterError.invalidEntry(name)
+        }
+        return metadata
+    }
+
+    private func unlink(named name: String) throws {
+        let result = name.withCString {
+            unlinkat(directoryFileDescriptor, $0, 0)
+        }
+        guard result == 0 else {
+            throw SecureJSONLWriterError.systemCall("unlinkat(\(name))", errno)
+        }
+    }
+
+    private func rename(_ source: String, to destination: String) throws {
+        let result = source.withCString { sourcePointer in
+            destination.withCString { destinationPointer in
+                renameat(
+                    directoryFileDescriptor,
+                    sourcePointer,
+                    directoryFileDescriptor,
+                    destinationPointer
+                )
+            }
+        }
+        guard result == 0 else {
+            throw SecureJSONLWriterError.systemCall("renameat(\(source))", errno)
+        }
+    }
+
+    private func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                return
+            }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if written < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    throw SecureJSONLWriterError.systemCall("write", errno)
+                }
+                guard written > 0 else {
+                    throw SecureJSONLWriterError.systemCall("write", EIO)
+                }
+                offset += written
+            }
+        }
+    }
+
+    private func repairPartialTail(fileDescriptor: Int32, metadata: stat) throws -> stat {
+        guard metadata.st_size > 0 else {
+            return metadata
+        }
+        var lastByte: UInt8 = 0
+        try readExactly(
+            fileDescriptor: fileDescriptor,
+            into: &lastByte,
+            count: 1,
+            offset: metadata.st_size - 1
+        )
+        guard lastByte != 0x0A else {
+            return metadata
+        }
+
+        let chunkSize = 64 * 1_024
+        var searchEnd = metadata.st_size
+        var repairedSize: off_t = 0
+        while searchEnd > 0 {
+            let readSize = min(off_t(chunkSize), searchEnd)
+            let readStart = searchEnd - readSize
+            var bytes = [UInt8](repeating: 0, count: Int(readSize))
+            try bytes.withUnsafeMutableBytes { buffer in
+                guard let baseAddress = buffer.baseAddress else {
+                    return
+                }
+                try readExactly(
+                    fileDescriptor: fileDescriptor,
+                    into: baseAddress,
+                    count: buffer.count,
+                    offset: readStart
+                )
+            }
+            if let newlineIndex = bytes.lastIndex(of: 0x0A) {
+                repairedSize = readStart + off_t(newlineIndex + 1)
+                break
+            }
+            searchEnd = readStart
+        }
+        guard ftruncate(fileDescriptor, repairedSize) == 0 else {
+            throw SecureJSONLWriterError.systemCall("ftruncate(repair)", errno)
+        }
+        return try fileMetadata(fileDescriptor, named: Self.currentFilename)
+    }
+
+    private func readExactly(
+        fileDescriptor: Int32,
+        into destination: UnsafeMutableRawPointer,
+        count: Int,
+        offset: off_t
+    ) throws {
+        var totalRead = 0
+        while totalRead < count {
+            let result = pread(
+                fileDescriptor,
+                destination.advanced(by: totalRead),
+                count - totalRead,
+                offset + off_t(totalRead)
+            )
+            if result < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw SecureJSONLWriterError.systemCall("pread", errno)
+            }
+            guard result > 0 else {
+                throw SecureJSONLWriterError.systemCall("pread", EIO)
+            }
+            totalRead += result
+        }
+    }
+
+    private func readExactly(
+        fileDescriptor: Int32,
+        into byte: inout UInt8,
+        count: Int,
+        offset: off_t
+    ) throws {
+        try withUnsafeMutablePointer(to: &byte) {
+            try readExactly(
+                fileDescriptor: fileDescriptor,
+                into: UnsafeMutableRawPointer($0),
+                count: count,
+                offset: offset
+            )
+        }
+    }
+
+    private static func openPrivateDirectory(at url: URL) throws -> Int32 {
+        guard url.isFileURL, url.standardizedFileURL.path.hasPrefix("/") else {
+            throw SecureJSONLWriterError.invalidDirectory
+        }
+        let standardizedPath = canonicalSystemPath(url.standardizedFileURL.path)
+        var currentDescriptor = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        guard currentDescriptor >= 0 else {
+            throw SecureJSONLWriterError.systemCall("open(/)", errno)
+        }
+        let components = URL(fileURLWithPath: standardizedPath, isDirectory: true)
+            .pathComponents
+            .dropFirst()
+        guard !components.isEmpty else {
+            close(currentDescriptor)
+            throw SecureJSONLWriterError.invalidDirectory
+        }
+        do {
+            for (offset, component) in components.enumerated() {
+                let isFinal = offset == components.count - 1
+                var nextDescriptor = component.withCString {
+                    openat(
+                        currentDescriptor,
+                        $0,
+                        O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+                    )
+                }
+                if nextDescriptor < 0, errno == ENOENT {
+                    let createResult = component.withCString {
+                        mkdirat(currentDescriptor, $0, mode_t(0o700))
+                    }
+                    if createResult != 0, errno != EEXIST {
+                        throw SecureJSONLWriterError.systemCall("mkdirat(\(component))", errno)
+                    }
+                    nextDescriptor = component.withCString {
+                        openat(
+                            currentDescriptor,
+                            $0,
+                            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+                        )
+                    }
+                }
+                guard nextDescriptor >= 0 else {
+                    throw SecureJSONLWriterError.systemCall("openat(\(component))", errno)
+                }
+                var metadata = stat()
+                guard fstat(nextDescriptor, &metadata) == 0,
+                      metadata.st_mode & S_IFMT == S_IFDIR
+                else {
+                    close(nextDescriptor)
+                    throw SecureJSONLWriterError.invalidEntry(component)
+                }
+                if isFinal {
+                    guard metadata.st_uid == geteuid() else {
+                        close(nextDescriptor)
+                        throw SecureJSONLWriterError.invalidEntry(component)
+                    }
+                    guard fchmod(nextDescriptor, mode_t(0o700)) == 0 else {
+                        close(nextDescriptor)
+                        throw SecureJSONLWriterError.systemCall("fchmod(directory)", errno)
+                    }
+                    do {
+                        try removeExtendedACL(from: nextDescriptor, name: component)
+                    } catch {
+                        close(nextDescriptor)
+                        throw error
+                    }
+                }
+                close(currentDescriptor)
+                currentDescriptor = nextDescriptor
+            }
+            return currentDescriptor
+        } catch {
+            close(currentDescriptor)
+            throw error
+        }
+    }
+
+    private static func canonicalSystemPath(_ path: String) -> String {
+        if path == "/var" || path.hasPrefix("/var/") || path == "/tmp" || path.hasPrefix("/tmp/") {
+            return "/private\(path)"
+        }
+        return path
+    }
+
+    private static func removeExtendedACL(from descriptor: Int32, name: String) throws {
+        guard let accessControlList = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            if errno == ENOENT {
+                return
+            }
+            throw SecureJSONLWriterError.systemCall("acl_get_fd_np(\(name))", errno)
+        }
+        defer { acl_free(UnsafeMutableRawPointer(accessControlList)) }
+        var entry: acl_entry_t?
+        while acl_get_entry(
+            accessControlList,
+            ACL_FIRST_ENTRY.rawValue,
+            &entry
+        ) == 0 {
+            guard let entry,
+                  acl_delete_entry(accessControlList, entry) == 0
+            else {
+                throw SecureJSONLWriterError.systemCall("acl_delete_entry(\(name))", errno)
+            }
+        }
+        guard acl_set_fd_np(descriptor, accessControlList, ACL_TYPE_EXTENDED) == 0 else {
+            throw SecureJSONLWriterError.systemCall("acl_set_fd_np(\(name))", errno)
+        }
+    }
+}
+
+private extension NSLock {
+    func withObservabilityLock<Result>(_ operation: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -31,6 +31,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var source: ConversionSource?
     @Published private(set) var state = WorkerLifecycleState()
     @Published private(set) var diagnosticLog = ""
+    @Published private(set) var liveObservabilityStatus = LiveObservabilityStatus.empty
     @Published private(set) var batchQueue: SourceFolderQueueState?
     @Published private(set) var queueItems: [ConversionQueueItem] = []
     @Published private(set) var completedBatchResults: [ConversionResult]?
@@ -39,6 +40,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private let diagnosticClock: () -> Date
     private let diagnosticStorageProbe: any DiagnosticStorageProbing
     private let diagnosticBundleBuilder: DiagnosticBundleBuilder
+    private let observabilityEventStore: any ObservabilityEventPersisting
     private let diagnosticRecorder = DiagnosticSessionRecorder()
     private let diagnosticLogBuffer = BoundedDiagnosticTextBuffer(maximumBytes: 128 * 1_024)
     private var client: (any WorkerProcessRunning)?
@@ -58,13 +60,15 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         },
         diagnosticClock: @escaping () -> Date = Date.init,
         diagnosticStorageProbe: any DiagnosticStorageProbing = FileSystemDiagnosticStorageProbe(),
-        diagnosticBundleBuilder: DiagnosticBundleBuilder? = nil
+        diagnosticBundleBuilder: DiagnosticBundleBuilder? = nil,
+        observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared
     ) {
         self.clientFactory = clientFactory
         self.diagnosticClock = diagnosticClock
         self.diagnosticStorageProbe = diagnosticStorageProbe
         self.diagnosticBundleBuilder = diagnosticBundleBuilder
             ?? DiagnosticBundleBuilder(storageProbe: diagnosticStorageProbe)
+        self.observabilityEventStore = observabilityEventStore
     }
 
     var isRunning: Bool {
@@ -132,7 +136,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             lifecycle: state,
             activeMode: activeRunMode?.diagnosticName,
             batchSummary: diagnosticBatchSummary,
-            process: processSnapshot
+            process: processSnapshot,
+            observabilityPersistence: observabilityEventStore.snapshot()
         )
         let builder = diagnosticBundleBuilder
         return try await Task.detached(priority: .utility) {
@@ -198,6 +203,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         let job = WorkerJobSpec(source: source)
         do {
             try state.begin(jobID: job.jobID)
+            liveObservabilityStatus = .empty
             pendingTerminalEvent = nil
             activeRunMode = mode
             diagnosticRecorder.beginJob(
@@ -318,6 +324,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         let job = WorkerJobSpec(draft: draft, jobID: jobID)
         do {
             try state.begin(jobID: job.jobID, operationKind: .conversion)
+            liveObservabilityStatus = .empty
             switch mode {
             case .singleConversion, .titleQueueConversion:
                 lastConversionDraft = draft
@@ -655,6 +662,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     private func receive(_ event: WorkerEvent) throws {
         let recordedAt = diagnosticClock()
+        if let observabilityEvent = event.payload.observabilityEvent {
+            observabilityEventStore.append(observabilityEvent)
+            liveObservabilityStatus.receive(observabilityEvent, receivedAt: recordedAt)
+        }
         if event.type.isTerminal {
             diagnosticRecorder.record(
                 event: event,
@@ -1101,6 +1112,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private func resetDiagnosticSession() {
         diagnosticRecorder.reset()
         batchItemDiagnosticJobIDs.removeAll(keepingCapacity: true)
+        liveObservabilityStatus = .empty
         resetDiagnosticLog()
     }
 

--- a/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
@@ -33,6 +33,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
 
     private let clientFactory: ClientFactory
     private let cache: PreviewCache
+    private let observabilityEventStore: any ObservabilityEventPersisting
     private var client: (any WorkerProcessRunning)?
     private var runTask: Task<Void, Never>?
     private var activeDraft: PreviewDraft?
@@ -44,10 +45,12 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         clientFactory: @escaping ClientFactory = {
             WorkerProcessClient(configuration: try WorkerLaunchConfiguration.automatic())
         },
-        cache: PreviewCache = .automatic()
+        cache: PreviewCache = .automatic(),
+        observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared
     ) {
         self.clientFactory = clientFactory
         self.cache = cache
+        self.observabilityEventStore = observabilityEventStore
         cache.removeExpired()
     }
 
@@ -179,6 +182,9 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     private func receive(_ event: WorkerEvent) throws {
+        if let observabilityEvent = event.payload.observabilityEvent {
+            observabilityEventStore.append(observabilityEvent)
+        }
         if event.type.isTerminal {
             pendingTerminalEvent = event
             return

--- a/macos/BluRayToVisionPro/Models/LiveObservabilityStatus.swift
+++ b/macos/BluRayToVisionPro/Models/LiveObservabilityStatus.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct LiveObservabilityStatus: Equatable, Sendable {
+    enum ProcessState: String, Equatable, Sendable {
+        case running
+        case cancelling
+        case completed
+        case failed
+        case cancelled
+
+        var isTerminal: Bool {
+            self == .completed || self == .failed || self == .cancelled
+        }
+    }
+
+    private(set) var stageID: String?
+    private(set) var toolID: String?
+    private(set) var processState: ProcessState?
+    private(set) var lastOutputAgeSeconds: Int64?
+    private(set) var lastOutputAgeSampledAt: Date?
+    private(set) var artifactRole: String?
+    private(set) var artifactState: String?
+    private(set) var artifactSizeBytes: Int64?
+    private(set) var artifactModificationAgeSeconds: Int64?
+    private(set) var artifactGrowthBytesPerSecond: Int64?
+    private(set) var updatedAt: Date?
+
+    static let empty = LiveObservabilityStatus()
+
+    var hasDetails: Bool {
+        stageID != nil
+            || toolID != nil
+            || processState != nil
+            || lastOutputAgeSeconds != nil
+            || artifactRole != nil
+            || artifactState != nil
+            || artifactSizeBytes != nil
+            || artifactGrowthBytesPerSecond != nil
+    }
+
+    mutating func receive(_ event: ObservabilityEvent, receivedAt: Date) {
+        let incomingToolID = Self.safeIdentifier(event.context.tool?.id)
+        let belongsToCurrentTool = incomingToolID == nil || incomingToolID == toolID
+        if let stageID = Self.safeIdentifier(event.context.stage?.id) {
+            self.stageID = stageID
+        }
+        if let processState = Self.processState(for: event) {
+            let wouldRegressTerminalState = self.processState?.isTerminal == true
+                && !processState.isTerminal
+                && event.kind != "tool.started"
+                && belongsToCurrentTool
+            if !wouldRegressTerminalState {
+                self.processState = processState
+            }
+        }
+        if let incomingToolID {
+            toolID = incomingToolID
+        }
+        if let age = event.data.activity?.lastOutputAgeSeconds {
+            lastOutputAgeSeconds = age
+            lastOutputAgeSampledAt = receivedAt
+        }
+        if let artifact = event.data.artifact {
+            artifactRole = Self.safeIdentifier(artifact.role)
+            artifactState = Self.safeIdentifier(artifact.state)
+            artifactSizeBytes = Self.nonNegative(artifact.sizeBytes)
+            artifactModificationAgeSeconds = Self.nonNegative(artifact.modificationAgeSeconds)
+            artifactGrowthBytesPerSecond = Self.nonNegative(artifact.growthBytesPerSecond)
+        }
+        updatedAt = receivedAt
+    }
+
+    func currentLastOutputAgeSeconds(at date: Date) -> Int64? {
+        guard let lastOutputAgeSeconds else {
+            return nil
+        }
+        guard processState == .running || processState == .cancelling,
+              let lastOutputAgeSampledAt
+        else {
+            return lastOutputAgeSeconds
+        }
+        let hostElapsed = max(
+            0,
+            Int64(date.timeIntervalSince(lastOutputAgeSampledAt).rounded(.down))
+        )
+        return lastOutputAgeSeconds + hostElapsed
+    }
+
+    func isStalled(at date: Date, thresholdSeconds: Int64 = 60) -> Bool {
+        guard processState == .running || processState == .cancelling,
+              let age = currentLastOutputAgeSeconds(at: date)
+        else {
+            return false
+        }
+        return age >= thresholdSeconds
+    }
+
+    static func processState(for event: ObservabilityEvent) -> ProcessState? {
+        switch event.kind {
+        case "tool.started":
+            return .running
+        case "tool.completed":
+            return .completed
+        case "tool.failed":
+            return .failed
+        case "tool.cancelled":
+            return .cancelled
+        default:
+            break
+        }
+        if event.data.cancellation?.requested == true {
+            return .cancelling
+        }
+        if event.context.process?.signal != nil {
+            return .failed
+        }
+        if let exitCode = event.context.process?.exitCode {
+            return exitCode == 0 ? .completed : .failed
+        }
+        if event.context.process?.processID != nil || event.context.process?.processGroupID != nil {
+            return .running
+        }
+        return nil
+    }
+
+    private static func nonNegative(_ value: Int64?) -> Int64? {
+        guard let value, value >= 0 else {
+            return nil
+        }
+        return value
+    }
+
+    private static func safeIdentifier(_ value: String?) -> String? {
+        guard let value,
+              !value.isEmpty,
+              value.utf8.count <= 128,
+              value.unicodeScalars.allSatisfy({ scalar in
+                  CharacterSet.alphanumerics.contains(scalar)
+                      || scalar == "."
+                      || scalar == "_"
+                      || scalar == "-"
+              })
+        else {
+            return nil
+        }
+        return value
+    }
+}

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -123,7 +123,7 @@ struct ContentView: View {
                 Divider()
                 ActivityDrawer(
                     state: viewModel.state,
-                    diagnosticLog: viewModel.diagnosticLog,
+                    observabilityStatus: viewModel.liveObservabilityStatus,
                     showTechnicalDetails: settings.showTechnicalDetails
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -980,11 +980,11 @@ private struct SaveProfileSheet: View {
 
 private struct ActivityDrawer: View {
     let state: WorkerLifecycleState
-    let diagnosticLog: String
+    let observabilityStatus: LiveObservabilityStatus
     let showTechnicalDetails: Bool
 
     private var activityText: String {
-        var entries = [
+        let entries = [
             state.stageMessage,
             state.activityMessage,
             state.warningMessage,
@@ -993,23 +993,90 @@ private struct ActivityDrawer: View {
         ]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
-        if showTechnicalDetails, !diagnosticLog.isEmpty, !entries.contains(diagnosticLog) {
-            entries.append(diagnosticLog)
-        }
         return entries.isEmpty ? "Activity will appear here when source analysis or conversion begins." : entries.joined(separator: "\n")
     }
 
     var body: some View {
         ScrollView {
-            Text(activityText)
-                .font(.caption.monospaced())
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(12)
+            VStack(alignment: .leading, spacing: 10) {
+                Text(activityText)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+
+                if showTechnicalDetails, observabilityStatus.hasDetails {
+                    Divider()
+                    LiveObservabilityStatusView(status: observabilityStatus)
+                }
+            }
+            .padding(12)
         }
         .frame(height: 145)
         .background(Color(nsColor: .textBackgroundColor))
         .accessibilityLabel("Activity details")
+    }
+}
+
+private struct LiveObservabilityStatusView: View {
+    let status: LiveObservabilityStatus
+
+    @State private var now = Date()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    private var processState: String? {
+        status.processState?.rawValue.capitalized
+    }
+
+    private var lastOutput: String? {
+        status.currentLastOutputAgeSeconds(at: now).map { "\($0)s ago" }
+    }
+
+    private var artifactDescription: String? {
+        let identity = [status.artifactRole, status.artifactState]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+        let size = status.artifactSizeBytes.map {
+            ByteCountFormatter.string(fromByteCount: $0, countStyle: .file)
+        }
+        let growth = status.artifactGrowthBytesPerSecond.map {
+            "+\(ByteCountFormatter.string(fromByteCount: $0, countStyle: .file))/s"
+        }
+        let values = [identity.isEmpty ? nil : identity, size, growth].compactMap { $0 }
+        return values.isEmpty ? nil : values.joined(separator: " · ")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Live Tool Status")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if status.isStalled(at: now) {
+                Label("No recent tool output", systemImage: "clock.badge.exclamationmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.orange)
+            }
+
+            statusRow("Stage", value: status.stageID)
+            statusRow("Tool", value: status.toolID)
+            statusRow("Process", value: processState)
+            statusRow("Last output", value: lastOutput)
+            statusRow("Artifact", value: artifactDescription)
+        }
+        .font(.caption.monospaced())
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Live tool status")
+        .accessibilityValue(status.isStalled(at: now) ? "No recent tool output" : "Active")
+        .onReceive(timer) { now = $0 }
+    }
+
+    @ViewBuilder
+    private func statusRow(_ label: String, value: String?) -> some View {
+        if let value {
+            LabeledContent(label, value: value)
+                .textSelection(.enabled)
+        }
     }
 }

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -5,6 +5,33 @@ import XCTest
 
 final class ConversionViewModelTests: XCTestCase {
     @MainActor
+    func testCanonicalObservabilityUpdatesLiveStatusAndPersists() async throws {
+        let terminalDelivered = expectation(description: "terminal delivered")
+        let observabilityEvent = try makeTestObservabilityEvent(kind: "tool.started")
+        let worker = ControlledWorkerClient(
+            terminalDelivered: terminalDelivered,
+            observabilityEvent: observabilityEvent
+        )
+        let store = RecordingObservabilityEventStore()
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            observabilityEventStore: store
+        )
+
+        try await withTemporarySource { sourceURL in
+            viewModel.selectSource(sourceURL)
+            await fulfillment(of: [terminalDelivered], timeout: 2)
+
+            XCTAssertEqual(store.events, [observabilityEvent])
+            XCTAssertEqual(viewModel.liveObservabilityStatus.stageID, "create_mkv")
+            XCTAssertEqual(viewModel.liveObservabilityStatus.toolID, "makemkvcon")
+            XCTAssertEqual(viewModel.liveObservabilityStatus.processState, .running)
+
+            await viewModel.stopForQuit()
+        }
+    }
+
+    @MainActor
     func testUpdateInstallRelaunchWaitsForActiveWorker() async throws {
         let terminalDelivered = expectation(description: "terminal delivered")
         let worker = ControlledWorkerClient(terminalDelivered: terminalDelivered)
@@ -1879,12 +1906,17 @@ private final class TwoPhaseWorkerClient: WorkerProcessRunning, @unchecked Senda
 
 private final class ControlledWorkerClient: WorkerProcessRunning, @unchecked Sendable {
     private let terminalDelivered: XCTestExpectation
+    private let observabilityEvent: ObservabilityEvent?
     private let lock = NSLock()
     private var cancellationContinuation: CheckedContinuation<Void, Never>?
     private var cancellationRequested = false
 
-    init(terminalDelivered: XCTestExpectation) {
+    init(
+        terminalDelivered: XCTestExpectation,
+        observabilityEvent: ObservabilityEvent? = nil
+    ) {
         self.terminalDelivered = terminalDelivered
+        self.observabilityEvent = observabilityEvent
     }
 
     func run(
@@ -1898,11 +1930,20 @@ private final class ControlledWorkerClient: WorkerProcessRunning, @unchecked Sen
             sequence: 0,
             payload: WorkerEventPayload(workerVersion: "test", processGroupID: 1)
         )
+        let observability = observabilityEvent.map {
+            WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .observability,
+                jobID: job.jobID,
+                sequence: 1,
+                payload: WorkerEventPayload(observabilityEvent: $0)
+            )
+        }
         let completed = WorkerEvent(
             protocolVersion: WorkerJobSpec.protocolVersion,
             type: .jobCompleted,
             jobID: job.jobID,
-            sequence: 1,
+            sequence: observability == nil ? 1 : 2,
             payload: WorkerEventPayload(
                 result: SourceInspection(
                     name: "movie",
@@ -1915,6 +1956,9 @@ private final class ControlledWorkerClient: WorkerProcessRunning, @unchecked Sen
         )
 
         try await onEvent(ready)
+        if let observability {
+            try await onEvent(observability)
+        }
         try await onEvent(completed)
         terminalDelivered.fulfill()
         await waitForCancellation()
@@ -1943,6 +1987,47 @@ private final class ControlledWorkerClient: WorkerProcessRunning, @unchecked Sen
             lock.unlock()
         }
     }
+}
+
+private final class RecordingObservabilityEventStore: ObservabilityEventPersisting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [ObservabilityEvent] = []
+
+    var events: [ObservabilityEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedEvents
+    }
+
+    func append(_ event: ObservabilityEvent) {
+        lock.lock()
+        recordedEvents.append(event)
+        lock.unlock()
+    }
+
+    func snapshot() -> ObservabilityEventPersistenceSnapshot {
+        .disabled
+    }
+}
+
+private func makeTestObservabilityEvent(kind: String) throws -> ObservabilityEvent {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("tests/fixtures/observability_event_v1.json")
+    let fixtureData = try XCTUnwrap(FileManager.default.contents(atPath: fixtureURL.path))
+    var fixture = try XCTUnwrap(
+        JSONSerialization.jsonObject(with: fixtureData) as? [String: Any]
+    )
+    fixture["kind"] = kind
+    var context = try XCTUnwrap(fixture["context"] as? [String: Any])
+    context["process"] = ["pid": 42, "process_group_id": 42]
+    fixture["context"] = context
+    return try JSONDecoder().decode(
+        ObservabilityEvent.self,
+        from: JSONSerialization.data(withJSONObject: fixture, options: [.sortedKeys])
+    )
 }
 
 private struct BatchJobRecord: Equatable {

--- a/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
@@ -547,7 +547,7 @@ final class DiagnosticBundleTests: XCTestCase {
     func testRecorderProjectsCanonicalObservabilityFields() throws {
         let observability = try JSONDecoder().decode(
             ObservabilityEvent.self,
-            from: Data(#"{"schema":"bd_to_avp.observability","schema_version":1,"emitter":"worker","stream_id":"11111111-1111-4111-8111-111111111111","sequence":0,"occurred_at":"2026-07-18T00:00:00Z","elapsed_ms":10,"kind":"tool.failed","severity":"error","privacy":"private","redaction":"raw","context":{"correlation":{},"stage":{"id":"create_mkv"},"tool":{"id":"makemkvcon"}},"data":{"message":{"value":"MakeMKV failed","privacy":"private","truncated":false},"detail":{"value":"bounded detail","privacy":"private","truncated":false},"failure":{"code":"nonzero_exit","retryable":false}}}"#.utf8)
+            from: Data(#"{"schema":"bd_to_avp.observability","schema_version":1,"emitter":"worker","stream_id":"11111111-1111-4111-8111-111111111111","sequence":0,"occurred_at":"2026-07-18T00:00:00Z","elapsed_ms":10,"kind":"tool.failed","severity":"error","privacy":"private","redaction":"raw","context":{"correlation":{},"stage":{"id":"create_mkv"},"tool":{"id":"makemkvcon"},"process":{"pid":42,"exit_code":1}},"data":{"message":{"value":"MakeMKV failed","privacy":"private","truncated":false},"detail":{"value":"bounded detail","privacy":"private","truncated":false},"artifact":{"role":"intermediate","state":"growing","location":{"value":"/private/output/movie.mkv","privacy":"private","truncated":false},"size_bytes":536870912,"modification_age_seconds":2,"growth_bytes_per_second":1048576},"failure":{"code":"nonzero_exit","retryable":false},"activity":{"last_output_age_seconds":31}}}"#.utf8)
         )
         let jobID = UUID()
         var lifecycle = WorkerLifecycleState()
@@ -581,11 +581,93 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertEqual(record.source, "worker")
         XCTAssertEqual(record.name, "tool.failed")
         XCTAssertEqual(record.stage, "create_mkv")
+        XCTAssertEqual(record.tool, "makemkvcon")
+        XCTAssertEqual(record.processState, "failed")
+        XCTAssertEqual(record.lastOutputAgeSeconds, 31)
+        XCTAssertEqual(record.artifactRole, "intermediate")
+        XCTAssertEqual(record.artifactState, "growing")
+        XCTAssertEqual(record.artifactSizeBytes, 536_870_912)
+        XCTAssertEqual(record.artifactModificationAgeSeconds, 2)
+        XCTAssertEqual(record.artifactGrowthBytesPerSecond, 1_048_576)
+        XCTAssertEqual(record.privacy, "private")
+        XCTAssertEqual(record.redaction, "raw")
+        XCTAssertEqual(record.messagePrivacy, "private")
+        XCTAssertEqual(record.detailsPrivacy, "private")
         XCTAssertEqual(record.message, "MakeMKV failed")
         XCTAssertEqual(record.details, "bounded detail")
         XCTAssertEqual(record.level, "error")
         XCTAssertEqual(record.failureCode, "nonzero_exit")
         XCTAssertEqual(record.retryable, false)
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let artifact = try DiagnosticBundleBuilder(
+            bundleIDProvider: { self.fixedBundleID }
+        ).createBundle(from: snapshot, outputDirectory: directory)
+        let eventsData = try unzipEntry("events.jsonl", from: artifact.archiveURL)
+        let exported = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: eventsData.split(separator: 0x0A)[0])
+                as? [String: Any]
+        )
+        XCTAssertEqual(exported["tool"] as? String, "makemkvcon")
+        XCTAssertEqual(exported["process_state"] as? String, "failed")
+        XCTAssertEqual(exported["last_output_age_seconds"] as? Int, 31)
+        XCTAssertEqual(exported["artifact_role"] as? String, "intermediate")
+        XCTAssertEqual(exported["privacy"] as? String, "private")
+        XCTAssertEqual(exported["redaction"] as? String, "raw")
+        XCTAssertEqual(exported["message_privacy"] as? String, "private")
+        XCTAssertEqual(exported["details_privacy"] as? String, "private")
+        XCTAssertEqual(
+            (exported["artifact_size_rounded_bytes"] as? NSNumber)?.int64Value,
+            536_870_912
+        )
+        XCTAssertEqual(
+            (exported["artifact_growth_rounded_bytes_per_second"] as? NSNumber)?.int64Value,
+            1_048_576
+        )
+        XCTAssertFalse(String(decoding: eventsData, as: UTF8.self).contains("/private/output"))
+    }
+
+    func testRecorderOmitsCanonicalTextMarkedOmitted() throws {
+        let observability = try JSONDecoder().decode(
+            ObservabilityEvent.self,
+            from: Data(#"{"schema":"bd_to_avp.observability","schema_version":1,"emitter":"worker","stream_id":"11111111-1111-4111-8111-111111111111","sequence":0,"occurred_at":"2026-07-19T00:00:00Z","kind":"tool.failed","severity":"error","privacy":"private","redaction":"omitted","context":{"correlation":{}},"data":{"message":{"value":"private message","privacy":"private","truncated":false},"detail":{"value":"private detail","privacy":"private","truncated":false}}}"#.utf8)
+        )
+        let jobID = UUID()
+        var lifecycle = WorkerLifecycleState()
+        lifecycle.selectSource(URL(fileURLWithPath: "/tmp/movie.mkv"))
+        try lifecycle.begin(jobID: jobID, operationKind: .conversion)
+        let event = WorkerEvent(
+            protocolVersion: WorkerJobSpec.protocolVersion,
+            type: .observability,
+            jobID: jobID,
+            sequence: 0,
+            payload: WorkerEventPayload(observabilityEvent: observability)
+        )
+        try lifecycle.receive(event)
+        let recorder = DiagnosticSessionRecorder()
+
+        recorder.record(
+            event: event,
+            lifecycle: lifecycle,
+            activeMode: "single_conversion",
+            recordedAt: fixedDate
+        )
+
+        let record = try XCTUnwrap(
+            recorder.snapshot(
+                capturedAt: fixedDate,
+                lifecycle: lifecycle,
+                activeMode: nil,
+                batchSummary: nil,
+                process: .empty
+            ).events.entries.last
+        )
+        XCTAssertEqual(record.redaction, "omitted")
+        XCTAssertNil(record.message)
+        XCTAssertNil(record.details)
     }
 
     func testWorkflowAttributionUsesExplicitJobInsteadOfLatestContext() throws {
@@ -833,10 +915,14 @@ final class DiagnosticBundleTests: XCTestCase {
         )
         XCTAssertEqual((sourceProbe["volume_total_rounded_bytes"] as? NSNumber)?.int64Value, volumeQuantum * 63)
         XCTAssertTrue(samples.allSatisfy { $0["file_size_bytes"] == nil && $0["volume_available_bytes"] == nil })
-        XCTAssertEqual(privacy["rules_version"] as? Int, 2)
+        XCTAssertEqual(privacy["rules_version"] as? Int, 3)
         XCTAssertEqual(privacy["size_rounding_mode"] as? String, "down")
         XCTAssertEqual((privacy["file_size_quantum_bytes"] as? NSNumber)?.int64Value, fileQuantum)
         XCTAssertEqual((privacy["volume_capacity_quantum_bytes"] as? NSNumber)?.int64Value, volumeQuantum)
+        XCTAssertEqual(
+            (privacy["byte_rate_quantum_bytes_per_second"] as? NSNumber)?.int64Value,
+            1_024 * 1_024
+        )
         XCTAssertFalse(serializedText.contains(String(rawFileSize)))
         XCTAssertFalse(serializedText.contains(String(rawAvailableSize)))
         XCTAssertFalse(serializedText.contains(String(rawTotalSize)))
@@ -949,7 +1035,19 @@ final class DiagnosticBundleTests: XCTestCase {
                 activeItems: 1,
                 statusCounts: ["completed": 1, "converting": 1, "pending": 2]
             ),
-            process: process
+            process: process,
+            observabilityPersistence: ObservabilityEventPersistenceSnapshot(
+                enabled: true,
+                maximumFileBytes: 4 * 1_024 * 1_024,
+                maximumTotalBytes: 12 * 1_024 * 1_024,
+                maximumPendingBytes: 4 * 1_024 * 1_024,
+                pendingBytes: 1_024,
+                writtenEvents: 30,
+                writtenBytes: 65_536,
+                droppedEvents: 2,
+                droppedBytes: 4_096,
+                failureCount: 1
+            )
         )
         let builder = DiagnosticBundleBuilder(
             storageProbe: storageProbe,
@@ -983,6 +1081,12 @@ final class DiagnosticBundleTests: XCTestCase {
 
         XCTAssertEqual(manifest["schema_version"] as? Int, 1)
         XCTAssertEqual((manifest["archive"] as? [String: Any])?["maximum_compressed_bytes"] as? Int, 2 * 1_024 * 1_024)
+        let localStore = try XCTUnwrap(manifest["local_observability_store"] as? [String: Any])
+        XCTAssertEqual(localStore["enabled"] as? Bool, true)
+        XCTAssertEqual(localStore["maximum_total_bytes"] as? Int, 12 * 1_024 * 1_024)
+        XCTAssertEqual(localStore["written_events"] as? Int, 30)
+        XCTAssertEqual(localStore["dropped_events"] as? Int, 2)
+        XCTAssertNil(localStore["location"])
         XCTAssertLessThanOrEqual(artifact.preview.archiveBytes, artifact.preview.maximumArchiveBytes)
         XCTAssertEqual(artifact.sharingItems, [artifact.archiveURL])
         XCTAssertTrue(artifact.preview.truncationNotices.contains("Older diagnostic events were omitted."))
@@ -1117,6 +1221,18 @@ final class DiagnosticBundleTests: XCTestCase {
             operation: "convert_source",
             activeMode: "single_conversion",
             stage: nil,
+            tool: nil,
+            processState: nil,
+            lastOutputAgeSeconds: nil,
+            artifactRole: nil,
+            artifactState: nil,
+            artifactSizeBytes: nil,
+            artifactModificationAgeSeconds: nil,
+            artifactGrowthBytesPerSecond: nil,
+            privacy: nil,
+            redaction: nil,
+            messagePrivacy: nil,
+            detailsPrivacy: nil,
             message: message,
             details: nil,
             level: "info",

--- a/macos/BluRayToVisionProTests/LiveObservabilityStatusTests.swift
+++ b/macos/BluRayToVisionProTests/LiveObservabilityStatusTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class LiveObservabilityStatusTests: XCTestCase {
+    func testReducerProjectsPathFreeLiveToolAndArtifactState() throws {
+        let event = try makeEvent(
+            kind: "tool.artifact",
+            stageID: "create_mkv",
+            toolID: "makemkvcon",
+            process: ["pid": 42, "process_group_id": 42],
+            activityAge: 12,
+            artifact: [
+                "role": "intermediate",
+                "state": "growing",
+                "location": [
+                    "value": "/private/output/Feature.mkv",
+                    "privacy": "private",
+                    "truncated": false,
+                ],
+                "size_bytes": 1_048_576,
+                "modification_age_seconds": 2,
+                "growth_bytes_per_second": 262_144,
+            ]
+        )
+        var status = LiveObservabilityStatus.empty
+
+        status.receive(event, receivedAt: Date(timeIntervalSince1970: 100))
+
+        XCTAssertEqual(status.stageID, "create_mkv")
+        XCTAssertEqual(status.toolID, "makemkvcon")
+        XCTAssertEqual(status.processState, .running)
+        XCTAssertEqual(status.lastOutputAgeSeconds, 12)
+        XCTAssertEqual(status.artifactRole, "intermediate")
+        XCTAssertEqual(status.artifactState, "growing")
+        XCTAssertEqual(status.artifactSizeBytes, 1_048_576)
+        XCTAssertEqual(status.artifactModificationAgeSeconds, 2)
+        XCTAssertEqual(status.artifactGrowthBytesPerSecond, 262_144)
+        XCTAssertFalse(String(describing: status).contains("/private/output"))
+    }
+
+    func testHostClockAdvancesLastOutputAgeAndDetectsStall() throws {
+        let event = try makeEvent(
+            kind: "tool.activity",
+            process: ["pid": 42, "process_group_id": 42],
+            activityAge: 12
+        )
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(event, receivedAt: receivedAt)
+
+        XCTAssertEqual(
+            status.currentLastOutputAgeSeconds(at: receivedAt.addingTimeInterval(5.9)),
+            17
+        )
+        XCTAssertFalse(status.isStalled(at: receivedAt.addingTimeInterval(47)))
+        XCTAssertTrue(status.isStalled(at: receivedAt.addingTimeInterval(48)))
+
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                process: ["pid": 42],
+                artifact: ["role": "intermediate", "state": "growing"]
+            ),
+            receivedAt: receivedAt.addingTimeInterval(20)
+        )
+        XCTAssertEqual(
+            status.currentLastOutputAgeSeconds(at: receivedAt.addingTimeInterval(21)),
+            33
+        )
+    }
+
+    func testTerminalToolEventUpdatesProcessState() throws {
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.started",
+                process: ["pid": 42, "process_group_id": 42]
+            ),
+            receivedAt: Date(timeIntervalSince1970: 100)
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.completed",
+                process: ["pid": 42, "process_group_id": 42, "exit_code": 0]
+            ),
+            receivedAt: Date(timeIntervalSince1970: 105)
+        )
+
+        XCTAssertEqual(status.processState, .completed)
+        XCTAssertEqual(status.currentLastOutputAgeSeconds(at: Date(timeIntervalSince1970: 200)), nil)
+
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                process: ["pid": 42, "process_group_id": 42],
+                artifact: ["role": "intermediate", "state": "complete"]
+            ),
+            receivedAt: Date(timeIntervalSince1970: 106)
+        )
+        XCTAssertEqual(status.processState, .completed)
+
+        status.receive(
+            try makeEvent(
+                kind: "tool.started",
+                process: ["pid": 43, "process_group_id": 43]
+            ),
+            receivedAt: Date(timeIntervalSince1970: 107)
+        )
+        XCTAssertEqual(status.processState, .running)
+    }
+
+    func testUnsafeIdentifiersAreNotProjected() throws {
+        let event = try makeEvent(
+            kind: "tool.started",
+            stageID: "../../private",
+            toolID: "/usr/bin/ffmpeg",
+            process: ["pid": 42]
+        )
+        var status = LiveObservabilityStatus.empty
+
+        status.receive(event, receivedAt: Date())
+
+        XCTAssertNil(status.stageID)
+        XCTAssertNil(status.toolID)
+        XCTAssertEqual(status.processState, .running)
+    }
+
+    private func makeEvent(
+        kind: String,
+        stageID: String = "encode",
+        toolID: String = "ffmpeg",
+        process: [String: Any]? = nil,
+        activityAge: Int64? = nil,
+        artifact: [String: Any]? = nil
+    ) throws -> ObservabilityEvent {
+        var fixture = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: sharedFixtureData()) as? [String: Any]
+        )
+        fixture["kind"] = kind
+        var context = try XCTUnwrap(fixture["context"] as? [String: Any])
+        context["stage"] = ["id": stageID]
+        context["tool"] = ["id": toolID]
+        context["process"] = process
+        fixture["context"] = context
+        var data = try XCTUnwrap(fixture["data"] as? [String: Any])
+        data["activity"] = activityAge.map { ["last_output_age_seconds": $0] }
+        data["artifact"] = artifact
+        fixture["data"] = data
+        return try JSONDecoder().decode(
+            ObservabilityEvent.self,
+            from: JSONSerialization.data(withJSONObject: fixture, options: [.sortedKeys])
+        )
+    }
+
+    private func sharedFixtureData() throws -> Data {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/observability_event_v1.json")
+        return try XCTUnwrap(FileManager.default.contents(atPath: fixtureURL.path))
+    }
+}

--- a/macos/BluRayToVisionProTests/ObservabilityEventStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ObservabilityEventStoreTests.swift
@@ -1,0 +1,498 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class ObservabilityEventStoreTests: XCTestCase {
+    func testAsyncFlushPersistsPendingEvent() async throws {
+        let createdURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: createdURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: createdURL) }
+        let rootURL = canonicalTemporaryURL(createdURL)
+        let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+        let store = makeStore(directoryURL: directoryURL)
+
+        store.append(try makeEvent(sequence: 1))
+        await store.flush()
+
+        XCTAssertEqual(store.snapshot().writtenEvents, 1)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: directoryURL.appendingPathComponent("events.jsonl").path
+            )
+        )
+    }
+
+    func testCanonicalEventPersistsAsOwnerOnlyJSONL() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            let store = makeStore(directoryURL: directoryURL)
+            let event = try makeEvent(sequence: 1)
+
+            store.append(event)
+            store.flushForTesting()
+
+            let eventURL = directoryURL.appendingPathComponent("events.jsonl")
+            let line = try Data(contentsOf: eventURL).dropLast()
+            XCTAssertEqual(try JSONDecoder().decode(ObservabilityEvent.self, from: line), event)
+            XCTAssertEqual(try permissions(at: directoryURL), 0o700)
+            XCTAssertEqual(try permissions(at: eventURL), 0o600)
+            XCTAssertEqual(
+                try permissions(at: directoryURL.appendingPathComponent(".events.jsonl.lock")),
+                0o600
+            )
+            let snapshot = store.snapshot()
+            XCTAssertEqual(snapshot.writtenEvents, 1)
+            XCTAssertEqual(snapshot.droppedEvents, 0)
+            XCTAssertEqual(snapshot.failureCount, 0)
+        }
+    }
+
+    func testRotationRespectsPerFileAndTotalLimitsAndRetainsNewestEvent() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            let maximumFileBytes = 4_096
+            let maximumTotalBytes = 8_192
+            let store = makeStore(
+                directoryURL: directoryURL,
+                maximumFileBytes: maximumFileBytes,
+                maximumTotalBytes: maximumTotalBytes,
+                maximumPendingBytes: 32_768
+            )
+
+            for sequence in 0 ..< 12 {
+                store.append(try makeEvent(sequence: Int64(sequence)))
+            }
+            store.flushForTesting()
+
+            let segmentURLs = try FileManager.default.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            )
+            .filter { $0.lastPathComponent.hasPrefix("events") && $0.pathExtension == "jsonl" }
+            let sizes = try segmentURLs.map {
+                try XCTUnwrap(
+                    FileManager.default.attributesOfItem(atPath: $0.path)[.size] as? NSNumber
+                ).intValue
+            }
+            XCTAssertFalse(sizes.isEmpty)
+            XCTAssertTrue(sizes.allSatisfy { $0 <= maximumFileBytes })
+            XCTAssertLessThanOrEqual(sizes.reduce(0, +), maximumTotalBytes)
+
+            let currentData = try Data(
+                contentsOf: directoryURL.appendingPathComponent("events.jsonl")
+            )
+            let currentEvents = try decodeLines(currentData)
+            XCTAssertTrue(currentEvents.contains { $0.sequence == 11 })
+        }
+    }
+
+    func testSymlinkedEventFileIsRejectedWithoutTouchingTarget() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let targetURL = rootURL.appendingPathComponent("target.txt")
+            try Data("unchanged".utf8).write(to: targetURL)
+            try FileManager.default.createSymbolicLink(
+                at: directoryURL.appendingPathComponent("events.jsonl"),
+                withDestinationURL: targetURL
+            )
+            let store = makeStore(directoryURL: directoryURL)
+
+            store.append(try makeEvent(sequence: 1))
+            store.flushForTesting()
+
+            XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "unchanged")
+            XCTAssertEqual(store.snapshot().writtenEvents, 0)
+            XCTAssertEqual(store.snapshot().droppedEvents, 1)
+            XCTAssertEqual(store.snapshot().failureCount, 1)
+        }
+    }
+
+    func testHardLinkedEventFileIsRejectedWithoutTouchingTarget() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let targetURL = rootURL.appendingPathComponent("target.txt")
+            try Data("unchanged".utf8).write(to: targetURL)
+            let eventURL = directoryURL.appendingPathComponent("events.jsonl")
+            XCTAssertEqual(link(targetURL.path, eventURL.path), 0)
+            let store = makeStore(directoryURL: directoryURL)
+
+            store.append(try makeEvent(sequence: 1))
+            store.flushForTesting()
+
+            XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "unchanged")
+            XCTAssertEqual(store.snapshot().writtenEvents, 0)
+            XCTAssertEqual(store.snapshot().failureCount, 1)
+        }
+    }
+
+    func testFIFOEventEntryIsRejectedWithoutBlockingDrain() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let eventURL = directoryURL.appendingPathComponent("events.jsonl")
+            XCTAssertEqual(mkfifo(eventURL.path, mode_t(0o600)), 0)
+            let store = makeStore(directoryURL: directoryURL)
+
+            store.append(try makeEvent(sequence: 1))
+            store.flushForTesting()
+
+            XCTAssertEqual(store.snapshot().writtenEvents, 0)
+            XCTAssertEqual(store.snapshot().failureCount, 1)
+        }
+    }
+
+    func testPendingQueueRemainsBoundedWhileWriterIsBlocked() throws {
+        let writer = BlockingObservabilityWriter()
+        let event = try makeEvent(sequence: 1)
+        let encodedBytes = try JSONEncoder().encode(event).count + 1
+        let maximumPendingBytes = encodedBytes * 2
+        let store = ObservabilityEventStore(
+            configuration: .init(
+                directoryURL: URL(fileURLWithPath: "/unused"),
+                maximumFileBytes: encodedBytes * 2,
+                maximumTotalBytes: encodedBytes * 4,
+                maximumPendingBytes: maximumPendingBytes
+            ),
+            writerFactory: { writer }
+        )
+
+        store.append(event)
+        XCTAssertEqual(writer.started.wait(timeout: .now() + 2), .success)
+        for sequence in 2 ... 20 {
+            store.append(try makeEvent(sequence: Int64(sequence)))
+        }
+
+        let blockedSnapshot = store.snapshot()
+        XCTAssertLessThanOrEqual(blockedSnapshot.pendingBytes, maximumPendingBytes)
+        XCTAssertGreaterThan(blockedSnapshot.droppedEvents, 0)
+
+        writer.release.signal()
+        store.flushForTesting()
+        XCTAssertEqual(store.snapshot().failureCount, 0)
+    }
+
+    func testExistingPartialTailIsTruncatedBeforeAppending() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let firstEvent = try makeEvent(sequence: 1)
+            let secondEvent = try makeEvent(sequence: 2)
+            var existing = try JSONEncoder().encode(firstEvent)
+            existing.append(0x0A)
+            existing.append(Data(#"{"partial":"tail""#.utf8))
+            try existing.write(to: directoryURL.appendingPathComponent("events.jsonl"))
+            let store = makeStore(directoryURL: directoryURL)
+
+            store.append(secondEvent)
+            store.flushForTesting()
+
+            XCTAssertEqual(
+                store.snapshot().failureCount,
+                0,
+                store.failureDescriptionForTesting() ?? "unknown store failure"
+            )
+            let eventData = try Data(
+                contentsOf: directoryURL.appendingPathComponent("events.jsonl")
+            )
+            XCTAssertFalse(String(decoding: eventData, as: UTF8.self).contains("partial"))
+            let events = try decodeLines(eventData)
+            XCTAssertEqual(events.map(\.sequence), [1, 2])
+        }
+    }
+
+    func testExistingExtendedACLsAreRemoved() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let eventURL = directoryURL.appendingPathComponent("events.jsonl")
+            try Data().write(to: eventURL)
+            try addEveryoneReadACL(to: directoryURL)
+            try addEveryoneReadACL(to: eventURL)
+            XCTAssertGreaterThan(try extendedACLCount(at: directoryURL), 0)
+            XCTAssertGreaterThan(try extendedACLCount(at: eventURL), 0)
+            let store = makeStore(directoryURL: directoryURL)
+
+            store.append(try makeEvent(sequence: 1))
+            store.flushForTesting()
+
+            XCTAssertEqual(try extendedACLCount(at: directoryURL), 0)
+            XCTAssertEqual(try extendedACLCount(at: eventURL), 0)
+        }
+    }
+
+    func testLowerRetentionLimitPrunesOutOfRangeSegments() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            let initialStore = makeStore(
+                directoryURL: directoryURL,
+                maximumFileBytes: 4_096,
+                maximumTotalBytes: 12_288,
+                maximumPendingBytes: 32_768
+            )
+            for sequence in 0 ..< 12 {
+                initialStore.append(try makeEvent(sequence: Int64(sequence)))
+            }
+            initialStore.flushForTesting()
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: directoryURL.appendingPathComponent("events.1.jsonl").path
+                )
+            )
+
+            let reducedStore = makeStore(
+                directoryURL: directoryURL,
+                maximumFileBytes: 4_096,
+                maximumTotalBytes: 4_096,
+                maximumPendingBytes: 8_192
+            )
+            reducedStore.append(try makeEvent(sequence: 100))
+            reducedStore.flushForTesting()
+            XCTAssertEqual(
+                reducedStore.snapshot().failureCount,
+                0,
+                reducedStore.failureDescriptionForTesting() ?? "unknown store failure"
+            )
+
+            let eventFiles = try FileManager.default.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            )
+            .map(\.lastPathComponent)
+            .filter { $0.hasPrefix("events") && $0.hasSuffix(".jsonl") }
+            XCTAssertEqual(eventFiles, ["events.jsonl"])
+        }
+    }
+
+    func testRotationPreservesOlderSegmentAcrossExistingGap() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let currentEvent = try makeEvent(sequence: 10)
+            let olderEvent = try makeEvent(sequence: 2)
+            let oldestEvent = try makeEvent(sequence: 1)
+            var currentLine = try JSONEncoder().encode(currentEvent)
+            currentLine.append(0x0A)
+            var olderLine = try JSONEncoder().encode(olderEvent)
+            olderLine.append(0x0A)
+            var oldestLine = try JSONEncoder().encode(oldestEvent)
+            oldestLine.append(0x0A)
+            try currentLine.write(to: directoryURL.appendingPathComponent("events.jsonl"))
+            try olderLine.write(to: directoryURL.appendingPathComponent("events.2.jsonl"))
+            try oldestLine.write(to: directoryURL.appendingPathComponent("events.3.jsonl"))
+            let maximumFileBytes = currentLine.count + 16
+            let store = makeStore(
+                directoryURL: directoryURL,
+                maximumFileBytes: maximumFileBytes,
+                maximumTotalBytes: maximumFileBytes * 4,
+                maximumPendingBytes: maximumFileBytes * 2
+            )
+
+            store.append(try makeEvent(sequence: 11))
+            store.flushForTesting()
+
+            let olderEvents = try decodeLines(
+                Data(contentsOf: directoryURL.appendingPathComponent("events.2.jsonl"))
+            )
+            let oldestEvents = try decodeLines(
+                Data(contentsOf: directoryURL.appendingPathComponent("events.3.jsonl"))
+            )
+            XCTAssertEqual(olderEvents.map(\.sequence), [2])
+            XCTAssertEqual(oldestEvents.map(\.sequence), [1])
+            XCTAssertEqual(store.snapshot().failureCount, 0)
+        }
+    }
+
+    func testRotationRemovesHardLinkedSegmentWithoutTouchingTarget() throws {
+        try withTemporaryDirectory { rootURL in
+            let directoryURL = rootURL.appendingPathComponent("Observability", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let currentEvent = try makeEvent(sequence: 10)
+            var currentLine = try JSONEncoder().encode(currentEvent)
+            currentLine.append(0x0A)
+            try currentLine.write(to: directoryURL.appendingPathComponent("events.jsonl"))
+            let targetURL = rootURL.appendingPathComponent("target.txt")
+            try Data("unchanged".utf8).write(to: targetURL)
+            XCTAssertEqual(
+                link(
+                    targetURL.path,
+                    directoryURL.appendingPathComponent("events.1.jsonl").path
+                ),
+                0
+            )
+            let maximumFileBytes = currentLine.count + 16
+            let store = makeStore(
+                directoryURL: directoryURL,
+                maximumFileBytes: maximumFileBytes,
+                maximumTotalBytes: maximumFileBytes * 3,
+                maximumPendingBytes: maximumFileBytes * 2
+            )
+
+            store.append(try makeEvent(sequence: 11))
+            store.flushForTesting()
+
+            XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "unchanged")
+            let rotatedEvents = try decodeLines(
+                Data(contentsOf: directoryURL.appendingPathComponent("events.1.jsonl"))
+            )
+            XCTAssertEqual(rotatedEvents.map(\.sequence), [10])
+            XCTAssertEqual(store.snapshot().failureCount, 0)
+        }
+    }
+
+    private func makeStore(
+        directoryURL: URL,
+        maximumFileBytes: Int = 256 * 1_024,
+        maximumTotalBytes: Int = 512 * 1_024,
+        maximumPendingBytes: Int = 256 * 1_024
+    ) -> ObservabilityEventStore {
+        ObservabilityEventStore(
+            configuration: .init(
+                directoryURL: directoryURL,
+                maximumFileBytes: maximumFileBytes,
+                maximumTotalBytes: maximumTotalBytes,
+                maximumPendingBytes: maximumPendingBytes
+            )
+        )
+    }
+
+    private func makeEvent(sequence: Int64) throws -> ObservabilityEvent {
+        var fixture = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: sharedFixtureData()) as? [String: Any]
+        )
+        fixture["sequence"] = sequence
+        return try JSONDecoder().decode(
+            ObservabilityEvent.self,
+            from: JSONSerialization.data(withJSONObject: fixture, options: [.sortedKeys])
+        )
+    }
+
+    private func decodeLines(_ data: Data) throws -> [ObservabilityEvent] {
+        try data.split(separator: 0x0A).map {
+            try JSONDecoder().decode(ObservabilityEvent.self, from: Data($0))
+        }
+    }
+
+    private func sharedFixtureData() throws -> Data {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/observability_event_v1.json")
+        return try XCTUnwrap(FileManager.default.contents(atPath: fixtureURL.path))
+    }
+
+    private func permissions(at url: URL) throws -> Int {
+        let value = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        )
+        return value.intValue & 0o777
+    }
+
+    private func addEveryoneReadACL(to url: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = [
+            "+a",
+            "everyone allow read,readattr,readextattr,readsecurity",
+            url.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+
+    private func extendedACLCount(at url: URL) throws -> Int {
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(descriptor) }
+        guard let accessControlList = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            if errno == ENOENT {
+                return 0
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { acl_free(UnsafeMutableRawPointer(accessControlList)) }
+        var count = 0
+        var entry: acl_entry_t?
+        var entryIdentifier = ACL_FIRST_ENTRY.rawValue
+        while acl_get_entry(accessControlList, entryIdentifier, &entry) == 0 {
+            count += 1
+            entryIdentifier = ACL_NEXT_ENTRY.rawValue
+        }
+        return count
+    }
+
+    private func withTemporaryDirectory(_ body: (URL) throws -> Void) throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: url) }
+        try body(canonicalTemporaryURL(url))
+    }
+
+    private func canonicalTemporaryURL(_ url: URL) -> URL {
+        if url.path.hasPrefix("/private/var/") {
+            return url
+        }
+        if url.path.hasPrefix("/var/") {
+            return URL(fileURLWithPath: "/private\(url.path)", isDirectory: true)
+        }
+        return url.resolvingSymlinksInPath()
+    }
+}
+
+private final class BlockingObservabilityWriter: ObservabilityEventWriting {
+    let started = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private var hasBlocked = false
+
+    func append(_: Data) throws {
+        let shouldBlock = lock.withLock { () -> Bool in
+            if hasBlocked {
+                return false
+            }
+            hasBlocked = true
+            return true
+        }
+        if shouldBlock {
+            started.signal()
+            release.wait()
+        }
+    }
+}

--- a/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
@@ -3,6 +3,31 @@ import XCTest
 
 final class PreviewViewModelTests: XCTestCase {
     @MainActor
+    func testCanonicalObservabilityPersistsDuringPreview() async throws {
+        try await withTemporaryPreviewEnvironment { sourceURL, cache in
+            let completed = expectation(description: "preview completed")
+            let observabilityEvent = try makePreviewObservabilityEvent()
+            let worker = PreviewWorkerClient(
+                observabilityEvent: observabilityEvent,
+                onCompleted: { completed.fulfill() }
+            )
+            let store = PreviewRecordingObservabilityEventStore()
+            let viewModel = PreviewViewModel(
+                clientFactory: { worker },
+                cache: cache,
+                observabilityEventStore: store
+            )
+            let previewDraft = try XCTUnwrap(makePreviewDraft(sourceURL: sourceURL))
+
+            viewModel.startPreview(previewDraft)
+            await fulfillment(of: [completed], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertEqual(store.events, [observabilityEvent])
+        }
+    }
+
+    @MainActor
     func testCompletedPreviewOwnsArtifactUntilDiscarded() async throws {
         try await withTemporaryPreviewEnvironment { sourceURL, cache in
             let completed = expectation(description: "preview completed")
@@ -214,6 +239,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     private let lock = NSLock()
     private let initialStage: String
     private let initialStageMessage: String
+    private let observabilityEvent: ObservabilityEvent?
     private let waitsForCancellation: Bool
     private let onStarted: (() -> Void)?
     private let onCancellationEventsDelivered: (() -> Void)?
@@ -228,6 +254,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     init(
         initialStage: String = "create_left_right_files",
         initialStageMessage: String = "Encoding Preview",
+        observabilityEvent: ObservabilityEvent? = nil,
         waitsForCancellation: Bool = false,
         onStarted: (() -> Void)? = nil,
         onCancellationEventsDelivered: (() -> Void)? = nil,
@@ -235,6 +262,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     ) {
         self.initialStage = initialStage
         self.initialStageMessage = initialStageMessage
+        self.observabilityEvent = observabilityEvent
         self.waitsForCancellation = waitsForCancellation
         self.onStarted = onStarted
         self.onCancellationEventsDelivered = onCancellationEventsDelivered
@@ -280,6 +308,21 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             )
         )
         try await onEvent(heartbeat)
+        let observabilityOffset: Int
+        if let observabilityEvent {
+            try await onEvent(
+                WorkerEvent(
+                    protocolVersion: WorkerJobSpec.protocolVersion,
+                    type: .observability,
+                    jobID: job.jobID,
+                    sequence: 3,
+                    payload: WorkerEventPayload(observabilityEvent: observabilityEvent)
+                )
+            )
+            observabilityOffset = 1
+        } else {
+            observabilityOffset = 0
+        }
         onStarted?()
 
         let destinationURL = URL(fileURLWithPath: job.destination!.path, isDirectory: true)
@@ -293,7 +336,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
                 protocolVersion: WorkerJobSpec.protocolVersion,
                 type: .stageStarted,
                 jobID: job.jobID,
-                sequence: 3,
+                sequence: 3 + observabilityOffset,
                 payload: WorkerEventPayload(
                     stage: "combine_to_mv_hevc",
                     message: "Combining stereo video into MV-HEVC",
@@ -305,7 +348,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
                 protocolVersion: WorkerJobSpec.protocolVersion,
                 type: .heartbeat,
                 jobID: job.jobID,
-                sequence: 4,
+                sequence: 4 + observabilityOffset,
                 payload: WorkerEventPayload(
                     elapsedSeconds: 66,
                     progress: WorkerProgress(currentStage: 10, totalStages: 13, stageFraction: 0.2)
@@ -320,7 +363,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
                 protocolVersion: WorkerJobSpec.protocolVersion,
                 type: .jobCancelled,
                 jobID: job.jobID,
-                sequence: 5,
+                sequence: 5 + observabilityOffset,
                 payload: WorkerEventPayload(message: "Preview stopped.")
             )
             try await onEvent(cancelled)
@@ -345,7 +388,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             protocolVersion: WorkerJobSpec.protocolVersion,
             type: .artifactReady,
             jobID: job.jobID,
-            sequence: 3,
+            sequence: 3 + observabilityOffset,
             payload: WorkerEventPayload(artifact: artifact)
         )
         try await onEvent(artifactReady)
@@ -354,7 +397,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             protocolVersion: WorkerJobSpec.protocolVersion,
             type: .jobCompleted,
             jobID: job.jobID,
-            sequence: 4,
+            sequence: 4 + observabilityOffset,
             payload: WorkerEventPayload(previewResult: artifact)
         )
         try await onEvent(completed)
@@ -410,4 +453,35 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             }
         }
     }
+}
+
+private final class PreviewRecordingObservabilityEventStore: ObservabilityEventPersisting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [ObservabilityEvent] = []
+
+    var events: [ObservabilityEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedEvents
+    }
+
+    func append(_ event: ObservabilityEvent) {
+        lock.lock()
+        recordedEvents.append(event)
+        lock.unlock()
+    }
+
+    func snapshot() -> ObservabilityEventPersistenceSnapshot {
+        .disabled
+    }
+}
+
+private func makePreviewObservabilityEvent() throws -> ObservabilityEvent {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("tests/fixtures/observability_event_v1.json")
+    let fixtureData = try XCTUnwrap(FileManager.default.contents(atPath: fixtureURL.path))
+    return try JSONDecoder().decode(ObservabilityEvent.self, from: fixtureData)
 }


### PR DESCRIPTION
## Summary
- persist canonical observability events in a shared, bounded, owner-only rotating JSONL store for conversion and preview
- project path-free live stage, tool, process, output-age, and artifact-growth status into the activity drawer
- extend diagnostic capture and bundle metadata with privacy-aware observability fields and local-store counters while excluding raw local segments
- add bounded termination flushing, retention/crash recovery, security hardening, documentation, and regression coverage

## Validation
- `uv run python -m unittest discover -s tests -t .` — 658 tests, 2 skipped
- `uv run python scripts/native_app.py test` — 217 tests
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/release.py validate`
- `uv run python -c "import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app"`
- `uv run python scripts/build_ssif_probe_macos.py`
- `git diff --check`

Closes #277