### PR TITLE
Recover Beta 3 metadata as build 148

### DIFF
--- a/.github/release-freezes.json
+++ b/.github/release-freezes.json
@@ -1,0 +1,10 @@
+{
+  "schema": "bd_to_avp.release_freezes",
+  "schema_version": 1,
+  "frozen_release_tags": {
+    "v0.3.0-beta.3": {
+      "issue": 294,
+      "reason": "Publication remains frozen until issue #294 removes this entry through protected-main review."
+    }
+  }
+}

--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -29,6 +29,7 @@ jobs:
       operator_actor: ${{ github.actor }}
       operator_triggering_actor: ${{ github.triggering_actor }}
     permissions:
+      actions: read
       attestations: write
       contents: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: uv run python scripts/build_ssif_probe_macos.py
 
       - name: Validate committed release metadata
-        run: uv run python scripts/release.py validate
+        run: uv run python -m scripts.release validate
 
       - name: Validate observability migration
         run: uv run python scripts/validate_observability_migration.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,6 +29,7 @@ jobs:
       operator_actor: ${{ github.actor }}
       operator_triggering_actor: ${{ github.triggering_actor }}
     permissions:
+      actions: read
       attestations: write
       contents: write
       id-token: write

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -589,6 +589,7 @@ jobs:
           CERTIFICATE: ${{ secrets.CERTIFICATE }}
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
           DEV_ID: ${{ secrets.DEV_ID }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           set -euo pipefail
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
@@ -596,10 +597,31 @@ jobs:
             echo "Protected main moved immediately before certificate use." >&2
             exit 1
           fi
-          case "$DEV_ID" in
-            "Developer ID Application:"*) ;;
-            *) echo "DEV_ID must name a Developer ID Application identity." >&2; exit 1 ;;
+          case "$TEAM_ID" in
+            ""|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789]*)
+              echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+              exit 1
+              ;;
           esac
+          if [ "${#TEAM_ID}" -ne 10 ]; then
+            echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+            exit 1
+          fi
+          DEV_ID_PREFIX="Developer ID Application: "
+          DEV_ID_SUFFIX=" ($TEAM_ID)"
+          case "$DEV_ID" in
+            "$DEV_ID_PREFIX"*"$DEV_ID_SUFFIX") ;;
+            *)
+              echo "DEV_ID must be a Developer ID Application identity ending in ($TEAM_ID)." >&2
+              exit 1
+              ;;
+          esac
+          DEV_ID_NAME=${DEV_ID#"$DEV_ID_PREFIX"}
+          DEV_ID_NAME=${DEV_ID_NAME%"$DEV_ID_SUFFIX"}
+          if [ -z "$DEV_ID_NAME" ]; then
+            echo "DEV_ID must include a non-empty Developer ID subject." >&2
+            exit 1
+          fi
 
           BUILD_KEYCHAIN_PASSWORD=$(openssl rand -hex 32)
           KEYCHAIN_PATH="$RUNNER_TEMP/bd-to-avp-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.keychain-db"
@@ -676,7 +698,11 @@ jobs:
             -S apple-tool:,apple:,codesign: \
             -s -k "$BUILD_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user | grep -F "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$DEV_ID"
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | awk -F '"' -v identity="$DEV_ID" '$2 == identity { found=1 } END { exit found ? 0 : 1 }'; then
+            echo "Configured Developer ID identity was not found in the ephemeral keychain." >&2
+            exit 1
+          fi
           trap - EXIT
 
       - name: Store notarization credentials in the ephemeral keychain
@@ -709,13 +735,71 @@ jobs:
           DEV_ID: ${{ secrets.DEV_ID }}
           DMG_NAME: ${{ needs.prepare.outputs.dmg_name }}
           PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           set -euo pipefail
+          verify_codesign_metadata() {
+            signed_path=$1
+            signed_label=$2
+            metadata_path=$3
+            if ! codesign -dv --verbose=4 "$signed_path" > "$metadata_path" 2>&1; then
+              echo "$signed_label code-signature metadata inspection failed." >&2
+              exit 1
+            fi
+            signing_authority=$(awk -F= '$1 == "Authority" { print substr($0, index($0, "=") + 1); exit }' "$metadata_path")
+            team_identifier=$(awk -F= '$1 == "TeamIdentifier" { print substr($0, index($0, "=") + 1); exit }' "$metadata_path")
+            if [ -z "$signing_authority" ]; then
+              echo "$signed_label code signature did not report a signing authority." >&2
+              exit 1
+            fi
+            if [ "$signing_authority" != "$DEV_ID" ]; then
+              echo "$signed_label signing authority does not match the configured Developer ID identity." >&2
+              exit 1
+            fi
+            if [ -z "$team_identifier" ]; then
+              echo "$signed_label code signature did not report a TeamIdentifier." >&2
+              exit 1
+            fi
+            if [ "$team_identifier" != "$TEAM_ID" ]; then
+              echo "$signed_label TeamIdentifier does not match the configured Team ID." >&2
+              exit 1
+            fi
+          }
+
+          validate_signing_identity() {
+            case "$TEAM_ID" in
+              ""|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789]*)
+                echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+                exit 1
+                ;;
+            esac
+            if [ "${#TEAM_ID}" -ne 10 ]; then
+              echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+              exit 1
+            fi
+            DEV_ID_PREFIX="Developer ID Application: "
+            DEV_ID_SUFFIX=" ($TEAM_ID)"
+            case "$DEV_ID" in
+              "$DEV_ID_PREFIX"*"$DEV_ID_SUFFIX") ;;
+              *)
+                echo "DEV_ID must be a Developer ID Application identity ending in ($TEAM_ID)." >&2
+                exit 1
+                ;;
+            esac
+            DEV_ID_NAME=${DEV_ID#"$DEV_ID_PREFIX"}
+            DEV_ID_NAME=${DEV_ID_NAME%"$DEV_ID_SUFFIX"}
+            if [ -z "$DEV_ID_NAME" ]; then
+              echo "DEV_ID must include a non-empty Developer ID subject." >&2
+              exit 1
+            fi
+          }
+
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if [ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]; then
             echo "Protected main moved immediately before package signing." >&2
             exit 1
           fi
+          validate_signing_identity
           security unlock-keychain -p "$BUILD_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           APP_PATH="macos/build/package/3D Blu-ray to Vision Pro.app"
           DMG_PATH="dist/$DMG_NAME"
@@ -725,6 +809,10 @@ jobs:
           uv run python scripts/native_app.py package \
             --sign-identity "$DEV_ID" \
             --sign-keychain "$KEYCHAIN_PATH"
+          verify_codesign_metadata \
+            "$APP_PATH" \
+            "Containing app" \
+            "$RUNNER_TEMP/bd-to-avp-app-codesign-$GITHUB_RUN_ID.txt"
           uv run python -m scripts.macos_release verify-app \
             --app "$APP_PATH" \
             --verify-signatures \
@@ -756,6 +844,10 @@ jobs:
             --app "$APP_PATH" \
             --output "$DMG_PATH"
           codesign --force --timestamp --sign "$DEV_ID" --keychain "$KEYCHAIN_PATH" "$DMG_PATH"
+          verify_codesign_metadata \
+            "$DMG_PATH" \
+            "DMG" \
+            "$RUNNER_TEMP/bd-to-avp-dmg-codesign-$GITHUB_RUN_ID.txt"
           uv run python -m scripts.macos_release notarize \
             --submission "$DMG_PATH" \
             --staple "$DMG_PATH" \

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -99,6 +99,7 @@ name: Signed release engine
         value: ${{ jobs.policy.outputs.release_sha }}
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -200,6 +201,9 @@ jobs:
     needs: policy
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
     outputs:
       package_version: ${{ steps.metadata.outputs.package_version }}
       public_version: ${{ steps.metadata.outputs.public_version }}
@@ -247,11 +251,12 @@ jobs:
 
       - name: Derive committed release metadata
         id: metadata
-        run: python scripts/release.py metadata --github-output "$GITHUB_OUTPUT"
+        run: python -m scripts.release metadata --github-output "$GITHUB_OUTPUT"
 
       - name: Validate route and summarize publication effects
         env:
           RELEASE_OPERATOR_WORKFLOW_REF: ${{ needs.policy.outputs.operator_workflow_ref }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
           RELEASE_CHANNEL: ${{ steps.metadata.outputs.channel }}
           RELEASE_PRERELEASE: ${{ steps.metadata.outputs.prerelease }}
           RELEASE_MAKE_LATEST: ${{ steps.metadata.outputs.make_latest }}
@@ -307,13 +312,22 @@ jobs:
             exit 1
           fi
 
+      - name: Revalidate Beta 3 recovery premise
+        if: steps.metadata.outputs.release_tag == 'v0.3.0-beta.3'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.beta3_recovery_evidence
+          --allow-beta3-draft
+          --expected-sha "$GITHUB_SHA"
+
       - name: Resolve channel-aware base for generated notes
         id: release_history
         env:
           RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
         run: |
           set -euo pipefail
-          python scripts/release.py notes-base \
+          python -m scripts.release notes-base \
             --release-tag "$RELEASE_TAG" \
             --releases-json release-identities.json \
             --head-ref "$GITHUB_SHA" \
@@ -389,7 +403,7 @@ jobs:
 
             BASE_SNAPSHOT_TAG=$(jq -r .release_tag release-preflight/appcast-state.json)
             STATE_APPCAST_SHA256=$(jq -r .appcast_sha256 release-preflight/appcast-state.json)
-            python scripts/release.py validate-tag "$BASE_SNAPSHOT_TAG" >/dev/null
+            python -m scripts.release validate-tag "$BASE_SNAPSHOT_TAG" >/dev/null
             BASE_RELEASE_COUNT=$(jq -r --arg tag "$BASE_SNAPSHOT_TAG" '
               [
                 .[][]
@@ -589,6 +603,8 @@ jobs:
           CERTIFICATE: ${{ secrets.CERTIFICATE }}
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
           DEV_ID: ${{ secrets.DEV_ID }}
+          PRODUCTION_DEV_ID: "Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)"
+          PRODUCTION_TEAM_ID: MM5YXC7T6E
           TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           set -euo pipefail
@@ -605,6 +621,14 @@ jobs:
           esac
           if [ "${#TEAM_ID}" -ne 10 ]; then
             echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+            exit 1
+          fi
+          if [ "$TEAM_ID" != "$PRODUCTION_TEAM_ID" ]; then
+            echo "TEAM_ID does not match the committed production Apple team." >&2
+            exit 1
+          fi
+          if [ "$DEV_ID" != "$PRODUCTION_DEV_ID" ]; then
+            echo "DEV_ID does not match the committed production Developer ID identity." >&2
             exit 1
           fi
           DEV_ID_PREFIX="Developer ID Application: "
@@ -735,6 +759,8 @@ jobs:
           DEV_ID: ${{ secrets.DEV_ID }}
           DMG_NAME: ${{ needs.prepare.outputs.dmg_name }}
           PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+          PRODUCTION_DEV_ID: "Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)"
+          PRODUCTION_TEAM_ID: MM5YXC7T6E
           TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           set -euo pipefail
@@ -760,8 +786,8 @@ jobs:
               echo "$signed_label code signature did not report a TeamIdentifier." >&2
               exit 1
             fi
-            if [ "$team_identifier" != "$TEAM_ID" ]; then
-              echo "$signed_label TeamIdentifier does not match the configured Team ID." >&2
+            if [ "$team_identifier" != "$PRODUCTION_TEAM_ID" ]; then
+              echo "$signed_label TeamIdentifier does not match the committed production Team ID." >&2
               exit 1
             fi
           }
@@ -775,6 +801,14 @@ jobs:
             esac
             if [ "${#TEAM_ID}" -ne 10 ]; then
               echo "TEAM_ID must be a 10-character Apple Team ID." >&2
+              exit 1
+            fi
+            if [ "$TEAM_ID" != "$PRODUCTION_TEAM_ID" ]; then
+              echo "TEAM_ID does not match the committed production Apple team." >&2
+              exit 1
+            fi
+            if [ "$DEV_ID" != "$PRODUCTION_DEV_ID" ]; then
+              echo "DEV_ID does not match the committed production Developer ID identity." >&2
               exit 1
             fi
             DEV_ID_PREFIX="Developer ID Application: "
@@ -1021,6 +1055,7 @@ jobs:
 
       - name: Validate the packaged app on macOS 26
         env:
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
           EXPECTED_DMG_NAME: ${{ needs.package.outputs.dmg_name }}
           EXPECTED_DMG_SHA256: ${{ needs.package.outputs.dmg_sha256 }}
         run: |
@@ -1065,7 +1100,7 @@ jobs:
       - name: Validate and build distributions
         run: |
           set -euo pipefail
-          python scripts/release.py validate
+          python -m scripts.release validate
           uv build
           mkdir -p python-distributions
           mv dist python-distributions/
@@ -1439,6 +1474,7 @@ jobs:
       - name: Inspect draft DMG
         id: bundle
         env:
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
           DMG_PATH: ${{ steps.release_asset.outputs.dmg_path }}
           EXPECTED_BUILD_VERSION: ${{ needs.prepare.outputs.build_version }}
           EXPECTED_SHORT_VERSION: ${{ needs.prepare.outputs.package_version }}
@@ -1474,7 +1510,7 @@ jobs:
           if [ "$BASE_SNAPSHOT_TAG" = "bootstrap" ]; then
             cp sparkle-feed/appcast.xml appcast-site/appcast.xml
           else
-            python scripts/release.py validate-tag "$BASE_SNAPSHOT_TAG" >/dev/null
+            python -m scripts.release validate-tag "$BASE_SNAPSHOT_TAG" >/dev/null
             curl --fail --location --silent --show-error \
               --retry 3 --retry-delay 2 --retry-all-errors \
               --connect-timeout 10 --max-time 60 \
@@ -1634,6 +1670,7 @@ jobs:
 
       - name: Re-download and verify every release boundary
         env:
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
           EXPECTED_APPCAST_SHA256: ${{ needs.publish-appcast.outputs.appcast_sha256 }}
           EXPECTED_APPCAST_SIZE: ${{ needs.publish-appcast.outputs.appcast_size }}
           EXPECTED_BUILD_VERSION: ${{ needs.prepare.outputs.build_version }}

--- a/.github/workflows/sparkle-pages.yml
+++ b/.github/workflows/sparkle-pages.yml
@@ -68,11 +68,11 @@ jobs:
                 echo "release_tag is required for $OPERATION." >&2
                 exit 1
               fi
-              python scripts/release.py validate-tag "$RELEASE_TAG"
+              python -m scripts.release validate-tag "$RELEASE_TAG"
               if [ "$OPERATION" = "deploy" ] \
                 && [ -n "$EXPECTED_BASE_RELEASE_TAG" ] \
                 && [ "$EXPECTED_BASE_RELEASE_TAG" != "bootstrap" ]; then
-                python scripts/release.py validate-tag "$EXPECTED_BASE_RELEASE_TAG"
+                python -m scripts.release validate-tag "$EXPECTED_BASE_RELEASE_TAG"
               fi
               ;;
             disable)

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ cython_debug/
 # Generated native macOS project and build products
 /macos/*.xcodeproj/
 /macos/build/
+/.bd-to-avp-release-transaction.json

--- a/docs/0.3.0-beta.3-cut-packet.md
+++ b/docs/0.3.0-beta.3-cut-packet.md
@@ -36,10 +36,10 @@ target state exists.
 
 ## Remote Forensic Evidence
 
-The state below was observed read-only on `2026-07-20T04:34:40Z` for repository
+The state below was observed read-only on `2026-07-20T04:59:47Z` for repository
 ID `771225421` (`cbusillo/BD_to_AVP`) and is duplicated exactly in the required
 JSON evidence. The receipt itself is pinned by SHA-256
-`4b9c546c1de98c9da63a8776fa7232dc3463c84af5f325b4404fb6f1e80b61ea`:
+`31bb6aba336eeca2400501c469c99b2682c6f1ff768dd43e54fa1cb230ba6a0a`:
 
 - Run `29693513480` at
   `438991f07fa19cd2ae2df4d3ec14716bc0371f8d` concluded `failure` before

--- a/docs/0.3.0-beta.3-cut-packet.md
+++ b/docs/0.3.0-beta.3-cut-packet.md
@@ -26,7 +26,8 @@ The normative release contract remains in
 | Publish to PyPI or Homebrew | `false` |
 | Product name | `3D Blu-ray to Vision Pro` |
 | Bundle identifier | `com.shinycomputers.bd-to-avp` |
-| Feed, Sparkle key, signing team, diagnostics endpoint | Existing production values |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
 
 Build `147` is permanently burned. Ordinary `release.py prepare` continues to
 reject the RC-to-Beta stage reversal. The dedicated `recover-beta3` operation
@@ -35,8 +36,10 @@ target state exists.
 
 ## Remote Forensic Evidence
 
-The state below was observed read-only on `2026-07-20T02:28:48Z` for
-`cbusillo/BD_to_AVP` and is duplicated exactly in the required JSON evidence:
+The state below was observed read-only on `2026-07-20T03:18:20Z` for repository
+ID `771225421` (`cbusillo/BD_to_AVP`) and is duplicated exactly in the required
+JSON evidence. The receipt itself is pinned by SHA-256
+`4b9c546c1de98c9da63a8776fa7232dc3463c84af5f325b4404fb6f1e80b61ea`:
 
 - Run `29693513480` at
   `438991f07fa19cd2ae2df4d3ec14716bc0371f8d` concluded `failure` before
@@ -48,6 +51,15 @@ The state below was observed read-only on `2026-07-20T02:28:48Z` for
 - Pages remains enabled at `v0.2.143`; its appcast SHA-256 is
   `d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e`.
 - PyPI Latest remains `0.2.143`, with neither `0.3.0rc1` nor `0.3.0b3` present.
+
+The reviewed source is base commit
+`e4d89a54412b50b556f51ea3c32034a1dc015eb6`, tree
+`4ff668a0f35ca5fe99880655e9f1c3de244778c5`. The receipt pins the exact
+pre-recovery digests of `pyproject.toml`, `uv.lock`, and `macos/project.yml`.
+Recovery verifies the authenticated live repository, failed run and attempt,
+complete job set, artifact absence, tag/release/draft absence, Latest, Pages,
+PyPI, and immutable Preview releases before staging and again immediately before
+the local commit point.
 
 The retired Preview releases remain immutable:
 
@@ -78,14 +90,17 @@ From the exact `0.3.0rc1` build `147` repository state, with the evidence file
 present and unmodified, run:
 
 ```sh
-uv run python scripts/release.py recover-beta3
+uv run python -m scripts.release recover-beta3
 ```
 
-The command atomically stages `pyproject.toml`, `uv.lock`, and
-`macos/project.yml`, refreshes the lock, validates `0.3.0b3` build `148`, and
-writes only after every check succeeds. Missing or mismatched evidence, wrong
-source metadata, lock failure, concurrent file changes, and reruns leave the
-release files unchanged.
+The command serializes metadata operations with an advisory lock, stages
+`pyproject.toml`, `uv.lock`, and `macos/project.yml`, refreshes the lock,
+validates `0.3.0b3` build `148`, and records originals plus target digests in a
+durable transaction journal before replacement. A surviving process rolls back
+any failure; the next invocation restores an interrupted prepared transaction
+or finalizes an interrupted committed transaction. Missing or mismatched
+evidence, wrong source identity, lock failure, concurrent file changes, remote
+drift, and reruns fail closed.
 
 ## Issue 294 Boundary
 
@@ -94,4 +109,7 @@ exact-SHA post-merge CI and CodeQL before it dispatches the guarded
 `Prerelease` workflow. Only #294 may request or apply `macos-signing` approval,
 use signing or notarization credentials, create or publish release artifacts,
 append the cumulative appcast, deploy Pages, or make any public-artifact claim.
-Issue #293 performs none of those actions.
+Issue #293 performs none of those actions. The committed
+`.github/release-freezes.json` entry blocks `v0.3.0-beta.3` before package or
+release construction; #294 must remove that exact entry through protected-main
+review before dispatch.

--- a/docs/0.3.0-beta.3-cut-packet.md
+++ b/docs/0.3.0-beta.3-cut-packet.md
@@ -1,0 +1,97 @@
+# 0.3.0 Beta 3 Cut Packet
+
+> **Metadata recovery only.** Issue #293 owns the exact one-time repository
+> transition documented here. Issue #294 exclusively owns workflow dispatch,
+> environment approval, signing, notarization, artifact construction, draft and
+> release creation, appcast mutation, Pages deployment, and publication. This
+> packet makes no claim that a Beta 3 public artifact exists.
+
+The normative release contract remains in
+[release-routes.md](release-routes.md). The machine-checked forensic record is
+[v0.3.0-beta.3-recovery.json](release-evidence/v0.3.0-beta.3-recovery.json).
+
+## Exact Metadata
+
+| Field | Required value |
+| --- | --- |
+| Recovered source | `0.3.0rc1`, build `147` |
+| Package and marketing version | `0.3.0b3` |
+| Public version | `0.3.0-beta.3` |
+| Bundle and Sparkle build | `148` |
+| GitHub tag and release title | `v0.3.0-beta.3` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Feed, Sparkle key, signing team, diagnostics endpoint | Existing production values |
+
+Build `147` is permanently burned. Ordinary `release.py prepare` continues to
+reject the RC-to-Beta stage reversal. The dedicated `recover-beta3` operation
+accepts only the source, target, and evidence above and fails closed after the
+target state exists.
+
+## Remote Forensic Evidence
+
+The state below was observed read-only on `2026-07-20T02:28:48Z` for
+`cbusillo/BD_to_AVP` and is duplicated exactly in the required JSON evidence:
+
+- Run `29693513480` at
+  `438991f07fa19cd2ae2df4d3ec14716bc0371f8d` concluded `failure` before
+  package upload, draft, appcast, PyPI, release, or Pages. Each boundary was
+  skipped and the run has zero artifacts.
+- Tags, releases, and drafts are absent for `v0.3.0rc1`, `v0.3.0-rc.1`, and
+  `v0.3.0-beta.3`.
+- GitHub Latest remains `v0.2.143`.
+- Pages remains enabled at `v0.2.143`; its appcast SHA-256 is
+  `d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e`.
+- PyPI Latest remains `0.2.143`, with neither `0.3.0rc1` nor `0.3.0b3` present.
+
+The retired Preview releases remain immutable:
+
+| Tag | Release ID | Target SHA | DMG asset ID / size / digest | `SHA256SUMS` asset ID / size / digest |
+| --- | ---: | --- | --- | --- |
+| `native-ui-preview-1` | `352841376` | `e1e4f851096cfeae70da1c56a88acef9c5e61055` | `474714228` / `406585971` / `sha256:119a86f829c0bc8962deaea5f1a8fb92ffbcd48002d062a0ac59cccffe61af71` | `474714389` / `118` / `sha256:1b142e59fea4ee0e0f734ae5cdf34815583765d2d0895a9ec25217436d52336e` |
+| `v0.3.0-beta.1` | `353900273` | `2378b46345185f05611f15a39658217bac7c6960` | `476861235` / `407183981` / `sha256:b611dca7de660efed218a0e2fc5c4ed9d6e5e652a54da938e13d40a6bd994bed` | `476861481` / `123` / `sha256:17eead4e3faf2ffd3110a9bf200d39f0ebfba78546f40aa0fa868fd3afb53b5b` |
+| `v0.3.0-beta.2` | `355845653` | `9e9a38c715dbbe5df97e6d3a8ba715731607db6a` | `480668646` / `408158527` / `sha256:e2e8a20c9fd4517076189e56598ff6b32cd1adc544c6ad0618f5a46f55dcae24` | `480668779` / `123` / `sha256:ab387b19cef2af5923b112735a10253d42f4fc37f002e6983deb44a5a17b7fb0` |
+
+## Reviewed Release-Note Seed
+
+Use this text only within issue #294's reviewed publication flow:
+
+> BD_to_AVP `v0.3.0-beta.3` is the one-time manual-download seed for the four
+> production update routes. Currently shipped Stable and RC installations
+> cannot discover this Beta through Sparkle, so testers must install the exact
+> GitHub Release DMG manually. Beta 3 adds structured observability for
+> conversion progress, artifact growth, and apparent stalls, plus one-button
+> privacy-redacted diagnostics for output-size and apparent-stall
+> investigations.
+
+Do not describe Beta 3 as currently downloadable or Sparkle-discoverable before
+issue #294 completes publication and independently verifies the public state.
+
+## Recovery Operation
+
+From the exact `0.3.0rc1` build `147` repository state, with the evidence file
+present and unmodified, run:
+
+```sh
+uv run python scripts/release.py recover-beta3
+```
+
+The command atomically stages `pyproject.toml`, `uv.lock`, and
+`macos/project.yml`, refreshes the lock, validates `0.3.0b3` build `148`, and
+writes only after every check succeeds. Missing or mismatched evidence, wrong
+source metadata, lock failure, concurrent file changes, and reruns leave the
+release files unchanged.
+
+## Issue 294 Boundary
+
+After this metadata slice merges, issue #294 must independently require green
+exact-SHA post-merge CI and CodeQL before it dispatches the guarded
+`Prerelease` workflow. Only #294 may request or apply `macos-signing` approval,
+use signing or notarization credentials, create or publish release artifacts,
+append the cumulative appcast, deploy Pages, or make any public-artifact claim.
+Issue #293 performs none of those actions.

--- a/docs/0.3.0-beta.3-cut-packet.md
+++ b/docs/0.3.0-beta.3-cut-packet.md
@@ -36,7 +36,7 @@ target state exists.
 
 ## Remote Forensic Evidence
 
-The state below was observed read-only on `2026-07-20T03:18:20Z` for repository
+The state below was observed read-only on `2026-07-20T04:34:40Z` for repository
 ID `771225421` (`cbusillo/BD_to_AVP`) and is duplicated exactly in the required
 JSON evidence. The receipt itself is pinned by SHA-256
 `4b9c546c1de98c9da63a8776fa7232dc3463c84af5f325b4404fb6f1e80b61ea`:

--- a/docs/release-evidence/v0.2.143-appcast.xml
+++ b/docs/release-evidence/v0.2.143-appcast.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>3D Blu-ray to Vision Pro Updates</title>
+    <link>https://github.com/cbusillo/BD_to_AVP</link>
+    <description>Stable direct-DMG updates for 3D Blu-ray to Vision Pro.</description>
+    <language>en</language>
+    <item>
+      <title>Version 0.2.143</title>
+      <link>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143</link>
+      <sparkle:version>146</sparkle:version>
+      <sparkle:shortVersionString>0.2.143</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143</sparkle:releaseNotesLink>
+      <pubDate>Sat, 11 Jul 2026 20:33:49 +0000</pubDate>
+      <enclosure url="https://github.com/cbusillo/BD_to_AVP/releases/download/v0.2.143/3D-Blu-ray-to-Vision-Pro-0.2.143.dmg" length="382758448" type="application/octet-stream" sparkle:edSignature="zLtGNQgEW6uWIkm53cdsWW8znIMYpsp3TWZl0whXJna4DdX2ogl11IuXDkaUBmYoO49e8tqQnwqoAL8xr5v4AQ==" />
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+    </item>
+    <item>
+      <title>Version 0.2.143rc5</title>
+      <link>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143rc5</link>
+      <sparkle:version>145</sparkle:version>
+      <sparkle:shortVersionString>0.2.143rc5</sparkle:shortVersionString>
+      <sparkle:channel>rc</sparkle:channel>
+      <sparkle:releaseNotesLink>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143rc5</sparkle:releaseNotesLink>
+      <pubDate>Sat, 11 Jul 2026 18:19:37 +0000</pubDate>
+      <enclosure url="https://github.com/cbusillo/BD_to_AVP/releases/download/v0.2.143rc5/3D-Blu-ray-to-Vision-Pro-0.2.143rc5.dmg" length="382775531" type="application/octet-stream" sparkle:edSignature="8YYAQlzYZnvCJcC1n62mbLi9qWvuxbRPMuDMaIGtP17PyluC80RLU51pr5NibkLnLMsG4EUkdjhw3no/qilXBw==" />
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+    </item>
+    <item>
+      <title>Version 0.2.143rc4</title>
+      <link>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143rc4</link>
+      <sparkle:version>144</sparkle:version>
+      <sparkle:shortVersionString>0.2.143rc4</sparkle:shortVersionString>
+      <sparkle:channel>rc</sparkle:channel>
+      <sparkle:releaseNotesLink>https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.2.143rc4</sparkle:releaseNotesLink>
+      <pubDate>Sat, 11 Jul 2026 16:51:39 +0000</pubDate>
+      <enclosure url="https://github.com/cbusillo/BD_to_AVP/releases/download/v0.2.143rc4/3D-Blu-ray-to-Vision-Pro-0.2.143rc4.dmg" length="382552940" type="application/octet-stream" sparkle:edSignature="62HZfMXQAzKQi6aZX14gBklF5ukT+gptbzxlBCUaT9DvYxBVruIuC8xxYv7OSi2OFIq+WHEnxnqS9IBcT8XOCg==" />
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+    </item>
+  </channel>
+</rss>

--- a/docs/release-evidence/v0.3.0-beta.3-recovery.json
+++ b/docs/release-evidence/v0.3.0-beta.3-recovery.json
@@ -1,7 +1,7 @@
 {
   "schema": "bd_to_avp.release_recovery",
   "schema_version": 2,
-  "observed_at": "2026-07-20T03:18:20Z",
+  "observed_at": "2026-07-20T04:59:47Z",
   "repository": "cbusillo/BD_to_AVP",
   "repository_identity": {
     "id": 771225421,

--- a/docs/release-evidence/v0.3.0-beta.3-recovery.json
+++ b/docs/release-evidence/v0.3.0-beta.3-recovery.json
@@ -1,0 +1,127 @@
+{
+  "schema": "bd_to_avp.release_recovery",
+  "schema_version": 1,
+  "observed_at": "2026-07-20T02:28:48Z",
+  "repository": "cbusillo/BD_to_AVP",
+  "transition": {
+    "source": {
+      "package_version": "0.3.0rc1",
+      "public_version": "0.3.0-rc.1",
+      "build": "147"
+    },
+    "target": {
+      "package_version": "0.3.0b3",
+      "public_version": "0.3.0-beta.3",
+      "release_tag": "v0.3.0-beta.3",
+      "build": "148"
+    }
+  },
+  "failed_run": {
+    "id": 29693513480,
+    "head_sha": "438991f07fa19cd2ae2df4d3ec14716bc0371f8d",
+    "conclusion": "failure",
+    "skipped_boundaries": {
+      "package_upload": "skipped",
+      "draft": "skipped",
+      "appcast": "skipped",
+      "pypi": "skipped",
+      "release": "skipped",
+      "pages": "skipped"
+    },
+    "artifact_count": 0
+  },
+  "absent_github_state": {
+    "tags": [
+      "v0.3.0rc1",
+      "v0.3.0-rc.1",
+      "v0.3.0-beta.3"
+    ],
+    "releases": [
+      "v0.3.0rc1",
+      "v0.3.0-rc.1",
+      "v0.3.0-beta.3"
+    ],
+    "drafts": [
+      "v0.3.0rc1",
+      "v0.3.0-rc.1",
+      "v0.3.0-beta.3"
+    ]
+  },
+  "github_latest": {
+    "release_tag": "v0.2.143"
+  },
+  "pages": {
+    "status": "enabled",
+    "release_tag": "v0.2.143",
+    "appcast_sha256": "d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e"
+  },
+  "pypi": {
+    "latest_version": "0.2.143",
+    "absent_versions": [
+      "0.3.0rc1",
+      "0.3.0b3"
+    ]
+  },
+  "retired_preview_releases": [
+    {
+      "tag": "native-ui-preview-1",
+      "immutable": true,
+      "release_id": 352841376,
+      "target_sha": "e1e4f851096cfeae70da1c56a88acef9c5e61055",
+      "assets": [
+        {
+          "asset_id": 474714228,
+          "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg",
+          "size": 406585971,
+          "digest": "sha256:119a86f829c0bc8962deaea5f1a8fb92ffbcd48002d062a0ac59cccffe61af71"
+        },
+        {
+          "asset_id": 474714389,
+          "name": "SHA256SUMS",
+          "size": 118,
+          "digest": "sha256:1b142e59fea4ee0e0f734ae5cdf34815583765d2d0895a9ec25217436d52336e"
+        }
+      ]
+    },
+    {
+      "tag": "v0.3.0-beta.1",
+      "immutable": true,
+      "release_id": 353900273,
+      "target_sha": "2378b46345185f05611f15a39658217bac7c6960",
+      "assets": [
+        {
+          "asset_id": 476861235,
+          "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.1.dmg",
+          "size": 407183981,
+          "digest": "sha256:b611dca7de660efed218a0e2fc5c4ed9d6e5e652a54da938e13d40a6bd994bed"
+        },
+        {
+          "asset_id": 476861481,
+          "name": "SHA256SUMS",
+          "size": 123,
+          "digest": "sha256:17eead4e3faf2ffd3110a9bf200d39f0ebfba78546f40aa0fa868fd3afb53b5b"
+        }
+      ]
+    },
+    {
+      "tag": "v0.3.0-beta.2",
+      "immutable": true,
+      "release_id": 355845653,
+      "target_sha": "9e9a38c715dbbe5df97e6d3a8ba715731607db6a",
+      "assets": [
+        {
+          "asset_id": 480668646,
+          "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.2.dmg",
+          "size": 408158527,
+          "digest": "sha256:e2e8a20c9fd4517076189e56598ff6b32cd1adc544c6ad0618f5a46f55dcae24"
+        },
+        {
+          "asset_id": 480668779,
+          "name": "SHA256SUMS",
+          "size": 123,
+          "digest": "sha256:ab387b19cef2af5923b112735a10253d42f4fc37f002e6983deb44a5a17b7fb0"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/release-evidence/v0.3.0-beta.3-recovery.json
+++ b/docs/release-evidence/v0.3.0-beta.3-recovery.json
@@ -1,8 +1,25 @@
 {
   "schema": "bd_to_avp.release_recovery",
-  "schema_version": 1,
-  "observed_at": "2026-07-20T02:28:48Z",
+  "schema_version": 2,
+  "observed_at": "2026-07-20T03:18:20Z",
   "repository": "cbusillo/BD_to_AVP",
+  "repository_identity": {
+    "id": 771225421,
+    "node_id": "R_kgDOLff3TQ",
+    "full_name": "cbusillo/BD_to_AVP",
+    "private": false,
+    "archived": false,
+    "disabled": false
+  },
+  "source_identity": {
+    "base_commit": "e4d89a54412b50b556f51ea3c32034a1dc015eb6",
+    "tree": "4ff668a0f35ca5fe99880655e9f1c3de244778c5",
+    "files": {
+      "pyproject.toml": "4a01dc9e5dedf55899cc1e903a40514b93a9507ee88f22d14a6a19beb91568af",
+      "uv.lock": "94015cc2525bcb84c3129f391593fa9fc624679c8592f630f7024a8ffd08fc20",
+      "macos/project.yml": "8fc365f4e3d8032ae9eb22734030ee50f0b7e6759b8a5952032266f6ba331ea4"
+    }
+  },
   "transition": {
     "source": {
       "package_version": "0.3.0rc1",
@@ -18,16 +35,81 @@
   },
   "failed_run": {
     "id": 29693513480,
+    "workflow_id": 101708423,
+    "run_number": 226,
+    "event": "workflow_dispatch",
+    "head_branch": "main",
     "head_sha": "438991f07fa19cd2ae2df4d3ec14716bc0371f8d",
+    "run_attempt": 1,
+    "actor": "shiny-code-bot",
+    "triggering_actor": "shiny-code-bot",
+    "repository": "cbusillo/BD_to_AVP",
+    "head_repository": "cbusillo/BD_to_AVP",
+    "workflow_path": ".github/workflows/briefcase.yml",
+    "workflow_name": "Release from protected main",
+    "display_title": "Stable",
+    "status": "completed",
     "conclusion": "failure",
-    "skipped_boundaries": {
-      "package_upload": "skipped",
-      "draft": "skipped",
-      "appcast": "skipped",
-      "pypi": "skipped",
-      "release": "skipped",
-      "pages": "skipped"
-    },
+    "failed_job": "Build, sign, notarize, and validate DMG",
+    "failed_step": "Package application for GitHub",
+    "package_upload_step": "Upload verified release package",
+    "skipped_jobs": [
+      "Build stable Python distributions",
+      "Attest verified release package",
+      "Verify notarized package on macOS 26",
+      "Create draft GitHub Release",
+      "Build signed cumulative appcast snapshot",
+      "Upload, re-download, and verify draft assets",
+      "Publish stable Python distribution with trusted publishing",
+      "Publish verified GitHub Release",
+      "Deploy verified appcast snapshot"
+    ],
+    "jobs": [
+      {
+        "name": "Validate release source and metadata",
+        "conclusion": "success"
+      },
+      {
+        "name": "Build, sign, notarize, and validate DMG",
+        "conclusion": "failure"
+      },
+      {
+        "name": "Build stable Python distributions",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Attest verified release package",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Verify notarized package on macOS 26",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Create draft GitHub Release",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Build signed cumulative appcast snapshot",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Upload, re-download, and verify draft assets",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Publish stable Python distribution with trusted publishing",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Publish verified GitHub Release",
+        "conclusion": "skipped"
+      },
+      {
+        "name": "Deploy verified appcast snapshot",
+        "conclusion": "skipped"
+      }
+    ],
     "artifact_count": 0
   },
   "absent_github_state": {
@@ -48,11 +130,20 @@
     ]
   },
   "github_latest": {
-    "release_tag": "v0.2.143"
+    "release_id": 352601989,
+    "release_tag": "v0.2.143",
+    "target_sha": "03fe03ab58abf85b74c32f6b3b7387d9ad6f1941",
+    "immutable": true
   },
   "pages": {
     "status": "enabled",
+    "public": true,
+    "build_type": "workflow",
     "release_tag": "v0.2.143",
+    "short_version": "0.2.143",
+    "build": "146",
+    "capture_path": "docs/release-evidence/v0.2.143-appcast.xml",
+    "capture_sha256": "7b9bbf76fedfd7eeb19181f392d660cc8f189afee6d5a0a4627d62bfa38b6765",
     "appcast_sha256": "d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e"
   },
   "pypi": {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,17 +4,19 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The next planned production-identity field build is `v0.3.0-beta.3`, internal
-version `0.3.0b3`, build `148`. The committed `0.3.0rc1` build `147` attempt
-failed before publication and its build number is permanently burned. The
-focused recovery and Beta 3 cut packet are owned by issue #293.
+The repository now carries the reviewed `v0.3.0-beta.3` metadata: internal
+version `0.3.0b3`, build `148`. The failed, unpublished `0.3.0rc1` build `147`
+attempt is preserved in the checked-in recovery evidence and its build number
+is permanently burned. The exact recovery and
+[Beta 3 cut packet](0.3.0-beta.3-cut-packet.md) are complete; they do not assert
+that any Beta 3 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
-filtering, appcast validation, reusable engine, and guarded Stable/Prerelease
-entrypoints are implemented. The Beta 3 manual-bootstrap contract is documented
-and regression-covered here. Its focused metadata migration and recovery remain
-owned by issue #293, so Alpha and Beta preparation and dispatch stay blocked
-until that gate and the focused signed-install smoke have landed.
+filtering, appcast validation, reusable engine, guarded Stable/Prerelease
+entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
+implemented and regression-covered. Publication remains frozen for issue #294,
+which exclusively owns the exact-SHA dispatch, approval, signing, publication,
+and verification work.
 
 ## Release Preparation
 
@@ -39,6 +41,14 @@ routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, and the Xcode Release version/build together only after every check
 succeeds. A lock refresh or metadata failure leaves all three files unchanged.
 
+The one-time `0.3.0rc1` build `147` to `0.3.0b3` build `148` correction used
+`scripts/release.py recover-beta3` and the exact checked-in evidence in
+[v0.3.0-beta.3-recovery.json](release-evidence/v0.3.0-beta.3-recovery.json).
+The command has no version, build, stage, or publication override. It rejects
+any other source or evidence and rejects a rerun after the target state exists.
+Ordinary `prepare` continues to reject RC-to-Beta movement; do not reuse or
+generalize the recovery path.
+
 The initial main-only Sparkle migration used `0.2.143rc4` build `144` and
 `0.2.143rc5` build `145` to prove a real RC-to-RC updater path. Stable
 `0.2.143` build `146` follows only after that smoke passes. Future releases
@@ -51,11 +61,12 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Release dispatch is frozen.** Protected `main` still contains the burned
-> `0.3.0rc1` build `147` metadata. Do not dispatch `Stable` or `Prerelease`
-> until issues #292 and #293 have landed and
-> `scripts/release.py metadata` reports the reviewed `0.3.0b3` build `148`
-> target. Publishing build `147` is prohibited.
+> **Release publication is frozen.** The repository metadata is the reviewed
+> `0.3.0b3` build `148` target and build `147` remains permanently burned. Do
+> not dispatch `Stable` or `Prerelease`, request environment approval, sign,
+> publish, or mutate the feed or Pages under this metadata-recovery work. Issue
+> #294 exclusively owns those actions after exact-SHA post-merge gates pass.
+> No Beta 3 public artifact is claimed by issue #293.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -24,7 +24,7 @@ Every release version and Sparkle build number is committed through a normal
 pull request before release orchestration runs. Use the repository command:
 
 ```sh
-uv run python scripts/release.py prepare \
+uv run python -m scripts.release prepare \
   --version <internal-pep440-version> \
   --build <next-global-build>
 ```
@@ -39,7 +39,11 @@ example, internal `0.3.0b3` maps to public `0.3.0-beta.3`, tag/title
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
 `uv.lock`, and the Xcode Release version/build together only after every check
-succeeds. A lock refresh or metadata failure leaves all three files unchanged.
+succeeds. Release metadata operations share an advisory checkout lock. Before
+replacement they write a durable transaction journal containing the original
+bytes and target digests; a later invocation restores an interrupted prepared
+transaction or finalizes an interrupted committed transaction. A lock refresh,
+metadata failure, or detected concurrent edit fails closed.
 
 The one-time `0.3.0rc1` build `147` to `0.3.0b3` build `148` correction used
 `scripts/release.py recover-beta3` and the exact checked-in evidence in
@@ -47,7 +51,11 @@ The one-time `0.3.0rc1` build `147` to `0.3.0b3` build `148` correction used
 The command has no version, build, stage, or publication override. It rejects
 any other source or evidence and rejects a rerun after the target state exists.
 Ordinary `prepare` continues to reject RC-to-Beta movement; do not reuse or
-generalize the recovery path.
+generalize the recovery path. The receipt pins repository ID `771225421`, base
+commit `e4d89a54412b50b556f51ea3c32034a1dc015eb6`, its source tree and release
+file digests, and the exact failed run/attempt/job boundaries. Recovery checks
+the authenticated live GitHub, Pages, and PyPI state before staging and again
+immediately before committing local metadata.
 
 The initial main-only Sparkle migration used `0.2.143rc4` build `144` and
 `0.2.143rc5` build `145` to prove a real RC-to-RC updater path. Stable
@@ -66,7 +74,10 @@ or from a stale main commit.
 > not dispatch `Stable` or `Prerelease`, request environment approval, sign,
 > publish, or mutate the feed or Pages under this metadata-recovery work. Issue
 > #294 exclusively owns those actions after exact-SHA post-merge gates pass.
-> No Beta 3 public artifact is claimed by issue #293.
+> No Beta 3 public artifact is claimed by issue #293. The committed
+> `.github/release-freezes.json` entry makes the shared engine reject
+> `v0.3.0-beta.3` before package or release construction until #294 removes it
+> through protected-main review.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -10,7 +10,9 @@ this four-route contract. The exact Beta 3 metadata migration and bootstrap are
 complete at `0.3.0b3` build `148`, with build `147` permanently burned.
 Publication remains frozen: issue #294 exclusively owns exact-SHA dispatch,
 approval, signing, publication, and public verification. The recovery work
-makes no public-artifact claim.
+makes no public-artifact claim. `.github/release-freezes.json` rejects the Beta
+3 tag before package or release construction until #294 removes that entry
+through protected-main review.
 
 ## Production Identity
 
@@ -26,7 +28,7 @@ services.
 | Architecture and deployment | Apple Silicon, macOS 26 or later for the `0.3.x` line |
 | Sparkle feed | `https://cbusillo.github.io/BD_to_AVP/appcast.xml` |
 | Sparkle public key | The value in `sparkle-public-ed-key.txt`, byte-identical to packaged metadata |
-| Apple signing identity | A `Developer ID Application` certificate whose Team Identifier equals the protected `TEAM_ID`; certificate rotation is allowed only within that team |
+| Apple signing identity | Exact authority `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` and Team Identifier `MM5YXC7T6E`, pinned in `scripts/production_identity.py` |
 | Diagnostics endpoint | The approved HTTPS value of the `SUPPORT_DIAGNOSTICS_ENDPOINT` repository variable, packaged as `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT` |
 
 Changing the bundle identifier, Apple Team Identifier, feed URL, or Sparkle key
@@ -74,12 +76,14 @@ backport trains require a new design rather than weakening global ordering.
 
 The committed but unpublished `0.3.0rc1` build `147` attempt was the sole
 one-time recovery exception. The dedicated audited `recover-beta3` migration
-validated that the failed RC attempt left no tag, release, draft, or artifact
-and caused no appcast, Pages, Latest, or PyPI mutation, then atomically replaced
-the repository metadata with `0.3.0b3` build `148`. Build `147` is permanently
-burned and normal forward-only enforcement has resumed. The ordinary release
-preparation command still rejects that backward stage move, and the recovery
-command rejects every other source, target, evidence record, and rerun.
+validated the pinned source tree and authenticated live remote state, proving
+that the failed RC attempt left no tag, release, draft, or artifact and caused
+no appcast, Pages, Latest, or PyPI mutation. It serialized the operation with a
+checkout lock and used a durable rollback journal while replacing repository
+metadata with `0.3.0b3` build `148`. Build `147` is permanently burned and
+normal forward-only enforcement has resumed. The ordinary release preparation
+command still rejects that backward stage move, and the recovery command
+rejects every other source, target, evidence record, and rerun.
 
 ## Sparkle Route Eligibility
 

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,10 +6,11 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. The Beta 3 metadata migration and bootstrap remain
-intentionally blocked on issues 292 and 293. Do not prepare or dispatch an Alpha
-or Beta release until those gates have landed and the focused signed-install
-smoke has passed.
+this four-route contract. The exact Beta 3 metadata migration and bootstrap are
+complete at `0.3.0b3` build `148`, with build `147` permanently burned.
+Publication remains frozen: issue #294 exclusively owns exact-SHA dispatch,
+approval, signing, publication, and public verification. The recovery work
+makes no public-artifact claim.
 
 ## Production Identity
 
@@ -71,15 +72,14 @@ version, the normal stage order is Alpha, Beta, RC, then Stable. Stages may be
 skipped but a published train does not move backward. Concurrent maintenance or
 backport trains require a new design rather than weakening global ordering.
 
-The committed but unpublished `0.3.0rc1` build `147` attempt is a one-time
-recovery exception. Build `147` is permanently burned. Because no tag, release,
-appcast item, Pages state, Latest change, or PyPI artifact was published, a
-focused migration may replace the repository metadata with `0.3.0b3` build
-`148`; normal forward-only enforcement resumes immediately afterward.
-The normal release preparation command intentionally rejects that backward
-stage move. The recovery must use a dedicated audited migration that first
-reconfirms the failed RC attempt left no tag, release, appcast, Pages, Latest,
-or PyPI residue; generic release preparation remains fail-closed.
+The committed but unpublished `0.3.0rc1` build `147` attempt was the sole
+one-time recovery exception. The dedicated audited `recover-beta3` migration
+validated that the failed RC attempt left no tag, release, draft, or artifact
+and caused no appcast, Pages, Latest, or PyPI mutation, then atomically replaced
+the repository metadata with `0.3.0b3` build `148`. Build `147` is permanently
+burned and normal forward-only enforcement has resumed. The ordinary release
+preparation command still rejects that backward stage move, and the recovery
+command rejects every other source, target, evidence record, and rerun.
 
 ## Sparkle Route Eligibility
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -168,7 +168,7 @@ Prepare the internal version, monotonic build counter, `uv.lock`, and Xcode Rele
 metadata with:
 
 ```sh
-uv run python scripts/release.py prepare --version <version> --build <build>
+uv run python -m scripts.release prepare --version <version> --build <build>
 ```
 
 The workflow must fail before release publication if the build number is

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,13 +37,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 147
+        CURRENT_PROJECT_VERSION: 148
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0rc1
+        MARKETING_VERSION: 0.3.0b3
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0rc1"
+version = "0.3.0b3"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -109,7 +109,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "147"
+CFBundleVersion = "148"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/scripts/beta3_recovery_evidence.py
+++ b/scripts/beta3_recovery_evidence.py
@@ -19,7 +19,7 @@ from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BETA3_RECOVERY_EVIDENCE_PATH = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0-beta.3-recovery.json"
-BETA3_RECOVERY_EVIDENCE_SHA256 = "4b9c546c1de98c9da63a8776fa7232dc3463c84af5f325b4404fb6f1e80b61ea"
+BETA3_RECOVERY_EVIDENCE_SHA256 = "31bb6aba336eeca2400501c469c99b2682c6f1ff768dd43e54fa1cb230ba6a0a"
 GITHUB_API_ROOT = "https://api.github.com"
 PYPI_URL = "https://pypi.org/pypi/bd-to-avp/json"
 PAGES_APPCAST_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"

--- a/scripts/beta3_recovery_evidence.py
+++ b/scripts/beta3_recovery_evidence.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, cast
+from urllib.error import HTTPError
+from urllib.parse import quote, unquote, urljoin, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BETA3_RECOVERY_EVIDENCE_PATH = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0-beta.3-recovery.json"
+BETA3_RECOVERY_EVIDENCE_SHA256 = "4b9c546c1de98c9da63a8776fa7232dc3463c84af5f325b4404fb6f1e80b61ea"
+GITHUB_API_ROOT = "https://api.github.com"
+PYPI_URL = "https://pypi.org/pypi/bd-to-avp/json"
+PAGES_APPCAST_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+MAX_REMOTE_BODY_BYTES = 16 * 1024 * 1024
+ALLOWED_REMOTE_HOSTS = frozenset({"api.github.com", "pypi.org", "cbusillo.github.io"})
+
+
+class Beta3RecoveryEvidenceError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RemoteResponse:
+    status: int
+    body: bytes
+
+
+RemoteFetcher = Callable[[str], RemoteResponse]
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise Beta3RecoveryEvidenceError(f"Duplicate JSON key in recovery evidence: {key!r}")
+        result[key] = value
+    return result
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise Beta3RecoveryEvidenceError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise Beta3RecoveryEvidenceError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(mapping: Mapping[str, Any], key: str, description: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise Beta3RecoveryEvidenceError(f"{description} is missing non-empty string {key!r}.")
+    return value
+
+
+def _integer(mapping: Mapping[str, Any], key: str, description: str) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise Beta3RecoveryEvidenceError(f"{description} is missing positive integer {key!r}.")
+    return value
+
+
+def _boolean(mapping: Mapping[str, Any], key: str, description: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise Beta3RecoveryEvidenceError(f"{description} is missing boolean {key!r}.")
+    return value
+
+
+def load_beta3_recovery_evidence(
+    path: Path = BETA3_RECOVERY_EVIDENCE_PATH,
+) -> dict[str, Any]:
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise Beta3RecoveryEvidenceError(f"Unable to read Beta 3 recovery evidence from {path}: {error}") from error
+    digest = hashlib.sha256(content).hexdigest()
+    if digest != BETA3_RECOVERY_EVIDENCE_SHA256:
+        raise Beta3RecoveryEvidenceError(
+            f"Beta 3 recovery evidence digest {digest} does not match the reviewed receipt."
+        )
+    try:
+        value = json.loads(content, object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise Beta3RecoveryEvidenceError(f"Beta 3 recovery evidence is invalid JSON: {error}") from error
+    evidence = dict(_mapping(value, "Beta 3 recovery evidence"))
+    expected_scalars = {
+        "schema": "bd_to_avp.release_recovery",
+        "schema_version": 2,
+        "repository": "cbusillo/BD_to_AVP",
+    }
+    for key, expected in expected_scalars.items():
+        if evidence.get(key) != expected:
+            raise Beta3RecoveryEvidenceError(f"Beta 3 recovery evidence {key!r} must be {expected!r}.")
+    expected_repository_identity = {
+        "id": 771225421,
+        "node_id": "R_kgDOLff3TQ",
+        "full_name": "cbusillo/BD_to_AVP",
+        "private": False,
+        "archived": False,
+        "disabled": False,
+    }
+    repository_identity = _mapping(evidence.get("repository_identity"), "Repository identity")
+    if dict(repository_identity) != expected_repository_identity:
+        raise Beta3RecoveryEvidenceError("Beta 3 recovery evidence does not identify the production repository.")
+    expected_source_identity = {
+        "base_commit": "e4d89a54412b50b556f51ea3c32034a1dc015eb6",
+        "tree": "4ff668a0f35ca5fe99880655e9f1c3de244778c5",
+        "files": {
+            "pyproject.toml": "4a01dc9e5dedf55899cc1e903a40514b93a9507ee88f22d14a6a19beb91568af",
+            "uv.lock": "94015cc2525bcb84c3129f391593fa9fc624679c8592f630f7024a8ffd08fc20",
+            "macos/project.yml": "8fc365f4e3d8032ae9eb22734030ee50f0b7e6759b8a5952032266f6ba331ea4",
+        },
+    }
+    source_identity = _mapping(evidence.get("source_identity"), "Recovery source identity")
+    if dict(source_identity) != expected_source_identity:
+        raise Beta3RecoveryEvidenceError("Beta 3 recovery evidence does not identify the reviewed source tree.")
+    transition = _mapping(evidence.get("transition"), "Recovery transition")
+    source = _mapping(transition.get("source"), "Recovery source")
+    target = _mapping(transition.get("target"), "Recovery target")
+    expected_source = {"package_version": "0.3.0rc1", "public_version": "0.3.0-rc.1", "build": "147"}
+    expected_target = {
+        "package_version": "0.3.0b3",
+        "public_version": "0.3.0-beta.3",
+        "release_tag": "v0.3.0-beta.3",
+        "build": "148",
+    }
+    if dict(source) != expected_source or dict(target) != expected_target:
+        raise Beta3RecoveryEvidenceError("Beta 3 recovery evidence does not describe the one approved transition.")
+    pages = _mapping(evidence.get("pages"), "Pages evidence")
+    capture_relative = Path(_string(pages, "capture_path", "Pages evidence"))
+    capture_path = (REPO_ROOT / capture_relative).resolve()
+    if REPO_ROOT.resolve() not in capture_path.parents:
+        raise Beta3RecoveryEvidenceError("Pages evidence capture path escapes the repository.")
+    try:
+        capture = capture_path.read_bytes()
+    except OSError as error:
+        raise Beta3RecoveryEvidenceError(f"Unable to read Pages evidence capture: {error}") from error
+    if hashlib.sha256(capture).hexdigest() != _string(pages, "capture_sha256", "Pages evidence"):
+        raise Beta3RecoveryEvidenceError("Pages evidence capture digest does not match the reviewed receipt.")
+    captured_remote_bytes = capture[:-1] if capture.endswith(b"\n") else capture
+    if hashlib.sha256(captured_remote_bytes).hexdigest() != _string(pages, "appcast_sha256", "Pages evidence"):
+        raise Beta3RecoveryEvidenceError(
+            "Pages evidence capture does not reproduce the observed remote appcast digest."
+        )
+    return evidence
+
+
+@lru_cache(maxsize=1)
+def _github_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        raise Beta3RecoveryEvidenceError(
+            "Authenticated GitHub access is required to verify draft-release absence. "
+            "Set GH_TOKEN or run gh auth login."
+        ) from error
+    token = result.stdout.strip()
+    if not token:
+        raise Beta3RecoveryEvidenceError("GitHub CLI returned an empty authentication token.")
+    return token
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlsplit(url)
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port
+
+
+class _SameOriginRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        absolute_url = urljoin(request.full_url, new_url)
+        if _origin(absolute_url) != _origin(request.full_url):
+            raise Beta3RecoveryEvidenceError(
+                f"Remote evidence request refused a cross-origin redirect: {request.full_url} -> {absolute_url}"
+            )
+        return super().redirect_request(request, file_pointer, code, message, headers, absolute_url)
+
+
+@lru_cache(maxsize=1)
+def _remote_opener():
+    return build_opener(_SameOriginRedirectHandler())
+
+
+def _read_bounded(response, url: str) -> bytes:
+    body = response.read(MAX_REMOTE_BODY_BYTES + 1)
+    if len(body) > MAX_REMOTE_BODY_BYTES:
+        raise Beta3RecoveryEvidenceError(f"Remote evidence response exceeded the size limit: {url}")
+    return body
+
+
+def fetch_remote(url: str) -> RemoteResponse:
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in ALLOWED_REMOTE_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise Beta3RecoveryEvidenceError(f"Remote evidence URL is not approved: {url}")
+    headers = {
+        "Accept": "application/vnd.github+json" if url.startswith(GITHUB_API_ROOT) else "application/octet-stream",
+        "Cache-Control": "no-cache",
+        "User-Agent": "bd-to-avp-beta3-recovery-verifier",
+    }
+    if url.startswith(GITHUB_API_ROOT):
+        headers["Authorization"] = f"Bearer {_github_token()}"
+        headers["X-GitHub-Api-Version"] = "2022-11-28"
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with _remote_opener().open(request, timeout=45) as response:
+            final_url = response.geturl()
+            if _origin(final_url) != _origin(url):
+                raise Beta3RecoveryEvidenceError(f"Remote evidence response changed origin: {url} -> {final_url}")
+            return RemoteResponse(status=response.status, body=_read_bounded(response, url))
+    except HTTPError as error:
+        body = _read_bounded(error, url)
+        if error.code == 404:
+            return RemoteResponse(status=404, body=body)
+        raise Beta3RecoveryEvidenceError(f"Remote evidence request failed with HTTP {error.code}: {url}") from error
+    except OSError as error:
+        raise Beta3RecoveryEvidenceError(f"Remote evidence request failed: {url}: {error}") from error
+
+
+def _json_response(fetcher: RemoteFetcher, url: str, description: str) -> Any:
+    response = fetcher(url)
+    if response.status != 200:
+        raise Beta3RecoveryEvidenceError(f"{description} returned HTTP {response.status}, expected 200.")
+    try:
+        return json.loads(response.body, object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise Beta3RecoveryEvidenceError(f"{description} returned invalid JSON.") from error
+
+
+def _expect_fields(actual: Mapping[str, Any], expected: Mapping[str, Any], description: str) -> None:
+    mismatches = [
+        f"{key}={actual.get(key)!r}, expected {value!r}" for key, value in expected.items() if actual.get(key) != value
+    ]
+    if mismatches:
+        raise Beta3RecoveryEvidenceError(f"{description} mismatch: {', '.join(mismatches)}")
+
+
+def _verify_repository_identity(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
+    expected = _mapping(evidence.get("repository_identity"), "Repository identity")
+    actual = _mapping(
+        _json_response(fetcher, f"{GITHUB_API_ROOT}/repos/{repository}", "GitHub repository identity"),
+        "GitHub repository identity",
+    )
+    _expect_fields(actual, expected, "GitHub repository identity")
+    permissions = _mapping(actual.get("permissions"), "GitHub repository token permissions")
+    if permissions.get("push") is not True:
+        raise Beta3RecoveryEvidenceError(
+            "GitHub repository token must have push visibility so draft-release absence is authoritative."
+        )
+
+
+def _verify_failed_run(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
+    run_evidence = _mapping(evidence.get("failed_run"), "Failed run evidence")
+    run_id = _integer(run_evidence, "id", "Failed run evidence")
+    api_root = f"{GITHUB_API_ROOT}/repos/{repository}"
+    run = _mapping(
+        _json_response(fetcher, f"{api_root}/actions/runs/{run_id}", "Failed release run"),
+        "Failed release run",
+    )
+    actor = _mapping(run.get("actor"), "Failed release run actor")
+    triggering_actor = _mapping(run.get("triggering_actor"), "Failed release run triggering actor")
+    run_repository = _mapping(run.get("repository"), "Failed release run repository")
+    head_repository = _mapping(run.get("head_repository"), "Failed release run head repository")
+    expected_run = {
+        "id": run_id,
+        "workflow_id": _integer(run_evidence, "workflow_id", "Failed run evidence"),
+        "run_number": _integer(run_evidence, "run_number", "Failed run evidence"),
+        "event": _string(run_evidence, "event", "Failed run evidence"),
+        "head_branch": _string(run_evidence, "head_branch", "Failed run evidence"),
+        "head_sha": _string(run_evidence, "head_sha", "Failed run evidence"),
+        "run_attempt": _integer(run_evidence, "run_attempt", "Failed run evidence"),
+        "path": _string(run_evidence, "workflow_path", "Failed run evidence"),
+        "name": _string(run_evidence, "workflow_name", "Failed run evidence"),
+        "display_title": _string(run_evidence, "display_title", "Failed run evidence"),
+        "status": _string(run_evidence, "status", "Failed run evidence"),
+        "conclusion": _string(run_evidence, "conclusion", "Failed run evidence"),
+    }
+    _expect_fields(run, expected_run, "Failed release run")
+    _expect_fields(actor, {"login": _string(run_evidence, "actor", "Failed run evidence")}, "Run actor")
+    _expect_fields(
+        triggering_actor,
+        {"login": _string(run_evidence, "triggering_actor", "Failed run evidence")},
+        "Run triggering actor",
+    )
+    _expect_fields(
+        run_repository,
+        {"full_name": _string(run_evidence, "repository", "Failed run evidence")},
+        "Run repository",
+    )
+    _expect_fields(
+        head_repository,
+        {"full_name": _string(run_evidence, "head_repository", "Failed run evidence")},
+        "Run head repository",
+    )
+
+    run_attempt = _integer(run_evidence, "run_attempt", "Failed run evidence")
+    jobs_payload = _mapping(
+        _json_response(
+            fetcher,
+            f"{api_root}/actions/runs/{run_id}/attempts/{run_attempt}/jobs?per_page=100",
+            "Failed run jobs",
+        ),
+        "Failed run jobs",
+    )
+    jobs = [_mapping(job, "Failed run job") for job in _sequence(jobs_payload.get("jobs"), "Failed run jobs")]
+    expected_jobs = sorted(
+        [
+            dict(_mapping(job, "Failed run evidence job"))
+            for job in _sequence(run_evidence.get("jobs"), "Failed run evidence jobs")
+        ],
+        key=lambda job: str(job.get("name")),
+    )
+    actual_jobs = sorted(
+        [{"name": job.get("name"), "conclusion": job.get("conclusion")} for job in jobs],
+        key=lambda job: str(job.get("name")),
+    )
+    if jobs_payload.get("total_count") != len(expected_jobs) or actual_jobs != expected_jobs:
+        raise Beta3RecoveryEvidenceError("Failed release run job set changed after the recovery receipt.")
+    if any(job.get("status") != "completed" for job in jobs):
+        raise Beta3RecoveryEvidenceError("Failed release run contains a job that is no longer completed.")
+    jobs_by_name = {str(job.get("name", "")): job for job in jobs}
+    if len(jobs_by_name) != len(jobs):
+        raise Beta3RecoveryEvidenceError("Failed release run contains duplicate job names.")
+    failed_job_name = _string(run_evidence, "failed_job", "Failed run evidence")
+    failed_job = jobs_by_name.get(failed_job_name)
+    if failed_job is None or failed_job.get("conclusion") != "failure":
+        raise Beta3RecoveryEvidenceError(f"Failed run job {failed_job_name!r} is not still recorded as failed.")
+    steps = [_mapping(step, "Failed job step") for step in _sequence(failed_job.get("steps"), "Failed job steps")]
+    steps_by_name = {str(step.get("name", "")): step for step in steps}
+    failed_step_name = _string(run_evidence, "failed_step", "Failed run evidence")
+    upload_step_name = _string(run_evidence, "package_upload_step", "Failed run evidence")
+    if steps_by_name.get(failed_step_name, {}).get("conclusion") != "failure":
+        raise Beta3RecoveryEvidenceError(f"Failed run step {failed_step_name!r} is not still recorded as failed.")
+    if steps_by_name.get(upload_step_name, {}).get("conclusion") != "skipped":
+        raise Beta3RecoveryEvidenceError(f"Package upload step {upload_step_name!r} was not skipped.")
+    for job_name in _sequence(run_evidence.get("skipped_jobs"), "Failed run skipped jobs"):
+        if not isinstance(job_name, str) or jobs_by_name.get(job_name, {}).get("conclusion") != "skipped":
+            raise Beta3RecoveryEvidenceError(f"Release boundary job {job_name!r} was not skipped.")
+
+    artifacts = _mapping(
+        _json_response(
+            fetcher,
+            f"{api_root}/actions/runs/{run_id}/artifacts?per_page=100",
+            "Failed run artifacts",
+        ),
+        "Failed run artifacts",
+    )
+    if artifacts.get("total_count") != run_evidence.get("artifact_count") or artifacts.get("artifacts") != []:
+        raise Beta3RecoveryEvidenceError("Failed release run artifact state no longer matches the recovery receipt.")
+
+
+def _all_releases(fetcher: RemoteFetcher, api_root: str) -> list[Mapping[str, Any]]:
+    releases: list[Mapping[str, Any]] = []
+    for page in range(1, 11):
+        page_values = _json_response(
+            fetcher,
+            f"{api_root}/releases?per_page=100&page={page}",
+            f"GitHub Releases page {page}",
+        )
+        page_releases = [_mapping(value, "GitHub Release") for value in _sequence(page_values, "GitHub Releases")]
+        releases.extend(page_releases)
+        if len(page_releases) < 100:
+            return releases
+    raise Beta3RecoveryEvidenceError("GitHub Releases exceeded the bounded pagination limit.")
+
+
+def _verify_release_absence(
+    fetcher: RemoteFetcher,
+    repository: str,
+    evidence: Mapping[str, Any],
+    *,
+    allow_beta3_draft: bool,
+    expected_sha: str | None,
+) -> None:
+    api_root = f"{GITHUB_API_ROOT}/repos/{repository}"
+    absence = _mapping(evidence.get("absent_github_state"), "Absent GitHub state")
+    target_tag = _string(
+        _mapping(_mapping(evidence.get("transition"), "Recovery transition").get("target"), "Recovery target"),
+        "release_tag",
+        "Recovery target",
+    )
+    releases = _all_releases(fetcher, api_root)
+    for tag in _sequence(absence.get("releases"), "Absent GitHub releases"):
+        published = [
+            release for release in releases if release.get("tag_name") == tag and release.get("draft") is False
+        ]
+        if published:
+            raise Beta3RecoveryEvidenceError(f"Published GitHub Release {tag!r} now exists.")
+    resumable_draft = False
+    for tag in _sequence(absence.get("drafts"), "Absent GitHub drafts"):
+        drafts = [release for release in releases if release.get("tag_name") == tag and release.get("draft") is True]
+        if tag == target_tag and allow_beta3_draft:
+            if len(drafts) > 1:
+                raise Beta3RecoveryEvidenceError(f"Multiple resumable Beta 3 drafts exist for {target_tag!r}.")
+            if drafts:
+                if expected_sha is None:
+                    raise Beta3RecoveryEvidenceError(
+                        "Expected protected-main SHA is required to validate a Beta 3 draft."
+                    )
+                _expect_fields(
+                    drafts[0],
+                    {
+                        "tag_name": target_tag,
+                        "name": target_tag,
+                        "draft": True,
+                        "prerelease": True,
+                        "target_commitish": expected_sha,
+                    },
+                    "Resumable Beta 3 draft",
+                )
+                resumable_draft = True
+        elif drafts:
+            raise Beta3RecoveryEvidenceError(f"Draft GitHub Release {tag!r} now exists.")
+
+    tags = [str(tag) for tag in _sequence(absence.get("tags"), "Absent GitHub tags")]
+    for tag in tags:
+        tag_url = f"{api_root}/git/ref/tags/{quote(tag, safe='')}"
+        response = fetcher(tag_url)
+        if response.status == 404:
+            continue
+        if tag != target_tag or not resumable_draft or response.status != 200 or expected_sha is None:
+            raise Beta3RecoveryEvidenceError(f"Git tag {tag!r} now exists; Beta 3 recovery premise is invalid.")
+        try:
+            reference = _mapping(
+                json.loads(response.body, object_pairs_hook=_reject_duplicate_json_keys),
+                "Resumable Beta 3 tag",
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise Beta3RecoveryEvidenceError("Resumable Beta 3 tag returned invalid JSON.") from error
+        _expect_fields(reference, {"ref": f"refs/tags/{target_tag}"}, "Resumable Beta 3 tag")
+        tag_object = _mapping(reference.get("object"), "Resumable Beta 3 tag object")
+        object_type = tag_object.get("type")
+        object_sha = tag_object.get("sha")
+        if object_type == "tag" and isinstance(object_sha, str):
+            annotated_tag = _mapping(
+                _json_response(
+                    fetcher,
+                    f"{api_root}/git/tags/{object_sha}",
+                    "Resumable annotated Beta 3 tag",
+                ),
+                "Resumable annotated Beta 3 tag",
+            )
+            tag_object = _mapping(annotated_tag.get("object"), "Resumable annotated Beta 3 tag target")
+            object_type = tag_object.get("type")
+            object_sha = tag_object.get("sha")
+        if object_type != "commit" or object_sha != expected_sha:
+            raise Beta3RecoveryEvidenceError("Resumable Beta 3 tag does not target the expected protected-main SHA.")
+
+
+def _verify_latest_pages_and_pypi(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
+    api_root = f"{GITHUB_API_ROOT}/repos/{repository}"
+    latest_evidence = _mapping(evidence.get("github_latest"), "GitHub Latest evidence")
+    latest = _mapping(_json_response(fetcher, f"{api_root}/releases/latest", "GitHub Latest release"), "GitHub Latest")
+    _expect_fields(
+        latest,
+        {
+            "id": _integer(latest_evidence, "release_id", "GitHub Latest evidence"),
+            "tag_name": _string(latest_evidence, "release_tag", "GitHub Latest evidence"),
+            "target_commitish": _string(latest_evidence, "target_sha", "GitHub Latest evidence"),
+            "immutable": _boolean(latest_evidence, "immutable", "GitHub Latest evidence"),
+            "draft": False,
+            "prerelease": False,
+        },
+        "GitHub Latest release",
+    )
+
+    pages_evidence = _mapping(evidence.get("pages"), "Pages evidence")
+    pages = _mapping(_json_response(fetcher, f"{api_root}/pages", "GitHub Pages state"), "GitHub Pages state")
+    _expect_fields(
+        pages,
+        {
+            "public": _boolean(pages_evidence, "public", "Pages evidence"),
+            "build_type": _string(pages_evidence, "build_type", "Pages evidence"),
+        },
+        "GitHub Pages state",
+    )
+    appcast_response = fetcher(f"{PAGES_APPCAST_URL}?beta3-recovery-audit=1")
+    if appcast_response.status != 200:
+        raise Beta3RecoveryEvidenceError(
+            f"Published Pages appcast returned HTTP {appcast_response.status}, expected 200."
+        )
+    appcast_digest = hashlib.sha256(appcast_response.body).hexdigest()
+    if appcast_digest != _string(pages_evidence, "appcast_sha256", "Pages evidence"):
+        raise Beta3RecoveryEvidenceError("Published Pages appcast digest changed after the recovery receipt.")
+    try:
+        channel = ET.fromstring(appcast_response.body).find("channel")
+    except ET.ParseError as error:
+        raise Beta3RecoveryEvidenceError("Published Pages appcast is invalid XML.") from error
+    item = channel.find("item") if channel is not None else None
+    if item is None:
+        raise Beta3RecoveryEvidenceError("Published Pages appcast has no release item.")
+    short_version = item.findtext(f"{{{SPARKLE_NAMESPACE}}}shortVersionString")
+    build = item.findtext(f"{{{SPARKLE_NAMESPACE}}}version")
+    enclosure = item.find("enclosure")
+    enclosure_url = enclosure.get("url", "") if enclosure is not None else ""
+    parts = urlsplit(enclosure_url).path.split("/")
+    release_tag = unquote(parts[parts.index("download") + 1]) if "download" in parts else ""
+    expected_appcast = {
+        "short_version": _string(pages_evidence, "short_version", "Pages evidence"),
+        "build": _string(pages_evidence, "build", "Pages evidence"),
+        "release_tag": _string(pages_evidence, "release_tag", "Pages evidence"),
+    }
+    actual_appcast = {"short_version": short_version, "build": build, "release_tag": release_tag}
+    if actual_appcast != expected_appcast:
+        raise Beta3RecoveryEvidenceError(
+            f"Published Pages appcast identity {actual_appcast!r} does not match {expected_appcast!r}."
+        )
+
+    pypi_evidence = _mapping(evidence.get("pypi"), "PyPI evidence")
+    pypi = _mapping(_json_response(fetcher, PYPI_URL, "PyPI project state"), "PyPI project state")
+    info = _mapping(pypi.get("info"), "PyPI project info")
+    releases = _mapping(pypi.get("releases"), "PyPI project releases")
+    if info.get("version") != _string(pypi_evidence, "latest_version", "PyPI evidence"):
+        raise Beta3RecoveryEvidenceError("PyPI Latest version changed after the recovery receipt.")
+    for version in _sequence(pypi_evidence.get("absent_versions"), "Absent PyPI versions"):
+        if version in releases:
+            raise Beta3RecoveryEvidenceError(f"PyPI version {version!r} now exists.")
+
+
+def _verify_retired_previews(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
+    api_root = f"{GITHUB_API_ROOT}/repos/{repository}"
+    for preview_value in _sequence(evidence.get("retired_preview_releases"), "Retired Preview releases"):
+        preview = _mapping(preview_value, "Retired Preview release")
+        tag = _string(preview, "tag", "Retired Preview release")
+        release = _mapping(
+            _json_response(
+                fetcher,
+                f"{api_root}/releases/tags/{quote(tag, safe='')}",
+                f"Retired Preview release {tag}",
+            ),
+            f"Retired Preview release {tag}",
+        )
+        _expect_fields(
+            release,
+            {
+                "id": _integer(preview, "release_id", f"Retired Preview release {tag}"),
+                "tag_name": tag,
+                "draft": False,
+                "prerelease": True,
+                "immutable": _boolean(preview, "immutable", f"Retired Preview release {tag}"),
+                "target_commitish": _string(preview, "target_sha", f"Retired Preview release {tag}"),
+            },
+            f"Retired Preview release {tag}",
+        )
+        actual_assets = sorted(
+            [
+                {
+                    "asset_id": asset.get("id"),
+                    "name": asset.get("name"),
+                    "size": asset.get("size"),
+                    "digest": asset.get("digest"),
+                }
+                for asset in _sequence(release.get("assets"), f"Retired Preview release {tag} assets")
+                if isinstance(asset, Mapping)
+            ],
+            key=lambda asset: str(asset["name"]),
+        )
+        expected_assets = sorted(
+            [
+                dict(_mapping(asset, f"Retired Preview release {tag} evidence asset"))
+                for asset in _sequence(
+                    preview.get("assets"),
+                    f"Retired Preview release {tag} evidence assets",
+                )
+            ],
+            key=lambda asset: str(asset["name"]),
+        )
+        if actual_assets != expected_assets:
+            raise Beta3RecoveryEvidenceError(f"Retired Preview release {tag!r} assets changed.")
+
+
+def verify_beta3_remote_state(
+    evidence: Mapping[str, Any],
+    *,
+    fetcher: RemoteFetcher = fetch_remote,
+    allow_beta3_draft: bool = False,
+    expected_sha: str | None = None,
+) -> None:
+    repository = _string(evidence, "repository", "Beta 3 recovery evidence")
+    valid_expected_sha = (
+        expected_sha is not None
+        and len(expected_sha) == 40
+        and all(character in "0123456789abcdef" for character in expected_sha)
+    )
+    if allow_beta3_draft and not valid_expected_sha:
+        raise Beta3RecoveryEvidenceError("Expected protected-main SHA must be a full lowercase Git SHA.")
+    _verify_repository_identity(fetcher, repository, evidence)
+    _verify_failed_run(fetcher, repository, evidence)
+    _verify_release_absence(
+        fetcher,
+        repository,
+        evidence,
+        allow_beta3_draft=allow_beta3_draft,
+        expected_sha=expected_sha,
+    )
+    _verify_latest_pages_and_pypi(fetcher, repository, evidence)
+    _verify_retired_previews(fetcher, repository, evidence)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify the live remote premises for the Beta 3 recovery.")
+    parser.add_argument("--evidence", type=Path, default=BETA3_RECOVERY_EVIDENCE_PATH)
+    parser.add_argument("--allow-beta3-draft", action="store_true")
+    parser.add_argument("--expected-sha")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.allow_beta3_draft and not args.expected_sha:
+        raise Beta3RecoveryEvidenceError("--expected-sha is required with --allow-beta3-draft.")
+    evidence = load_beta3_recovery_evidence(args.evidence)
+    verify_beta3_remote_state(
+        evidence,
+        allow_beta3_draft=args.allow_beta3_draft,
+        expected_sha=args.expected_sha,
+    )
+    print(
+        json.dumps(
+            {
+                "evidence_sha256": BETA3_RECOVERY_EVIDENCE_SHA256,
+                "repository": evidence["repository"],
+                "verified": True,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -50,6 +50,7 @@ WORKER_PROTOCOL_VERSION = PROTOCOL_VERSION
 WORKER_ENTITLEMENTS = MACOS_ROOT / "BluRayToVisionPro" / "Worker.entitlements"
 DEPLOYMENT_TARGET_OVERRIDE_ENV = "BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE"
 SUPPORT_DIAGNOSTICS_ENDPOINT_ENV = "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT"
+SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY = "BDToAVPSupportDiagnosticsEndpoint"
 USER_INTERFACE_SOURCE_FILES = sorted(
     [
         *(MACOS_ROOT / "BluRayToVisionPro" / "App").glob("*.swift"),
@@ -140,6 +141,59 @@ def xcodebuild(action: str, configuration: str) -> None:
     )
 
 
+def validate_support_diagnostics_endpoint(endpoint: str) -> str:
+    approved_endpoint = endpoint.strip()
+    if not approved_endpoint:
+        raise ValueError("Invalid support diagnostics endpoint")
+    try:
+        parsed_endpoint = urlsplit(approved_endpoint)
+        endpoint_port = parsed_endpoint.port
+    except ValueError as error:
+        raise ValueError("Invalid support diagnostics endpoint") from error
+    if (
+        parsed_endpoint.scheme != "https"
+        or parsed_endpoint.hostname is None
+        or parsed_endpoint.username is not None
+        or parsed_endpoint.password is not None
+        or parsed_endpoint.path not in {"", "/"}
+        or parsed_endpoint.query
+        or parsed_endpoint.fragment
+        or any(character.isspace() for character in approved_endpoint)
+        or (endpoint_port is not None and not 1 <= endpoint_port <= 65535)
+    ):
+        raise ValueError("Invalid support diagnostics endpoint")
+    return approved_endpoint
+
+
+def verify_support_diagnostics_endpoint(
+    info: Mapping[str, object],
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> str:
+    invalid_endpoint_message = f"{SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY} must be a non-empty valid HTTPS endpoint."
+    endpoint = info.get(SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY)
+    if not isinstance(endpoint, str):
+        raise ValueError(invalid_endpoint_message)
+    try:
+        validated_endpoint = validate_support_diagnostics_endpoint(endpoint)
+    except ValueError as error:
+        raise ValueError(invalid_endpoint_message) from error
+    if endpoint != validated_endpoint:
+        raise ValueError(invalid_endpoint_message)
+
+    environment = os.environ if environment is None else environment
+    if SUPPORT_DIAGNOSTICS_ENDPOINT_ENV in environment:
+        try:
+            approved_endpoint = validate_support_diagnostics_endpoint(environment[SUPPORT_DIAGNOSTICS_ENDPOINT_ENV])
+        except ValueError as error:
+            raise ValueError("Approved support diagnostics endpoint is invalid.") from error
+        if endpoint != approved_endpoint:
+            raise ValueError(
+                f"{SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY} must exactly match the approved support diagnostics endpoint."
+            )
+    return endpoint
+
+
 def native_build_settings(configuration: str, environment: Mapping[str, str]) -> list[str]:
     build_settings = ["CODE_SIGNING_ALLOWED=NO"]
     deployment_target = environment.get(DEPLOYMENT_TARGET_OVERRIDE_ENV, "").strip()
@@ -151,23 +205,7 @@ def native_build_settings(configuration: str, environment: Mapping[str, str]) ->
     if configuration == "Release" and not support_endpoint:
         raise ValueError("Release builds require an approved support diagnostics endpoint")
     if support_endpoint:
-        parsed_endpoint = urlsplit(support_endpoint)
-        try:
-            endpoint_port = parsed_endpoint.port
-        except ValueError as error:
-            raise ValueError("Invalid support diagnostics endpoint") from error
-        if (
-            parsed_endpoint.scheme != "https"
-            or parsed_endpoint.hostname is None
-            or parsed_endpoint.username is not None
-            or parsed_endpoint.password is not None
-            or parsed_endpoint.path not in {"", "/"}
-            or parsed_endpoint.query
-            or parsed_endpoint.fragment
-            or any(character.isspace() for character in support_endpoint)
-            or (endpoint_port is not None and not 1 <= endpoint_port <= 65535)
-        ):
-            raise ValueError("Invalid support diagnostics endpoint")
+        support_endpoint = validate_support_diagnostics_endpoint(support_endpoint)
         build_settings.append(f"BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT={support_endpoint}")
     if configuration == "Release":
         build_settings.extend(["ARCHS=arm64", "ENABLE_CODE_COVERAGE=NO", "ONLY_ACTIVE_ARCH=NO"])
@@ -229,7 +267,7 @@ def assemble_package() -> Path:
         plistlib.dump(info, info_file, sort_keys=True)
 
     strip_native_executable(PACKAGED_APP)
-    verify_layout(PACKAGED_APP)
+    verify_layout(PACKAGED_APP, environment=os.environ)
     return PACKAGED_APP
 
 
@@ -240,8 +278,8 @@ def copy_tree(source: Path, destination: Path) -> None:
     shutil.copytree(source, destination, symlinks=True, dirs_exist_ok=True)
 
 
-def verify_layout(app_path: Path) -> None:
-    verify_product_identity(app_path)
+def verify_layout(app_path: Path, *, environment: Mapping[str, str] | None = None) -> None:
+    verify_product_identity(app_path, environment=environment)
     native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
     worker_executable = app_path / "Contents" / "MacOS" / WORKER_EXECUTABLE_NAME
     ffprobe_executable = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / "ffprobe"
@@ -266,7 +304,7 @@ def verify_layout(app_path: Path) -> None:
     verify_package_paths(app_path)
 
 
-def verify_product_identity(app_path: Path) -> None:
+def verify_product_identity(app_path: Path, *, environment: Mapping[str, str] | None = None) -> None:
     if app_path.name != NATIVE_APP_NAME:
         raise RuntimeError(f"macOS app must use the product name: {NATIVE_APP_NAME}")
 
@@ -292,6 +330,10 @@ def verify_product_identity(app_path: Path) -> None:
         for key, expected in expected_values.items()
         if info.get(key) != expected
     ]
+    try:
+        verify_support_diagnostics_endpoint(info, environment=environment)
+    except ValueError as error:
+        mismatches.append(str(error))
     development_keys = [key for key in info if "DevelopmentRepositoryRoot" in key]
     if development_keys:
         mismatches.append("development repository metadata is present")

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -19,6 +19,14 @@ from uuid import uuid4
 
 from bd_to_avp.observability import ObservabilityEvent
 from bd_to_avp.worker.protocol import PROTOCOL_VERSION
+from scripts.production_identity import (
+    PRODUCTION_BUNDLE_IDENTIFIER,
+    PRODUCTION_DISTRIBUTION_CHANNEL,
+    PRODUCTION_FEED_URL,
+    PRODUCTION_PRODUCT_NAME,
+    PRODUCTION_SPARKLE_PUBLIC_KEY,
+    validate_production_public_key,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MACOS_ROOT = REPO_ROOT / "macos"
@@ -30,8 +38,8 @@ with PYPROJECT_PATH.open("rb") as pyproject_file:
 PROJECT_METADATA = PYPROJECT["project"]
 BRIEFCASE_METADATA = PYPROJECT["tool"]["briefcase"]
 BRIEFCASE_APP_METADATA = BRIEFCASE_METADATA["app"]["bd-to-avp"]
-NATIVE_PRODUCT_NAME = str(BRIEFCASE_APP_METADATA["formal_name"])
-NATIVE_BUNDLE_IDENTIFIER = f"{BRIEFCASE_METADATA['bundle']}.bd-to-avp"
+NATIVE_PRODUCT_NAME = PRODUCTION_PRODUCT_NAME
+NATIVE_BUNDLE_IDENTIFIER = PRODUCTION_BUNDLE_IDENTIFIER
 NATIVE_SHORT_VERSION = str(PROJECT_METADATA["version"])
 NATIVE_UPDATE_INFO = dict(BRIEFCASE_APP_METADATA["macOS"]["info"])
 NATIVE_BUILD_VERSION = str(NATIVE_UPDATE_INFO["CFBundleVersion"])
@@ -86,6 +94,37 @@ MACH_O_MAGICS = {
     b"\xcf\xfa\xed\xfe",
     b"\xfe\xed\xfa\xcf",
 }
+
+
+def validate_repository_production_identity() -> None:
+    derived_bundle_identifier = f"{BRIEFCASE_METADATA['bundle']}.bd-to-avp"
+    expected_values = {
+        "Briefcase product name": (str(BRIEFCASE_APP_METADATA["formal_name"]), PRODUCTION_PRODUCT_NAME),
+        "Briefcase bundle identifier": (derived_bundle_identifier, PRODUCTION_BUNDLE_IDENTIFIER),
+        "distribution channel": (
+            str(NATIVE_UPDATE_INFO.get("BDToAVPDistributionChannel", "")),
+            PRODUCTION_DISTRIBUTION_CHANNEL,
+        ),
+        "Sparkle feed URL": (str(NATIVE_UPDATE_INFO.get("SUFeedURL", "")), PRODUCTION_FEED_URL),
+        "Sparkle public key": (
+            str(NATIVE_UPDATE_INFO.get("SUPublicEDKey", "")),
+            PRODUCTION_SPARKLE_PUBLIC_KEY,
+        ),
+    }
+    mismatches = [
+        f"{description}: expected {expected!r}, found {actual!r}"
+        for description, (actual, expected) in expected_values.items()
+        if actual != expected
+    ]
+    try:
+        validate_production_public_key(str(NATIVE_UPDATE_INFO.get("SUPublicEDKey", "")))
+    except ValueError as error:
+        mismatches.append(str(error))
+    if mismatches:
+        raise RuntimeError("Repository production identity validation failed:\n" + "\n".join(mismatches))
+
+
+validate_repository_production_identity()
 
 
 def run(

--- a/scripts/production_identity.py
+++ b/scripts/production_identity.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import hashlib
+
+
+PRODUCTION_PRODUCT_NAME = "3D Blu-ray to Vision Pro"
+PRODUCTION_BUNDLE_IDENTIFIER = "com.shinycomputers.bd-to-avp"
+PRODUCTION_FEED_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+PRODUCTION_SPARKLE_PUBLIC_KEY = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="
+PRODUCTION_SPARKLE_PUBLIC_KEY_SHA256 = "74fe16c5b2761a4c2e562d72eff6095a1bada3e68f78e9eb384af808fb7b3196"
+PRODUCTION_TEAM_ID = "MM5YXC7T6E"
+PRODUCTION_DEVELOPER_IDENTITY = "Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)"
+PRODUCTION_DISTRIBUTION_CHANNEL = "direct"
+
+
+def validate_production_public_key(value: str) -> str:
+    if value != PRODUCTION_SPARKLE_PUBLIC_KEY:
+        raise ValueError("Sparkle public key does not match the production identity.")
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if digest != PRODUCTION_SPARKLE_PUBLIC_KEY_SHA256:
+        raise ValueError("Sparkle public key digest does not match the production identity.")
+    return value

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 LOCK_PATH = REPO_ROOT / "uv.lock"
 MACOS_PROJECT_PATH = REPO_ROOT / "macos" / "project.yml"
+BETA3_RECOVERY_EVIDENCE_PATH = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0-beta.3-recovery.json"
 VERSION_PATTERN = re.compile(
     r"^(?P<major>0|[1-9][0-9]*)\."
     r"(?P<minor>0|[1-9][0-9]*)\."
@@ -41,6 +42,120 @@ DMG_NAME_PREFIX = "3D-Blu-ray-to-Vision-Pro"
 INTERNAL_STAGE_NAMES = {"a": "alpha", "b": "beta", "rc": "rc"}
 PUBLIC_STAGE_SUFFIXES = {"alpha": "a", "beta": "b", "rc": "rc"}
 STAGE_ORDER = {"alpha": 0, "beta": 1, "rc": 2, "stable": 3}
+BETA3_RECOVERY_SOURCE_VERSION = "0.3.0rc1"
+BETA3_RECOVERY_SOURCE_BUILD = "147"
+BETA3_RECOVERY_TARGET_VERSION = "0.3.0b3"
+BETA3_RECOVERY_TARGET_BUILD = "148"
+BETA3_RECOVERY_EVIDENCE: dict[str, Any] = {
+    "schema": "bd_to_avp.release_recovery",
+    "schema_version": 1,
+    "observed_at": "2026-07-20T02:28:48Z",
+    "repository": "cbusillo/BD_to_AVP",
+    "transition": {
+        "source": {
+            "package_version": BETA3_RECOVERY_SOURCE_VERSION,
+            "public_version": "0.3.0-rc.1",
+            "build": BETA3_RECOVERY_SOURCE_BUILD,
+        },
+        "target": {
+            "package_version": BETA3_RECOVERY_TARGET_VERSION,
+            "public_version": "0.3.0-beta.3",
+            "release_tag": "v0.3.0-beta.3",
+            "build": BETA3_RECOVERY_TARGET_BUILD,
+        },
+    },
+    "failed_run": {
+        "id": 29693513480,
+        "head_sha": "438991f07fa19cd2ae2df4d3ec14716bc0371f8d",
+        "conclusion": "failure",
+        "skipped_boundaries": {
+            "package_upload": "skipped",
+            "draft": "skipped",
+            "appcast": "skipped",
+            "pypi": "skipped",
+            "release": "skipped",
+            "pages": "skipped",
+        },
+        "artifact_count": 0,
+    },
+    "absent_github_state": {
+        "tags": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
+        "releases": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
+        "drafts": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
+    },
+    "github_latest": {"release_tag": "v0.2.143"},
+    "pages": {
+        "status": "enabled",
+        "release_tag": "v0.2.143",
+        "appcast_sha256": "d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e",
+    },
+    "pypi": {
+        "latest_version": "0.2.143",
+        "absent_versions": ["0.3.0rc1", "0.3.0b3"],
+    },
+    "retired_preview_releases": [
+        {
+            "tag": "native-ui-preview-1",
+            "immutable": True,
+            "release_id": 352841376,
+            "target_sha": "e1e4f851096cfeae70da1c56a88acef9c5e61055",
+            "assets": [
+                {
+                    "asset_id": 474714228,
+                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg",
+                    "size": 406585971,
+                    "digest": "sha256:119a86f829c0bc8962deaea5f1a8fb92ffbcd48002d062a0ac59cccffe61af71",
+                },
+                {
+                    "asset_id": 474714389,
+                    "name": "SHA256SUMS",
+                    "size": 118,
+                    "digest": "sha256:1b142e59fea4ee0e0f734ae5cdf34815583765d2d0895a9ec25217436d52336e",
+                },
+            ],
+        },
+        {
+            "tag": "v0.3.0-beta.1",
+            "immutable": True,
+            "release_id": 353900273,
+            "target_sha": "2378b46345185f05611f15a39658217bac7c6960",
+            "assets": [
+                {
+                    "asset_id": 476861235,
+                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.1.dmg",
+                    "size": 407183981,
+                    "digest": "sha256:b611dca7de660efed218a0e2fc5c4ed9d6e5e652a54da938e13d40a6bd994bed",
+                },
+                {
+                    "asset_id": 476861481,
+                    "name": "SHA256SUMS",
+                    "size": 123,
+                    "digest": "sha256:17eead4e3faf2ffd3110a9bf200d39f0ebfba78546f40aa0fa868fd3afb53b5b",
+                },
+            ],
+        },
+        {
+            "tag": "v0.3.0-beta.2",
+            "immutable": True,
+            "release_id": 355845653,
+            "target_sha": "9e9a38c715dbbe5df97e6d3a8ba715731607db6a",
+            "assets": [
+                {
+                    "asset_id": 480668646,
+                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.2.dmg",
+                    "size": 408158527,
+                    "digest": "sha256:e2e8a20c9fd4517076189e56598ff6b32cd1adc544c6ad0618f5a46f55dcae24",
+                },
+                {
+                    "asset_id": 480668779,
+                    "name": "SHA256SUMS",
+                    "size": 123,
+                    "digest": "sha256:ab387b19cef2af5923b112735a10253d42f4fc37f002e6983deb44a5a17b7fb0",
+                },
+            ],
+        },
+    ],
+}
 
 
 class ReleaseError(RuntimeError):
@@ -273,6 +388,55 @@ def _load_toml(path: Path) -> dict[str, Any]:
         raise ReleaseError(f"Unable to load {path}: {error}") from error
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReleaseError(f"Recovery evidence contains duplicate key {key!r}.")
+        result[key] = value
+    return result
+
+
+def _validate_exact_evidence_value(actual: Any, expected: Any, location: str) -> None:
+    if type(actual) is not type(expected):
+        raise ReleaseError(f"Recovery evidence {location} has the wrong type.")
+    if isinstance(expected, dict):
+        missing = sorted(set(expected) - set(actual))
+        extra = sorted(set(actual) - set(expected))
+        if missing or extra:
+            details: list[str] = []
+            if missing:
+                details.append(f"missing {missing}")
+            if extra:
+                details.append(f"unexpected {extra}")
+            raise ReleaseError(f"Recovery evidence {location} has invalid keys: {', '.join(details)}.")
+        for key, expected_value in expected.items():
+            _validate_exact_evidence_value(actual[key], expected_value, f"{location}.{key}")
+        return
+    if isinstance(expected, list):
+        if len(actual) != len(expected):
+            raise ReleaseError(f"Recovery evidence {location} has the wrong number of entries.")
+        for index, (actual_value, expected_value) in enumerate(zip(actual, expected, strict=True)):
+            _validate_exact_evidence_value(actual_value, expected_value, f"{location}[{index}]")
+        return
+    if actual != expected:
+        raise ReleaseError(f"Recovery evidence {location} does not match the audited value.")
+
+
+def validate_beta3_recovery_evidence(
+    evidence_path: Path = BETA3_RECOVERY_EVIDENCE_PATH,
+) -> dict[str, Any]:
+    try:
+        evidence = json.loads(
+            evidence_path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"Unable to load Beta 3 recovery evidence from {evidence_path}: {error}") from error
+    _validate_exact_evidence_value(evidence, BETA3_RECOVERY_EVIDENCE, "$")
+    return evidence
+
+
 def _locked_project_version(lock_path: Path) -> str:
     lock = _load_toml(lock_path)
     packages = lock.get("package")
@@ -455,32 +619,33 @@ def _atomic_write(path: Path, content: bytes) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
-def prepare_release(
-    version_value: str,
-    build_value: str,
-    *,
-    pyproject_path: Path = PYPROJECT_PATH,
-    lock_path: Path = LOCK_PATH,
-    macos_project_path: Path | None = None,
-    uv_executable: str = "uv",
-    lock_runner: LockRunner = refresh_uv_lock,
-) -> ReleaseMetadata:
+def _resolve_macos_project_path(
+    pyproject_path: Path,
+    lock_path: Path,
+    macos_project_path: Path | None,
+) -> Path | None:
     if macos_project_path is None and pyproject_path == PYPROJECT_PATH and lock_path == LOCK_PATH:
-        macos_project_path = MACOS_PROJECT_PATH
-    current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
-    current_version = parse_release_version(current.package_version)
-    next_version = parse_release_version(version_value)
-    _validate_production_version(next_version)
-    current_build = parse_build_version(current.build_version)
-    next_build = parse_build_version(build_value)
-    if next_version.order_key <= current_version.order_key:
-        raise ReleaseError(f"Release version {version_value} must be newer than {current.package_version}.")
-    if next_build <= current_build:
-        raise ReleaseError(f"CFBundleVersion {build_value} must be greater than {current.build_version}.")
+        return MACOS_PROJECT_PATH
+    return macos_project_path
 
+
+def _write_release_metadata(
+    next_version: ReleaseVersion,
+    next_build: int,
+    current: ReleaseMetadata,
+    *,
+    pyproject_path: Path,
+    lock_path: Path,
+    macos_project_path: Path | None,
+    uv_executable: str,
+    lock_runner: LockRunner,
+) -> ReleaseMetadata:
     original_pyproject = pyproject_path.read_bytes()
     original_lock = lock_path.read_bytes()
     original_macos_project = macos_project_path.read_bytes() if macos_project_path is not None else None
+    if load_release_metadata(pyproject_path, lock_path, macos_project_path) != current:
+        raise ReleaseError("Release files changed before release preparation; no updates were applied.")
+
     updated_pyproject = _replace_section_value(
         original_pyproject.decode("utf-8"),
         "project",
@@ -540,13 +705,79 @@ def prepare_release(
         _atomic_write(lock_path, staged_lock_content)
         if macos_project_path is not None and updated_macos_project is not None:
             _atomic_write(macos_project_path, updated_macos_project.encode("utf-8"))
+        metadata = load_release_metadata(pyproject_path, lock_path, macos_project_path)
     except Exception:
         _atomic_write(pyproject_path, original_pyproject)
         _atomic_write(lock_path, original_lock)
         if macos_project_path is not None and original_macos_project is not None:
             _atomic_write(macos_project_path, original_macos_project)
         raise
-    return load_release_metadata(pyproject_path, lock_path, macos_project_path)
+    return metadata
+
+
+def prepare_release(
+    version_value: str,
+    build_value: str,
+    *,
+    pyproject_path: Path = PYPROJECT_PATH,
+    lock_path: Path = LOCK_PATH,
+    macos_project_path: Path | None = None,
+    uv_executable: str = "uv",
+    lock_runner: LockRunner = refresh_uv_lock,
+) -> ReleaseMetadata:
+    macos_project_path = _resolve_macos_project_path(pyproject_path, lock_path, macos_project_path)
+    current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
+    current_version = parse_release_version(current.package_version)
+    next_version = parse_release_version(version_value)
+    _validate_production_version(next_version)
+    current_build = parse_build_version(current.build_version)
+    next_build = parse_build_version(build_value)
+    if next_version.order_key <= current_version.order_key:
+        raise ReleaseError(f"Release version {version_value} must be newer than {current.package_version}.")
+    if next_build <= current_build:
+        raise ReleaseError(f"CFBundleVersion {build_value} must be greater than {current.build_version}.")
+    return _write_release_metadata(
+        next_version,
+        next_build,
+        current,
+        pyproject_path=pyproject_path,
+        lock_path=lock_path,
+        macos_project_path=macos_project_path,
+        uv_executable=uv_executable,
+        lock_runner=lock_runner,
+    )
+
+
+def recover_beta3(
+    *,
+    pyproject_path: Path = PYPROJECT_PATH,
+    lock_path: Path = LOCK_PATH,
+    macos_project_path: Path | None = None,
+    evidence_path: Path = BETA3_RECOVERY_EVIDENCE_PATH,
+    uv_executable: str = "uv",
+    lock_runner: LockRunner = refresh_uv_lock,
+) -> ReleaseMetadata:
+    validate_beta3_recovery_evidence(evidence_path)
+    macos_project_path = _resolve_macos_project_path(pyproject_path, lock_path, macos_project_path)
+    current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
+    if current.package_version != BETA3_RECOVERY_SOURCE_VERSION or current.build_version != BETA3_RECOVERY_SOURCE_BUILD:
+        raise ReleaseError(
+            "Beta 3 recovery requires exact source metadata "
+            f"{BETA3_RECOVERY_SOURCE_VERSION} build {BETA3_RECOVERY_SOURCE_BUILD}; "
+            f"found {current.package_version} build {current.build_version}."
+        )
+    target_version = parse_release_version(BETA3_RECOVERY_TARGET_VERSION)
+    target_build = parse_build_version(BETA3_RECOVERY_TARGET_BUILD)
+    return _write_release_metadata(
+        target_version,
+        target_build,
+        current,
+        pyproject_path=pyproject_path,
+        lock_path=lock_path,
+        macos_project_path=macos_project_path,
+        uv_executable=uv_executable,
+        lock_runner=lock_runner,
+    )
 
 
 def _add_paths(parser: argparse.ArgumentParser) -> None:
@@ -581,6 +812,13 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--build", required=True)
     prepare.add_argument("--uv", default="uv")
 
+    recover_beta3_parser = commands.add_parser(
+        "recover-beta3",
+        help="Apply the audited one-time 0.3.0rc1 build 147 to 0.3.0b3 build 148 recovery.",
+    )
+    _add_paths(recover_beta3_parser)
+    recover_beta3_parser.add_argument("--uv", default="uv")
+
     validate_tag = commands.add_parser("validate-tag", help="Validate a v-prefixed release tag.")
     validate_tag.add_argument("tag")
     return parser
@@ -610,6 +848,13 @@ def main(argv: list[str] | None = None) -> int:
         metadata = prepare_release(
             args.version,
             args.build,
+            pyproject_path=args.pyproject,
+            lock_path=args.lock,
+            macos_project_path=args.macos_project,
+            uv_executable=args.uv,
+        )
+    elif args.command == "recover-beta3":
+        metadata = recover_beta3(
             pyproject_path=args.pyproject,
             lock_path=args.lock,
             macos_project_path=args.macos_project,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -854,6 +854,9 @@ def _apply_metadata_transaction(
         metadata = validate()
         if precommit_validator is not None:
             precommit_validator()
+        for file in files:
+            if file.path.read_bytes() != file.target:
+                raise ReleaseError(f"Release file changed during final validation: {file.path}")
         _write_transaction_journal(journal_path, _transaction_payload(files, "committed"))
         if observer is not None:
             observer("journal-committed", journal_path)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,24 +1,50 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import copy
+import fcntl
+import hashlib
 import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import tomllib
 
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable
+
+from scripts.beta3_recovery_evidence import (
+    BETA3_RECOVERY_EVIDENCE_PATH,
+    Beta3RecoveryEvidenceError,
+    load_beta3_recovery_evidence,
+    verify_beta3_remote_state,
+)
+from scripts.production_identity import (
+    PRODUCTION_BUNDLE_IDENTIFIER,
+    PRODUCTION_DISTRIBUTION_CHANNEL,
+    PRODUCTION_FEED_URL,
+    PRODUCTION_PRODUCT_NAME,
+    PRODUCTION_SPARKLE_PUBLIC_KEY,
+    validate_production_public_key,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 LOCK_PATH = REPO_ROOT / "uv.lock"
 MACOS_PROJECT_PATH = REPO_ROOT / "macos" / "project.yml"
-BETA3_RECOVERY_EVIDENCE_PATH = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0-beta.3-recovery.json"
+PUBLIC_KEY_PATH = REPO_ROOT / "sparkle-public-ed-key.txt"
+TRANSACTION_JOURNAL_NAME = ".bd-to-avp-release-transaction.json"
+TRANSACTION_SCHEMA = "bd_to_avp.release_metadata_transaction"
+TRANSACTION_SCHEMA_VERSION = 1
 VERSION_PATTERN = re.compile(
     r"^(?P<major>0|[1-9][0-9]*)\."
     r"(?P<minor>0|[1-9][0-9]*)\."
@@ -46,116 +72,6 @@ BETA3_RECOVERY_SOURCE_VERSION = "0.3.0rc1"
 BETA3_RECOVERY_SOURCE_BUILD = "147"
 BETA3_RECOVERY_TARGET_VERSION = "0.3.0b3"
 BETA3_RECOVERY_TARGET_BUILD = "148"
-BETA3_RECOVERY_EVIDENCE: dict[str, Any] = {
-    "schema": "bd_to_avp.release_recovery",
-    "schema_version": 1,
-    "observed_at": "2026-07-20T02:28:48Z",
-    "repository": "cbusillo/BD_to_AVP",
-    "transition": {
-        "source": {
-            "package_version": BETA3_RECOVERY_SOURCE_VERSION,
-            "public_version": "0.3.0-rc.1",
-            "build": BETA3_RECOVERY_SOURCE_BUILD,
-        },
-        "target": {
-            "package_version": BETA3_RECOVERY_TARGET_VERSION,
-            "public_version": "0.3.0-beta.3",
-            "release_tag": "v0.3.0-beta.3",
-            "build": BETA3_RECOVERY_TARGET_BUILD,
-        },
-    },
-    "failed_run": {
-        "id": 29693513480,
-        "head_sha": "438991f07fa19cd2ae2df4d3ec14716bc0371f8d",
-        "conclusion": "failure",
-        "skipped_boundaries": {
-            "package_upload": "skipped",
-            "draft": "skipped",
-            "appcast": "skipped",
-            "pypi": "skipped",
-            "release": "skipped",
-            "pages": "skipped",
-        },
-        "artifact_count": 0,
-    },
-    "absent_github_state": {
-        "tags": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
-        "releases": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
-        "drafts": ["v0.3.0rc1", "v0.3.0-rc.1", "v0.3.0-beta.3"],
-    },
-    "github_latest": {"release_tag": "v0.2.143"},
-    "pages": {
-        "status": "enabled",
-        "release_tag": "v0.2.143",
-        "appcast_sha256": "d231c47d69606bc6f28113bb396c0ac9d24f656cbe0930c770259e0739f9904e",
-    },
-    "pypi": {
-        "latest_version": "0.2.143",
-        "absent_versions": ["0.3.0rc1", "0.3.0b3"],
-    },
-    "retired_preview_releases": [
-        {
-            "tag": "native-ui-preview-1",
-            "immutable": True,
-            "release_id": 352841376,
-            "target_sha": "e1e4f851096cfeae70da1c56a88acef9c5e61055",
-            "assets": [
-                {
-                    "asset_id": 474714228,
-                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-1.dmg",
-                    "size": 406585971,
-                    "digest": "sha256:119a86f829c0bc8962deaea5f1a8fb92ffbcd48002d062a0ac59cccffe61af71",
-                },
-                {
-                    "asset_id": 474714389,
-                    "name": "SHA256SUMS",
-                    "size": 118,
-                    "digest": "sha256:1b142e59fea4ee0e0f734ae5cdf34815583765d2d0895a9ec25217436d52336e",
-                },
-            ],
-        },
-        {
-            "tag": "v0.3.0-beta.1",
-            "immutable": True,
-            "release_id": 353900273,
-            "target_sha": "2378b46345185f05611f15a39658217bac7c6960",
-            "assets": [
-                {
-                    "asset_id": 476861235,
-                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.1.dmg",
-                    "size": 407183981,
-                    "digest": "sha256:b611dca7de660efed218a0e2fc5c4ed9d6e5e652a54da938e13d40a6bd994bed",
-                },
-                {
-                    "asset_id": 476861481,
-                    "name": "SHA256SUMS",
-                    "size": 123,
-                    "digest": "sha256:17eead4e3faf2ffd3110a9bf200d39f0ebfba78546f40aa0fa868fd3afb53b5b",
-                },
-            ],
-        },
-        {
-            "tag": "v0.3.0-beta.2",
-            "immutable": True,
-            "release_id": 355845653,
-            "target_sha": "9e9a38c715dbbe5df97e6d3a8ba715731607db6a",
-            "assets": [
-                {
-                    "asset_id": 480668646,
-                    "name": "3D-Blu-ray-to-Vision-Pro-Native-Preview-0.3.0-beta.2.dmg",
-                    "size": 408158527,
-                    "digest": "sha256:e2e8a20c9fd4517076189e56598ff6b32cd1adc544c6ad0618f5a46f55dcae24",
-                },
-                {
-                    "asset_id": 480668779,
-                    "name": "SHA256SUMS",
-                    "size": 123,
-                    "digest": "sha256:ab387b19cef2af5923b112735a10253d42f4fc37f002e6983deb44a5a17b7fb0",
-                },
-            ],
-        },
-    ],
-}
 
 
 class ReleaseError(RuntimeError):
@@ -231,8 +147,25 @@ class PublishedRelease:
 
 
 LockRunner = Callable[[Path, str], None]
+RemoteEvidenceVerifier = Callable[[Mapping[str, Any]], None]
+TransactionObserver = Callable[[str, Path], None]
+PrecommitValidator = Callable[[], None]
 TagExists = Callable[[str], bool]
 AncestorCheck = Callable[[str, str], bool]
+
+
+@dataclass(frozen=True)
+class TransactionFile:
+    path: Path
+    original: bytes
+    target: bytes
+
+
+@dataclass(frozen=True)
+class JournalFile:
+    path: Path
+    original: bytes
+    target_sha256: str
 
 
 def parse_release_version(value: str) -> ReleaseVersion:
@@ -388,53 +321,13 @@ def _load_toml(path: Path) -> dict[str, Any]:
         raise ReleaseError(f"Unable to load {path}: {error}") from error
 
 
-def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ReleaseError(f"Recovery evidence contains duplicate key {key!r}.")
-        result[key] = value
-    return result
-
-
-def _validate_exact_evidence_value(actual: Any, expected: Any, location: str) -> None:
-    if type(actual) is not type(expected):
-        raise ReleaseError(f"Recovery evidence {location} has the wrong type.")
-    if isinstance(expected, dict):
-        missing = sorted(set(expected) - set(actual))
-        extra = sorted(set(actual) - set(expected))
-        if missing or extra:
-            details: list[str] = []
-            if missing:
-                details.append(f"missing {missing}")
-            if extra:
-                details.append(f"unexpected {extra}")
-            raise ReleaseError(f"Recovery evidence {location} has invalid keys: {', '.join(details)}.")
-        for key, expected_value in expected.items():
-            _validate_exact_evidence_value(actual[key], expected_value, f"{location}.{key}")
-        return
-    if isinstance(expected, list):
-        if len(actual) != len(expected):
-            raise ReleaseError(f"Recovery evidence {location} has the wrong number of entries.")
-        for index, (actual_value, expected_value) in enumerate(zip(actual, expected, strict=True)):
-            _validate_exact_evidence_value(actual_value, expected_value, f"{location}[{index}]")
-        return
-    if actual != expected:
-        raise ReleaseError(f"Recovery evidence {location} does not match the audited value.")
-
-
 def validate_beta3_recovery_evidence(
     evidence_path: Path = BETA3_RECOVERY_EVIDENCE_PATH,
 ) -> dict[str, Any]:
     try:
-        evidence = json.loads(
-            evidence_path.read_text(encoding="utf-8"),
-            object_pairs_hook=_reject_duplicate_json_keys,
-        )
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ReleaseError(f"Unable to load Beta 3 recovery evidence from {evidence_path}: {error}") from error
-    _validate_exact_evidence_value(evidence, BETA3_RECOVERY_EVIDENCE, "$")
-    return evidence
+        return load_beta3_recovery_evidence(evidence_path)
+    except Beta3RecoveryEvidenceError as error:
+        raise ReleaseError(str(error)) from error
 
 
 def _locked_project_version(lock_path: Path) -> str:
@@ -532,6 +425,165 @@ def _validate_macos_project_metadata(path: Path, pyproject: dict[str, Any], vers
         raise ReleaseError("Production macOS project metadata is inconsistent:\n" + "\n".join(mismatches))
 
 
+def _validate_beta3_recovery_source_identity(
+    pyproject_path: Path,
+    lock_path: Path,
+    macos_project_path: Path,
+    evidence: Mapping[str, Any],
+) -> dict[Path, str] | None:
+    operated_paths = (pyproject_path, lock_path, macos_project_path)
+    for path in operated_paths:
+        if path.is_symlink() or not path.is_file():
+            raise ReleaseError(f"Beta 3 recovery requires a regular non-symlink source file: {path}")
+    pyproject = _load_toml(pyproject_path)
+    try:
+        project = pyproject["project"]
+        briefcase = pyproject["tool"]["briefcase"]
+        app = briefcase["app"]["bd-to-avp"]
+        info = app["macOS"]["info"]
+    except (KeyError, TypeError) as error:
+        raise ReleaseError("Beta 3 recovery source is missing production identity metadata.") from error
+    expected_values = {
+        "project.name": (project.get("name"), "bd_to_avp"),
+        "tool.briefcase.project_name": (briefcase.get("project_name"), PRODUCTION_PRODUCT_NAME),
+        "tool.briefcase.bundle": (briefcase.get("bundle"), "com.shinycomputers"),
+        "tool.briefcase.app.bd-to-avp.formal_name": (app.get("formal_name"), PRODUCTION_PRODUCT_NAME),
+        "BDToAVPDistributionChannel": (
+            info.get("BDToAVPDistributionChannel"),
+            PRODUCTION_DISTRIBUTION_CHANNEL,
+        ),
+        "SUFeedURL": (info.get("SUFeedURL"), PRODUCTION_FEED_URL),
+        "SUPublicEDKey": (info.get("SUPublicEDKey"), PRODUCTION_SPARKLE_PUBLIC_KEY),
+        "SUAllowsAutomaticUpdates": (info.get("SUAllowsAutomaticUpdates"), False),
+        "SUVerifyUpdateBeforeExtraction": (info.get("SUVerifyUpdateBeforeExtraction"), True),
+    }
+    mismatches = [
+        f"{name}: expected {expected!r}, found {actual!r}"
+        for name, (actual, expected) in expected_values.items()
+        if actual != expected
+    ]
+    if "SUEnableAutomaticChecks" in info:
+        mismatches.append("SUEnableAutomaticChecks must remain unset")
+    public_key_path = pyproject_path.parent / PUBLIC_KEY_PATH.name
+    try:
+        public_key = public_key_path.read_text(encoding="utf-8").strip()
+        validate_production_public_key(public_key)
+    except (OSError, ValueError) as error:
+        mismatches.append(f"production Sparkle public key: {error}")
+    try:
+        project_text = macos_project_path.read_text(encoding="utf-8")
+        base_path = ("targets", "BluRayToVisionPro", "settings", "base")
+        release_path = ("targets", "BluRayToVisionPro", "settings", "configs", "Release")
+        project_expectations = {
+            "PRODUCT_BUNDLE_IDENTIFIER": PRODUCTION_BUNDLE_IDENTIFIER,
+            "PRODUCT_NAME": PRODUCTION_PRODUCT_NAME,
+            "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT": "",
+        }
+        for key, expected in project_expectations.items():
+            actual = _yaml_mapping_value(project_text, base_path, key)
+            if actual != expected:
+                mismatches.append(f"{key}: expected {expected!r}, found {actual!r}")
+        expected_release_plist = "BluRayToVisionPro/Info-Release.plist"
+        release_plist = _yaml_mapping_value(project_text, release_path, "INFOPLIST_FILE")
+        if release_plist != expected_release_plist:
+            mismatches.append(f"INFOPLIST_FILE: expected {expected_release_plist!r}, found {release_plist!r}")
+    except (OSError, UnicodeDecodeError, ReleaseError) as error:
+        mismatches.append(f"production macOS project identity: {error}")
+    canonical_paths = tuple(path.resolve() for path in operated_paths) == (
+        PYPROJECT_PATH.resolve(),
+        LOCK_PATH.resolve(),
+        MACOS_PROJECT_PATH.resolve(),
+    )
+    expected_original_digests: dict[Path, str] | None = None
+    if canonical_paths:
+        source_identity = evidence.get("source_identity")
+        if not isinstance(source_identity, Mapping):
+            mismatches.append("reviewed source identity is missing")
+        else:
+            source_files = source_identity.get("files")
+            if not isinstance(source_files, Mapping):
+                mismatches.append("reviewed source file digests are missing")
+            else:
+                expected_original_digests = {}
+                for relative_path, path in (
+                    ("pyproject.toml", pyproject_path),
+                    ("uv.lock", lock_path),
+                    ("macos/project.yml", macos_project_path),
+                ):
+                    expected_digest = source_files.get(relative_path)
+                    actual_digest = _sha256(path.read_bytes())
+                    if expected_digest != actual_digest:
+                        mismatches.append(
+                            f"{relative_path} source digest: expected {expected_digest!r}, found {actual_digest!r}"
+                        )
+                    if isinstance(expected_digest, str):
+                        expected_original_digests[path.resolve()] = expected_digest
+            base_commit = source_identity.get("base_commit")
+            expected_tree = source_identity.get("tree")
+            try:
+                repository_root = subprocess.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    check=True,
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+                origin_url = subprocess.run(
+                    ["git", "remote", "get-url", "origin"],
+                    check=True,
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+                actual_tree = subprocess.run(
+                    ["git", "show", "-s", "--format=%T", str(base_commit)],
+                    check=True,
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+                subprocess.run(
+                    ["git", "merge-base", "--is-ancestor", str(base_commit), "HEAD"],
+                    check=True,
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                source_status = subprocess.run(
+                    [
+                        "git",
+                        "status",
+                        "--porcelain",
+                        "--",
+                        "pyproject.toml",
+                        "uv.lock",
+                        "macos/project.yml",
+                        "sparkle-public-ed-key.txt",
+                    ],
+                    check=True,
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+            except (OSError, subprocess.CalledProcessError) as error:
+                mismatches.append(f"reviewed Git source identity: {error}")
+            else:
+                normalized_origin = origin_url.removesuffix(".git").rstrip("/")
+                if Path(repository_root).resolve() != REPO_ROOT.resolve():
+                    mismatches.append(f"Git top-level must be {REPO_ROOT}, found {repository_root!r}")
+                if normalized_origin != "https://github.com/cbusillo/BD_to_AVP":
+                    mismatches.append(f"origin must be the production GitHub repository, found {origin_url!r}")
+                if actual_tree != expected_tree:
+                    mismatches.append(f"reviewed source tree: expected {expected_tree!r}, found {actual_tree!r}")
+                if source_status:
+                    mismatches.append("reviewed source files must be clean before recovery")
+    if mismatches:
+        raise ReleaseError("Beta 3 recovery source identity is invalid:\n" + "\n".join(mismatches))
+    if expected_original_digests is None:
+        expected_original_digests = {path.resolve(): _sha256(path.read_bytes()) for path in operated_paths}
+    return expected_original_digests
+
+
 def load_release_metadata(
     pyproject_path: Path = PYPROJECT_PATH,
     lock_path: Path = LOCK_PATH,
@@ -606,17 +658,215 @@ def refresh_uv_lock(stage_root: Path, uv_executable: str) -> None:
     )
 
 
+def _load_toml_bytes(content: bytes, description: str) -> dict[str, Any]:
+    try:
+        return tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ReleaseError(f"Unable to load {description}: {error}") from error
+
+
+def _editable_project_package(lock: dict[str, Any], description: str) -> dict[str, Any]:
+    packages = lock.get("package")
+    if not isinstance(packages, list):
+        raise ReleaseError(f"{description} does not contain package entries.")
+    matches = [
+        package
+        for package in packages
+        if isinstance(package, dict)
+        and str(package.get("name", "")).replace("_", "-") == "bd-to-avp"
+        and package.get("source") == {"editable": "."}
+    ]
+    if len(matches) != 1:
+        raise ReleaseError(f"{description} must contain exactly one editable bd-to-avp package.")
+    return matches[0]
+
+
+def _validate_lock_refresh(
+    original_content: bytes,
+    staged_content: bytes,
+    *,
+    current_version: str,
+    next_version: str,
+) -> None:
+    original = _load_toml_bytes(original_content, "original uv.lock")
+    staged = _load_toml_bytes(staged_content, "staged uv.lock")
+    original_package = _editable_project_package(original, "Original uv.lock")
+    staged_package = _editable_project_package(staged, "Staged uv.lock")
+    if original_package.get("version") != current_version:
+        raise ReleaseError("Original uv.lock project version changed before release preparation.")
+    if staged_package.get("version") != next_version:
+        raise ReleaseError("Staged uv.lock project version does not match the requested release version.")
+    normalized_staged = copy.deepcopy(staged)
+    _editable_project_package(normalized_staged, "Staged uv.lock")["version"] = current_version
+    if normalized_staged != original:
+        raise ReleaseError("uv lock refresh changed data other than the editable project version.")
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _atomic_write(path: Path, content: bytes) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
     descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     temporary_path = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "wb") as handle:
+            os.fchmod(handle.fileno(), mode)
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary_path, path)
+        _fsync_directory(path.parent)
     finally:
         temporary_path.unlink(missing_ok=True)
+
+
+def _remove_file_durably(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    _fsync_directory(path.parent)
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _transaction_journal_path(pyproject_path: Path) -> Path:
+    return pyproject_path.parent / TRANSACTION_JOURNAL_NAME
+
+
+def _release_lock_path(pyproject_path: Path) -> Path:
+    root_digest = hashlib.sha256(str(pyproject_path.parent.resolve()).encode("utf-8")).hexdigest()
+    return Path(tempfile.gettempdir()) / f"bd-to-avp-release-{root_digest}.lock"
+
+
+@contextmanager
+def _release_metadata_lock(pyproject_path: Path) -> Iterator[None]:
+    lock_path = _release_lock_path(pyproject_path)
+    with lock_path.open("a+b") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise ReleaseError("Another release metadata operation is already running for this checkout.") from error
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _transaction_payload(files: Sequence[TransactionFile], state: str) -> dict[str, Any]:
+    return {
+        "schema": TRANSACTION_SCHEMA,
+        "schema_version": TRANSACTION_SCHEMA_VERSION,
+        "state": state,
+        "files": [
+            {
+                "path": str(file.path.resolve()),
+                "original_sha256": _sha256(file.original),
+                "original_base64": base64.b64encode(file.original).decode("ascii"),
+                "target_sha256": _sha256(file.target),
+            }
+            for file in files
+        ],
+    }
+
+
+def _write_transaction_journal(path: Path, payload: Mapping[str, Any]) -> None:
+    content = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    _atomic_write(path, content)
+
+
+def _load_transaction_files(path: Path, expected_paths: Sequence[Path]) -> tuple[str, list[JournalFile]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"Release metadata transaction journal is invalid: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReleaseError("Release metadata transaction journal must be a JSON object.")
+    if payload.get("schema") != TRANSACTION_SCHEMA or payload.get("schema_version") != TRANSACTION_SCHEMA_VERSION:
+        raise ReleaseError("Release metadata transaction journal has an unsupported schema.")
+    state = payload.get("state")
+    if state not in {"prepared", "committed"}:
+        raise ReleaseError("Release metadata transaction journal has an invalid state.")
+    entries = payload.get("files")
+    if not isinstance(entries, list) or len(entries) != len(expected_paths):
+        raise ReleaseError("Release metadata transaction journal has an invalid file set.")
+    expected_resolved = [path.resolve() for path in expected_paths]
+    files: list[JournalFile] = []
+    for entry, expected_path in zip(entries, expected_resolved, strict=True):
+        if not isinstance(entry, dict) or entry.get("path") != str(expected_path):
+            raise ReleaseError("Release metadata transaction journal path does not match this checkout.")
+        try:
+            original = base64.b64decode(str(entry["original_base64"]), validate=True)
+        except (KeyError, ValueError, binascii.Error) as error:
+            raise ReleaseError("Release metadata transaction journal contains invalid backup data.") from error
+        if _sha256(original) != entry.get("original_sha256"):
+            raise ReleaseError("Release metadata transaction journal backup digest is invalid.")
+        target_digest = entry.get("target_sha256")
+        if not isinstance(target_digest, str) or not re.fullmatch(r"[0-9a-f]{64}", target_digest):
+            raise ReleaseError("Release metadata transaction journal target digest is invalid.")
+        files.append(JournalFile(path=expected_path, original=original, target_sha256=target_digest))
+    return str(state), files
+
+
+def _recover_interrupted_transaction(journal_path: Path, expected_paths: Sequence[Path]) -> None:
+    if not journal_path.exists():
+        return
+    state, journal_files = _load_transaction_files(journal_path, expected_paths)
+    if state == "committed":
+        for file in journal_files:
+            if _sha256(file.path.read_bytes()) != file.target_sha256:
+                raise ReleaseError("Committed release metadata transaction does not match its target digest.")
+        _remove_file_durably(journal_path)
+        return
+    for file in journal_files:
+        current_digest = _sha256(file.path.read_bytes())
+        if current_digest not in {_sha256(file.original), file.target_sha256}:
+            raise ReleaseError(f"Interrupted release transaction cannot restore externally changed file: {file.path}")
+    for file in journal_files:
+        _atomic_write(file.path, file.original)
+    _remove_file_durably(journal_path)
+
+
+def _apply_metadata_transaction(
+    files: Sequence[TransactionFile],
+    journal_path: Path,
+    validate: Callable[[], ReleaseMetadata],
+    observer: TransactionObserver | None = None,
+    precommit_validator: PrecommitValidator | None = None,
+) -> ReleaseMetadata:
+    expected_paths = [file.path for file in files]
+    prepared = _transaction_payload(files, "prepared")
+    _write_transaction_journal(journal_path, prepared)
+    if observer is not None:
+        observer("journal-prepared", journal_path)
+    try:
+        for file in files:
+            if file.path.read_bytes() != file.original:
+                raise ReleaseError(f"Release file changed immediately before replacement: {file.path}")
+            _atomic_write(file.path, file.target)
+            if observer is not None:
+                observer("file-applied", file.path)
+        metadata = validate()
+        if precommit_validator is not None:
+            precommit_validator()
+        _write_transaction_journal(journal_path, _transaction_payload(files, "committed"))
+        if observer is not None:
+            observer("journal-committed", journal_path)
+        _remove_file_durably(journal_path)
+        return metadata
+    except BaseException:
+        try:
+            _recover_interrupted_transaction(journal_path, expected_paths)
+        except Exception as rollback_error:
+            raise ReleaseError(
+                f"Release metadata transaction could not be recovered; journal retained at {journal_path}."
+            ) from rollback_error
+        raise
 
 
 def _resolve_macos_project_path(
@@ -639,10 +889,25 @@ def _write_release_metadata(
     macos_project_path: Path | None,
     uv_executable: str,
     lock_runner: LockRunner,
+    transaction_observer: TransactionObserver | None = None,
+    precommit_validator: PrecommitValidator | None = None,
+    expected_original_digests: Mapping[Path, str] | None = None,
 ) -> ReleaseMetadata:
     original_pyproject = pyproject_path.read_bytes()
     original_lock = lock_path.read_bytes()
     original_macos_project = macos_project_path.read_bytes() if macos_project_path is not None else None
+    original_contents = {
+        pyproject_path.resolve(): original_pyproject,
+        lock_path.resolve(): original_lock,
+    }
+    if macos_project_path is not None and original_macos_project is not None:
+        original_contents[macos_project_path.resolve()] = original_macos_project
+    if expected_original_digests is not None:
+        if set(expected_original_digests) != set(original_contents):
+            raise ReleaseError("Beta 3 recovery source digest set does not match the operated release files.")
+        for path, content in original_contents.items():
+            if _sha256(content) != expected_original_digests[path]:
+                raise ReleaseError(f"Beta 3 recovery source changed after identity validation: {path}")
     if load_release_metadata(pyproject_path, lock_path, macos_project_path) != current:
         raise ReleaseError("Release files changed before release preparation; no updates were applied.")
 
@@ -695,24 +960,40 @@ def _write_release_metadata(
         if staged_metadata.package_version != next_version.text or staged_metadata.build_version != str(next_build):
             raise ReleaseError("Staged release metadata does not match the requested version and build.")
         staged_lock_content = staged_lock.read_bytes()
+        _validate_lock_refresh(
+            original_lock,
+            staged_lock_content,
+            current_version=current.package_version,
+            next_version=next_version.text,
+        )
 
     if pyproject_path.read_bytes() != original_pyproject or lock_path.read_bytes() != original_lock:
         raise ReleaseError("Release files changed while release preparation was running; no updates were applied.")
     if macos_project_path is not None and macos_project_path.read_bytes() != original_macos_project:
         raise ReleaseError("Release files changed while release preparation was running; no updates were applied.")
-    try:
-        _atomic_write(pyproject_path, updated_pyproject.encode("utf-8"))
-        _atomic_write(lock_path, staged_lock_content)
-        if macos_project_path is not None and updated_macos_project is not None:
-            _atomic_write(macos_project_path, updated_macos_project.encode("utf-8"))
-        metadata = load_release_metadata(pyproject_path, lock_path, macos_project_path)
-    except Exception:
-        _atomic_write(pyproject_path, original_pyproject)
-        _atomic_write(lock_path, original_lock)
-        if macos_project_path is not None and original_macos_project is not None:
-            _atomic_write(macos_project_path, original_macos_project)
-        raise
-    return metadata
+    files = [
+        TransactionFile(
+            path=pyproject_path,
+            original=original_pyproject,
+            target=updated_pyproject.encode("utf-8"),
+        ),
+        TransactionFile(path=lock_path, original=original_lock, target=staged_lock_content),
+    ]
+    if macos_project_path is not None and updated_macos_project is not None and original_macos_project is not None:
+        files.append(
+            TransactionFile(
+                path=macos_project_path,
+                original=original_macos_project,
+                target=updated_macos_project.encode("utf-8"),
+            )
+        )
+    return _apply_metadata_transaction(
+        files,
+        _transaction_journal_path(pyproject_path),
+        lambda: load_release_metadata(pyproject_path, lock_path, macos_project_path),
+        transaction_observer,
+        precommit_validator,
+    )
 
 
 def prepare_release(
@@ -724,28 +1005,33 @@ def prepare_release(
     macos_project_path: Path | None = None,
     uv_executable: str = "uv",
     lock_runner: LockRunner = refresh_uv_lock,
+    transaction_observer: TransactionObserver | None = None,
 ) -> ReleaseMetadata:
     macos_project_path = _resolve_macos_project_path(pyproject_path, lock_path, macos_project_path)
-    current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
-    current_version = parse_release_version(current.package_version)
-    next_version = parse_release_version(version_value)
-    _validate_production_version(next_version)
-    current_build = parse_build_version(current.build_version)
-    next_build = parse_build_version(build_value)
-    if next_version.order_key <= current_version.order_key:
-        raise ReleaseError(f"Release version {version_value} must be newer than {current.package_version}.")
-    if next_build <= current_build:
-        raise ReleaseError(f"CFBundleVersion {build_value} must be greater than {current.build_version}.")
-    return _write_release_metadata(
-        next_version,
-        next_build,
-        current,
-        pyproject_path=pyproject_path,
-        lock_path=lock_path,
-        macos_project_path=macos_project_path,
-        uv_executable=uv_executable,
-        lock_runner=lock_runner,
-    )
+    expected_paths = [pyproject_path, lock_path, *([macos_project_path] if macos_project_path is not None else [])]
+    with _release_metadata_lock(pyproject_path):
+        _recover_interrupted_transaction(_transaction_journal_path(pyproject_path), expected_paths)
+        current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
+        current_version = parse_release_version(current.package_version)
+        next_version = parse_release_version(version_value)
+        _validate_production_version(next_version)
+        current_build = parse_build_version(current.build_version)
+        next_build = parse_build_version(build_value)
+        if next_version.order_key <= current_version.order_key:
+            raise ReleaseError(f"Release version {version_value} must be newer than {current.package_version}.")
+        if next_build <= current_build:
+            raise ReleaseError(f"CFBundleVersion {build_value} must be greater than {current.build_version}.")
+        return _write_release_metadata(
+            next_version,
+            next_build,
+            current,
+            pyproject_path=pyproject_path,
+            lock_path=lock_path,
+            macos_project_path=macos_project_path,
+            uv_executable=uv_executable,
+            lock_runner=lock_runner,
+            transaction_observer=transaction_observer,
+        )
 
 
 def recover_beta3(
@@ -754,30 +1040,56 @@ def recover_beta3(
     lock_path: Path = LOCK_PATH,
     macos_project_path: Path | None = None,
     evidence_path: Path = BETA3_RECOVERY_EVIDENCE_PATH,
-    uv_executable: str = "uv",
     lock_runner: LockRunner = refresh_uv_lock,
+    remote_verifier: RemoteEvidenceVerifier = verify_beta3_remote_state,
+    transaction_observer: TransactionObserver | None = None,
 ) -> ReleaseMetadata:
-    validate_beta3_recovery_evidence(evidence_path)
+    evidence = validate_beta3_recovery_evidence(evidence_path)
     macos_project_path = _resolve_macos_project_path(pyproject_path, lock_path, macos_project_path)
-    current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
-    if current.package_version != BETA3_RECOVERY_SOURCE_VERSION or current.build_version != BETA3_RECOVERY_SOURCE_BUILD:
-        raise ReleaseError(
-            "Beta 3 recovery requires exact source metadata "
-            f"{BETA3_RECOVERY_SOURCE_VERSION} build {BETA3_RECOVERY_SOURCE_BUILD}; "
-            f"found {current.package_version} build {current.build_version}."
+    if macos_project_path is None:
+        raise ReleaseError("Beta 3 recovery requires the production macOS project metadata.")
+    expected_paths = [pyproject_path, lock_path, macos_project_path]
+    with _release_metadata_lock(pyproject_path):
+        _recover_interrupted_transaction(_transaction_journal_path(pyproject_path), expected_paths)
+        expected_original_digests = _validate_beta3_recovery_source_identity(
+            pyproject_path,
+            lock_path,
+            macos_project_path,
+            evidence,
         )
-    target_version = parse_release_version(BETA3_RECOVERY_TARGET_VERSION)
-    target_build = parse_build_version(BETA3_RECOVERY_TARGET_BUILD)
-    return _write_release_metadata(
-        target_version,
-        target_build,
-        current,
-        pyproject_path=pyproject_path,
-        lock_path=lock_path,
-        macos_project_path=macos_project_path,
-        uv_executable=uv_executable,
-        lock_runner=lock_runner,
-    )
+        current = load_release_metadata(pyproject_path, lock_path, macos_project_path)
+        if (
+            current.package_version != BETA3_RECOVERY_SOURCE_VERSION
+            or current.build_version != BETA3_RECOVERY_SOURCE_BUILD
+        ):
+            raise ReleaseError(
+                "Beta 3 recovery requires exact source metadata "
+                f"{BETA3_RECOVERY_SOURCE_VERSION} build {BETA3_RECOVERY_SOURCE_BUILD}; "
+                f"found {current.package_version} build {current.build_version}."
+            )
+
+        def verify_remote_premise() -> None:
+            try:
+                remote_verifier(evidence)
+            except Beta3RecoveryEvidenceError as error:
+                raise ReleaseError(str(error)) from error
+
+        verify_remote_premise()
+        target_version = parse_release_version(BETA3_RECOVERY_TARGET_VERSION)
+        target_build = parse_build_version(BETA3_RECOVERY_TARGET_BUILD)
+        return _write_release_metadata(
+            target_version,
+            target_build,
+            current,
+            pyproject_path=pyproject_path,
+            lock_path=lock_path,
+            macos_project_path=macos_project_path,
+            uv_executable="uv",
+            lock_runner=lock_runner,
+            transaction_observer=transaction_observer,
+            precommit_validator=verify_remote_premise,
+            expected_original_digests=expected_original_digests,
+        )
 
 
 def _add_paths(parser: argparse.ArgumentParser) -> None:
@@ -816,8 +1128,7 @@ def build_parser() -> argparse.ArgumentParser:
         "recover-beta3",
         help="Apply the audited one-time 0.3.0rc1 build 147 to 0.3.0b3 build 148 recovery.",
     )
-    _add_paths(recover_beta3_parser)
-    recover_beta3_parser.add_argument("--uv", default="uv")
+    recover_beta3_parser.add_argument("--evidence", type=Path, default=BETA3_RECOVERY_EVIDENCE_PATH)
 
     validate_tag = commands.add_parser("validate-tag", help="Validate a v-prefixed release tag.")
     validate_tag.add_argument("tag")
@@ -854,12 +1165,7 @@ def main(argv: list[str] | None = None) -> int:
             uv_executable=args.uv,
         )
     elif args.command == "recover-beta3":
-        metadata = recover_beta3(
-            pyproject_path=args.pyproject,
-            lock_path=args.lock,
-            macos_project_path=args.macos_project,
-            uv_executable=args.uv,
-        )
+        metadata = recover_beta3(evidence_path=args.evidence)
     else:
         metadata = load_release_metadata(args.pyproject, args.lock, args.macos_project)
     if args.command == "metadata" and args.github_output:

--- a/scripts/release_workflow_policy.py
+++ b/scripts/release_workflow_policy.py
@@ -18,7 +18,9 @@ from urllib.request import Request, urlopen
 
 
 REPOSITORY = "cbusillo/BD_to_AVP"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 ENGINE_WORKFLOW_PATH = ".github/workflows/release-engine.yml"
+RELEASE_FREEZES_PATH = REPO_ROOT / ".github" / "release-freezes.json"
 REQUIRED_REF = "refs/heads/main"
 REQUIRED_EVENT = "workflow_dispatch"
 REQUIRED_ACTOR = "shiny-code-bot"
@@ -241,6 +243,7 @@ class ReleaseRouteMetadata:
     operator_name: str
     operator_route: str
     operator_workflow_path: str
+    release_tag: str
     channel: str
     prerelease: bool
     make_latest: bool
@@ -256,6 +259,7 @@ class ReleaseRouteMetadata:
                 "| --- | --- |",
                 f"| Operator route | {self.operator_name} |",
                 f"| Operator workflow | `{self.operator_workflow_path}` |",
+                f"| Release tag | `{self.release_tag}` |",
                 f"| Committed release stage | `{self.channel}` |",
                 f"| GitHub prerelease | {yes_no[self.prerelease]} |",
                 f"| GitHub Latest | {yes_no[self.make_latest]} |",
@@ -361,12 +365,28 @@ def validate_engine_environment(environment: Mapping[str, str]) -> ReleaseWorkfl
     return evidence
 
 
-def validate_release_metadata(environment: Mapping[str, str]) -> ReleaseRouteMetadata:
+def _frozen_release_tags(path: Path = RELEASE_FREEZES_PATH) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseWorkflowPolicyError(f"Unable to load committed release freezes from {path}: {error}") from error
+    freezes = _mapping(payload, "Release freeze policy")
+    if freezes.get("schema") != "bd_to_avp.release_freezes" or freezes.get("schema_version") != 1:
+        raise ReleaseWorkflowPolicyError("Release freeze policy has an unsupported schema.")
+    return _mapping(freezes.get("frozen_release_tags"), "Frozen release tags")
+
+
+def validate_release_metadata(
+    environment: Mapping[str, str],
+    *,
+    freezes_path: Path = RELEASE_FREEZES_PATH,
+) -> ReleaseRouteMetadata:
     operator_policy = _operator_policy_from_ref(_required(environment, "RELEASE_OPERATOR_WORKFLOW_REF"))
     metadata = ReleaseRouteMetadata(
         operator_name=operator_policy.name,
         operator_route=operator_policy.route,
         operator_workflow_path=operator_policy.path,
+        release_tag=_required(environment, "RELEASE_TAG"),
         channel=_required(environment, "RELEASE_CHANNEL"),
         prerelease=_boolean(_required(environment, "RELEASE_PRERELEASE"), "GitHub prerelease policy"),
         make_latest=_boolean(_required(environment, "RELEASE_MAKE_LATEST"), "GitHub Latest policy"),
@@ -391,6 +411,15 @@ def validate_release_metadata(environment: Mapping[str, str]) -> ReleaseRouteMet
             f"channel={metadata.channel!r}, prerelease={metadata.prerelease!r}, "
             f"make_latest={metadata.make_latest!r}, publish_pypi={metadata.publish_pypi!r}."
         )
+    freeze = _frozen_release_tags(freezes_path).get(metadata.release_tag)
+    if freeze is not None:
+        freeze_record = _mapping(freeze, f"Release freeze for {metadata.release_tag}")
+        issue = freeze_record.get("issue")
+        reason = freeze_record.get("reason")
+        invalid_issue = isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0
+        if invalid_issue or not isinstance(reason, str) or not reason:
+            raise ReleaseWorkflowPolicyError(f"Release freeze for {metadata.release_tag} is invalid.")
+        raise ReleaseWorkflowPolicyError(f"Release {metadata.release_tag} is frozen by issue #{issue}: {reason}")
     return metadata
 
 

--- a/scripts/sparkle_bundle.py
+++ b/scripts/sparkle_bundle.py
@@ -7,18 +7,20 @@ import re
 import subprocess
 import tomllib
 
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterator
 
+from scripts.native_app import verify_support_diagnostics_endpoint
+from scripts.release import RETIRED_RELEASE_TAGS, ReleaseError, parse_release_version
 from scripts.sparkle_macos import FRAMEWORK_RELATIVE_PATH, REPO_ROOT, load_release, verify_framework_layout
 
 
 INFO_PLIST_RELATIVE_PATH = Path("Contents/Info.plist")
 PUBLIC_KEY_PATH = REPO_ROOT / "sparkle-public-ed-key.txt"
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
-SHORT_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:rc[0-9]+)?$")
 SYSTEM_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){1,2}$")
 
 
@@ -33,6 +35,7 @@ class SparkleBundleMetadata:
     build_version: str
     short_version: str
     distribution_channel: str
+    support_diagnostics_endpoint: str
     feed_url: str
     minimum_system_version: str
     public_key: str
@@ -55,6 +58,18 @@ def _require_equal(info: dict[str, object], key: str, expected: object) -> objec
     if actual != expected:
         raise SparkleBundleError(f"Info.plist {key} must be {expected!r}; found {actual!r}.")
     return actual
+
+
+def _parse_short_version(value: str) -> str:
+    try:
+        version = parse_release_version(value)
+    except ReleaseError as error:
+        raise SparkleBundleError(
+            "CFBundleShortVersionString must be a canonical three-part PEP 440 Stable, Alpha, Beta, or RC version."
+        ) from error
+    if version.release_tag in RETIRED_RELEASE_TAGS:
+        raise SparkleBundleError("CFBundleShortVersionString belongs to a retired preview identity.")
+    return version.text
 
 
 def verify_code_signatures(app_path: Path) -> None:
@@ -120,6 +135,7 @@ def inspect_app_bundle(
     expected_info: dict[str, object] | None = None,
     verify_signatures: bool = False,
     require_repository_build: bool = True,
+    environment: Mapping[str, str] | None = None,
 ) -> SparkleBundleMetadata:
     info_path = app_path / INFO_PLIST_RELATIVE_PATH
     if not info_path.is_file():
@@ -148,12 +164,14 @@ def inspect_app_bundle(
     build_number = int(build_version)
     if build_number <= 1 or str(build_number) != build_version:
         raise SparkleBundleError("CFBundleVersion must be a canonical numeric repository counter greater than 1.")
-    short_version = str(info.get("CFBundleShortVersionString", "")).strip()
-    if SHORT_VERSION_PATTERN.fullmatch(short_version) is None:
-        raise SparkleBundleError("CFBundleShortVersionString must be a three-part version with an optional rc suffix.")
+    short_version = _parse_short_version(str(info.get("CFBundleShortVersionString", "")))
     minimum_system_version = str(info.get("LSMinimumSystemVersion", "")).strip()
     if SYSTEM_VERSION_PATTERN.fullmatch(minimum_system_version) is None:
         raise SparkleBundleError("LSMinimumSystemVersion must be a numeric dotted version.")
+    try:
+        support_diagnostics_endpoint = verify_support_diagnostics_endpoint(info, environment=environment)
+    except ValueError as error:
+        raise SparkleBundleError(str(error)) from error
 
     framework_path = app_path / FRAMEWORK_RELATIVE_PATH
     verify_framework_layout(framework_path, expected_version=load_release().version)
@@ -166,6 +184,7 @@ def inspect_app_bundle(
         build_version=build_version,
         short_version=short_version,
         distribution_channel=str(info["BDToAVPDistributionChannel"]),
+        support_diagnostics_endpoint=support_diagnostics_endpoint,
         feed_url=str(info["SUFeedURL"]),
         minimum_system_version=minimum_system_version,
         public_key=str(info["SUPublicEDKey"]),
@@ -198,6 +217,7 @@ def inspect_dmg(
     verify_signatures: bool = False,
     require_repository_build: bool = True,
     verify_distribution: bool = False,
+    environment: Mapping[str, str] | None = None,
 ) -> SparkleBundleMetadata:
     if verify_distribution:
         verify_dmg_distribution(dmg_path)
@@ -209,6 +229,7 @@ def inspect_dmg(
             app_paths[0],
             verify_signatures=verify_signatures,
             require_repository_build=require_repository_build,
+            environment=environment,
         )
         if verify_distribution:
             verify_app_distribution(app_paths[0])

--- a/scripts/sparkle_bundle.py
+++ b/scripts/sparkle_bundle.py
@@ -14,6 +14,15 @@ from pathlib import Path
 from typing import Iterator
 
 from scripts.native_app import verify_support_diagnostics_endpoint
+from scripts.production_identity import (
+    PRODUCTION_BUNDLE_IDENTIFIER,
+    PRODUCTION_DEVELOPER_IDENTITY,
+    PRODUCTION_DISTRIBUTION_CHANNEL,
+    PRODUCTION_FEED_URL,
+    PRODUCTION_SPARKLE_PUBLIC_KEY,
+    PRODUCTION_TEAM_ID,
+    validate_production_public_key,
+)
 from scripts.release import RETIRED_RELEASE_TAGS, ReleaseError, parse_release_version
 from scripts.sparkle_macos import FRAMEWORK_RELATIVE_PATH, REPO_ROOT, load_release, verify_framework_layout
 
@@ -48,8 +57,16 @@ def load_expected_info(
         pyproject = tomllib.load(handle)
     info = dict(pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["macOS"]["info"])
     public_key = public_key_path.read_text(encoding="utf-8").strip()
+    try:
+        validate_production_public_key(public_key)
+    except ValueError as error:
+        raise SparkleBundleError(str(error)) from error
     if info.get("SUPublicEDKey") != public_key:
         raise SparkleBundleError("The Briefcase SUPublicEDKey does not match sparkle-public-ed-key.txt.")
+    if info.get("SUFeedURL") != PRODUCTION_FEED_URL:
+        raise SparkleBundleError("The Briefcase SUFeedURL does not match the production feed identity.")
+    if info.get("BDToAVPDistributionChannel") != PRODUCTION_DISTRIBUTION_CHANNEL:
+        raise SparkleBundleError("The Briefcase distribution channel does not match the production identity.")
     return info
 
 
@@ -70,6 +87,26 @@ def _parse_short_version(value: str) -> str:
     if version.release_tag in RETIRED_RELEASE_TAGS:
         raise SparkleBundleError("CFBundleShortVersionString belongs to a retired preview identity.")
     return version.text
+
+
+def _verify_codesign_identity(path: Path, description: str) -> None:
+    result = subprocess.run(
+        ["codesign", "-dv", "--verbose=4", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = f"{result.stdout}\n{result.stderr}"
+    authorities = re.findall(r"^Authority=(.+)$", metadata, re.MULTILINE)
+    team_identifiers = re.findall(r"^TeamIdentifier=(.+)$", metadata, re.MULTILINE)
+    if authorities[:1] != [PRODUCTION_DEVELOPER_IDENTITY]:
+        raise SparkleBundleError(
+            f"{description} signing authority must be {PRODUCTION_DEVELOPER_IDENTITY!r}; found {authorities[:1]!r}."
+        )
+    if team_identifiers != [PRODUCTION_TEAM_ID]:
+        raise SparkleBundleError(
+            f"{description} TeamIdentifier must be {PRODUCTION_TEAM_ID!r}; found {team_identifiers!r}."
+        )
 
 
 def verify_code_signatures(app_path: Path) -> None:
@@ -94,9 +131,11 @@ def verify_code_signatures(app_path: Path) -> None:
         capture_output=True,
         text=True,
     )
+    _verify_codesign_identity(app_path, "Containing app")
 
 
 def verify_dmg_distribution(dmg_path: Path) -> None:
+    _verify_codesign_identity(dmg_path, "DMG")
     subprocess.run(
         ["xcrun", "stapler", "validate", dmg_path],
         check=True,
@@ -155,6 +194,10 @@ def inspect_app_bundle(
         expected_keys.insert(0, "CFBundleVersion")
     for key in expected_keys:
         _require_equal(info, key, expected_info[key])
+    _require_equal(info, "CFBundleIdentifier", PRODUCTION_BUNDLE_IDENTIFIER)
+    _require_equal(info, "BDToAVPDistributionChannel", PRODUCTION_DISTRIBUTION_CHANNEL)
+    _require_equal(info, "SUFeedURL", PRODUCTION_FEED_URL)
+    _require_equal(info, "SUPublicEDKey", PRODUCTION_SPARKLE_PUBLIC_KEY)
     if "SUEnableAutomaticChecks" in info:
         raise SparkleBundleError("SUEnableAutomaticChecks must remain unset so Sparkle owns consent prompting.")
 

--- a/tests/test_beta3_recovery_evidence.py
+++ b/tests/test_beta3_recovery_evidence.py
@@ -144,6 +144,9 @@ class Beta3RecoveryEvidenceTests(unittest.TestCase):
         self.assertEqual(self.evidence["schema_version"], 2)
         self.assertEqual(self.evidence["repository_identity"]["id"], 771225421)
         self.assertEqual(self.evidence["pages"]["release_tag"], "v0.2.143")
+        cut_packet = (recovery_evidence.REPO_ROOT / "docs" / "0.3.0-beta.3-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn(str(self.evidence["observed_at"]), cut_packet)
+        self.assertIn(recovery_evidence.BETA3_RECOVERY_EVIDENCE_SHA256, cut_packet)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             changed = Path(temp_dir) / "evidence.json"

--- a/tests/test_beta3_recovery_evidence.py
+++ b/tests/test_beta3_recovery_evidence.py
@@ -1,0 +1,285 @@
+import copy
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from urllib.parse import quote
+
+from scripts import beta3_recovery_evidence as recovery_evidence
+
+
+def json_response(value: object) -> recovery_evidence.RemoteResponse:
+    return recovery_evidence.RemoteResponse(status=200, body=json.dumps(value).encode("utf-8"))
+
+
+class FakeFetcher:
+    def __init__(self, responses: dict[str, recovery_evidence.RemoteResponse]) -> None:
+        self.responses = responses
+        self.requests: list[str] = []
+
+    def __call__(self, url: str) -> recovery_evidence.RemoteResponse:
+        self.requests.append(url)
+        try:
+            return self.responses[url]
+        except KeyError as error:
+            raise AssertionError(f"Unexpected remote evidence request: {url}") from error
+
+
+def make_responses(evidence: dict[str, object]) -> dict[str, recovery_evidence.RemoteResponse]:
+    repository = str(evidence["repository"])
+    api_root = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}"
+    failed_run = evidence["failed_run"]
+    assert isinstance(failed_run, dict)
+    run_id = failed_run["id"]
+    run = {
+        "id": run_id,
+        "workflow_id": failed_run["workflow_id"],
+        "run_number": failed_run["run_number"],
+        "event": failed_run["event"],
+        "head_branch": failed_run["head_branch"],
+        "head_sha": failed_run["head_sha"],
+        "run_attempt": failed_run["run_attempt"],
+        "path": failed_run["workflow_path"],
+        "name": failed_run["workflow_name"],
+        "display_title": failed_run["display_title"],
+        "status": failed_run["status"],
+        "conclusion": failed_run["conclusion"],
+        "actor": {"login": failed_run["actor"]},
+        "triggering_actor": {"login": failed_run["triggering_actor"]},
+        "repository": {"full_name": failed_run["repository"]},
+        "head_repository": {"full_name": failed_run["head_repository"]},
+    }
+    jobs = []
+    for expected_job in failed_run["jobs"]:
+        steps = []
+        if expected_job["name"] == failed_run["failed_job"]:
+            steps = [
+                {"name": failed_run["failed_step"], "conclusion": "failure"},
+                {"name": failed_run["package_upload_step"], "conclusion": "skipped"},
+            ]
+        jobs.append(
+            {
+                "name": expected_job["name"],
+                "status": "completed",
+                "conclusion": expected_job["conclusion"],
+                "steps": steps,
+            }
+        )
+    previews = evidence["retired_preview_releases"]
+    assert isinstance(previews, list)
+    releases = []
+    repository_identity = dict(evidence["repository_identity"])
+    repository_identity["permissions"] = {"push": True}
+    responses = {
+        api_root: json_response(repository_identity),
+        f"{api_root}/actions/runs/{run_id}": json_response(run),
+        f"{api_root}/actions/runs/{run_id}/attempts/{failed_run['run_attempt']}/jobs?per_page=100": json_response(
+            {"total_count": len(jobs), "jobs": jobs}
+        ),
+        f"{api_root}/actions/runs/{run_id}/artifacts?per_page=100": json_response(
+            {"total_count": failed_run["artifact_count"], "artifacts": []}
+        ),
+        f"{api_root}/releases?per_page=100&page=1": json_response(releases),
+        f"{api_root}/releases/latest": json_response(
+            {
+                "id": evidence["github_latest"]["release_id"],
+                "tag_name": evidence["github_latest"]["release_tag"],
+                "target_commitish": evidence["github_latest"]["target_sha"],
+                "immutable": evidence["github_latest"]["immutable"],
+                "draft": False,
+                "prerelease": False,
+            }
+        ),
+        f"{api_root}/pages": json_response(
+            {
+                "public": evidence["pages"]["public"],
+                "build_type": evidence["pages"]["build_type"],
+            }
+        ),
+        f"{recovery_evidence.PAGES_APPCAST_URL}?beta3-recovery-audit=1": recovery_evidence.RemoteResponse(
+            status=200,
+            body=(recovery_evidence.REPO_ROOT / str(evidence["pages"]["capture_path"])).read_bytes().rstrip(b"\n"),
+        ),
+        recovery_evidence.PYPI_URL: json_response(
+            {
+                "info": {"version": evidence["pypi"]["latest_version"]},
+                "releases": {"0.2.143": [{}]},
+            }
+        ),
+    }
+    for tag in evidence["absent_github_state"]["tags"]:
+        responses[f"{api_root}/git/ref/tags/{quote(tag, safe='')}"] = recovery_evidence.RemoteResponse(
+            status=404,
+            body=b"{}",
+        )
+    for preview in previews:
+        assert isinstance(preview, dict)
+        release = {
+            "id": preview["release_id"],
+            "tag_name": preview["tag"],
+            "draft": False,
+            "prerelease": True,
+            "immutable": preview["immutable"],
+            "target_commitish": preview["target_sha"],
+            "assets": [
+                {
+                    "id": asset["asset_id"],
+                    "name": asset["name"],
+                    "size": asset["size"],
+                    "digest": asset["digest"],
+                }
+                for asset in preview["assets"]
+            ],
+        }
+        responses[f"{api_root}/releases/tags/{quote(str(preview['tag']), safe='')}"] = json_response(release)
+    return responses
+
+
+class Beta3RecoveryEvidenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.evidence = recovery_evidence.load_beta3_recovery_evidence()
+
+    def test_reviewed_receipt_and_appcast_capture_are_digest_pinned(self) -> None:
+        self.assertEqual(self.evidence["schema_version"], 2)
+        self.assertEqual(self.evidence["repository_identity"]["id"], 771225421)
+        self.assertEqual(self.evidence["pages"]["release_tag"], "v0.2.143")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            changed = Path(temp_dir) / "evidence.json"
+            changed.write_bytes(
+                recovery_evidence.BETA3_RECOVERY_EVIDENCE_PATH.read_bytes().replace(
+                    b'"artifact_count": 0',
+                    b'"artifact_count": 1',
+                )
+            )
+            with self.assertRaisesRegex(recovery_evidence.Beta3RecoveryEvidenceError, "digest"):
+                recovery_evidence.load_beta3_recovery_evidence(changed)
+
+    def test_live_remote_verifier_accepts_the_exact_receipt(self) -> None:
+        fetcher = FakeFetcher(make_responses(self.evidence))
+
+        recovery_evidence.verify_beta3_remote_state(self.evidence, fetcher=fetcher)
+
+        self.assertIn(recovery_evidence.PYPI_URL, fetcher.requests)
+        self.assertIn(
+            f"{recovery_evidence.PAGES_APPCAST_URL}?beta3-recovery-audit=1",
+            fetcher.requests,
+        )
+
+    def test_read_only_repository_visibility_cannot_prove_draft_absence(self) -> None:
+        responses = make_responses(self.evidence)
+        repository = str(self.evidence["repository"])
+        repository_url = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}"
+        repository_identity = json.loads(responses[repository_url].body)
+        repository_identity["permissions"] = {"push": False}
+        responses[repository_url] = json_response(repository_identity)
+
+        with self.assertRaisesRegex(
+            recovery_evidence.Beta3RecoveryEvidenceError,
+            "push visibility",
+        ):
+            recovery_evidence.verify_beta3_remote_state(self.evidence, fetcher=FakeFetcher(responses))
+
+    def test_live_remote_verifier_rejects_new_tag_or_artifact_state(self) -> None:
+        repository = str(self.evidence["repository"])
+        api_root = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}"
+        failed_run = self.evidence["failed_run"]
+        assert isinstance(failed_run, dict)
+        target_tag = self.evidence["transition"]["target"]["release_tag"]
+        tag_url = f"{api_root}/git/ref/tags/{quote(target_tag, safe='')}"
+        artifact_url = f"{api_root}/actions/runs/{failed_run['id']}/artifacts?per_page=100"
+        for name, url, response, message in (
+            ("tag", tag_url, json_response({"ref": f"refs/tags/{target_tag}"}), "now exists"),
+            ("artifact", artifact_url, json_response({"total_count": 1, "artifacts": [{}]}), "artifact state"),
+        ):
+            with self.subTest(name=name):
+                responses = make_responses(self.evidence)
+                responses[url] = response
+                with self.assertRaisesRegex(recovery_evidence.Beta3RecoveryEvidenceError, message):
+                    recovery_evidence.verify_beta3_remote_state(
+                        self.evidence,
+                        fetcher=FakeFetcher(responses),
+                    )
+
+    def test_publication_preflight_allows_only_matching_beta3_draft(self) -> None:
+        expected_sha = "a" * 40
+        repository = str(self.evidence["repository"])
+        releases_url = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}/releases?per_page=100&page=1"
+        target_tag = self.evidence["transition"]["target"]["release_tag"]
+        matching_draft = {
+            "tag_name": target_tag,
+            "name": target_tag,
+            "draft": True,
+            "prerelease": True,
+            "target_commitish": expected_sha,
+        }
+        responses = make_responses(self.evidence)
+        responses[releases_url] = json_response([matching_draft])
+
+        recovery_evidence.verify_beta3_remote_state(
+            self.evidence,
+            fetcher=FakeFetcher(responses),
+            allow_beta3_draft=True,
+            expected_sha=expected_sha,
+        )
+
+        target_tag_url = (
+            f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}/git/ref/tags/{quote(target_tag, safe='')}"
+        )
+        responses[target_tag_url] = json_response(
+            {
+                "ref": f"refs/tags/{target_tag}",
+                "object": {"type": "commit", "sha": expected_sha},
+            }
+        )
+        recovery_evidence.verify_beta3_remote_state(
+            self.evidence,
+            fetcher=FakeFetcher(responses),
+            allow_beta3_draft=True,
+            expected_sha=expected_sha,
+        )
+
+        changed = copy.deepcopy(matching_draft)
+        changed["target_commitish"] = "b" * 40
+        responses[releases_url] = json_response([changed])
+        with self.assertRaisesRegex(recovery_evidence.Beta3RecoveryEvidenceError, "mismatch"):
+            recovery_evidence.verify_beta3_remote_state(
+                self.evidence,
+                fetcher=FakeFetcher(responses),
+                allow_beta3_draft=True,
+                expected_sha=expected_sha,
+            )
+
+    def test_live_remote_verifier_rejects_repository_or_job_identity_drift(self) -> None:
+        repository = str(self.evidence["repository"])
+        api_root = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}"
+        failed_run = self.evidence["failed_run"]
+        jobs_url = f"{api_root}/actions/runs/{failed_run['id']}/attempts/{failed_run['run_attempt']}/jobs?per_page=100"
+        for name, url, mutate, message in (
+            (
+                "repository",
+                api_root,
+                lambda value: {**value, "id": 1},
+                "repository identity mismatch",
+            ),
+            (
+                "job",
+                jobs_url,
+                lambda value: {**value, "jobs": value["jobs"][:-1], "total_count": value["total_count"] - 1},
+                "job set changed",
+            ),
+        ):
+            with self.subTest(name=name):
+                responses = make_responses(self.evidence)
+                original = json.loads(responses[url].body)
+                responses[url] = json_response(mutate(original))
+                with self.assertRaisesRegex(recovery_evidence.Beta3RecoveryEvidenceError, message):
+                    recovery_evidence.verify_beta3_remote_state(
+                        self.evidence,
+                        fetcher=FakeFetcher(responses),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -33,6 +33,7 @@ def release_metadata(app_path: Path) -> SparkleBundleMetadata:
         build_version="146",
         short_version="0.2.143",
         distribution_channel="direct",
+        support_diagnostics_endpoint="https://support.example",
         feed_url="https://cbusillo.github.io/BD_to_AVP/appcast.xml",
         minimum_system_version="26.0",
         public_key="test-key",

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -92,8 +92,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0rc1")
-        self.assertEqual(NATIVE_BUILD_VERSION, "147")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b3")
+        self.assertEqual(NATIVE_BUILD_VERSION, "148")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -21,6 +21,8 @@ from scripts.native_app import (
     NATIVE_PRODUCT_NAME,
     NATIVE_SHORT_VERSION,
     NATIVE_UPDATE_INFO,
+    SUPPORT_DIAGNOSTICS_ENDPOINT_ENV,
+    SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY,
     WORKER_PROTOCOL_VERSION,
     MACOS_ROOT,
     PROJECT_PATH,
@@ -60,6 +62,22 @@ def canonical_ffprobe_event(job_id: str) -> dict[str, object]:
             "tool": {"id": "ffprobe"},
         },
         "data": {},
+    }
+
+
+def production_info(*, support_diagnostics_endpoint: object = "https://support.example") -> dict[str, object]:
+    return {
+        "CFBundleDisplayName": NATIVE_PRODUCT_NAME,
+        "CFBundleName": NATIVE_PRODUCT_NAME,
+        "CFBundleExecutable": NATIVE_EXECUTABLE_NAME,
+        "CFBundleIdentifier": NATIVE_BUNDLE_IDENTIFIER,
+        "CFBundleShortVersionString": NATIVE_SHORT_VERSION,
+        "CFBundleVersion": NATIVE_BUILD_VERSION,
+        "LSMinimumSystemVersion": NATIVE_MINIMUM_SYSTEM_VERSION,
+        "MainModule": "bd_to_avp.worker",
+        "BluRayToVisionProEngineBundled": True,
+        **NATIVE_UPDATE_INFO,
+        SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: support_diagnostics_endpoint,
     }
 
 
@@ -406,23 +424,53 @@ Load command 3
             info_path = app_path / "Contents" / "Info.plist"
             info_path.parent.mkdir(parents=True)
             with info_path.open("wb") as info_file:
+                plistlib.dump(production_info(), info_file)
+
+            verify_product_identity(
+                app_path,
+                environment={SUPPORT_DIAGNOSTICS_ENDPOINT_ENV: "https://support.example"},
+            )
+
+    def test_rejects_missing_support_diagnostics_endpoint_in_release_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            info_path = app_path / "Contents" / "Info.plist"
+            info_path.parent.mkdir(parents=True)
+            info = production_info()
+            del info[SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY]
+            with info_path.open("wb") as info_file:
+                plistlib.dump(info, info_file)
+
+            with self.assertRaisesRegex(RuntimeError, "must be a non-empty valid HTTPS endpoint"):
+                verify_product_identity(app_path, environment={})
+
+    def test_rejects_invalid_support_diagnostics_endpoint_in_release_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            info_path = app_path / "Contents" / "Info.plist"
+            info_path.parent.mkdir(parents=True)
+            with info_path.open("wb") as info_file:
                 plistlib.dump(
-                    {
-                        "CFBundleDisplayName": NATIVE_PRODUCT_NAME,
-                        "CFBundleName": NATIVE_PRODUCT_NAME,
-                        "CFBundleExecutable": NATIVE_EXECUTABLE_NAME,
-                        "CFBundleIdentifier": NATIVE_BUNDLE_IDENTIFIER,
-                        "CFBundleShortVersionString": NATIVE_SHORT_VERSION,
-                        "CFBundleVersion": NATIVE_BUILD_VERSION,
-                        "LSMinimumSystemVersion": NATIVE_MINIMUM_SYSTEM_VERSION,
-                        "MainModule": "bd_to_avp.worker",
-                        "BluRayToVisionProEngineBundled": True,
-                        **NATIVE_UPDATE_INFO,
-                    },
+                    production_info(support_diagnostics_endpoint="https://support.example/diagnostics"),
                     info_file,
                 )
 
-            verify_product_identity(app_path)
+            with self.assertRaisesRegex(RuntimeError, "must be a non-empty valid HTTPS endpoint"):
+                verify_product_identity(app_path, environment={})
+
+    def test_rejects_mismatched_support_diagnostics_endpoint_in_release_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            info_path = app_path / "Contents" / "Info.plist"
+            info_path.parent.mkdir(parents=True)
+            with info_path.open("wb") as info_file:
+                plistlib.dump(production_info(), info_file)
+
+            with self.assertRaisesRegex(RuntimeError, "must exactly match the approved"):
+                verify_product_identity(
+                    app_path,
+                    environment={SUPPORT_DIAGNOSTICS_ENDPOINT_ENV: "https://other-support.example"},
+                )
 
     def test_rejects_development_metadata_in_release_app(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -432,23 +480,14 @@ Load command 3
             with info_path.open("wb") as info_file:
                 plistlib.dump(
                     {
-                        "CFBundleDisplayName": NATIVE_PRODUCT_NAME,
-                        "CFBundleName": NATIVE_PRODUCT_NAME,
-                        "CFBundleExecutable": NATIVE_EXECUTABLE_NAME,
-                        "CFBundleIdentifier": NATIVE_BUNDLE_IDENTIFIER,
-                        "CFBundleShortVersionString": NATIVE_SHORT_VERSION,
-                        "CFBundleVersion": NATIVE_BUILD_VERSION,
-                        "LSMinimumSystemVersion": NATIVE_MINIMUM_SYSTEM_VERSION,
-                        "MainModule": "bd_to_avp.worker",
-                        "BluRayToVisionProEngineBundled": True,
-                        **NATIVE_UPDATE_INFO,
+                        **production_info(),
                         "BDToAVPDevelopmentRepositoryRoot": "/private/tmp/source",
                     },
                     info_file,
                 )
 
             with self.assertRaisesRegex(RuntimeError, "development repository metadata"):
-                verify_product_identity(app_path)
+                verify_product_identity(app_path, environment={})
 
     def test_rejects_repository_documents_in_release_app(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -456,27 +495,13 @@ Load command 3
             info_path = app_path / "Contents" / "Info.plist"
             info_path.parent.mkdir(parents=True)
             with info_path.open("wb") as info_file:
-                plistlib.dump(
-                    {
-                        "CFBundleDisplayName": NATIVE_PRODUCT_NAME,
-                        "CFBundleName": NATIVE_PRODUCT_NAME,
-                        "CFBundleExecutable": NATIVE_EXECUTABLE_NAME,
-                        "CFBundleIdentifier": NATIVE_BUNDLE_IDENTIFIER,
-                        "CFBundleShortVersionString": NATIVE_SHORT_VERSION,
-                        "CFBundleVersion": NATIVE_BUILD_VERSION,
-                        "LSMinimumSystemVersion": NATIVE_MINIMUM_SYSTEM_VERSION,
-                        "MainModule": "bd_to_avp.worker",
-                        "BluRayToVisionProEngineBundled": True,
-                        **NATIVE_UPDATE_INFO,
-                    },
-                    info_file,
-                )
+                plistlib.dump(production_info(), info_file)
             internal_document = app_path / "Contents" / "Resources" / "app" / "README.md"
             internal_document.parent.mkdir(parents=True)
             internal_document.write_text("internal", encoding="utf-8")
 
             with self.assertRaisesRegex(RuntimeError, "repository-only documents"):
-                verify_product_identity(app_path)
+                verify_product_identity(app_path, environment={})
 
     def test_accepts_complete_worker_smoke_contract(self) -> None:
         job_id = "97456c4a-f3c5-44e4-a548-0bd833ead4bb"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -843,6 +843,36 @@ class Beta3RecoveryTests(unittest.TestCase):
                     remote_verifier=mutate_source,
                 )
 
+    def test_recovery_rejects_target_drift_during_commit_point_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+            verification_count = 0
+
+            def mutate_target_at_commit(_evidence: object) -> None:
+                nonlocal verification_count
+                verification_count += 1
+                if verification_count == 2:
+                    pyproject_path.write_bytes(originals[pyproject_path])
+
+            with self.assertRaisesRegex(release.ReleaseError, "changed during final validation"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=fake_lock_runner,
+                    remote_verifier=mutate_target_at_commit,
+                )
+
+            self.assertEqual(verification_count, 2)
+            for path, original in originals.items():
+                self.assertEqual(path.read_bytes(), original)
+            self.assertFalse((root / release.TRANSACTION_JOURNAL_NAME).exists())
+
     def test_recovery_rejects_production_identity_drift(self) -> None:
         cases = (
             ("feed", "pyproject.toml", "https://cbusillo.github.io/BD_to_AVP/appcast.xml", "https://example.test/feed"),

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,4 +1,6 @@
+import copy
 import importlib
+import json
 import re
 import subprocess
 import tempfile
@@ -95,6 +97,15 @@ def fake_lock_runner(stage_root: Path, _uv_executable: str) -> None:
     lock_path.write_text(lock_text, encoding="utf-8")
 
 
+def make_recovery_evidence(root: Path, evidence: dict[str, object] | None = None) -> Path:
+    evidence_path = root / "v0.3.0-beta.3-recovery.json"
+    evidence_path.write_text(
+        json.dumps(evidence if evidence is not None else release.BETA3_RECOVERY_EVIDENCE, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return evidence_path
+
+
 class ReleaseMetadataTests(unittest.TestCase):
     def test_repository_keeps_gui_dependency_out_of_cli_base(self) -> None:
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
@@ -127,19 +138,25 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_for_release_candidate(self) -> None:
+    def test_repository_is_prepared_for_beta3(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0rc1")
-        self.assertEqual(metadata.public_version, "0.3.0-rc.1")
-        self.assertEqual(metadata.build_version, "147")
-        self.assertEqual(metadata.release_tag, "v0.3.0-rc.1")
-        self.assertEqual(metadata.release_name, "v0.3.0-rc.1")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.1.dmg")
-        self.assertEqual(metadata.channel, "rc")
+        self.assertEqual(metadata.package_version, "0.3.0b3")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.3")
+        self.assertEqual(metadata.build_version, "148")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.3")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg")
+        self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
+
+    def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
+        self.assertEqual(
+            release.validate_beta3_recovery_evidence(),
+            release.BETA3_RECOVERY_EVIDENCE,
+        )
 
     def test_beta3_seed_metadata_uses_the_production_beta_identity(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -539,6 +556,168 @@ class ReleasePreparationTests(unittest.TestCase):
                     lock_path=lock_path,
                     lock_runner=fake_lock_runner,
                 )
+
+
+class Beta3RecoveryTests(unittest.TestCase):
+    def test_recovery_cli_exposes_no_version_or_build_override(self) -> None:
+        args = release.build_parser().parse_args(["recover-beta3"])
+
+        self.assertEqual(args.command, "recover-beta3")
+        self.assertFalse(hasattr(args, "version"))
+        self.assertFalse(hasattr(args, "build"))
+
+    def test_recovery_accepts_only_the_exact_source_target_and_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+
+            metadata = release.recover_beta3(
+                pyproject_path=pyproject_path,
+                lock_path=lock_path,
+                macos_project_path=macos_project_path,
+                evidence_path=evidence_path,
+                lock_runner=fake_lock_runner,
+            )
+
+            with pyproject_path.open("rb") as handle:
+                pyproject = tomllib.load(handle)
+            with lock_path.open("rb") as handle:
+                lock = tomllib.load(handle)
+            project_text = macos_project_path.read_text(encoding="utf-8")
+
+        self.assertEqual(metadata.package_version, "0.3.0b3")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.3")
+        self.assertEqual(metadata.build_version, "148")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
+        self.assertEqual(metadata.channel, "beta")
+        self.assertEqual(pyproject["project"]["version"], "0.3.0b3")
+        self.assertEqual(
+            pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["macOS"]["info"]["CFBundleVersion"],
+            "148",
+        )
+        self.assertEqual(lock["package"][0]["version"], "0.3.0b3")
+        self.assertIn("MARKETING_VERSION: 0.3.0b3", project_text)
+        self.assertIn("CURRENT_PROJECT_VERSION: 148", project_text)
+
+    def test_recovery_rejects_bad_evidence_before_writes(self) -> None:
+        evidence_cases: list[tuple[str, str | dict[str, object] | None]] = [
+            ("missing", None),
+            ("malformed", "{"),
+            ("mismatched", copy.deepcopy(release.BETA3_RECOVERY_EVIDENCE)),
+        ]
+        mismatched = evidence_cases[-1][1]
+        assert isinstance(mismatched, dict)
+        failed_run = mismatched["failed_run"]
+        assert isinstance(failed_run, dict)
+        failed_run["artifact_count"] = 1
+
+        for name, evidence in evidence_cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+                macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+                evidence_path = root / "evidence.json"
+                if isinstance(evidence, str):
+                    evidence_path.write_text(evidence, encoding="utf-8")
+                elif isinstance(evidence, dict):
+                    make_recovery_evidence(root, evidence).replace(evidence_path)
+                originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+                lock_called = False
+
+                def unexpected_lock(_stage_root: Path, _uv_executable: str) -> None:
+                    nonlocal lock_called
+                    lock_called = True
+
+                with self.assertRaises(release.ReleaseError):
+                    release.recover_beta3(
+                        pyproject_path=pyproject_path,
+                        lock_path=lock_path,
+                        macos_project_path=macos_project_path,
+                        evidence_path=evidence_path,
+                        lock_runner=unexpected_lock,
+                    )
+
+                self.assertFalse(lock_called)
+                for path, original in originals.items():
+                    self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_rejects_wrong_current_metadata_without_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="146")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="146")
+            evidence_path = make_recovery_evidence(root)
+            originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+            lock_called = False
+
+            def unexpected_lock(_stage_root: Path, _uv_executable: str) -> None:
+                nonlocal lock_called
+                lock_called = True
+
+            with self.assertRaisesRegex(release.ReleaseError, "requires exact source metadata"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=unexpected_lock,
+                )
+
+            self.assertFalse(lock_called)
+            for path, original in originals.items():
+                self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_is_atomic_when_lock_refresh_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+
+            def fail_lock(_stage_root: Path, _uv_executable: str) -> None:
+                raise subprocess.CalledProcessError(1, ["uv", "lock"])
+
+            with self.assertRaises(subprocess.CalledProcessError):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=fail_lock,
+                )
+
+            for path, original in originals.items():
+                self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_rerun_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            release.recover_beta3(
+                pyproject_path=pyproject_path,
+                lock_path=lock_path,
+                macos_project_path=macos_project_path,
+                evidence_path=evidence_path,
+                lock_runner=fake_lock_runner,
+            )
+            recovered = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+
+            with self.assertRaisesRegex(release.ReleaseError, "requires exact source metadata"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=fake_lock_runner,
+                )
+
+            for path, recovered_content in recovered.items():
+                self.assertEqual(path.read_bytes(), recovered_content)
 
 
 if __name__ == "__main__":

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,8 +1,9 @@
-import copy
+import hashlib
 import importlib
-import json
 import re
+import stat
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
@@ -10,6 +11,8 @@ import unittest
 from pathlib import Path
 
 from scripts import briefcase_macos_signing, release
+from scripts.beta3_recovery_evidence import BETA3_RECOVERY_EVIDENCE_PATH, Beta3RecoveryEvidenceError
+from scripts.production_identity import PRODUCTION_SPARKLE_PUBLIC_KEY
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -28,17 +31,23 @@ name = "bd_to_avp"
 version = "{version}"
 
 [tool.briefcase]
-project_name = "Test"
+project_name = "3D Blu-ray to Vision Pro"
 bundle = "com.shinycomputers"
 
 [tool.briefcase.app.bd-to-avp]
-formal_name = "Test"
+formal_name = "3D Blu-ray to Vision Pro"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
 CFBundleVersion = "{build}"
+BDToAVPDistributionChannel = "direct"
+SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+SUPublicEDKey = "{PRODUCTION_SPARKLE_PUBLIC_KEY}"
+SUAllowsAutomaticUpdates = false
+SUVerifyUpdateBeforeExtraction = true
 """,
         encoding="utf-8",
     )
+    (root / "sparkle-public-ed-key.txt").write_text(f"{PRODUCTION_SPARKLE_PUBLIC_KEY}\n", encoding="utf-8")
     lock_path.write_text(
         f"""\
 version = 1
@@ -62,9 +71,10 @@ targets:
     settings:
       base:
         CURRENT_PROJECT_VERSION: {build}
+        BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         MARKETING_VERSION: {version}
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
-        PRODUCT_NAME: Test
+        PRODUCT_NAME: 3D Blu-ray to Vision Pro
       configs:
         Release:
           INFOPLIST_FILE: BluRayToVisionPro/Info-Release.plist
@@ -97,13 +107,14 @@ def fake_lock_runner(stage_root: Path, _uv_executable: str) -> None:
     lock_path.write_text(lock_text, encoding="utf-8")
 
 
-def make_recovery_evidence(root: Path, evidence: dict[str, object] | None = None) -> Path:
+def make_recovery_evidence(root: Path, content: bytes | None = None) -> Path:
     evidence_path = root / "v0.3.0-beta.3-recovery.json"
-    evidence_path.write_text(
-        json.dumps(evidence if evidence is not None else release.BETA3_RECOVERY_EVIDENCE, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    evidence_path.write_bytes(content if content is not None else BETA3_RECOVERY_EVIDENCE_PATH.read_bytes())
     return evidence_path
+
+
+def skip_remote_verification(_evidence: object) -> None:
+    return None
 
 
 class ReleaseMetadataTests(unittest.TestCase):
@@ -153,10 +164,31 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertFalse(metadata.publish_pypi)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
+        evidence = release.validate_beta3_recovery_evidence()
+
+        self.assertEqual(evidence["schema_version"], 2)
+        self.assertEqual(evidence["repository"], "cbusillo/BD_to_AVP")
+        self.assertEqual(evidence["transition"]["target"]["release_tag"], "v0.3.0-beta.3")
+
+    def test_reviewed_source_identity_matches_the_pre_recovery_base_commit(self) -> None:
+        evidence = release.validate_beta3_recovery_evidence()
+        source_identity = evidence["source_identity"]
+        base_commit = source_identity["base_commit"]
+
         self.assertEqual(
-            release.validate_beta3_recovery_evidence(),
-            release.BETA3_RECOVERY_EVIDENCE,
+            subprocess.check_output(
+                ["git", "show", "-s", "--format=%T", base_commit],
+                cwd=REPO_ROOT,
+                text=True,
+            ).strip(),
+            source_identity["tree"],
         )
+        for relative_path, expected_digest in source_identity["files"].items():
+            content = subprocess.check_output(
+                ["git", "show", f"{base_commit}:{relative_path}"],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(hashlib.sha256(content).hexdigest(), expected_digest)
 
     def test_beta3_seed_metadata_uses_the_production_beta_identity(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -402,6 +434,17 @@ class ReleaseNotesBaseTests(unittest.TestCase):
 
 
 class ReleasePreparationTests(unittest.TestCase):
+    def test_atomic_write_preserves_existing_file_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "metadata.toml"
+            path.write_text("before\n", encoding="utf-8")
+            path.chmod(0o640)
+
+            release._atomic_write(path, b"after\n")
+
+            self.assertEqual(path.read_bytes(), b"after\n")
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o640)
+
     def test_prepare_updates_version_build_and_lock_together(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             pyproject_path, lock_path = make_release_files(Path(temp_dir))
@@ -559,12 +602,28 @@ class ReleasePreparationTests(unittest.TestCase):
 
 
 class Beta3RecoveryTests(unittest.TestCase):
+    def test_release_cli_runs_as_a_module_from_a_clean_checkout_root(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, "-m", "scripts.release", "--help"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("recover-beta3", completed.stdout)
+
     def test_recovery_cli_exposes_no_version_or_build_override(self) -> None:
         args = release.build_parser().parse_args(["recover-beta3"])
 
         self.assertEqual(args.command, "recover-beta3")
         self.assertFalse(hasattr(args, "version"))
         self.assertFalse(hasattr(args, "build"))
+        self.assertFalse(hasattr(args, "pyproject"))
+        self.assertFalse(hasattr(args, "lock"))
+        self.assertFalse(hasattr(args, "macos_project"))
+        self.assertFalse(hasattr(args, "uv"))
 
     def test_recovery_accepts_only_the_exact_source_target_and_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -579,6 +638,7 @@ class Beta3RecoveryTests(unittest.TestCase):
                 macos_project_path=macos_project_path,
                 evidence_path=evidence_path,
                 lock_runner=fake_lock_runner,
+                remote_verifier=skip_remote_verification,
             )
 
             with pyproject_path.open("rb") as handle:
@@ -602,27 +662,24 @@ class Beta3RecoveryTests(unittest.TestCase):
         self.assertIn("CURRENT_PROJECT_VERSION: 148", project_text)
 
     def test_recovery_rejects_bad_evidence_before_writes(self) -> None:
-        evidence_cases: list[tuple[str, str | dict[str, object] | None]] = [
+        reviewed_evidence = BETA3_RECOVERY_EVIDENCE_PATH.read_bytes()
+        evidence_cases: list[tuple[str, bytes | None]] = [
             ("missing", None),
-            ("malformed", "{"),
-            ("mismatched", copy.deepcopy(release.BETA3_RECOVERY_EVIDENCE)),
+            ("malformed", b"{"),
+            (
+                "mismatched",
+                reviewed_evidence.replace(b'"artifact_count": 0', b'"artifact_count": 1'),
+            ),
         ]
-        mismatched = evidence_cases[-1][1]
-        assert isinstance(mismatched, dict)
-        failed_run = mismatched["failed_run"]
-        assert isinstance(failed_run, dict)
-        failed_run["artifact_count"] = 1
 
-        for name, evidence in evidence_cases:
+        for name, content in evidence_cases:
             with self.subTest(name=name), tempfile.TemporaryDirectory() as temp_dir:
                 root = Path(temp_dir)
                 pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
                 macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
                 evidence_path = root / "evidence.json"
-                if isinstance(evidence, str):
-                    evidence_path.write_text(evidence, encoding="utf-8")
-                elif isinstance(evidence, dict):
-                    make_recovery_evidence(root, evidence).replace(evidence_path)
+                if content is not None:
+                    evidence_path.write_bytes(content)
                 originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
                 lock_called = False
 
@@ -637,6 +694,7 @@ class Beta3RecoveryTests(unittest.TestCase):
                         macos_project_path=macos_project_path,
                         evidence_path=evidence_path,
                         lock_runner=unexpected_lock,
+                        remote_verifier=skip_remote_verification,
                     )
 
                 self.assertFalse(lock_called)
@@ -663,6 +721,7 @@ class Beta3RecoveryTests(unittest.TestCase):
                     macos_project_path=macos_project_path,
                     evidence_path=evidence_path,
                     lock_runner=unexpected_lock,
+                    remote_verifier=skip_remote_verification,
                 )
 
             self.assertFalse(lock_called)
@@ -687,10 +746,252 @@ class Beta3RecoveryTests(unittest.TestCase):
                     macos_project_path=macos_project_path,
                     evidence_path=evidence_path,
                     lock_runner=fail_lock,
+                    remote_verifier=skip_remote_verification,
                 )
 
             for path, original in originals.items():
                 self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_rejects_remote_drift_before_lock_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+            lock_called = False
+
+            def reject_remote_state(_evidence: object) -> None:
+                raise Beta3RecoveryEvidenceError("remote release state changed")
+
+            def unexpected_lock(_stage_root: Path, _uv_executable: str) -> None:
+                nonlocal lock_called
+                lock_called = True
+
+            with self.assertRaisesRegex(release.ReleaseError, "remote release state changed"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=unexpected_lock,
+                    remote_verifier=reject_remote_state,
+                )
+
+            self.assertFalse(lock_called)
+            for path, original in originals.items():
+                self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_rechecks_remote_state_immediately_before_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+            verification_count = 0
+            events: list[str] = []
+
+            def remote_changes_after_staging(_evidence: object) -> None:
+                nonlocal verification_count
+                verification_count += 1
+                events.append(f"verify-{verification_count}")
+                if verification_count == 2:
+                    raise Beta3RecoveryEvidenceError("remote state changed before commit")
+
+            def observe_transaction(event: str, _path: Path) -> None:
+                events.append(event)
+
+            with self.assertRaisesRegex(release.ReleaseError, "remote state changed before commit"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=fake_lock_runner,
+                    remote_verifier=remote_changes_after_staging,
+                    transaction_observer=observe_transaction,
+                )
+
+            self.assertEqual(verification_count, 2)
+            self.assertGreater(
+                events.index("verify-2"),
+                max(index for index, event in enumerate(events) if event == "file-applied"),
+            )
+            self.assertNotIn("journal-committed", events)
+            for path, original in originals.items():
+                self.assertEqual(path.read_bytes(), original)
+
+    def test_recovery_rejects_source_drift_during_remote_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+            original_pyproject = pyproject_path.read_bytes()
+
+            def mutate_source(_evidence: object) -> None:
+                pyproject_path.write_bytes(original_pyproject + b"\n# concurrent drift\n")
+
+            with self.assertRaisesRegex(release.ReleaseError, "changed after identity validation"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=fake_lock_runner,
+                    remote_verifier=mutate_source,
+                )
+
+    def test_recovery_rejects_production_identity_drift(self) -> None:
+        cases = (
+            ("feed", "pyproject.toml", "https://cbusillo.github.io/BD_to_AVP/appcast.xml", "https://example.test/feed"),
+            ("public-key", "sparkle-public-ed-key.txt", PRODUCTION_SPARKLE_PUBLIC_KEY, "invalid-key"),
+            ("bundle", "project.yml", "com.shinycomputers.bd-to-avp", "com.example.changed"),
+        )
+        for name, filename, original_value, replacement in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+                macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+                evidence_path = make_recovery_evidence(root)
+                changed_path = root / filename
+                changed_path.write_text(
+                    changed_path.read_text(encoding="utf-8").replace(original_value, replacement),
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(release.ReleaseError, "source identity is invalid"):
+                    release.recover_beta3(
+                        pyproject_path=pyproject_path,
+                        lock_path=lock_path,
+                        macos_project_path=macos_project_path,
+                        evidence_path=evidence_path,
+                        lock_runner=fake_lock_runner,
+                        remote_verifier=skip_remote_verification,
+                    )
+
+    def test_recovery_rejects_unrelated_lockfile_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+            macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+            evidence_path = make_recovery_evidence(root)
+
+            def change_unrelated_lock_data(stage_root: Path, uv_executable: str) -> None:
+                fake_lock_runner(stage_root, uv_executable)
+                staged_lock = stage_root / "uv.lock"
+                staged_lock.write_text(
+                    staged_lock.read_text(encoding="utf-8") + '\n[unexpected]\nvalue = "drift"\n',
+                    encoding="utf-8",
+                )
+
+            with self.assertRaisesRegex(release.ReleaseError, "other than the editable project version"):
+                release.recover_beta3(
+                    pyproject_path=pyproject_path,
+                    lock_path=lock_path,
+                    macos_project_path=macos_project_path,
+                    evidence_path=evidence_path,
+                    lock_runner=change_unrelated_lock_data,
+                    remote_verifier=skip_remote_verification,
+                )
+
+    def test_recovery_rolls_back_interrupt_after_each_file_replacement(self) -> None:
+        class SimulatedInterrupt(BaseException):
+            pass
+
+        for stop_after in (1, 2, 3):
+            with self.subTest(stop_after=stop_after), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                pyproject_path, lock_path = make_release_files(root, version="0.3.0rc1", build="147")
+                macos_project_path = make_macos_project(root, version="0.3.0rc1", build="147")
+                evidence_path = make_recovery_evidence(root)
+                originals = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
+                applied = 0
+
+                def interrupt(event: str, _path: Path, expected_stop: int = stop_after) -> None:
+                    nonlocal applied
+                    if event == "file-applied":
+                        applied += 1
+                        if applied == expected_stop:
+                            raise SimulatedInterrupt
+
+                with self.assertRaises(SimulatedInterrupt):
+                    release.recover_beta3(
+                        pyproject_path=pyproject_path,
+                        lock_path=lock_path,
+                        macos_project_path=macos_project_path,
+                        evidence_path=evidence_path,
+                        lock_runner=fake_lock_runner,
+                        remote_verifier=skip_remote_verification,
+                        transaction_observer=interrupt,
+                    )
+
+                for path, original in originals.items():
+                    self.assertEqual(path.read_bytes(), original)
+                self.assertFalse((root / release.TRANSACTION_JOURNAL_NAME).exists())
+
+    def test_prepared_transaction_journal_restores_original_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root)
+            macos_project_path = make_macos_project(root)
+            files = [
+                release.TransactionFile(
+                    path=path,
+                    original=path.read_bytes(),
+                    target=path.read_bytes() + b"\n# target\n",
+                )
+                for path in (pyproject_path, lock_path, macos_project_path)
+            ]
+            journal_path = root / release.TRANSACTION_JOURNAL_NAME
+            release._write_transaction_journal(journal_path, release._transaction_payload(files, "prepared"))
+            release._atomic_write(files[0].path, files[0].target)
+
+            release._recover_interrupted_transaction(journal_path, [file.path for file in files])
+
+            for file in files:
+                self.assertEqual(file.path.read_bytes(), file.original)
+            self.assertFalse(journal_path.exists())
+
+    def test_committed_transaction_journal_preserves_target_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root)
+            macos_project_path = make_macos_project(root)
+            files = [
+                release.TransactionFile(
+                    path=path,
+                    original=path.read_bytes(),
+                    target=path.read_bytes() + b"\n# target\n",
+                )
+                for path in (pyproject_path, lock_path, macos_project_path)
+            ]
+            journal_path = root / release.TRANSACTION_JOURNAL_NAME
+            for file in files:
+                release._atomic_write(file.path, file.target)
+            release._write_transaction_journal(journal_path, release._transaction_payload(files, "committed"))
+
+            release._recover_interrupted_transaction(journal_path, [file.path for file in files])
+
+            for file in files:
+                self.assertEqual(file.path.read_bytes(), file.target)
+            self.assertFalse(journal_path.exists())
+
+    def test_release_metadata_lock_rejects_concurrent_operation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pyproject_path, lock_path = make_release_files(root, version="1.2.3", build="10")
+
+            with release._release_metadata_lock(pyproject_path):
+                with self.assertRaisesRegex(release.ReleaseError, "already running"):
+                    release.prepare_release(
+                        "1.2.4",
+                        "11",
+                        pyproject_path=pyproject_path,
+                        lock_path=lock_path,
+                        lock_runner=fake_lock_runner,
+                    )
 
     def test_recovery_rerun_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -704,6 +1005,7 @@ class Beta3RecoveryTests(unittest.TestCase):
                 macos_project_path=macos_project_path,
                 evidence_path=evidence_path,
                 lock_runner=fake_lock_runner,
+                remote_verifier=skip_remote_verification,
             )
             recovered = {path: path.read_bytes() for path in (pyproject_path, lock_path, macos_project_path)}
 
@@ -714,6 +1016,7 @@ class Beta3RecoveryTests(unittest.TestCase):
                     macos_project_path=macos_project_path,
                     evidence_path=evidence_path,
                     lock_runner=fake_lock_runner,
+                    remote_verifier=skip_remote_verification,
                 )
 
             for path, recovered_content in recovered.items():

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -61,13 +61,17 @@ def valid_environment(workflow: str = STABLE_WORKFLOW_NAME) -> dict[str, str]:
 def valid_metadata_environment(
     workflow: str = STABLE_WORKFLOW_NAME,
     *,
+    release_tag: str | None = None,
     channel: str = "stable",
     prerelease: str = "false",
     make_latest: str = "true",
     publish_pypi: str = "true",
 ) -> dict[str, str]:
+    if release_tag is None:
+        release_tag = "v1.2.3" if channel == "stable" else f"v1.2.3-{channel}.1"
     return {
         "RELEASE_OPERATOR_WORKFLOW_REF": f"{REPOSITORY}/{OPERATOR_WORKFLOWS[workflow].path}@{REQUIRED_REF}",
+        "RELEASE_TAG": release_tag,
         "RELEASE_CHANNEL": channel,
         "RELEASE_PRERELEASE": prerelease,
         "RELEASE_MAKE_LATEST": make_latest,
@@ -284,9 +288,40 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Validated release route", summary)
         self.assertIn("| Operator route | Prerelease |", summary)
         self.assertIn(f"`{PRERELEASE_OPERATOR_WORKFLOW_PATH}`", summary)
+        self.assertIn("| Release tag | `v1.2.3-beta.1` |", summary)
         self.assertIn("| Committed release stage | `beta` |", summary)
         self.assertIn("| GitHub Latest | No |", summary)
         self.assertIn("| PyPI publication | No |", summary)
+
+    def test_beta3_is_frozen_until_issue_294_removes_the_policy_entry(self) -> None:
+        environment = valid_metadata_environment(
+            PRERELEASE_WORKFLOW_NAME,
+            release_tag="v0.3.0-beta.3",
+            channel="beta",
+            prerelease="true",
+            make_latest="false",
+            publish_pypi="false",
+        )
+
+        with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #294"):
+            validate_release_metadata(environment)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            freezes_path = Path(temporary_directory) / "release-freezes.json"
+            freezes_path.write_text(
+                json.dumps(
+                    {
+                        "schema": "bd_to_avp.release_freezes",
+                        "schema_version": 1,
+                        "frozen_release_tags": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metadata = validate_release_metadata(environment, freezes_path=freezes_path)
+
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
 
     @patch("scripts.release_workflow_policy.urlopen")
     def test_engine_identity_is_loaded_from_github_oidc_claims(self, urlopen_mock: Mock) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -478,7 +478,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "147")
+        self.assertEqual(info["CFBundleVersion"], "148")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from scripts import briefcase_macos_signing, sparkle_bundle, sparkle_macos
+from scripts.native_app import SUPPORT_DIAGNOSTICS_ENDPOINT_ENV, SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY
 
 
 def make_framework(root: Path, *, version: str = "2.9.4") -> Path:
@@ -290,21 +291,45 @@ class SparkleBundleTests(unittest.TestCase):
 
     def test_inspect_app_bundle_validates_metadata_and_layout(self) -> None:
         expected = self.expected_info()
+        support_endpoint = "https://support.example"
         info = {
             **expected,
             "CFBundleIdentifier": "com.example.test",
             "CFBundleShortVersionString": "1.2.3rc1",
             "LSMinimumSystemVersion": "11.0",
+            SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: support_endpoint,
         }
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_app(Path(temp_dir), info)
 
-            metadata = sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+            metadata = sparkle_bundle.inspect_app_bundle(
+                app_path,
+                expected_info=expected,
+                environment={SUPPORT_DIAGNOSTICS_ENDPOINT_ENV: support_endpoint},
+            )
 
         self.assertEqual(metadata.build_version, "144")
         self.assertEqual(metadata.short_version, "1.2.3rc1")
         self.assertEqual(metadata.distribution_channel, "direct")
+        self.assertEqual(metadata.support_diagnostics_endpoint, support_endpoint)
         self.assertEqual(metadata.minimum_system_version, "11.0")
+
+    def test_inspect_app_bundle_accepts_canonical_pep440_short_versions(self) -> None:
+        expected = self.expected_info()
+        for short_version in ("0.3.0", "0.3.0a3", "0.3.0b3", "0.3.0rc3"):
+            with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
+                info = {
+                    **expected,
+                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleShortVersionString": short_version,
+                    "LSMinimumSystemVersion": "11.0",
+                    SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
+                }
+                app_path = make_app(Path(temp_dir), info)
+
+                metadata = sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected, environment={})
+
+                self.assertEqual(metadata.short_version, short_version)
 
     def test_inspect_app_bundle_rejects_default_build_number(self) -> None:
         expected = self.expected_info()
@@ -345,6 +370,7 @@ class SparkleBundleTests(unittest.TestCase):
             "CFBundleIdentifier": "com.example.test",
             "CFBundleShortVersionString": "1.2.4rc1",
             "LSMinimumSystemVersion": "11.0",
+            SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
         }
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_app(Path(temp_dir), info)
@@ -353,23 +379,101 @@ class SparkleBundleTests(unittest.TestCase):
                 app_path,
                 expected_info=expected,
                 require_repository_build=False,
+                environment={},
             )
 
         self.assertEqual(metadata.build_version, "145")
 
-    def test_inspect_app_bundle_rejects_output_unsafe_versions(self) -> None:
+    def test_inspect_app_bundle_rejects_malformed_short_versions(self) -> None:
+        expected = self.expected_info()
+        malformed_versions = ("0.3", "0.3.0-beta.3", "0.3.0b0", "00.3.0", "0.3.0b03", "1.2.3\nforged=value")
+        for short_version in malformed_versions:
+            with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
+                info = {
+                    **expected,
+                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleShortVersionString": short_version,
+                    "LSMinimumSystemVersion": "11.0",
+                    SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
+                }
+                app_path = make_app(Path(temp_dir), info)
+
+                with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "canonical three-part PEP 440"):
+                    sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected, environment={})
+
+    def test_inspect_app_bundle_rejects_retired_preview_short_versions(self) -> None:
+        expected = self.expected_info()
+        for short_version in ("0.3.0b1", "0.3.0b2"):
+            with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
+                info = {
+                    **expected,
+                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleShortVersionString": short_version,
+                    "LSMinimumSystemVersion": "11.0",
+                    SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
+                }
+                app_path = make_app(Path(temp_dir), info)
+
+                with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "retired preview identity"):
+                    sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected, environment={})
+
+    def test_inspect_app_bundle_rejects_missing_support_diagnostics_endpoint(self) -> None:
         expected = self.expected_info()
         info = {
             **expected,
             "CFBundleIdentifier": "com.example.test",
-            "CFBundleShortVersionString": "1.2.3\nforged=value",
+            "CFBundleShortVersionString": "0.3.0b3",
             "LSMinimumSystemVersion": "11.0",
         }
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_app(Path(temp_dir), info)
 
-            with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "three-part version"):
-                sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected)
+            with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "must be a non-empty valid HTTPS endpoint"):
+                sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected, environment={})
+
+    def test_inspect_app_bundle_rejects_invalid_support_diagnostics_endpoint(self) -> None:
+        expected = self.expected_info()
+        invalid_endpoints = (
+            "https://user:secret@support.example",
+            "https://support.example/diagnostics",
+            "https://support.example?token=secret",
+            "https://support.example#fragment",
+        )
+        for endpoint in invalid_endpoints:
+            with self.subTest(endpoint=endpoint), tempfile.TemporaryDirectory() as temp_dir:
+                info = {
+                    **expected,
+                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleShortVersionString": "0.3.0b3",
+                    "LSMinimumSystemVersion": "11.0",
+                    SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: endpoint,
+                }
+                app_path = make_app(Path(temp_dir), info)
+
+                with self.assertRaisesRegex(
+                    sparkle_bundle.SparkleBundleError,
+                    "must be a non-empty valid HTTPS endpoint",
+                ):
+                    sparkle_bundle.inspect_app_bundle(app_path, expected_info=expected, environment={})
+
+    def test_inspect_app_bundle_rejects_mismatched_support_diagnostics_endpoint(self) -> None:
+        expected = self.expected_info()
+        info = {
+            **expected,
+            "CFBundleIdentifier": "com.example.test",
+            "CFBundleShortVersionString": "0.3.0b3",
+            "LSMinimumSystemVersion": "11.0",
+            SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_app(Path(temp_dir), info)
+
+            with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "must exactly match the approved"):
+                sparkle_bundle.inspect_app_bundle(
+                    app_path,
+                    expected_info=expected,
+                    environment={SUPPORT_DIAGNOSTICS_ENDPOINT_ENV: "https://other-support.example"},
+                )
 
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -10,6 +10,14 @@ from unittest.mock import Mock, patch
 
 from scripts import briefcase_macos_signing, sparkle_bundle, sparkle_macos
 from scripts.native_app import SUPPORT_DIAGNOSTICS_ENDPOINT_ENV, SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY
+from scripts.production_identity import (
+    PRODUCTION_BUNDLE_IDENTIFIER,
+    PRODUCTION_DEVELOPER_IDENTITY,
+    PRODUCTION_DISTRIBUTION_CHANNEL,
+    PRODUCTION_FEED_URL,
+    PRODUCTION_SPARKLE_PUBLIC_KEY,
+    PRODUCTION_TEAM_ID,
+)
 
 
 def make_framework(root: Path, *, version: str = "2.9.4") -> Path:
@@ -282,19 +290,47 @@ class SparkleBundleTests(unittest.TestCase):
     def expected_info(self) -> dict[str, object]:
         return {
             "CFBundleVersion": "144",
-            "BDToAVPDistributionChannel": "direct",
-            "SUFeedURL": "https://example.invalid/appcast.xml",
-            "SUPublicEDKey": "public-key",
+            "BDToAVPDistributionChannel": PRODUCTION_DISTRIBUTION_CHANNEL,
+            "SUFeedURL": PRODUCTION_FEED_URL,
+            "SUPublicEDKey": PRODUCTION_SPARKLE_PUBLIC_KEY,
             "SUAllowsAutomaticUpdates": False,
             "SUVerifyUpdateBeforeExtraction": True,
         }
+
+    @patch("scripts.sparkle_bundle.subprocess.run")
+    def test_codesign_identity_requires_exact_production_authority_and_team(self, run_mock: Mock) -> None:
+        run_mock.return_value = Mock(
+            stdout="",
+            stderr=(
+                f"Authority={PRODUCTION_DEVELOPER_IDENTITY}\n"
+                "Authority=Developer ID Certification Authority\n"
+                f"TeamIdentifier={PRODUCTION_TEAM_ID}\n"
+            ),
+        )
+
+        sparkle_bundle._verify_codesign_identity(Path("Signed.app"), "Test app")
+
+        invalid_metadata = (
+            f"Authority=Developer ID Application: Other Company ({PRODUCTION_TEAM_ID})\n"
+            f"TeamIdentifier={PRODUCTION_TEAM_ID}\n"
+        )
+        run_mock.return_value = Mock(stdout="", stderr=invalid_metadata)
+        with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "signing authority must be"):
+            sparkle_bundle._verify_codesign_identity(Path("Signed.app"), "Test app")
+
+        run_mock.return_value = Mock(
+            stdout="",
+            stderr=f"Authority={PRODUCTION_DEVELOPER_IDENTITY}\nTeamIdentifier=ZZZZZ12345\n",
+        )
+        with self.assertRaisesRegex(sparkle_bundle.SparkleBundleError, "TeamIdentifier must be"):
+            sparkle_bundle._verify_codesign_identity(Path("Signed.app"), "Test app")
 
     def test_inspect_app_bundle_validates_metadata_and_layout(self) -> None:
         expected = self.expected_info()
         support_endpoint = "https://support.example"
         info = {
             **expected,
-            "CFBundleIdentifier": "com.example.test",
+            "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
             "CFBundleShortVersionString": "1.2.3rc1",
             "LSMinimumSystemVersion": "11.0",
             SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: support_endpoint,
@@ -320,7 +356,7 @@ class SparkleBundleTests(unittest.TestCase):
             with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
                 info = {
                     **expected,
-                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
                     "CFBundleShortVersionString": short_version,
                     "LSMinimumSystemVersion": "11.0",
                     SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
@@ -336,7 +372,7 @@ class SparkleBundleTests(unittest.TestCase):
         expected["CFBundleVersion"] = "1"
         info = {
             **expected,
-            "CFBundleIdentifier": "com.example.test",
+            "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
             "CFBundleShortVersionString": "1.2.3",
             "LSMinimumSystemVersion": "11.0",
         }
@@ -353,7 +389,7 @@ class SparkleBundleTests(unittest.TestCase):
                 expected["CFBundleVersion"] = build_version
                 info = {
                     **expected,
-                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
                     "CFBundleShortVersionString": "1.2.3",
                     "LSMinimumSystemVersion": "11.0",
                 }
@@ -367,7 +403,7 @@ class SparkleBundleTests(unittest.TestCase):
         info = {
             **expected,
             "CFBundleVersion": "145",
-            "CFBundleIdentifier": "com.example.test",
+            "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
             "CFBundleShortVersionString": "1.2.4rc1",
             "LSMinimumSystemVersion": "11.0",
             SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
@@ -391,7 +427,7 @@ class SparkleBundleTests(unittest.TestCase):
             with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
                 info = {
                     **expected,
-                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
                     "CFBundleShortVersionString": short_version,
                     "LSMinimumSystemVersion": "11.0",
                     SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
@@ -407,7 +443,7 @@ class SparkleBundleTests(unittest.TestCase):
             with self.subTest(short_version=short_version), tempfile.TemporaryDirectory() as temp_dir:
                 info = {
                     **expected,
-                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
                     "CFBundleShortVersionString": short_version,
                     "LSMinimumSystemVersion": "11.0",
                     SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",
@@ -421,7 +457,7 @@ class SparkleBundleTests(unittest.TestCase):
         expected = self.expected_info()
         info = {
             **expected,
-            "CFBundleIdentifier": "com.example.test",
+            "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
             "CFBundleShortVersionString": "0.3.0b3",
             "LSMinimumSystemVersion": "11.0",
         }
@@ -443,7 +479,7 @@ class SparkleBundleTests(unittest.TestCase):
             with self.subTest(endpoint=endpoint), tempfile.TemporaryDirectory() as temp_dir:
                 info = {
                     **expected,
-                    "CFBundleIdentifier": "com.example.test",
+                    "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
                     "CFBundleShortVersionString": "0.3.0b3",
                     "LSMinimumSystemVersion": "11.0",
                     SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: endpoint,
@@ -460,7 +496,7 @@ class SparkleBundleTests(unittest.TestCase):
         expected = self.expected_info()
         info = {
             **expected,
-            "CFBundleIdentifier": "com.example.test",
+            "CFBundleIdentifier": PRODUCTION_BUNDLE_IDENTIFIER,
             "CFBundleShortVersionString": "0.3.0b3",
             "LSMinimumSystemVersion": "11.0",
             SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: "https://support.example",

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -258,6 +258,82 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("KEYCHAIN_NAME", str(package))
         self.assertNotIn("SPARKLE_EDDSA_PRIVATE_KEY", str(package))
 
+    def test_certificate_install_binds_developer_id_identity_to_team_id(self) -> None:
+        workflow = load_release_engine()
+        package = workflow["jobs"]["package"]
+        certificate_step = next(
+            step for step in package["steps"] if step["name"] == "Install signing certificate in an ephemeral keychain"
+        )
+        certificate_script = certificate_step["run"]
+
+        self.assertEqual(certificate_step["env"]["TEAM_ID"], "${{ secrets.TEAM_ID }}")
+        self.assertIn('case "$TEAM_ID" in', certificate_script)
+        self.assertIn('if [ "${#TEAM_ID}" -ne 10 ]; then', certificate_script)
+        self.assertIn('DEV_ID_PREFIX="Developer ID Application: "', certificate_script)
+        self.assertIn('DEV_ID_SUFFIX=" ($TEAM_ID)"', certificate_script)
+        self.assertIn('DEV_ID_NAME=${DEV_ID#"$DEV_ID_PREFIX"}', certificate_script)
+        self.assertIn('DEV_ID_NAME=${DEV_ID_NAME%"$DEV_ID_SUFFIX"}', certificate_script)
+        self.assertIn('if [ -z "$DEV_ID_NAME" ]; then', certificate_script)
+        self.assertIn("$2 == identity", certificate_script)
+        self.assertNotIn('grep -F "$DEV_ID"', certificate_script)
+        self.assertLess(certificate_script.index('case "$TEAM_ID" in'), certificate_script.index("security import"))
+        self.assertLess(
+            certificate_script.index('DEV_ID_SUFFIX=" ($TEAM_ID)"'), certificate_script.index("security import")
+        )
+        self.assertLess(certificate_script.index("security import"), certificate_script.index("security find-identity"))
+
+        validation_script = certificate_script[
+            certificate_script.index('case "$TEAM_ID" in') : certificate_script.index("BUILD_KEYCHAIN_PASSWORD=")
+        ]
+        self._assert_signing_identity_validation(validation_script)
+
+    def test_package_inspects_signed_app_and_dmg_identity_metadata(self) -> None:
+        workflow = load_release_engine()
+        package = workflow["jobs"]["package"]
+        package_step = next(step for step in package["steps"] if step["name"] == "Package application for GitHub")
+        package_script = package_step["run"]
+
+        self.assertEqual(package_step["env"]["TEAM_ID"], "${{ secrets.TEAM_ID }}")
+        self.assertIn("verify_codesign_metadata()", package_script)
+        self.assertIn('codesign -dv --verbose=4 "$signed_path"', package_script)
+        self.assertIn('$1 == "Authority"', package_script)
+        self.assertIn('$1 == "TeamIdentifier"', package_script)
+        self.assertIn('[ "$signing_authority" != "$DEV_ID" ]', package_script)
+        self.assertIn('[ "$team_identifier" != "$TEAM_ID" ]', package_script)
+        self.assertIn("validate_signing_identity()", package_script)
+        self.assertLess(
+            package_script.index("git fetch --no-tags origin"), package_script.rindex("validate_signing_identity")
+        )
+        self.assertLess(
+            package_script.rindex("validate_signing_identity"), package_script.index("security unlock-keychain")
+        )
+
+        package_command_index = package_script.index("uv run python scripts/native_app.py package")
+        app_metadata_index = package_script.index('"$RUNNER_TEMP/bd-to-avp-app-codesign-$GITHUB_RUN_ID.txt"')
+        app_notary_index = package_script.index("--log dist/notary/app-notary.json")
+        dmg_sign_index = package_script.index('codesign --force --timestamp --sign "$DEV_ID"')
+        dmg_metadata_index = package_script.index('"$RUNNER_TEMP/bd-to-avp-dmg-codesign-$GITHUB_RUN_ID.txt"')
+        dmg_notary_index = package_script.index("--log dist/notary/dmg-notary.json")
+        self.assertLess(package_command_index, app_metadata_index)
+        self.assertLess(app_metadata_index, app_notary_index)
+        self.assertLess(dmg_sign_index, dmg_metadata_index)
+        self.assertLess(dmg_metadata_index, dmg_notary_index)
+
+        identity_validation = (
+            package_script[
+                package_script.index("validate_signing_identity() {") : package_script.index(
+                    "git fetch --no-tags origin"
+                )
+            ]
+            + "\nvalidate_signing_identity\n"
+        )
+        self._assert_signing_identity_validation(identity_validation)
+
+        metadata_validation = package_script[
+            package_script.index("verify_codesign_metadata() {") : package_script.index("validate_signing_identity() {")
+        ]
+        self._assert_codesign_metadata_validation(metadata_validation)
+
     def test_keychain_search_list_empty_array_branch_is_bash_3_2_safe(self) -> None:
         shell_script = (
             'set -u; keychains=(); if [ "${#keychains[@]}" -eq 0 ]; '
@@ -381,6 +457,118 @@ esac
             "snapshot": snapshot,
         }
         return result, state, paths
+
+    def _assert_signing_identity_validation(self, validation_script: str) -> None:
+        valid = self._run_release_shell_fragment(
+            validation_script,
+            {
+                "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
+                "TEAM_ID": "ABCDE12345",
+            },
+        )
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+
+        invalid_cases = [
+            ("", "Developer ID Application: Shiny Computers, LLC (ABCDE12345)"),
+            ("ABCDE1234", "Developer ID Application: Shiny Computers, LLC (ABCDE1234)"),
+            ("ABCDE12345", "Apple Distribution: Shiny Computers, LLC (ABCDE12345)"),
+            ("ABCDE12345", "Developer ID Application:  (ABCDE12345)"),
+            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ZZZZZ12345)"),
+            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ABCDE12345) extra"),
+            ("ABCDE12345", "prefix Developer ID Application: Shiny Computers, LLC (ABCDE12345)"),
+            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ABCDE12345) (ZZZZZ12345)"),
+        ]
+        for team_id, dev_id in invalid_cases:
+            with self.subTest(team_id=team_id, dev_id=dev_id):
+                result = self._run_release_shell_fragment(
+                    validation_script,
+                    {"DEV_ID": dev_id, "TEAM_ID": team_id},
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+    def _assert_codesign_metadata_validation(self, metadata_script: str) -> None:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        temporary_path = Path(temporary_directory.name)
+        metadata_path = temporary_path / "codesign.txt"
+        fake_bin = temporary_path / "bin"
+        fake_bin.mkdir()
+        fake_codesign = fake_bin / "codesign"
+        fake_codesign.write_text(
+            """#!/bin/bash
+set -eu
+printf '%s' "$CODESIGN_METADATA"
+""",
+            encoding="utf-8",
+        )
+        fake_codesign.chmod(0o755)
+        signed_path = temporary_path / "Signed.app"
+        signed_path.touch()
+        invocation = f'{metadata_script}\nverify_codesign_metadata "{signed_path}" "Test app" "{metadata_path}"\n'
+
+        valid_metadata = "".join(
+            [
+                "Executable=/tmp/Test.app/Contents/MacOS/Test\n",
+                "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n",
+                "Authority=Developer ID Certification Authority\n",
+                "TeamIdentifier=ABCDE12345\n",
+            ]
+        )
+        valid = self._run_release_shell_fragment(
+            invocation,
+            {
+                "CODESIGN_METADATA": valid_metadata,
+                "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "TEAM_ID": "ABCDE12345",
+            },
+        )
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+
+        invalid_cases = [
+            "TeamIdentifier=ABCDE12345\n",
+            "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n",
+            ("Authority=Developer ID Application: Other Company (ABCDE12345)\nTeamIdentifier=ABCDE12345\n"),
+            (
+                "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345) extra\n"
+                "TeamIdentifier=ABCDE12345\n"
+            ),
+            ("Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\nTeamIdentifier=ZZZZZ12345\n"),
+            (
+                "NotAuthority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n"
+                "NotTeamIdentifier=ABCDE12345\n"
+            ),
+        ]
+        for metadata in invalid_cases:
+            with self.subTest(metadata=metadata):
+                result = self._run_release_shell_fragment(
+                    invocation,
+                    {
+                        "CODESIGN_METADATA": metadata,
+                        "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
+                        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                        "TEAM_ID": "ABCDE12345",
+                    },
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+    def _run_release_shell_fragment(
+        self,
+        shell_script: str,
+        environment_overrides: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        temporary_path = Path(temporary_directory.name)
+        environment = {**os.environ, **environment_overrides}
+        return subprocess.run(
+            ["/bin/bash", "-c", shell_script],
+            cwd=temporary_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
     def test_release_is_draft_until_assets_are_redownloaded_and_verified(self) -> None:
         workflow = load_release_engine()

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -30,6 +30,14 @@ def load_release_engine() -> dict:
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_ci_fetches_full_history_for_recovery_provenance(self) -> None:
+        workflow = load_workflow("ci.yml")
+        checkout = workflow["jobs"]["validate"]["steps"][0]
+
+        self.assertEqual(checkout["uses"], "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0")
+        self.assertEqual(checkout["with"]["fetch-depth"], "0")
+        self.assertEqual(checkout["with"]["persist-credentials"], "false")
+
     def test_sparkle_bundle_uses_importable_module_entrypoint(self) -> None:
         workflow = load_release_engine()
         workflow_text = str(workflow)

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -8,6 +8,8 @@ import unittest
 
 from pathlib import Path
 
+from scripts.production_identity import PRODUCTION_DEVELOPER_IDENTITY, PRODUCTION_TEAM_ID
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 yaml = importlib.import_module("yaml")
@@ -108,8 +110,15 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("secrets", release)
         self.assertEqual(
             release["permissions"],
-            {"attestations": "write", "contents": "write", "id-token": "write", "pages": "write"},
+            {
+                "actions": "read",
+                "attestations": "write",
+                "contents": "write",
+                "id-token": "write",
+                "pages": "write",
+            },
         )
+        self.assertEqual(workflow["permissions"], {"actions": "read", "contents": "read"})
         self.assertEqual(release["with"]["release_sha"], "${{ github.sha }}")
         self.assertEqual(release["with"]["operator_workflow_ref"], "${{ github.workflow_ref }}")
         self.assertEqual(release["with"]["operator_workflow_sha"], "${{ github.workflow_sha }}")
@@ -160,13 +169,15 @@ class ReleaseWorkflowTests(unittest.TestCase):
             step for step in prepare["steps"] if step["name"] == "Validate route and summarize publication effects"
         )
 
-        self.assertIn("python scripts/release.py metadata", str(prepare))
+        self.assertIn("python -m scripts.release metadata", str(prepare))
+        self.assertEqual(prepare["permissions"], {"actions": "read", "contents": "write"})
         self.assertIn("release_workflow_policy.py metadata", route_validation["run"])
         self.assertIn("$GITHUB_STEP_SUMMARY", route_validation["run"])
         self.assertEqual(
             route_validation["env"]["RELEASE_OPERATOR_WORKFLOW_REF"],
             "${{ needs.policy.outputs.operator_workflow_ref }}",
         )
+        self.assertEqual(route_validation["env"]["RELEASE_TAG"], "${{ steps.metadata.outputs.release_tag }}")
         self.assertEqual(route_validation["env"]["RELEASE_CHANNEL"], "${{ steps.metadata.outputs.channel }}")
         self.assertNotIn("RELEASE_ROUTE", route_validation["env"])
         self.assertNotIn("awk -v version", str(workflow))
@@ -175,7 +186,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("dmg_name", prepare["outputs"])
         self.assertIn("publish_pypi", prepare["outputs"])
         self.assertIn("previous_release_tag", prepare["outputs"])
-        self.assertIn("python scripts/release.py notes-base", str(release_history))
+        self.assertIn("python -m scripts.release notes-base", str(release_history))
         self.assertIn("check-release", str(prepare))
         self.assertNotIn("sort_by(.published_at)", str(release_history))
         self.assertNotIn("git merge-base --is-ancestor", str(release_history))
@@ -187,6 +198,51 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("${LATEST_SNAPSHOT_TAG#v}", str(prepare))
         self.assertIn('--release-tag "$BASE_SNAPSHOT_TAG"', str(prepare))
         self.assertIn('--release-tag "$LATEST_SNAPSHOT_TAG"', str(prepare))
+
+    def test_beta3_publication_is_frozen_before_any_release_construction(self) -> None:
+        workflow = load_release_engine()
+        prepare_steps = workflow["jobs"]["prepare"]["steps"]
+        step_names = [step["name"] for step in prepare_steps]
+        freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(freeze_policy["schema"], "bd_to_avp.release_freezes")
+        self.assertEqual(freeze_policy["frozen_release_tags"]["v0.3.0-beta.3"]["issue"], 294)
+        self.assertLess(
+            step_names.index("Validate route and summarize publication effects"),
+            step_names.index("Reject existing release identity"),
+        )
+        recovery_step = next(step for step in prepare_steps if step["name"] == "Revalidate Beta 3 recovery premise")
+        self.assertEqual(recovery_step["if"], "steps.metadata.outputs.release_tag == 'v0.3.0-beta.3'")
+        self.assertIn("--allow-beta3-draft", recovery_step["run"])
+        self.assertIn('--expected-sha "$GITHUB_SHA"', recovery_step["run"])
+
+    def test_every_release_artifact_inspection_pins_the_diagnostics_endpoint(self) -> None:
+        workflow = load_release_engine()
+        inspections = (
+            (
+                workflow["jobs"]["package"],
+                "Package application for GitHub",
+            ),
+            (
+                workflow["jobs"]["compatibility"],
+                "Validate the packaged app on macOS 26",
+            ),
+            (
+                workflow["jobs"]["publish-appcast"],
+                "Inspect draft DMG",
+            ),
+            (
+                workflow["jobs"]["verify-draft"],
+                "Re-download and verify every release boundary",
+            ),
+        )
+        for job, step_name in inspections:
+            with self.subTest(step=step_name):
+                step = next(step for step in job["steps"] if step["name"] == step_name)
+                self.assertEqual(
+                    step["env"]["BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT"],
+                    "${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}",
+                )
 
     def test_package_preserves_dmg_validation_without_write_token(self) -> None:
         workflow = load_release_engine()
@@ -267,6 +323,8 @@ class ReleaseWorkflowTests(unittest.TestCase):
         certificate_script = certificate_step["run"]
 
         self.assertEqual(certificate_step["env"]["TEAM_ID"], "${{ secrets.TEAM_ID }}")
+        self.assertEqual(certificate_step["env"]["PRODUCTION_TEAM_ID"], PRODUCTION_TEAM_ID)
+        self.assertEqual(certificate_step["env"]["PRODUCTION_DEV_ID"], PRODUCTION_DEVELOPER_IDENTITY)
         self.assertIn('case "$TEAM_ID" in', certificate_script)
         self.assertIn('if [ "${#TEAM_ID}" -ne 10 ]; then', certificate_script)
         self.assertIn('DEV_ID_PREFIX="Developer ID Application: "', certificate_script)
@@ -294,12 +352,14 @@ class ReleaseWorkflowTests(unittest.TestCase):
         package_script = package_step["run"]
 
         self.assertEqual(package_step["env"]["TEAM_ID"], "${{ secrets.TEAM_ID }}")
+        self.assertEqual(package_step["env"]["PRODUCTION_TEAM_ID"], PRODUCTION_TEAM_ID)
+        self.assertEqual(package_step["env"]["PRODUCTION_DEV_ID"], PRODUCTION_DEVELOPER_IDENTITY)
         self.assertIn("verify_codesign_metadata()", package_script)
         self.assertIn('codesign -dv --verbose=4 "$signed_path"', package_script)
         self.assertIn('$1 == "Authority"', package_script)
         self.assertIn('$1 == "TeamIdentifier"', package_script)
         self.assertIn('[ "$signing_authority" != "$DEV_ID" ]', package_script)
-        self.assertIn('[ "$team_identifier" != "$TEAM_ID" ]', package_script)
+        self.assertIn('[ "$team_identifier" != "$PRODUCTION_TEAM_ID" ]', package_script)
         self.assertIn("validate_signing_identity()", package_script)
         self.assertLess(
             package_script.index("git fetch --no-tags origin"), package_script.rindex("validate_signing_identity")
@@ -462,27 +522,34 @@ esac
         valid = self._run_release_shell_fragment(
             validation_script,
             {
-                "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
-                "TEAM_ID": "ABCDE12345",
+                "DEV_ID": PRODUCTION_DEVELOPER_IDENTITY,
+                "PRODUCTION_DEV_ID": PRODUCTION_DEVELOPER_IDENTITY,
+                "PRODUCTION_TEAM_ID": PRODUCTION_TEAM_ID,
+                "TEAM_ID": PRODUCTION_TEAM_ID,
             },
         )
         self.assertEqual(valid.returncode, 0, valid.stderr)
 
         invalid_cases = [
-            ("", "Developer ID Application: Shiny Computers, LLC (ABCDE12345)"),
-            ("ABCDE1234", "Developer ID Application: Shiny Computers, LLC (ABCDE1234)"),
-            ("ABCDE12345", "Apple Distribution: Shiny Computers, LLC (ABCDE12345)"),
-            ("ABCDE12345", "Developer ID Application:  (ABCDE12345)"),
-            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ZZZZZ12345)"),
-            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ABCDE12345) extra"),
-            ("ABCDE12345", "prefix Developer ID Application: Shiny Computers, LLC (ABCDE12345)"),
-            ("ABCDE12345", "Developer ID Application: Shiny Computers, LLC (ABCDE12345) (ZZZZZ12345)"),
+            ("", PRODUCTION_DEVELOPER_IDENTITY),
+            ("ABCDE1234", "Developer ID Application: Shiny Computers Leasing LLC (ABCDE1234)"),
+            (PRODUCTION_TEAM_ID, f"Apple Distribution: Shiny Computers Leasing LLC ({PRODUCTION_TEAM_ID})"),
+            (PRODUCTION_TEAM_ID, f"Developer ID Application:  ({PRODUCTION_TEAM_ID})"),
+            (PRODUCTION_TEAM_ID, "Developer ID Application: Shiny Computers Leasing LLC (ZZZZZ12345)"),
+            (PRODUCTION_TEAM_ID, f"{PRODUCTION_DEVELOPER_IDENTITY} extra"),
+            (PRODUCTION_TEAM_ID, f"prefix {PRODUCTION_DEVELOPER_IDENTITY}"),
+            (PRODUCTION_TEAM_ID, f"{PRODUCTION_DEVELOPER_IDENTITY} (ZZZZZ12345)"),
         ]
         for team_id, dev_id in invalid_cases:
             with self.subTest(team_id=team_id, dev_id=dev_id):
                 result = self._run_release_shell_fragment(
                     validation_script,
-                    {"DEV_ID": dev_id, "TEAM_ID": team_id},
+                    {
+                        "DEV_ID": dev_id,
+                        "PRODUCTION_DEV_ID": PRODUCTION_DEVELOPER_IDENTITY,
+                        "PRODUCTION_TEAM_ID": PRODUCTION_TEAM_ID,
+                        "TEAM_ID": team_id,
+                    },
                 )
                 self.assertNotEqual(result.returncode, 0)
 
@@ -509,35 +576,32 @@ printf '%s' "$CODESIGN_METADATA"
         valid_metadata = "".join(
             [
                 "Executable=/tmp/Test.app/Contents/MacOS/Test\n",
-                "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n",
+                f"Authority={PRODUCTION_DEVELOPER_IDENTITY}\n",
                 "Authority=Developer ID Certification Authority\n",
-                "TeamIdentifier=ABCDE12345\n",
+                f"TeamIdentifier={PRODUCTION_TEAM_ID}\n",
             ]
         )
         valid = self._run_release_shell_fragment(
             invocation,
             {
                 "CODESIGN_METADATA": valid_metadata,
-                "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
+                "DEV_ID": PRODUCTION_DEVELOPER_IDENTITY,
                 "PATH": f"{fake_bin}:{os.environ['PATH']}",
-                "TEAM_ID": "ABCDE12345",
+                "PRODUCTION_TEAM_ID": PRODUCTION_TEAM_ID,
             },
         )
         self.assertEqual(valid.returncode, 0, valid.stderr)
 
         invalid_cases = [
-            "TeamIdentifier=ABCDE12345\n",
-            "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n",
-            ("Authority=Developer ID Application: Other Company (ABCDE12345)\nTeamIdentifier=ABCDE12345\n"),
+            f"TeamIdentifier={PRODUCTION_TEAM_ID}\n",
+            f"Authority={PRODUCTION_DEVELOPER_IDENTITY}\n",
             (
-                "Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345) extra\n"
-                "TeamIdentifier=ABCDE12345\n"
+                f"Authority=Developer ID Application: Other Company ({PRODUCTION_TEAM_ID})\n"
+                f"TeamIdentifier={PRODUCTION_TEAM_ID}\n"
             ),
-            ("Authority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\nTeamIdentifier=ZZZZZ12345\n"),
-            (
-                "NotAuthority=Developer ID Application: Shiny Computers, LLC (ABCDE12345)\n"
-                "NotTeamIdentifier=ABCDE12345\n"
-            ),
+            (f"Authority={PRODUCTION_DEVELOPER_IDENTITY} extra\nTeamIdentifier={PRODUCTION_TEAM_ID}\n"),
+            (f"Authority={PRODUCTION_DEVELOPER_IDENTITY}\nTeamIdentifier=ZZZZZ12345\n"),
+            (f"NotAuthority={PRODUCTION_DEVELOPER_IDENTITY}\nNotTeamIdentifier={PRODUCTION_TEAM_ID}\n"),
         ]
         for metadata in invalid_cases:
             with self.subTest(metadata=metadata):
@@ -545,9 +609,9 @@ printf '%s' "$CODESIGN_METADATA"
                     invocation,
                     {
                         "CODESIGN_METADATA": metadata,
-                        "DEV_ID": "Developer ID Application: Shiny Computers, LLC (ABCDE12345)",
+                        "DEV_ID": PRODUCTION_DEVELOPER_IDENTITY,
                         "PATH": f"{fake_bin}:{os.environ['PATH']}",
-                        "TEAM_ID": "ABCDE12345",
+                        "PRODUCTION_TEAM_ID": PRODUCTION_TEAM_ID,
                     },
                 )
                 self.assertNotEqual(result.returncode, 0)

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0rc1"
+version = "0.3.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- recover the unpublished RC1 metadata to production Beta 3 (`0.3.0b3` / `v0.3.0-beta.3`) at global build `148`
- pin the production bundle, feed, Sparkle key, Developer ID authority/team, and diagnostics identity across packaging and verification
- add digest-pinned live recovery evidence, durable multi-file transaction recovery, source-byte binding, and a machine-enforced publication freeze owned by #294
- invoke release tooling as modules and grant only the Actions/draft visibility permissions needed by preflight

## Safety
- recovery machinery and commit-point hardening precede the fresh evidence receipt
- the sole RC1-to-Beta3 metadata transition is the final commit
- recovery performs an initial live scan and a second scan immediately before the durable commit marker, then rechecks every target byte
- this PR cannot dispatch or publish Beta 3; `.github/release-freezes.json` blocks the tag until #294 removes the freeze through protected main

## Validation
- 756 Python tests passed (2 skipped)
- 225 native macOS tests passed
- Ruff lint and format checks passed
- mypy passed for 37 source files
- Actionlint passed for all changed workflows
- Python wheel and sdist built for `0.3.0b3`
- release metadata and live remote-evidence verification passed
- independent final review: no blockers found

Closes #293