### PR TITLE
Allow exact Actions token in Beta 3 recovery preflight

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -319,6 +319,7 @@ jobs:
         run: >-
           python -m scripts.beta3_recovery_evidence
           --allow-beta3-draft
+          --allow-github-actions-contents-write-token
           --expected-sha "$GITHUB_SHA"
 
       - name: Resolve channel-aware base for generated notes

--- a/scripts/beta3_recovery_evidence.py
+++ b/scripts/beta3_recovery_evidence.py
@@ -26,6 +26,8 @@ PAGES_APPCAST_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 MAX_REMOTE_BODY_BYTES = 16 * 1024 * 1024
 ALLOWED_REMOTE_HOSTS = frozenset({"api.github.com", "pypi.org", "cbusillo.github.io"})
+PRODUCTION_REPOSITORY = "cbusillo/BD_to_AVP"
+PRERELEASE_WORKFLOW_REF = f"{PRODUCTION_REPOSITORY}/.github/workflows/prerelease.yml@refs/heads/main"
 
 
 class Beta3RecoveryEvidenceError(RuntimeError):
@@ -264,7 +266,13 @@ def _expect_fields(actual: Mapping[str, Any], expected: Mapping[str, Any], descr
         raise Beta3RecoveryEvidenceError(f"{description} mismatch: {', '.join(mismatches)}")
 
 
-def _verify_repository_identity(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
+def _verify_repository_identity(
+    fetcher: RemoteFetcher,
+    repository: str,
+    evidence: Mapping[str, Any],
+    *,
+    allow_github_actions_contents_write_token: bool,
+) -> None:
     expected = _mapping(evidence.get("repository_identity"), "Repository identity")
     actual = _mapping(
         _json_response(fetcher, f"{GITHUB_API_ROOT}/repos/{repository}", "GitHub repository identity"),
@@ -272,10 +280,33 @@ def _verify_repository_identity(fetcher: RemoteFetcher, repository: str, evidenc
     )
     _expect_fields(actual, expected, "GitHub repository identity")
     permissions = _mapping(actual.get("permissions"), "GitHub repository token permissions")
-    if permissions.get("push") is not True:
+    if permissions.get("push") is not True and not allow_github_actions_contents_write_token:
         raise Beta3RecoveryEvidenceError(
             "GitHub repository token must have push visibility so draft-release absence is authoritative."
         )
+
+
+def _validate_github_actions_publication_context(repository: str, expected_sha: str | None) -> None:
+    expected_context = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_REPOSITORY": PRODUCTION_REPOSITORY,
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_SHA": expected_sha,
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_WORKFLOW_REF": PRERELEASE_WORKFLOW_REF,
+        "GITHUB_ACTOR": "shiny-code-bot",
+        "GITHUB_TRIGGERING_ACTOR": "shiny-code-bot",
+    }
+    mismatches = [
+        f"{name}={os.environ.get(name)!r}, expected {expected!r}"
+        for name, expected in expected_context.items()
+        if os.environ.get(name) != expected
+    ]
+    if repository != PRODUCTION_REPOSITORY:
+        mismatches.append(f"repository={repository!r}, expected {PRODUCTION_REPOSITORY!r}")
+    if mismatches:
+        raise Beta3RecoveryEvidenceError("GitHub Actions publication context mismatch: " + ", ".join(mismatches))
 
 
 def _verify_failed_run(fetcher: RemoteFetcher, repository: str, evidence: Mapping[str, Any]) -> None:
@@ -604,6 +635,7 @@ def verify_beta3_remote_state(
     fetcher: RemoteFetcher = fetch_remote,
     allow_beta3_draft: bool = False,
     expected_sha: str | None = None,
+    allow_github_actions_contents_write_token: bool = False,
 ) -> None:
     repository = _string(evidence, "repository", "Beta 3 recovery evidence")
     valid_expected_sha = (
@@ -613,7 +645,18 @@ def verify_beta3_remote_state(
     )
     if allow_beta3_draft and not valid_expected_sha:
         raise Beta3RecoveryEvidenceError("Expected protected-main SHA must be a full lowercase Git SHA.")
-    _verify_repository_identity(fetcher, repository, evidence)
+    if allow_github_actions_contents_write_token:
+        if not allow_beta3_draft:
+            raise Beta3RecoveryEvidenceError(
+                "GitHub Actions contents-write token allowance is valid only for publication preflight."
+            )
+        _validate_github_actions_publication_context(repository, expected_sha)
+    _verify_repository_identity(
+        fetcher,
+        repository,
+        evidence,
+        allow_github_actions_contents_write_token=allow_github_actions_contents_write_token,
+    )
     _verify_failed_run(fetcher, repository, evidence)
     _verify_release_absence(
         fetcher,
@@ -630,6 +673,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Verify the live remote premises for the Beta 3 recovery.")
     parser.add_argument("--evidence", type=Path, default=BETA3_RECOVERY_EVIDENCE_PATH)
     parser.add_argument("--allow-beta3-draft", action="store_true")
+    parser.add_argument("--allow-github-actions-contents-write-token", action="store_true")
     parser.add_argument("--expected-sha")
     return parser
 
@@ -638,11 +682,14 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.allow_beta3_draft and not args.expected_sha:
         raise Beta3RecoveryEvidenceError("--expected-sha is required with --allow-beta3-draft.")
+    if args.allow_github_actions_contents_write_token and not args.allow_beta3_draft:
+        raise Beta3RecoveryEvidenceError("--allow-github-actions-contents-write-token requires --allow-beta3-draft.")
     evidence = load_beta3_recovery_evidence(args.evidence)
     verify_beta3_remote_state(
         evidence,
         allow_beta3_draft=args.allow_beta3_draft,
         expected_sha=args.expected_sha,
+        allow_github_actions_contents_write_token=args.allow_github_actions_contents_write_token,
     )
     print(
         json.dumps(

--- a/tests/test_beta3_recovery_evidence.py
+++ b/tests/test_beta3_recovery_evidence.py
@@ -1,16 +1,36 @@
 import copy
 import json
+import os
 import tempfile
 import unittest
 
 from pathlib import Path
+from unittest.mock import patch
 from urllib.parse import quote
 
 from scripts import beta3_recovery_evidence as recovery_evidence
 
 
+EXPECTED_PRODUCTION_REPOSITORY = "cbusillo/BD_to_AVP"
+EXPECTED_PRERELEASE_WORKFLOW_REF = "cbusillo/BD_to_AVP/.github/workflows/prerelease.yml@refs/heads/main"
+
+
 def json_response(value: object) -> recovery_evidence.RemoteResponse:
     return recovery_evidence.RemoteResponse(status=200, body=json.dumps(value).encode("utf-8"))
+
+
+def github_actions_publication_environment(expected_sha: str) -> dict[str, str]:
+    return {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_REPOSITORY": EXPECTED_PRODUCTION_REPOSITORY,
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_SHA": expected_sha,
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_WORKFLOW_REF": EXPECTED_PRERELEASE_WORKFLOW_REF,
+        "GITHUB_ACTOR": "shiny-code-bot",
+        "GITHUB_TRIGGERING_ACTOR": "shiny-code-bot",
+    }
 
 
 class FakeFetcher:
@@ -141,6 +161,8 @@ class Beta3RecoveryEvidenceTests(unittest.TestCase):
         self.evidence = recovery_evidence.load_beta3_recovery_evidence()
 
     def test_reviewed_receipt_and_appcast_capture_are_digest_pinned(self) -> None:
+        self.assertEqual(recovery_evidence.PRODUCTION_REPOSITORY, EXPECTED_PRODUCTION_REPOSITORY)
+        self.assertEqual(recovery_evidence.PRERELEASE_WORKFLOW_REF, EXPECTED_PRERELEASE_WORKFLOW_REF)
         self.assertEqual(self.evidence["schema_version"], 2)
         self.assertEqual(self.evidence["repository_identity"]["id"], 771225421)
         self.assertEqual(self.evidence["pages"]["release_tag"], "v0.2.143")
@@ -183,6 +205,65 @@ class Beta3RecoveryEvidenceTests(unittest.TestCase):
             "push visibility",
         ):
             recovery_evidence.verify_beta3_remote_state(self.evidence, fetcher=FakeFetcher(responses))
+
+    def test_github_actions_contents_write_token_can_prove_draft_absence(self) -> None:
+        expected_sha = "a" * 40
+        responses = make_responses(self.evidence)
+        repository = str(self.evidence["repository"])
+        repository_url = f"{recovery_evidence.GITHUB_API_ROOT}/repos/{repository}"
+        repository_identity = json.loads(responses[repository_url].body)
+        repository_identity["permissions"] = {"push": False}
+        responses[repository_url] = json_response(repository_identity)
+
+        with patch.dict(os.environ, github_actions_publication_environment(expected_sha), clear=True):
+            recovery_evidence.verify_beta3_remote_state(
+                self.evidence,
+                fetcher=FakeFetcher(responses),
+                allow_beta3_draft=True,
+                expected_sha=expected_sha,
+                allow_github_actions_contents_write_token=True,
+            )
+
+    def test_github_actions_token_allowance_rejects_context_drift(self) -> None:
+        expected_sha = "a" * 40
+        expected_environment = github_actions_publication_environment(expected_sha)
+        for name in expected_environment:
+            for change in ("changed", "missing"):
+                with self.subTest(name=name, change=change):
+                    environment = dict(expected_environment)
+                    if change == "changed":
+                        environment[name] = "__wrong__"
+                    else:
+                        del environment[name]
+                    with patch.dict(os.environ, environment, clear=True):
+                        with self.assertRaisesRegex(
+                            recovery_evidence.Beta3RecoveryEvidenceError,
+                            "publication context mismatch",
+                        ):
+                            recovery_evidence.verify_beta3_remote_state(
+                                self.evidence,
+                                fetcher=FakeFetcher(make_responses(self.evidence)),
+                                allow_beta3_draft=True,
+                                expected_sha=expected_sha,
+                                allow_github_actions_contents_write_token=True,
+                            )
+
+    def test_github_actions_token_allowance_requires_publication_preflight(self) -> None:
+        with self.assertRaisesRegex(
+            recovery_evidence.Beta3RecoveryEvidenceError,
+            "valid only for publication preflight",
+        ):
+            recovery_evidence.verify_beta3_remote_state(
+                self.evidence,
+                fetcher=FakeFetcher(make_responses(self.evidence)),
+                allow_github_actions_contents_write_token=True,
+            )
+
+        with self.assertRaisesRegex(
+            recovery_evidence.Beta3RecoveryEvidenceError,
+            "requires --allow-beta3-draft",
+        ):
+            recovery_evidence.main(["--allow-github-actions-contents-write-token"])
 
     def test_live_remote_verifier_rejects_new_tag_or_artifact_state(self) -> None:
         repository = str(self.evidence["repository"])

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -221,7 +221,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
         )
         recovery_step = next(step for step in prepare_steps if step["name"] == "Revalidate Beta 3 recovery premise")
         self.assertEqual(recovery_step["if"], "steps.metadata.outputs.release_tag == 'v0.3.0-beta.3'")
+        self.assertEqual(recovery_step["env"]["GH_TOKEN"], "${{ github.token }}")
         self.assertIn("--allow-beta3-draft", recovery_step["run"])
+        self.assertIn("--allow-github-actions-contents-write-token", recovery_step["run"])
         self.assertIn('--expected-sha "$GITHUB_SHA"', recovery_step["run"])
 
     def test_every_release_artifact_inspection_pins_the_diagnostics_endpoint(self) -> None:


### PR DESCRIPTION
## Summary
- allow the Beta 3 recovery verifier to accept GitHub's contents-write workflow token even when the repository identity endpoint reports `permissions.push=false`
- scope that allowance to the exact protected-main Prerelease `workflow_dispatch` context and `shiny-code-bot` actor
- preserve strict local/default verification and test every required context field for changed and missing values

## Why
Prerelease run `29720853589` failed safely before signing or publication because the Actions token could not satisfy the repository `permissions.push` visibility probe, despite the prepare job having `contents: write`. This change relaxes only that unreliable signal; all repository identity, draft/tag/artifact/feed, exact-SHA, workflow, branch-protection, and actor checks remain enforced.

## Validation
- `uv run --locked python -m unittest discover` — 760 passed, 2 skipped
- focused recovery/workflow tests — 35 passed
- Ruff check and format check
- Actionlint
- `git diff --check`
- live recovery verifier against protected-main SHA `dac41ccc3b67a834840a239656a5b50c90ce8ca2`
- independent release-security review: no blockers

Unblocks the next publication attempt for #294.