### PR TITLE
Authorize guarded Beta 3 publication

### DIFF
--- a/.github/release-freezes.json
+++ b/.github/release-freezes.json
@@ -1,10 +1,5 @@
 {
   "schema": "bd_to_avp.release_freezes",
   "schema_version": 1,
-  "frozen_release_tags": {
-    "v0.3.0-beta.3": {
-      "issue": 294,
-      "reason": "Publication remains frozen until issue #294 removes this entry through protected-main review."
-    }
-  }
+  "frozen_release_tags": {}
 }

--- a/docs/0.3.0-beta.3-cut-packet.md
+++ b/docs/0.3.0-beta.3-cut-packet.md
@@ -104,12 +104,10 @@ drift, and reruns fail closed.
 
 ## Issue 294 Boundary
 
-After this metadata slice merges, issue #294 must independently require green
-exact-SHA post-merge CI and CodeQL before it dispatches the guarded
-`Prerelease` workflow. Only #294 may request or apply `macos-signing` approval,
-use signing or notarization credentials, create or publish release artifacts,
-append the cumulative appcast, deploy Pages, or make any public-artifact claim.
-Issue #293 performs none of those actions. The committed
-`.github/release-freezes.json` entry blocks `v0.3.0-beta.3` before package or
-release construction; #294 must remove that exact entry through protected-main
-review before dispatch.
+Issue #294 has removed the `v0.3.0-beta.3` entry from
+`.github/release-freezes.json` through protected-main review. It must still
+require green exact-SHA post-merge CI and CodeQL for the unfreeze merge before
+dispatching the guarded `Prerelease` workflow. Only #294 may request or apply
+`macos-signing` approval, use signing or notarization credentials, create or
+publish release artifacts, append the cumulative appcast, deploy Pages, or make
+any public-artifact claim. Issue #293 performs none of those actions.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -14,9 +14,10 @@ that any Beta 3 public artifact exists.
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Publication remains frozen for issue #294,
-which exclusively owns the exact-SHA dispatch, approval, signing, publication,
-and verification work.
+implemented and regression-covered. Issue #294 has authorized publication by
+removing the Beta 3 release-freeze entry through protected-main review and now
+exclusively owns the exact-SHA dispatch, approval, signing, publication, and
+verification work.
 
 ## Release Preparation
 
@@ -69,19 +70,17 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Release publication is frozen.** The repository metadata is the reviewed
-> `0.3.0b3` build `148` target and build `147` remains permanently burned. Do
-> not dispatch `Stable` or `Prerelease`, request environment approval, sign,
-> publish, or mutate the feed or Pages under this metadata-recovery work. Issue
-> #294 exclusively owns those actions after exact-SHA post-merge gates pass.
-> No Beta 3 public artifact is claimed by issue #293. The committed
-> `.github/release-freezes.json` entry makes the shared engine reject
-> `v0.3.0-beta.3` before package or release construction until #294 removes it
-> through protected-main review.
+> **Beta 3 publication is authorized only through issue #294.** The repository
+> metadata is the reviewed `0.3.0b3` build `148` target and build `147` remains
+> permanently burned. The Beta 3 entry has been removed from
+> `.github/release-freezes.json` through protected-main review. Do not dispatch
+> until the exact unfreeze merge SHA has green post-merge CI and CodeQL. Only
+> the guarded `Prerelease` workflow may request `macos-signing` approval, sign,
+> publish, append the cumulative appcast, or deploy Pages for this release.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,
-after the release freeze above has been lifted. The only optional input to
+after any applicable release-freeze entry has been lifted. The only optional input to
 either workflow is release-note text. There is no route or mode override: the
 committed project version determines the public release tag/title and DMG name,
 Latest behavior, Sparkle channel, and whether PyPI is published. A workflow and

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -7,12 +7,11 @@ closed when it cannot satisfy this contract.
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
 this four-route contract. The exact Beta 3 metadata migration and bootstrap are
-complete at `0.3.0b3` build `148`, with build `147` permanently burned.
-Publication remains frozen: issue #294 exclusively owns exact-SHA dispatch,
-approval, signing, publication, and public verification. The recovery work
-makes no public-artifact claim. `.github/release-freezes.json` rejects the Beta
-3 tag before package or release construction until #294 removes that entry
-through protected-main review.
+complete at `0.3.0b3` build `148`, with build `147` permanently burned. Issue
+#294 has removed the Beta 3 release-freeze entry through protected-main review
+and exclusively owns exact-SHA dispatch, approval, signing, publication, and
+public verification. No public-artifact claim exists until that guarded flow
+completes and its public state is independently verified.
 
 ## Production Identity
 

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -293,7 +293,7 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
         self.assertIn("| GitHub Latest | No |", summary)
         self.assertIn("| PyPI publication | No |", summary)
 
-    def test_beta3_is_frozen_until_issue_294_removes_the_policy_entry(self) -> None:
+    def test_beta3_unfreeze_allows_metadata_while_freeze_entries_fail_closed(self) -> None:
         environment = valid_metadata_environment(
             PRERELEASE_WORKFLOW_NAME,
             release_tag="v0.3.0-beta.3",
@@ -303,8 +303,8 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
             publish_pypi="false",
         )
 
-        with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #294"):
-            validate_release_metadata(environment)
+        metadata = validate_release_metadata(environment)
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             freezes_path = Path(temporary_directory) / "release-freezes.json"
@@ -313,15 +313,19 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
                     {
                         "schema": "bd_to_avp.release_freezes",
                         "schema_version": 1,
-                        "frozen_release_tags": {},
+                        "frozen_release_tags": {
+                            "v0.3.0-beta.3": {
+                                "issue": 294,
+                                "reason": "test freeze",
+                            }
+                        },
                     }
                 ),
                 encoding="utf-8",
             )
 
-            metadata = validate_release_metadata(environment, freezes_path=freezes_path)
-
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
+            with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #294"):
+                validate_release_metadata(environment, freezes_path=freezes_path)
 
     @patch("scripts.release_workflow_policy.urlopen")
     def test_engine_identity_is_loaded_from_github_oidc_claims(self, urlopen_mock: Mock) -> None:

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -207,14 +207,14 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('--release-tag "$BASE_SNAPSHOT_TAG"', str(prepare))
         self.assertIn('--release-tag "$LATEST_SNAPSHOT_TAG"', str(prepare))
 
-    def test_beta3_publication_is_frozen_before_any_release_construction(self) -> None:
+    def test_beta3_unfreeze_retains_release_preflight_guards(self) -> None:
         workflow = load_release_engine()
         prepare_steps = workflow["jobs"]["prepare"]["steps"]
         step_names = [step["name"] for step in prepare_steps]
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
 
         self.assertEqual(freeze_policy["schema"], "bd_to_avp.release_freezes")
-        self.assertEqual(freeze_policy["frozen_release_tags"]["v0.3.0-beta.3"]["issue"], 294)
+        self.assertEqual(freeze_policy["frozen_release_tags"], {})
         self.assertLess(
             step_names.index("Validate route and summarize publication effects"),
             step_names.index("Reject existing release identity"),


### PR DESCRIPTION
## Summary
- remove only the `v0.3.0-beta.3` entry from the committed release-freeze policy
- retain the generic fail-closed freeze mechanism and all exact-SHA, live-evidence, draft, signing, notarization, appcast, and publication guards
- update the release docs from metadata-recovery state to the active issue #294 publication boundary

## Safety
- this PR does not dispatch a workflow, request signing approval, create a draft, publish an asset, mutate Pages, or touch PyPI
- the guarded `Prerelease` workflow remains the only publication entrypoint
- dispatch is permitted only after this PR's exact merge SHA has green post-merge CI and CodeQL
- `macos-signing` human approval remains mandatory before certificate, notarization, or signing credential use

## Validation
- 44 targeted release-policy/workflow tests passed
- Ruff lint and format checks passed
- live Beta 3 evidence/publication preflight passed against protected main
- independent release-safety review found no blockers

Refs #294