### PR TITLE
Fix diagnostic process identifier redaction

### DIFF
--- a/docs/native-support-bundle-v1.md
+++ b/docs/native-support-bundle-v1.md
@@ -53,12 +53,14 @@ bytes.
 - `batch`: Queue kind, total/active counts, and counts by status. Item IDs,
   source names, and output names are omitted.
 - `files`: Entry names, uncompressed byte counts, and truncation flags.
-- `truncation`: Original, retained, history-dropped, archive-dropped, and
-  field-truncated counts/bytes for each bounded stream.
+- `truncation`: Original, retained, history-dropped, boundary-dropped,
+  archive-dropped, and field-truncated counts/bytes for each bounded stream.
 - `privacy`: Human-readable included/excluded categories, redaction-rules
   version, bundle-only token scope, and the media/storage size-rounding
-  contract. Privacy rules version `2` uses round-down quanta of 256 MiB for
-  media/artifact file sizes and 16 GiB for volume capacities.
+  contract. Privacy rules version `4` uses round-down quanta of 256 MiB for
+  media/artifact file sizes and 16 GiB for volume capacities, removes process
+  and thread identifiers from free text, and excludes incomplete tool-output
+  records from export.
 
 ## Event Fields
 
@@ -108,8 +110,11 @@ they do not describe host storage or media files.
 512 KiB UTF-8 tail. DispatchIO callbacks append bounded chunks directly to the
 tail; there is no unbounded `AsyncThrowingStream` continuation queue between
 the pipe and the bound. This prevents pipe backpressure while preserving exact
-original/retained/dropped byte accounting. `tool-tail.txt` begins with those
-counts and a `truncated` flag before the redacted retained text.
+original/retained/dropped byte accounting. Before redaction, archive creation
+drops a potentially partial leading record after buffer truncation and any
+unterminated trailing record. `tool-tail.txt`
+begins with separate buffer, record-boundary, and archive-limit drop counts plus
+a `truncated` flag before the redacted retained text.
 
 The existing UI-facing diagnostic string is separately limited to 128 KiB.
 
@@ -140,8 +145,9 @@ not use reusable hashes.
   JWTs, serial/device identifiers, long hexadecimal identifiers, email
   addresses, IP addresses, and MAC addresses are removed. Assignment matching
   accepts optional whitespace and quoted keys/values.
-- PID/PGID assignments found in free text are removed in addition to omitting
-  the structured fields.
+- PID/PGID/TID assignments, quoted identifier values, and Apple-style
+  `ProcessName[PID:TID]` prefixes found in free text are removed in addition to
+  omitting the structured fields.
 - UUID-like identifiers found in free text receive per-bundle identifier tokens.
   Structured worker job UUIDs receive per-bundle job tokens.
 - ANSI escapes and unsafe control characters are removed.
@@ -150,8 +156,8 @@ not use reusable hashes.
   UTF-8 byte cap.
 
 The bundle never contains media bytes, screenshots, environment dumps, raw
-commands, source titles, raw paths, raw process identifiers, exact media/storage
-sizes, serials, or reusable file fingerprints.
+commands, source titles, raw paths, raw process or thread identifiers, exact
+media/storage sizes, serials, or reusable file fingerprints.
 
 ## Local Foundation APIs
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,13 +106,13 @@ diagnosis; standard output remains protocol-only.
 
 Every event declares its maximum privacy level and redaction state. Secrets are
 omitted instead of being logged. Executable paths, source paths, filenames,
-movie titles, command arguments, environment values, raw process identifiers,
-serial numbers, and reusable hashes are not exportable as-is.
+movie titles, command arguments, environment values, raw process and thread
+identifiers, serial numbers, and reusable hashes are not exportable as-is.
 
 Local raw records may contain private paths needed for active-file sampling.
 User-created support bundles apply a second redaction boundary that replaces
-paths and job identifiers with bundle-scoped tokens, removes process IDs and
-command details, redacts credential-like text and arbitrary media-metadata
+paths and job identifiers with bundle-scoped tokens, removes process and thread
+IDs and command details, redacts credential-like text and arbitrary media-metadata
 values, and coarsens sizes.
 Public and private classifications are retained in exported event metadata;
 private text is eligible for export only after that second redaction pass.

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
@@ -419,7 +419,8 @@ final class DiagnosticBundleBuilder: Sendable {
         _ snapshot: DiagnosticTextSnapshot,
         redactor: DiagnosticRedactor
     ) -> ToolTailBuildResult {
-        let redactedText = redactor.redact(snapshot.text)
+        let safeInput = Self.redactionSafeToolTailInput(snapshot)
+        let redactedText = redactor.redact(safeInput.text)
         let bodyBudget = max(0, configuration.maximumToolTailBytes - 512)
         let boundedBody = Self.boundedUTF8Suffix(redactedText, maximumBytes: bodyBudget)
         let archiveDropped = max(0, redactedText.utf8.count - boundedBody.utf8.count)
@@ -427,14 +428,16 @@ final class DiagnosticBundleBuilder: Sendable {
             totalInputBytes: snapshot.totalBytes,
             retainedInputBytes: snapshot.retainedBytes,
             bufferDroppedBytes: snapshot.droppedBytes,
+            boundaryDroppedInputBytes: safeInput.droppedBytes,
             archiveDroppedBytes: archiveDropped,
-            truncated: snapshot.truncated || archiveDropped > 0
+            truncated: snapshot.truncated || safeInput.droppedBytes > 0 || archiveDropped > 0
         )
         let header = [
             "# bd_to_avp_support_tool_tail schema_version=1",
             "# total_input_bytes=\(truncation.totalInputBytes)",
             "# retained_input_bytes=\(truncation.retainedInputBytes)",
             "# buffer_dropped_bytes=\(truncation.bufferDroppedBytes)",
+            "# boundary_dropped_input_bytes=\(truncation.boundaryDroppedInputBytes)",
             "# archive_dropped_bytes=\(truncation.archiveDroppedBytes)",
             "# truncated=\(truncation.truncated)",
             "",
@@ -442,6 +445,48 @@ final class DiagnosticBundleBuilder: Sendable {
         .joined(separator: "\n")
         let data = Data((header + boundedBody).utf8)
         return ToolTailBuildResult(data: data, truncation: truncation)
+    }
+
+    static func redactionSafeToolTailInput(
+        _ snapshot: DiagnosticTextSnapshot
+    ) -> (text: String, droppedBytes: Int) {
+        guard !snapshot.text.isEmpty else {
+            return ("", 0)
+        }
+
+        var safeText = snapshot.text[...]
+        var droppedBytes = 0
+        if snapshot.truncated {
+            let scalars = safeText.unicodeScalars
+            guard let firstTerminator = scalars.firstIndex(where: Self.isLineTerminator) else {
+                return ("", snapshot.text.utf8.count)
+            }
+            var safeStart = scalars.index(after: firstTerminator)
+            if scalars[firstTerminator].value == 0x0D,
+               safeStart < scalars.endIndex,
+               scalars[safeStart].value == 0x0A {
+                safeStart = scalars.index(after: safeStart)
+            }
+            droppedBytes += safeText[..<safeStart].utf8.count
+            safeText = safeText[safeStart...]
+        }
+
+        let scalars = safeText.unicodeScalars
+        if let lastScalar = scalars.last,
+           !Self.isLineTerminator(lastScalar) {
+            guard let lastTerminator = scalars.lastIndex(where: Self.isLineTerminator) else {
+                return ("", droppedBytes + safeText.utf8.count)
+            }
+            let safeEnd = scalars.index(after: lastTerminator)
+            droppedBytes += safeText[safeEnd...].utf8.count
+            safeText = safeText[..<safeEnd]
+        }
+
+        return (String(safeText), droppedBytes)
+    }
+
+    private static func isLineTerminator(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.value == 0x0A || scalar.value == 0x0D
     }
 
     private func makeManifest(
@@ -652,7 +697,7 @@ final class DiagnosticBundleBuilder: Sendable {
     }
 
     private static let privacyManifest = BundlePrivacy(
-        rulesVersion: 3,
+        rulesVersion: 4,
         pathTokenScope: "bundle",
         sizeRoundingMode: "down",
         fileSizeQuantumBytes: DiagnosticSizeRounding.fileSizeQuantumBytes,
@@ -674,7 +719,7 @@ final class DiagnosticBundleBuilder: Sendable {
             "raw full paths, filenames, volume names, and movie titles",
             "raw job requests and command arguments",
             "environment variables and credentials",
-            "raw process identifiers",
+            "raw process and thread identifiers",
             "raw local observability JSONL segments",
             "hardware serial numbers and reusable file hashes",
         ]
@@ -858,6 +903,7 @@ private struct BundleToolTailTruncation: Encodable {
     let totalInputBytes: Int
     let retainedInputBytes: Int
     let bufferDroppedBytes: Int
+    let boundaryDroppedInputBytes: Int
     let archiveDroppedBytes: Int
     let truncated: Bool
 }

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
@@ -58,10 +58,8 @@ final class BoundedDiagnosticTextBuffer: @unchecked Sendable {
 
     func snapshot() -> DiagnosticTextSnapshot {
         lock.withDiagnosticLock {
-            let text = String(decoding: data, as: UTF8.self)
-                .trimmingCharacters(in: .newlines)
             return DiagnosticTextSnapshot(
-                text: text,
+                text: String(decoding: data, as: UTF8.self),
                 retainedBytes: data.count,
                 totalBytes: totalBytes,
                 droppedBytes: max(0, totalBytes - data.count)

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
@@ -84,6 +84,7 @@ final class DiagnosticRedactor {
     func redact(_ value: String) -> String {
         var redacted = Self.removingUnsafeControlCharacters(from: value)
         redacted = redactMediaMetadataBlocks(in: redacted)
+        redacted = redactProcessIdentifiers(in: redacted)
         redacted = redactCommandArguments(in: redacted)
         redacted = redactTitleArguments(in: redacted)
         for (sensitiveValue, replacement) in exactReplacements.sorted(by: { $0.key.count > $1.key.count }) {
@@ -147,11 +148,6 @@ final class DiagnosticRedactor {
             return self.nameTokens[filename.lowercased()] ?? "<name:redacted>"
         }
         redacted = redactSensitiveAssignments(in: redacted)
-        redacted = replaceCapturedMatches(
-            pattern: #"(?i)\b(pid|ppid|pgid|process[_ -]?(?:group[_ -]?)?id)\b(?:\s*[:=]\s*|\s+)[0-9]+"#,
-            in: redacted,
-            captureGroup: 1
-        ) { key in "\(key)=<redacted>" }
         redacted = replaceMatches(
             pattern: #"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"#,
             in: redacted
@@ -223,6 +219,29 @@ final class DiagnosticRedactor {
             return "\(indentation)\(key): <metadata:redacted>"
         }
         .joined(separator: "\n")
+    }
+
+    private func redactProcessIdentifiers(in text: String) -> String {
+        var redacted = replaceCapturedMatches(
+            pattern: #"(?i)(?<![A-Za-z0-9_])[\"']?((?:p|pp|pg|t)id|(?:parent|child)[_ -]?pid|(?:(?:parent|child)[_ -]?)?process(?:[_ -]?group)?[_ -]?(?:id|identifier)|p?thread[_ -]?(?:id|identifier))[\"']?(?:\s*[:=]\s*|\s+)(?:([\"']?)(?:0[xX][0-9A-Fa-f]{1,16}|[0-9A-Fa-f]{1,20})\2|\[(?:0[xX][0-9A-Fa-f]{1,16}|[0-9A-Fa-f]{1,20})\])(?![A-Za-z0-9])"#,
+            in: text,
+            captureGroup: 1
+        ) { key in
+            "\(key)=<redacted>"
+        }
+        redacted = replaceMatches(
+            pattern: #"\[[0-9]{1,10}[ \t]*:[ \t]*(?:0[xX][0-9A-Fa-f]{1,16}|[0-9A-Fa-f]{1,20})\]"#,
+            in: redacted
+        ) { _ in
+            "[<process:redacted>]"
+        }
+        redacted = replaceMatches(
+            pattern: #"(?<=[^\s\[\]])\[[0-9]{1,10}\]"#,
+            in: redacted
+        ) { _ in
+            "[<process:redacted>]"
+        }
+        return redacted
     }
 
     private func identifierToken(for identifier: String) -> String {

--- a/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
@@ -49,6 +49,16 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertTrue(snapshot.truncated)
     }
 
+    func testBoundedTextBufferSnapshotPreservesLineTerminators() {
+        let buffer = BoundedDiagnosticTextBuffer(maximumBytes: 32)
+
+        buffer.append(Data("complete line\r\n".utf8))
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(snapshot.text, "complete line\r\n")
+        XCTAssertEqual(snapshot.retainedBytes, "complete line\r\n".utf8.count)
+    }
+
     func testBoundedTextBufferCapsLargeChunksWithoutSplittingLeadingUTF8() {
         let buffer = BoundedDiagnosticTextBuffer(maximumBytes: 17)
         let input = Data((String(repeating: "old", count: 100_000) + "😀tail-marker").utf8)
@@ -184,6 +194,124 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertTrue(output.contains("pid=<redacted>"))
         XCTAssertTrue(output.contains("NORMAL_VALUE = visible"))
         XCTAssertGreaterThanOrEqual(output.components(separatedBy: "<path:01234567:").count - 1, 4)
+    }
+
+    func testRedactorRemovesAppleLogProcessAndThreadPrefixes() {
+        let redactor = DiagnosticRedactor(bundleID: fixedBundleID)
+        let text = """
+        2026-07-20 16:21:42.737 BluRayToVisionProEngine[37058:75443740] No Python arguments
+        helper[42:0xABCDEF] failed
+        renderer[123:ABCDEF] failed
+        worker[42: 18446744073709551615] stopped
+        [31415:27182] line-start prefix
+        Process ID: [27182:31415]
+        worker[7] stopped
+        HTTP [404]
+        [1721492502]
+        frame window[1920x1080]
+        Stream #0:0[0x1](und)
+        """
+
+        let output = redactor.redact(text)
+
+        XCTAssertFalse(output.contains("[37058:75443740]"))
+        XCTAssertFalse(output.contains("[42:0xABCDEF]"))
+        XCTAssertFalse(output.contains("[42: 18446744073709551615]"))
+        XCTAssertFalse(output.contains("worker[7]"))
+        XCTAssertFalse(output.contains("[123:ABCDEF]"))
+        XCTAssertEqual(output.components(separatedBy: "[<process:redacted>]").count - 1, 7)
+        XCTAssertTrue(
+            output.contains(
+                "2026-07-20 16:21:42.737 BluRayToVisionProEngine[<process:redacted>] No Python <arguments:redacted>"
+            )
+        )
+        XCTAssertTrue(output.contains("HTTP [404]"))
+        XCTAssertTrue(output.contains("[1721492502]"))
+        XCTAssertTrue(output.contains("frame window[1920x1080]"))
+        XCTAssertTrue(output.contains("Stream #0:0[0x1](und)"))
+    }
+
+    func testRedactorRemovesLabeledProcessAndThreadIdentifiers() {
+        let redactor = DiagnosticRedactor(bundleID: fixedBundleID)
+        let text = """
+        pid=37058 tid: 75443740
+        ppid 42 pgid=43
+        thread_id=0xABCDEF pthreadIdentifier: ABC123
+        processIdentifier=99 processGroupID: 100
+        parentProcessIdentifier=103 child_process_id: 104
+        "processID": 101, 'threadID'=102
+        "pid":"105", 'threadID':'0xABCDEF'
+        pid: [106]
+        NORMAL_VALUE=visible
+        """
+
+        let output = redactor.redact(text)
+
+        for identifier in ["37058", "75443740", "0xABCDEF", "ABC123"] {
+            XCTAssertFalse(output.contains(identifier))
+        }
+        XCTAssertTrue(output.contains("pid=<redacted>"))
+        XCTAssertTrue(output.contains("tid=<redacted>"))
+        XCTAssertTrue(output.contains("ppid=<redacted>"))
+        XCTAssertTrue(output.contains("pgid=<redacted>"))
+        XCTAssertTrue(output.contains("thread_id=<redacted>"))
+        XCTAssertTrue(output.contains("pthreadIdentifier=<redacted>"))
+        XCTAssertTrue(output.contains("processIdentifier=<redacted>"))
+        XCTAssertTrue(output.contains("processGroupID=<redacted>"))
+        XCTAssertTrue(output.contains("parentProcessIdentifier=<redacted>"))
+        XCTAssertTrue(output.contains("child_process_id=<redacted>"))
+        XCTAssertTrue(output.contains("processID=<redacted>"))
+        XCTAssertTrue(output.contains("threadID=<redacted>"))
+        XCTAssertTrue(output.contains("pid=<redacted>"))
+        XCTAssertTrue(output.contains("NORMAL_VALUE=visible"))
+    }
+
+    func testTruncatedToolTailDropsPotentiallyPartialLeadingLine() {
+        let partialPrefix = "058:75443740] private prefix\n"
+        let completeLine = "complete safe line\n"
+        let snapshot = DiagnosticTextSnapshot(
+            text: partialPrefix + completeLine,
+            retainedBytes: partialPrefix.utf8.count + completeLine.utf8.count,
+            totalBytes: partialPrefix.utf8.count + completeLine.utf8.count + 10,
+            droppedBytes: 10
+        )
+
+        let result = DiagnosticBundleBuilder.redactionSafeToolTailInput(snapshot)
+
+        XCTAssertEqual(result.text, completeLine)
+        XCTAssertEqual(result.droppedBytes, partialPrefix.utf8.count)
+
+        let noNewline = DiagnosticTextSnapshot(
+            text: "543740] private prefix",
+            retainedBytes: 22,
+            totalBytes: 32,
+            droppedBytes: 10
+        )
+        let emptyResult = DiagnosticBundleBuilder.redactionSafeToolTailInput(noNewline)
+        XCTAssertEqual(emptyResult.text, "")
+        XCTAssertEqual(emptyResult.droppedBytes, noNewline.text.utf8.count)
+
+        let activeText = "complete line\r\nApp[37058:7544"
+        let activeSnapshot = DiagnosticTextSnapshot(
+            text: activeText,
+            retainedBytes: activeText.utf8.count,
+            totalBytes: activeText.utf8.count,
+            droppedBytes: 0
+        )
+        let activeResult = DiagnosticBundleBuilder.redactionSafeToolTailInput(activeSnapshot)
+        XCTAssertEqual(activeResult.text, "complete line\r\n")
+        XCTAssertEqual(activeResult.droppedBytes, "App[37058:7544".utf8.count)
+
+        let carriageReturnText = "partial prefix\rcomplete line\r"
+        let carriageReturnSnapshot = DiagnosticTextSnapshot(
+            text: carriageReturnText,
+            retainedBytes: carriageReturnText.utf8.count,
+            totalBytes: carriageReturnText.utf8.count + 10,
+            droppedBytes: 10
+        )
+        let carriageReturnResult = DiagnosticBundleBuilder.redactionSafeToolTailInput(carriageReturnSnapshot)
+        XCTAssertEqual(carriageReturnResult.text, "complete line\r")
+        XCTAssertEqual(carriageReturnResult.droppedBytes, "partial prefix\r".utf8.count)
     }
 
     func testRedactorRemovesArbitraryMediaMetadataValues() {
@@ -949,7 +1077,7 @@ final class DiagnosticBundleTests: XCTestCase {
         )
         XCTAssertEqual((sourceProbe["volume_total_rounded_bytes"] as? NSNumber)?.int64Value, volumeQuantum * 63)
         XCTAssertTrue(samples.allSatisfy { $0["file_size_bytes"] == nil && $0["volume_available_bytes"] == nil })
-        XCTAssertEqual(privacy["rules_version"] as? Int, 3)
+        XCTAssertEqual(privacy["rules_version"] as? Int, 4)
         XCTAssertEqual(privacy["size_rounding_mode"] as? String, "down")
         XCTAssertEqual((privacy["file_size_quantum_bytes"] as? NSNumber)?.int64Value, fileQuantum)
         XCTAssertEqual((privacy["volume_capacity_quantum_bytes"] as? NSNumber)?.int64Value, volumeQuantum)
@@ -1011,7 +1139,9 @@ final class DiagnosticBundleTests: XCTestCase {
                     sequence: sequence,
                     payload: WorkerEventPayload(
                         stage: "combine_to_mv_hevc",
-                        message: "Working on \(sourceURL.path)",
+                    message: sequence == 5
+                        ? "Working on \(sourceURL.path) BluRayToVisionProEngine[37058:75443740] {\"pid\":\"37058\",\"threadID\":\"0xABCDEF\"}"
+                        : "Working on \(sourceURL.path)",
                         elapsedSeconds: sequence,
                         progress: WorkerProgress(currentStage: 5, totalStages: 9, stageFraction: 0.5)
                     )
@@ -1049,6 +1179,9 @@ final class DiagnosticBundleTests: XCTestCase {
                 File "\(sourceURL.path)", line 12
                 command: /usr/bin/ffmpeg -i "\(sourceURL.path)" -metadata title="Secret Feature"
                 token=ghp_abcdefghijklmnopqrstuvwxyz123456
+                2026-07-20 16:21:42.737 BluRayToVisionProEngine[37058:75443740] No Python arguments
+                state={"pid":"37058","threadID":"0xABCDEF"}
+                App[99999:88888
                 """.utf8
             )
         )
@@ -1108,12 +1241,19 @@ final class DiagnosticBundleTests: XCTestCase {
         let storage = try XCTUnwrap(
             JSONSerialization.jsonObject(with: storageData) as? [String: Any]
         )
+        let privacy = try XCTUnwrap(manifest["privacy"] as? [String: Any])
+        let excludedCategories = try XCTUnwrap(privacy["excluded"] as? [String])
+        let truncation = try XCTUnwrap(manifest["truncation"] as? [String: Any])
+        let toolTailTruncation = try XCTUnwrap(truncation["tool_tail"] as? [String: Any])
         let manifestText = String(decoding: manifestData, as: UTF8.self)
         let combinedText = [manifestData, eventsData, storageData, toolTailData]
             .map { String(decoding: $0, as: UTF8.self) }
             .joined(separator: "\n")
 
         XCTAssertEqual(manifest["schema_version"] as? Int, 1)
+        XCTAssertEqual(privacy["rules_version"] as? Int, 4)
+        XCTAssertTrue(excludedCategories.contains("raw process and thread identifiers"))
+        XCTAssertGreaterThan(toolTailTruncation["boundary_dropped_input_bytes"] as? Int ?? 0, 0)
         XCTAssertEqual((manifest["archive"] as? [String: Any])?["maximum_compressed_bytes"] as? Int, 2 * 1_024 * 1_024)
         let localStore = try XCTUnwrap(manifest["local_observability_store"] as? [String: Any])
         XCTAssertEqual(localStore["enabled"] as? Bool, true)
@@ -1129,10 +1269,22 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertFalse(combinedText.contains(sourceURL.path))
         XCTAssertFalse(combinedText.contains("Secret Feature"))
         XCTAssertFalse(combinedText.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"))
+        let toolTailText = String(decoding: toolTailData, as: UTF8.self)
+        let eventsText = String(decoding: eventsData, as: UTF8.self)
+        XCTAssertFalse(toolTailText.contains("[37058:75443740]"))
+        XCTAssertFalse(toolTailText.contains("App[99999:88888"))
+        XCTAssertFalse(toolTailText.contains("\"pid\":\"37058\""))
+        XCTAssertFalse(eventsText.contains("[37058:75443740]"))
+        XCTAssertFalse(eventsText.contains("\"pid\":\"37058\""))
         XCTAssertTrue(combinedText.contains("<path:01234567:"))
         XCTAssertTrue(combinedText.contains("ffmpeg <arguments:redacted>"))
+        XCTAssertTrue(toolTailText.contains("BluRayToVisionProEngine[<process:redacted>]"))
+        XCTAssertTrue(toolTailText.contains("pid=<redacted>"))
+        XCTAssertTrue(eventsText.contains("BluRayToVisionProEngine[<process:redacted>]"))
+        XCTAssertTrue(eventsText.contains("pid=<redacted>"))
         XCTAssertTrue(manifestText.contains("\"active\" : true"))
-        XCTAssertTrue(String(decoding: toolTailData, as: UTF8.self).contains("# truncated=true"))
+        XCTAssertTrue(toolTailText.contains("# truncated=true"))
+        XCTAssertTrue(toolTailText.contains("# boundary_dropped_input_bytes="))
         let sourcePathToken = try XCTUnwrap(
             (manifest["job"] as? [String: Any])?["source_path_token"] as? String
         )
@@ -1195,8 +1347,10 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertEqual(storageThread.mainThreadObservation, false)
         XCTAssertEqual(builderThread.mainThreadObservation, false)
         let manifestData = try unzipEntry("manifest.json", from: artifact.archiveURL)
+        let toolTailData = try unzipEntry("tool-tail.txt", from: artifact.archiveURL)
         let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
         XCTAssertEqual((manifest["worker"] as? [String: Any])?["active"] as? Bool, true)
+        XCTAssertFalse(String(decoding: toolTailData, as: UTF8.self).contains(sourceURL.path))
 
         await viewModel.stopForQuit()
         XCTAssertEqual(worker.cancelCallCount, 1)
@@ -1507,10 +1661,11 @@ private final class HoldingDiagnosticWorkerClient: WorkerProcessRunning, @unchec
         lock.lock()
         let cancelled = cancellationRequested
         lock.unlock()
+        let output = "File \"\(sensitivePath)\" remains active\n"
         let text = DiagnosticTextSnapshot(
-            text: "File \"\(sensitivePath)\" remains active",
-            retainedBytes: sensitivePath.utf8.count + 22,
-            totalBytes: sensitivePath.utf8.count + 22,
+            text: output,
+            retainedBytes: output.utf8.count,
+            totalBytes: output.utf8.count,
             droppedBytes: 0
         )
         return WorkerProcessDiagnosticSnapshot(


### PR DESCRIPTION
## Summary

- redact Apple-style process/thread prefixes and labeled PID/TID values, including quoted JSON forms
- preserve line-boundary evidence and omit partial leading/trailing tool-output records before export
- separate boundary-dropped input bytes from archive-limit truncation and advance privacy rules to version 4
- document the support-bundle contract and add archive-level privacy regressions

## Context

Field qualification of the signed Beta 3 build found a support bundle containing `BluRayToVisionProEngine[37058:75443740]`. Beta 3 is immutable, so this fixes the export boundary for the next signed build. This PR supports #278 but does not close it; signed submit/retrieve/delete qualification still requires a new published fixture and maintainer credential.

## Validation

- `uv run python scripts/native_app.py test` — 229 tests passed
- `git diff --check`
- three independent security/regression review rounds; final two reviewers reported no merge blocker

## Safety

- complete newline-terminated diagnostics remain available
- incomplete records are omitted rather than guessed at
- FFmpeg stream identifiers such as `Stream #0:0[0x1](und)` remain unchanged
