### PR TITLE
Add diagnostic comments and safe GitHub issue handoff

### DIFF
--- a/docs/native-support-bundle-v1.md
+++ b/docs/native-support-bundle-v1.md
@@ -52,6 +52,14 @@ bytes.
   preferred language, and override values are omitted.
 - `batch`: Queue kind, total/active counts, and counts by status. Item IDs,
   source names, and output names are omitted.
+- `user_description`: The optional user-provided "What went wrong?" note. It
+  records `included`, the `redacted_bytes` size, a `truncated` flag, and the
+  redacted `text`. The text is normalized (line endings unified to `\n`, control
+  characters removed, ends trimmed), bounded to 2,000 characters and 8 KiB before
+  redaction, then passed through the same redactor as all other free text and
+  bounded again to 16 KiB. It lives in the manifest rather than a separate archive
+  entry so the immutable four-entry envelope is unchanged. `included` is `false`
+  and `text` is absent when the field was left blank.
 - `files`: Entry names, uncompressed byte counts, and truncation flags.
 - `truncation`: Original, retained, history-dropped, boundary-dropped,
   archive-dropped, and field-truncated counts/bytes for each bounded stream.
@@ -181,9 +189,20 @@ secondary entry point. Capturing, reviewing, uploading, cancelling, saving, and
 sharing diagnostics never call `stopActiveWorker()` or
 `WorkerProcessRunning.cancel()`.
 
+Before any capture begins, the sheet shows an optional multiline **What went
+wrong?** field so the user can describe the problem or leave it blank. The field
+has a clear label, placeholder guidance, a character counter bounded to 2,000
+characters, keyboard accessibility, and an explicit warning not to enter
+passwords or personal information. Capture only starts once the user chooses
+**Capture Diagnostics**; the raw text is normalized and redacted before it enters
+the immutable ZIP. The same redacted description is used for online Send, Save a
+Copy, and Share because it is part of the one reviewed archive.
+
 The flow captures the archive before presenting consent and displays
 `DiagnosticBundleArtifact.preview` directly:
 
+- The redacted description, when present, is shown verbatim in the review as
+  included content so the reviewed ZIP and its preview never disagree.
 - Included and excluded categories are shown verbatim from the artifact.
 - The compressed ZIP size, 2 MiB ceiling, member sizes, and truncation notices
   are visible before upload consent.
@@ -195,6 +214,29 @@ The flow captures the archive before presenting consent and displays
   never reused.
 - Success presents a selectable and copyable support code plus the retention
   expiry before the temporary local copy is removed.
+
+## GitHub Issue Handoff
+
+After a successful private upload, the success state offers **Create GitHub
+Issue…**. This opens the user's browser at the public
+`cbusillo/BD_to_AVP` new-issue page with a prefilled draft that the user can
+review and edit before submitting. The success state clearly warns that GitHub
+issue text is public and stays editable.
+
+The draft is built by a dedicated safe URL builder (`GitHubIssueDraft`) that
+accepts only an allowlist of non-secret fields: the redacted user description,
+the app version and build, the captured stage, and the public support code. The
+support code is the only report linkage exposed publicly because it cannot
+retrieve the report by itself. Every field value is percent-encoded with a strict
+allowlist so no value can inject an extra query parameter, and only `title` and
+`body` parameters are ever present.
+
+The builder never accepts and the URL never contains the report ID, upload or
+status tokens, private object keys, raw ZIP contents, or local paths. The app
+opens the browser without embedding any GitHub credential and never calls the
+GitHub API or requests a GitHub token. Offline/local-only mode keeps the
+description in the ZIP but never reaches the success state, so it does not offer
+the handoff or claim a linked private report exists.
 
 When no service endpoint is configured, the same action becomes **Save
 Diagnostics…**. Capture and consent/review remain available, but the sheet

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -28,8 +28,11 @@ struct BluRayToVisionProApp: App {
         }
         let diagnosticReportViewModel = DiagnosticReportViewModel(
             uploader: diagnosticUploader,
-            capture: { outputDirectory in
-                try await viewModel.captureDiagnosticBundle(in: outputDirectory)
+            capture: { outputDirectory, userComment in
+                try await viewModel.captureDiagnosticBundle(
+                    in: outputDirectory,
+                    userComment: userComment
+                )
             }
         )
         let workCoordinator = AppWorkCoordinator(conversion: viewModel, preview: previewViewModel)

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticBundle.swift
@@ -33,6 +33,45 @@ struct DiagnosticBundlePreview: Equatable, Sendable {
     let truncationNotices: [String]
     let archiveBytes: Int
     let maximumArchiveBytes: Int
+    /// The exact redacted "What went wrong?" text included in the archive, or
+    /// `nil` when the user left the field blank. Shown verbatim in the review
+    /// disclosure so the reviewed ZIP and its preview never disagree.
+    let userDescription: String?
+
+    init(
+        includedCategories: [String],
+        excludedCategories: [String],
+        files: [DiagnosticBundleFilePreview],
+        truncationNotices: [String],
+        archiveBytes: Int,
+        maximumArchiveBytes: Int,
+        userDescription: String? = nil
+    ) {
+        self.includedCategories = includedCategories
+        self.excludedCategories = excludedCategories
+        self.files = files
+        self.truncationNotices = truncationNotices
+        self.archiveBytes = archiveBytes
+        self.maximumArchiveBytes = maximumArchiveBytes
+        self.userDescription = userDescription
+    }
+}
+
+/// Non-secret context carried out of capture so a successful private upload can
+/// offer a public GitHub issue draft. It never contains the report ID, upload or
+/// status tokens, private object keys, raw ZIP contents, or local paths.
+struct DiagnosticReportHandoffContext: Equatable, Sendable {
+    let appVersion: String
+    let appBuild: String
+    let capturedStage: String
+    let redactedDescription: String?
+
+    static let empty = DiagnosticReportHandoffContext(
+        appVersion: "",
+        appBuild: "",
+        capturedStage: "",
+        redactedDescription: nil
+    )
 }
 
 struct DiagnosticBundleArtifact: Sendable {
@@ -41,6 +80,23 @@ struct DiagnosticBundleArtifact: Sendable {
     let archiveURL: URL
     let suggestedFilename: String
     let preview: DiagnosticBundlePreview
+    let handoff: DiagnosticReportHandoffContext
+
+    init(
+        bundleID: UUID,
+        createdAt: Date,
+        archiveURL: URL,
+        suggestedFilename: String,
+        preview: DiagnosticBundlePreview,
+        handoff: DiagnosticReportHandoffContext = .empty
+    ) {
+        self.bundleID = bundleID
+        self.createdAt = createdAt
+        self.archiveURL = archiveURL
+        self.suggestedFilename = suggestedFilename
+        self.preview = preview
+        self.handoff = handoff
+    }
 
     var sharingItems: [URL] { [archiveURL] }
 
@@ -135,6 +191,7 @@ final class DiagnosticBundleBuilder: Sendable {
         let maximumEventsBytes: Int
         let maximumStorageBytes: Int
         let maximumToolTailBytes: Int
+        let maximumUserDescriptionBytes: Int
 
         static let production = Configuration(
             maximumArchiveBytes: 2 * 1_024 * 1_024,
@@ -142,7 +199,8 @@ final class DiagnosticBundleBuilder: Sendable {
             maximumManifestBytes: 64 * 1_024,
             maximumEventsBytes: 320 * 1_024,
             maximumStorageBytes: 160 * 1_024,
-            maximumToolTailBytes: 640 * 1_024
+            maximumToolTailBytes: 640 * 1_024,
+            maximumUserDescriptionBytes: 16 * 1_024
         )
     }
 
@@ -170,8 +228,10 @@ final class DiagnosticBundleBuilder: Sendable {
 
     func createBundle(
         from snapshot: DiagnosticCaptureSnapshot,
+        userComment: DiagnosticUserComment? = nil,
         outputDirectory: URL? = nil
     ) throws -> DiagnosticBundleArtifact {
+        try Task.checkCancellation()
         let bundleID = bundleIDProvider()
         let redactor = DiagnosticRedactor(bundleID: bundleID)
         preRegisterSensitiveValues(from: snapshot, redactor: redactor)
@@ -189,20 +249,27 @@ final class DiagnosticBundleBuilder: Sendable {
             redactor: redactor
         )
         let toolTailResult = buildToolTail(snapshot.process.toolOutput, redactor: redactor)
+        let runtime = runtimeMetadataProvider()
+        let userDescriptionResult = buildUserDescription(userComment, redactor: redactor)
+        try Task.checkCancellation()
         let manifest = makeManifest(
             bundleID: bundleID,
             snapshot: snapshot,
-            runtime: runtimeMetadataProvider(),
+            runtime: runtime,
             redactor: redactor,
             eventResult: eventResult,
             storageResult: storageResult,
-            toolTailResult: toolTailResult
+            toolTailResult: toolTailResult,
+            userDescriptionResult: userDescriptionResult
         )
         let manifestData = try Self.encode(manifest, prettyPrinted: true)
         guard manifestData.count <= configuration.maximumManifestBytes else {
             throw DiagnosticBundleError.manifestTooLarge
         }
 
+        // The immutable envelope is exactly these four entries. The redacted user
+        // description travels inside manifest.json so Send/Save/Share stay byte
+        // identical and the upload service's fixed-entry contract is preserved.
         let entries = [
             DiagnosticZipArchive.Entry(name: "manifest.json", data: manifestData),
             DiagnosticZipArchive.Entry(name: "events.jsonl", data: eventResult.data),
@@ -220,6 +287,7 @@ final class DiagnosticBundleBuilder: Sendable {
             entries: entries,
             modificationDate: snapshot.capturedAt
         )
+        try Task.checkCancellation()
         guard archiveData.count <= configuration.maximumArchiveBytes else {
             throw DiagnosticBundleError.archiveTooLarge(
                 actualBytes: archiveData.count,
@@ -233,6 +301,7 @@ final class DiagnosticBundleBuilder: Sendable {
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         let filename = Self.suggestedFilename(createdAt: snapshot.capturedAt, bundleID: bundleID)
         let archiveURL = directory.appendingPathComponent(filename, isDirectory: false)
+        try Task.checkCancellation()
         do {
             try archiveWriter(archiveData, archiveURL)
         } catch {
@@ -278,6 +347,9 @@ final class DiagnosticBundleBuilder: Sendable {
         if toolTailResult.truncation.truncated {
             truncationNotices.append("Older tool output was omitted.")
         }
+        if userDescriptionResult.truncated {
+            truncationNotices.append("Your description was shortened to fit the size limit.")
+        }
         return DiagnosticBundleArtifact(
             bundleID: bundleID,
             createdAt: snapshot.capturedAt,
@@ -289,8 +361,33 @@ final class DiagnosticBundleBuilder: Sendable {
                 files: files,
                 truncationNotices: truncationNotices,
                 archiveBytes: archiveData.count,
-                maximumArchiveBytes: configuration.maximumArchiveBytes
+                maximumArchiveBytes: configuration.maximumArchiveBytes,
+                userDescription: userDescriptionResult.redactedText
+            ),
+            handoff: DiagnosticReportHandoffContext(
+                appVersion: runtime.appVersion,
+                appBuild: runtime.appBuild,
+                capturedStage: snapshot.lifecycle.phase.rawValue,
+                redactedDescription: userDescriptionResult.redactedText
             )
+        )
+    }
+
+    private func buildUserDescription(
+        _ comment: DiagnosticUserComment?,
+        redactor: DiagnosticRedactor
+    ) -> UserDescriptionBuildResult {
+        guard let comment else {
+            return UserDescriptionBuildResult(redactedText: nil, truncated: false)
+        }
+        let redacted = redactor.redact(comment.text)
+        let bounded = Self.boundedUTF8Prefix(
+            redacted,
+            maximumBytes: configuration.maximumUserDescriptionBytes
+        )
+        return UserDescriptionBuildResult(
+            redactedText: bounded.value,
+            truncated: comment.truncated || bounded.truncated
         )
     }
 
@@ -496,7 +593,8 @@ final class DiagnosticBundleBuilder: Sendable {
         redactor: DiagnosticRedactor,
         eventResult: EventBuildResult,
         storageResult: StorageBuildResult,
-        toolTailResult: ToolTailBuildResult
+        toolTailResult: ToolTailBuildResult,
+        userDescriptionResult: UserDescriptionBuildResult
     ) -> BundleManifest {
         let lifecycle = snapshot.lifecycle
         let job = snapshot.jobContext.map { context in
@@ -510,7 +608,25 @@ final class DiagnosticBundleBuilder: Sendable {
                 settings: context.settings
             )
         }
+        let descriptionBytes = userDescriptionResult.redactedText.map { Data($0.utf8).count } ?? 0
         let payloadBytes = eventResult.data.count + storageResult.data.count + toolTailResult.data.count
+        let files = [
+            BundleFile(
+                name: "events.jsonl",
+                uncompressedBytes: eventResult.data.count,
+                truncated: eventResult.truncation.truncated
+            ),
+            BundleFile(
+                name: "storage.json",
+                uncompressedBytes: storageResult.data.count,
+                truncated: storageResult.truncation.truncated
+            ),
+            BundleFile(
+                name: "tool-tail.txt",
+                uncompressedBytes: toolTailResult.data.count,
+                truncated: toolTailResult.truncation.truncated
+            ),
+        ]
         return BundleManifest(
             schemaVersion: 1,
             bundleID: bundleID.uuidString.lowercased(),
@@ -579,23 +695,13 @@ final class DiagnosticBundleBuilder: Sendable {
             localObservabilityStore: BundleLocalObservabilityStore(
                 snapshot.observabilityPersistence
             ),
-            files: [
-                BundleFile(
-                    name: "events.jsonl",
-                    uncompressedBytes: eventResult.data.count,
-                    truncated: eventResult.truncation.truncated
-                ),
-                BundleFile(
-                    name: "storage.json",
-                    uncompressedBytes: storageResult.data.count,
-                    truncated: storageResult.truncation.truncated
-                ),
-                BundleFile(
-                    name: "tool-tail.txt",
-                    uncompressedBytes: toolTailResult.data.count,
-                    truncated: toolTailResult.truncation.truncated
-                ),
-            ],
+            userDescription: BundleUserDescription(
+                included: userDescriptionResult.redactedText != nil,
+                redactedBytes: descriptionBytes,
+                truncated: userDescriptionResult.truncated,
+                text: userDescriptionResult.redactedText
+            ),
+            files: files,
             truncation: BundleTruncation(
                 events: eventResult.truncation,
                 storage: storageResult.truncation,
@@ -746,6 +852,11 @@ private struct ToolTailBuildResult {
     let truncation: BundleToolTailTruncation
 }
 
+private struct UserDescriptionBuildResult {
+    let redactedText: String?
+    let truncated: Bool
+}
+
 private struct BundleManifest: Encodable {
     let schemaVersion: Int
     let bundleID: String
@@ -757,9 +868,17 @@ private struct BundleManifest: Encodable {
     let job: BundleJob?
     let batch: BundleBatch?
     let localObservabilityStore: BundleLocalObservabilityStore
+    let userDescription: BundleUserDescription
     let files: [BundleFile]
     let truncation: BundleTruncation
     let privacy: BundlePrivacy
+}
+
+private struct BundleUserDescription: Encodable {
+    let included: Bool
+    let redactedBytes: Int
+    let truncated: Bool
+    let text: String?
 }
 
 private struct BundleArchiveContract: Encodable {

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
@@ -182,7 +182,7 @@ final class DiagnosticRedactor {
             pattern: #"(?i)\b(?:[0-9A-F]{2}:){5}[0-9A-F]{2}\b"#,
             in: redacted
         ) { _ in "<network:redacted>" }
-        return redacted
+        return Self.removingUnsafeControlCharacters(from: redacted)
     }
 
     private func redactMediaMetadataBlocks(in text: String) -> String {
@@ -440,7 +440,11 @@ final class DiagnosticRedactor {
         }
         return String(
             withoutANSI.unicodeScalars.filter { scalar in
-                scalar == "\n" || scalar == "\r" || scalar == "\t" || scalar.value >= 0x20
+                if scalar == "\n" || scalar == "\r" || scalar == "\t" {
+                    return true
+                }
+                let category = scalar.properties.generalCategory
+                return category != .control && category != .format
             }
         )
     }

--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticUserComment.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticUserComment.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Normalizes and bounds the optional user-provided "What went wrong?" description
+/// before it is redacted and written into an immutable diagnostic bundle.
+///
+/// Normalization is deliberately conservative and happens before redaction:
+/// line endings collapse to `\n`, control characters are removed, the ends are
+/// trimmed, and the text is bounded by both a user-visible character count and a
+/// UTF-8 byte size that stays well within the archive budget. Empty or
+/// whitespace-only input produces `nil` so the bundle omits the field entirely.
+struct DiagnosticUserComment: Equatable, Sendable {
+    /// Maximum number of user-visible characters retained in the description.
+    static let maximumCharacterCount = 2_000
+
+    /// Maximum UTF-8 byte size retained after normalization. This is comfortably
+    /// within the 1,500,000-byte uncompressed archive budget even after redaction.
+    static let maximumByteCount = 8 * 1_024
+
+    /// Normalized, control-character-free text with `\n` line endings. Never empty.
+    let text: String
+
+    /// True when normalization dropped characters to satisfy the character or byte bound.
+    let truncated: Bool
+
+    /// Returns a normalized comment, or `nil` when the raw text is empty or whitespace-only.
+    static func normalize(_ rawText: String) -> DiagnosticUserComment? {
+        let unifiedLineEndings = rawText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let withoutControlCharacters = String(
+            String.UnicodeScalarView(
+                unifiedLineEndings.unicodeScalars.filter { scalar in
+                    if scalar == "\n" || scalar == "\t" {
+                        return true
+                    }
+                    let category = scalar.properties.generalCategory
+                    return category != .control && category != .format
+                }
+            )
+        )
+        let trimmed = withoutControlCharacters.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        var bounded = trimmed
+        var truncated = false
+        if bounded.count > maximumCharacterCount {
+            bounded = String(bounded.prefix(maximumCharacterCount))
+            truncated = true
+        }
+        let byteBounded = boundedUTF8Prefix(bounded, maximumBytes: maximumByteCount)
+        return DiagnosticUserComment(
+            text: byteBounded.text,
+            truncated: truncated || byteBounded.truncated
+        )
+    }
+
+    private static func boundedUTF8Prefix(
+        _ value: String,
+        maximumBytes: Int
+    ) -> (text: String, truncated: Bool) {
+        let data = Data(value.utf8)
+        guard data.count > maximumBytes else {
+            return (value, false)
+        }
+        var count = maximumBytes
+        while count > 0 {
+            if let decoded = String(data: data.prefix(count), encoding: .utf8) {
+                return (decoded, true)
+            }
+            count -= 1
+        }
+        return ("", true)
+    }
+}

--- a/macos/BluRayToVisionPro/Diagnostics/GitHubIssueDraft.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/GitHubIssueDraft.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Builds a safe GitHub "new issue" URL for the public BD_to_AVP repository.
+///
+/// The draft only ever carries a small allowlist of non-secret fields: a
+/// redacted user description, the app version/build, the captured stage, and the
+/// public support code that links to the private report without being able to
+/// download it. Report IDs, upload/status tokens, private object keys, raw ZIP
+/// contents, and local paths are never accepted by this type, so they cannot
+/// reach the browser draft. The app opens the URL in the user's browser and
+/// never calls the GitHub API or embeds any credential.
+struct GitHubIssueDraft: Equatable, Sendable {
+    static let repositoryOwner = "cbusillo"
+    static let repositoryName = "BD_to_AVP"
+
+    /// Maximum characters retained in the issue title.
+    static let maximumTitleCharacterCount = 120
+
+    /// Maximum characters retained in the issue body before URL encoding, keeping
+    /// the whole URL comfortably within browser and GitHub length limits.
+    static let maximumBodyCharacterCount = 4_000
+
+    /// The only characters left unescaped in the query. Everything else, including
+    /// every URL sub-delimiter (`&`, `=`, `+`, …), is percent-encoded so no field
+    /// value can inject an extra query parameter.
+    private static let queryValueAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    let supportCode: String
+    let appVersion: String
+    let appBuild: String
+    let capturedStage: String
+    let redactedDescription: String?
+
+    var title: String {
+        Self.bounded(
+            "Beta diagnostics report \(supportCode)",
+            maximumCharacterCount: Self.maximumTitleCharacterCount
+        )
+    }
+
+    var body: String {
+        let description = redactedDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let descriptionSection = (description?.isEmpty == false)
+            ? description!
+            : "_No description was provided._"
+        let lines = [
+            "> GitHub issues are public and stay editable until you submit them.",
+            "> Review this text and remove anything you would not share publicly.",
+            "",
+            "**Support code:** \(supportCode)",
+            "**App version:** \(appVersion) (\(appBuild))",
+            "**Captured stage:** \(capturedStage)",
+            "",
+            "## What went wrong?",
+            descriptionSection,
+        ]
+        return Self.bounded(
+            lines.joined(separator: "\n"),
+            maximumCharacterCount: Self.maximumBodyCharacterCount
+        )
+    }
+
+    /// Returns the GitHub new-issue URL, or `nil` if it cannot be constructed.
+    func url() -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "github.com"
+        components.path = "/\(Self.repositoryOwner)/\(Self.repositoryName)/issues/new"
+        components.percentEncodedQueryItems = [
+            URLQueryItem(name: "title", value: Self.encoded(title)),
+            URLQueryItem(name: "body", value: Self.encoded(body)),
+        ]
+        return components.url
+    }
+
+    private static func encoded(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: queryValueAllowed) ?? ""
+    }
+
+    private static func bounded(_ value: String, maximumCharacterCount: Int) -> String {
+        guard value.count > maximumCharacterCount else {
+            return value
+        }
+        let marker = "…"
+        let keep = max(0, maximumCharacterCount - marker.count)
+        return String(value.prefix(keep)) + marker
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -123,7 +123,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     func captureDiagnosticBundle(
-        in outputDirectory: URL? = nil
+        in outputDirectory: URL? = nil,
+        userComment: DiagnosticUserComment? = nil
     ) async throws -> DiagnosticBundleArtifact {
         let capturedAt = diagnosticClock()
         let processSnapshot = client?.diagnosticSnapshot()
@@ -138,12 +139,18 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             observabilityPersistence: observabilityEventStore.snapshot()
         )
         let builder = diagnosticBundleBuilder
-        return try await Task.detached(priority: .utility) {
+        let buildTask = Task.detached(priority: .utility) {
             try builder.createBundle(
                 from: snapshot,
+                userComment: userComment,
                 outputDirectory: outputDirectory
             )
-        }.value
+        }
+        return try await withTaskCancellationHandler {
+            try await buildTask.value
+        } onCancel: {
+            buildTask.cancel()
+        }
     }
 
     func selectSource(_ sourceURL: URL) {

--- a/macos/BluRayToVisionPro/Feature/DiagnosticReportViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/DiagnosticReportViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum DiagnosticReportPhase: Equatable {
     case idle
+    case composing
     case capturing
     case review
     case uploading(progress: Double)
@@ -14,7 +15,7 @@ enum DiagnosticReportPhase: Equatable {
         switch self {
         case .capturing, .uploading, .cancelling:
             return true
-        case .idle, .review, .success, .cancelled, .failed:
+        case .idle, .composing, .review, .success, .cancelled, .failed:
             return false
         }
     }
@@ -119,12 +120,20 @@ struct DiagnosticArtifactWorkspace {
 
 @MainActor
 final class DiagnosticReportViewModel: ObservableObject {
-    typealias Capture = @MainActor (URL) async throws -> DiagnosticBundleArtifact
+    typealias Capture = @MainActor (URL, DiagnosticUserComment?) async throws -> DiagnosticBundleArtifact
 
     @Published private(set) var phase = DiagnosticReportPhase.idle
     @Published private(set) var artifact: DiagnosticBundleArtifact?
     @Published private(set) var lastSavedCopyURL: URL?
     @Published private(set) var exportErrorMessage: String?
+
+    /// Raw "What went wrong?" text bound to the composing field. It is normalized
+    /// and redacted before it ever enters the immutable bundle.
+    @Published var userDescription = ""
+
+    /// Non-secret context from the most recent capture, retained after a successful
+    /// upload removes the local artifact so the GitHub handoff can still be offered.
+    @Published private(set) var handoffContext: DiagnosticReportHandoffContext?
 
     let isUploadAvailable: Bool
 
@@ -168,23 +177,54 @@ final class DiagnosticReportViewModel: ObservableObject {
             return true
         case let .failed(failure):
             return failure.stage == .upload
-        case .idle, .capturing, .review, .uploading, .cancelling, .success:
+        case .idle, .composing, .capturing, .review, .uploading, .cancelling, .success:
             return false
         }
     }
 
+    /// Opens the composing step where the user can review or leave blank the
+    /// optional description before any capture begins.
     func begin() {
         guard !phase.isBusy else {
             return
         }
         switch phase {
         case .idle:
-            captureNew()
+            phase = .composing
         case let .failed(failure) where failure.stage == .capture && artifact == nil:
-            captureNew()
-        case .capturing, .review, .uploading, .cancelling, .success, .cancelled, .failed:
+            phase = .composing
+        case .composing, .capturing, .review, .uploading, .cancelling, .success, .cancelled, .failed:
             break
         }
+    }
+
+    /// Captures the bundle using the currently entered description. Callable from
+    /// the composing step or a capture-failure retry.
+    func beginCapture() {
+        guard !phase.isBusy, artifact == nil else {
+            return
+        }
+        switch phase {
+        case .composing:
+            captureNew()
+        case let .failed(failure) where failure.stage == .capture:
+            captureNew()
+        case .idle, .capturing, .review, .uploading, .cancelling, .success, .cancelled, .failed:
+            break
+        }
+    }
+
+    /// Returns to the composing step to start a fresh session after a successful
+    /// upload cleared the previous artifact.
+    func composeNewDiagnostics() {
+        guard !phase.isBusy, artifact == nil else {
+            return
+        }
+        userDescription = ""
+        handoffContext = nil
+        lastSavedCopyURL = nil
+        exportErrorMessage = nil
+        phase = .composing
     }
 
     func prepareForNewDiagnosticSession() {
@@ -192,15 +232,38 @@ final class DiagnosticReportViewModel: ObservableObject {
             return
         }
         phase = .idle
+        userDescription = ""
+        handoffContext = nil
         lastSavedCopyURL = nil
         exportErrorMessage = nil
+    }
+
+    func gitHubIssueDraft() -> GitHubIssueDraft? {
+        guard case let .success(receipt) = phase,
+              let handoffContext,
+              !receipt.supportCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !handoffContext.appVersion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !handoffContext.appBuild.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !handoffContext.capturedStage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return GitHubIssueDraft(
+            supportCode: receipt.supportCode,
+            appVersion: handoffContext.appVersion,
+            appBuild: handoffContext.appBuild,
+            capturedStage: handoffContext.capturedStage,
+            redactedDescription: handoffContext.redactedDescription
+        )
     }
 
     func captureNew() {
         guard !phase.isBusy, artifact == nil else {
             return
         }
+        let userComment = DiagnosticUserComment.normalize(userDescription)
         discardLocalCopySilently()
+        handoffContext = nil
         lastSavedCopyURL = nil
         exportErrorMessage = nil
         phase = .capturing
@@ -212,12 +275,14 @@ final class DiagnosticReportViewModel: ObservableObject {
             do {
                 let directory = try workspace.makeCaptureDirectory()
                 captureDirectory = directory
-                let artifact = try await capture(directory)
+                let artifact = try await capture(directory, userComment)
                 try Task.checkCancellation()
                 self.artifact = artifact
+                userDescription = ""
                 phase = .review
             } catch is CancellationError {
                 discardLocalCopySilently()
+                userDescription = ""
                 phase = .idle
             } catch {
                 discardLocalCopySilently()
@@ -254,6 +319,7 @@ final class DiagnosticReportViewModel: ObservableObject {
                     }
                     self.phase = .uploading(progress: min(max(progress, 0), 1))
                 }
+                handoffContext = artifact.handoff
                 phase = .success(receipt)
                 cleanupAfterSuccess()
             } catch is CancellationError {
@@ -305,6 +371,7 @@ final class DiagnosticReportViewModel: ObservableObject {
         guard let artifact else {
             try? workspace.removeCaptureDirectory(captureDirectory)
             captureDirectory = nil
+            clearUserContext()
             phase = .idle
             return true
         }
@@ -314,6 +381,7 @@ final class DiagnosticReportViewModel: ObservableObject {
             try? workspace.removeCaptureDirectory(captureDirectory)
             captureDirectory = nil
             exportErrorMessage = nil
+            clearUserContext()
             if case .success = phase {
                 return true
             }
@@ -350,5 +418,11 @@ final class DiagnosticReportViewModel: ObservableObject {
         try? workspace.removeCaptureDirectory(captureDirectory)
         artifact = nil
         captureDirectory = nil
+        handoffContext = nil
+    }
+
+    private func clearUserContext() {
+        userDescription = ""
+        handoffContext = nil
     }
 }

--- a/macos/BluRayToVisionPro/Views/DiagnosticReportSheet.swift
+++ b/macos/BluRayToVisionPro/Views/DiagnosticReportSheet.swift
@@ -8,6 +8,7 @@ struct DiagnosticReportSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var copiedSupportCode = false
     @State private var isConfirmingDiscard = false
+    @FocusState private var isDescriptionFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -59,6 +60,8 @@ struct DiagnosticReportSheet: View {
                 message: "Capture a privacy-safe support bundle without stopping the current conversion.",
                 color: .accentColor
             )
+        case .composing:
+            composingContent
         case .capturing:
             captureContent
         case .review:
@@ -91,6 +94,80 @@ struct DiagnosticReportSheet: View {
                 )
             }
         }
+    }
+
+    private var composingContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                DiagnosticReportHeader(
+                    systemImage: "text.bubble",
+                    title: "Describe the Problem",
+                    message: "Optionally tell us what went wrong. Your note is included with the diagnostics, or you can leave it blank and continue.",
+                    color: .accentColor
+                )
+                DiagnosticNotice(
+                    systemImage: "lock.shield",
+                    text: "Do not enter passwords or personal information. Your text is redacted for paths, names, and credentials before it is added to the reviewable ZIP.",
+                    color: .orange
+                )
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("What went wrong? (optional)")
+                        .font(.headline)
+                    TextEditor(text: descriptionBinding)
+                        .font(.body)
+                        .frame(minHeight: 120, maxHeight: 220)
+                        .focused($isDescriptionFocused)
+                        .overlay(alignment: .topLeading) {
+                            if viewModel.userDescription.isEmpty {
+                                Text("Describe what happened, where it stopped, and what you expected.")
+                                    .foregroundStyle(.secondary)
+                                    .padding(.top, 8)
+                                    .padding(.leading, 5)
+                                    .allowsHitTesting(false)
+                                    .accessibilityHidden(true)
+                            }
+                        }
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.secondary.opacity(0.3))
+                        )
+                        .accessibilityLabel("What went wrong")
+                        .accessibilityHint(
+                            "Optional description included with the diagnostics. Do not enter passwords or personal information."
+                        )
+                    HStack {
+                        Spacer()
+                        Text("\(viewModel.userDescription.count)/\(DiagnosticUserComment.maximumCharacterCount)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(descriptionCounterColor)
+                            .accessibilityLabel(
+                                "\(viewModel.userDescription.count) of \(DiagnosticUserComment.maximumCharacterCount) characters used"
+                            )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task {
+            await Task.yield()
+            isDescriptionFocused = true
+        }
+    }
+
+    private var descriptionBinding: Binding<String> {
+        Binding(
+            get: { viewModel.userDescription },
+            set: { newValue in
+                let limit = DiagnosticUserComment.maximumCharacterCount
+                viewModel.userDescription = newValue.count > limit
+                    ? String(newValue.prefix(limit))
+                    : newValue
+            }
+        )
+    }
+
+    private var descriptionCounterColor: Color {
+        viewModel.userDescription.count >= DiagnosticUserComment.maximumCharacterCount ? .orange : .secondary
     }
 
     private var captureContent: some View {
@@ -145,6 +222,9 @@ struct DiagnosticReportSheet: View {
                         color: .secondary,
                         categories: preview.excludedCategories
                     )
+                    if let description = preview.userDescription {
+                        userDescriptionSection(description)
+                    }
                     fileSection(preview)
                     if !preview.truncationNotices.isEmpty {
                         truncationSection(preview.truncationNotices)
@@ -227,6 +307,8 @@ struct DiagnosticReportSheet: View {
                     .padding(4)
                 }
 
+                gitHubHandoffSection(receipt)
+
                 if viewModel.hasLocalArtifact {
                     DiagnosticNotice(
                         systemImage: "externaldrive.badge.exclamationmark",
@@ -273,6 +355,24 @@ struct DiagnosticReportSheet: View {
                 Spacer()
                 Button("Close") { dismiss() }
             }
+        case .composing:
+            HStack {
+                Button("Cancel") {
+                    viewModel.prepareForNewDiagnosticSession()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button {
+                    viewModel.beginCapture()
+                } label: {
+                    Label("Capture Diagnostics", systemImage: "doc.zipper")
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .help("Capture a privacy-safe diagnostic bundle, including your description")
+                .accessibilityLabel("Capture diagnostics including your description")
+            }
         case .capturing:
             HStack {
                 Spacer()
@@ -303,9 +403,9 @@ struct DiagnosticReportSheet: View {
                 if !viewModel.hasLocalArtifact {
                     Button("Capture New Diagnostics") {
                         copiedSupportCode = false
-                        viewModel.captureNew()
+                        viewModel.composeNewDiagnostics()
                     }
-                    .help("Capture another privacy-safe diagnostic bundle")
+                    .help("Describe and capture another privacy-safe diagnostic bundle")
                 }
                 Spacer()
                 Button("Done") { dismiss() }
@@ -319,7 +419,7 @@ struct DiagnosticReportSheet: View {
                 HStack {
                     Button("Close") { dismiss() }
                     Spacer()
-                    Button("Try Again") { viewModel.captureNew() }
+                    Button("Try Again") { viewModel.beginCapture() }
                         .buttonStyle(.borderedProminent)
                         .keyboardShortcut(.defaultAction)
                 }
@@ -561,6 +661,48 @@ struct DiagnosticReportSheet: View {
         } label: {
             Label("Truncation Notices", systemImage: "exclamationmark.circle")
                 .font(.headline)
+        }
+    }
+
+    private func userDescriptionSection(_ description: String) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("This redacted text is included in the ZIP exactly as shown.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(description)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(4)
+        } label: {
+            Label("Your Description (Included)", systemImage: "text.bubble")
+                .font(.headline)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Your description is included: \(description)")
+    }
+
+    @ViewBuilder
+    private func gitHubHandoffSection(_ receipt: DiagnosticReportReceipt) -> some View {
+        if let draft = viewModel.gitHubIssueDraft(), let url = draft.url() {
+            VStack(alignment: .leading, spacing: 10) {
+                DiagnosticNotice(
+                    systemImage: "exclamationmark.bubble",
+                    text: "GitHub issues are public and stay editable in your browser before you submit. The draft includes only your redacted description, the app version, the captured stage, and this support code. Do not add passwords or personal information.",
+                    color: .orange
+                )
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label("Create GitHub Issue…", systemImage: "arrow.up.forward.square")
+                }
+                .help("Open a prefilled, public GitHub issue draft in your browser")
+                .accessibilityLabel("Create a public GitHub issue draft in your browser")
+            }
         }
     }
 

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -252,6 +252,65 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testDiagnosticBundleIncludesUserCommentFromViewModel() async throws {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let viewModel = ConversionViewModel()
+        let comment = try XCTUnwrap(
+            DiagnosticUserComment.normalize("Left and right outputs stop growing at 1.48 GB.")
+        )
+
+        let artifact = try await viewModel.captureDiagnosticBundle(
+            in: outputDirectory,
+            userComment: comment
+        )
+
+        XCTAssertEqual(
+            artifact.preview.userDescription,
+            "Left and right outputs stop growing at 1.48 GB."
+        )
+        XCTAssertEqual(
+            artifact.handoff.redactedDescription,
+            "Left and right outputs stop growing at 1.48 GB."
+        )
+    }
+
+    @MainActor
+    func testDiagnosticBundleCancellationReachesDetachedBuilder() async throws {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let archiveWriter = BlockingDiagnosticArchiveWriter()
+        let builder = DiagnosticBundleBuilder(archiveWriter: archiveWriter.write)
+        let viewModel = ConversionViewModel(diagnosticBundleBuilder: builder)
+        let captureTask = Task {
+            try await viewModel.captureDiagnosticBundle(in: outputDirectory)
+        }
+
+        let deadline = Date().addingTimeInterval(2)
+        while !archiveWriter.hasStarted, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(archiveWriter.hasStarted)
+
+        captureTask.cancel()
+        do {
+            _ = try await captureTask.value
+            XCTFail("Expected diagnostic bundle capture to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        XCTAssertTrue(archiveWriter.observedCancellation)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: outputDirectory.path)).isEmpty)
+    }
+
+    @MainActor
     func testUnavailableDiscTitleCanBeReanalyzedBeforeRetry() async throws {
         let inspectionDone = expectation(description: "inspection done")
         inspectionDone.expectedFulfillmentCount = 2
@@ -2307,5 +2366,30 @@ private final class BatchWorkerClient: WorkerProcessRunning, @unchecked Sendable
                 continuation.resume()
             }
         }
+    }
+}
+
+private final class BlockingDiagnosticArchiveWriter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    private var cancelled = false
+
+    var hasStarted: Bool {
+        lock.withLock { started }
+    }
+
+    var observedCancellation: Bool {
+        lock.withLock { cancelled }
+    }
+
+    func write(_ data: Data, to url: URL) throws {
+        _ = data
+        _ = url
+        lock.withLock { started = true }
+        while !Task.isCancelled {
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+        lock.withLock { cancelled = true }
+        throw CancellationError()
     }
 }

--- a/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
@@ -488,7 +488,8 @@ final class DiagnosticBundleTests: XCTestCase {
             maximumManifestBytes: 64 * 1_024,
             maximumEventsBytes: 320 * 1_024,
             maximumStorageBytes: 1,
-            maximumToolTailBytes: 640 * 1_024
+            maximumToolTailBytes: 640 * 1_024,
+            maximumUserDescriptionBytes: 16 * 1_024
         )
         let recorder = DiagnosticSessionRecorder()
         let snapshot = recorder.snapshot(
@@ -547,6 +548,123 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertNil(manifest["job"])
         XCTAssertTrue(eventsData.isEmpty)
         XCTAssertLessThanOrEqual(artifact.preview.archiveBytes, artifact.preview.maximumArchiveBytes)
+    }
+
+    func testUserDescriptionIsRedactedAndIncludedInImmutableArchive() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var lifecycle = WorkerLifecycleState()
+        lifecycle.selectSource(URL(fileURLWithPath: "/tmp/Movie.mkv"))
+        try lifecycle.begin(jobID: UUID(), operationKind: .conversion)
+        let recorder = DiagnosticSessionRecorder()
+        let snapshot = recorder.snapshot(
+            capturedAt: fixedDate,
+            lifecycle: lifecycle,
+            activeMode: nil,
+            batchSummary: nil,
+            process: .empty
+        )
+        let builder = DiagnosticBundleBuilder(
+            bundleIDProvider: { self.fixedBundleID },
+            runtimeMetadataProvider: {
+                DiagnosticRuntimeMetadata(
+                    appVersion: "1.2.3",
+                    appBuild: "456",
+                    distributionChannel: "direct",
+                    operatingSystemVersion: "27.0.0",
+                    architecture: "arm64"
+                )
+            }
+        )
+        let raw = "It failed reading /Users/alice/secret.mkv\r\ntoken ghp_ABCDEFGHIJKLMNOPQRSTUVWX email alice@\u{200B}example.com id 01234567-89AB-4CDE-8F01-23456789ABCD"
+        let comment = try XCTUnwrap(DiagnosticUserComment.normalize(raw))
+
+        let artifact = try builder.createBundle(
+            from: snapshot,
+            userComment: comment,
+            outputDirectory: directory
+        )
+
+        // The redacted description lives in the manifest so the immutable four-entry
+        // envelope (which the upload service enforces) is unchanged.
+        XCTAssertThrowsError(try unzipEntry("description.txt", from: artifact.archiveURL))
+        let manifestData = try unzipEntry("manifest.json", from: artifact.archiveURL)
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
+        let userDescription = try XCTUnwrap(manifest["user_description"] as? [String: Any])
+        let description = try XCTUnwrap(userDescription["text"] as? String)
+        XCTAssertFalse(description.contains("/Users/alice"))
+        XCTAssertFalse(description.contains("secret.mkv"))
+        XCTAssertFalse(description.contains("ghp_ABCDEFGHIJKLMNOPQRSTUVWX"))
+        XCTAssertFalse(description.contains("alice@example.com"))
+        XCTAssertFalse(description.contains("\u{200B}"))
+        XCTAssertFalse(description.contains("01234567-89AB-4CDE-8F01-23456789ABCD"))
+        XCTAssertTrue(description.contains("<path:"))
+        XCTAssertTrue(description.contains("<credential:redacted>"))
+        XCTAssertTrue(description.contains("<email:redacted>"))
+        XCTAssertFalse(description.contains("\r"))
+        XCTAssertEqual(userDescription["included"] as? Bool, true)
+        XCTAssertGreaterThan(userDescription["redacted_bytes"] as? Int ?? 0, 0)
+        let files = try XCTUnwrap(manifest["files"] as? [[String: Any]])
+        XCTAssertFalse(files.contains { $0["name"] as? String == "description.txt" })
+
+        XCTAssertEqual(artifact.preview.userDescription, description)
+        XCTAssertEqual(artifact.handoff.redactedDescription, description)
+        XCTAssertEqual(artifact.handoff.appVersion, "1.2.3")
+        XCTAssertEqual(artifact.handoff.appBuild, "456")
+        XCTAssertEqual(artifact.handoff.capturedStage, snapshot.lifecycle.phase.rawValue)
+        XCTAssertLessThanOrEqual(artifact.preview.archiveBytes, artifact.preview.maximumArchiveBytes)
+    }
+
+    func testRedactorRemovesInvisibleControlsBeforeSensitiveValueMatching() {
+        let redactor = DiagnosticRedactor(bundleID: fixedBundleID)
+
+        let redacted = redactor.redact(
+            "email alice@\u{200B}example.com path /Users/\u{202E}alice/Movies/private.mkv control \u{0085}"
+        )
+
+        XCTAssertTrue(redacted.contains("<email:redacted>"))
+        XCTAssertTrue(redacted.contains("<path:"))
+        XCTAssertFalse(redacted.contains("alice@example.com"))
+        XCTAssertFalse(redacted.unicodeScalars.contains { scalar in
+            let category = scalar.properties.generalCategory
+            return category == .control || category == .format
+        })
+    }
+
+    func testEmptyUserDescriptionOmitsDedicatedEntry() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let recorder = DiagnosticSessionRecorder()
+        let snapshot = recorder.snapshot(
+            capturedAt: fixedDate,
+            lifecycle: WorkerLifecycleState(),
+            activeMode: nil,
+            batchSummary: nil,
+            process: .empty
+        )
+        let builder = DiagnosticBundleBuilder(bundleIDProvider: { self.fixedBundleID })
+
+        let artifact = try builder.createBundle(
+            from: snapshot,
+            userComment: DiagnosticUserComment.normalize("   \n  "),
+            outputDirectory: directory
+        )
+
+        XCTAssertNil(artifact.preview.userDescription)
+        XCTAssertNil(artifact.handoff.redactedDescription)
+        XCTAssertThrowsError(try unzipEntry("description.txt", from: artifact.archiveURL))
+        let manifestData = try unzipEntry("manifest.json", from: artifact.archiveURL)
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
+        let userDescription = try XCTUnwrap(manifest["user_description"] as? [String: Any])
+        XCTAssertEqual(userDescription["included"] as? Bool, false)
+        let files = try XCTUnwrap(manifest["files"] as? [[String: Any]])
+        XCTAssertFalse(files.contains { $0["name"] as? String == "description.txt" })
     }
 
     func testRecorderBoundsHistoryAndRetainsTerminalRetryAndCancellationEvidence() throws {

--- a/macos/BluRayToVisionProTests/DiagnosticReportViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticReportViewModelTests.swift
@@ -18,12 +18,13 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         let viewModel = DiagnosticReportViewModel(
             uploader: nil,
             workspace: workspace,
-            capture: { directory in
+            capture: { directory, _ in
                 try Self.makeArtifact(in: directory, data: Data("local diagnostics".utf8))
             }
         )
 
         viewModel.begin()
+        viewModel.beginCapture()
         try await waitUntil { viewModel.phase == .review }
 
         XCTAssertFalse(viewModel.isUploadAvailable)
@@ -56,12 +57,13 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         let viewModel = DiagnosticReportViewModel(
             uploader: uploader,
             workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
-            capture: { directory in
+            capture: { directory, _ in
                 try Self.makeArtifact(in: directory, data: Data("upload diagnostics".utf8))
             }
         )
 
         viewModel.begin()
+        viewModel.beginCapture()
         try await waitUntil { viewModel.phase == .review }
         let temporaryURL = try XCTUnwrap(viewModel.artifact?.archiveURL)
         viewModel.uploadCapturedArtifact()
@@ -95,12 +97,13 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         let viewModel = DiagnosticReportViewModel(
             uploader: uploader,
             workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
-            capture: { directory in
+            capture: { directory, _ in
                 try Self.makeArtifact(in: directory, data: Data("cancel diagnostics".utf8))
             }
         )
 
         viewModel.begin()
+        viewModel.beginCapture()
         try await waitUntil { viewModel.phase == .review }
         let artifactURL = try XCTUnwrap(viewModel.artifact?.archiveURL)
         viewModel.uploadCapturedArtifact()
@@ -133,12 +136,13 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         let viewModel = DiagnosticReportViewModel(
             uploader: uploader,
             workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
-            capture: { directory in
+            capture: { directory, _ in
                 try Self.makeArtifact(in: directory, data: Data("retry diagnostics".utf8))
             }
         )
 
         viewModel.begin()
+        viewModel.beginCapture()
         try await waitUntil { viewModel.phase == .review }
         viewModel.uploadCapturedArtifact()
         try await waitUntil {
@@ -153,6 +157,8 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         XCTAssertEqual(failure.kind, .offline)
         XCTAssertTrue(viewModel.hasLocalArtifact)
         XCTAssertTrue(viewModel.canRetryUpload)
+        XCTAssertNil(viewModel.handoffContext)
+        XCTAssertNil(viewModel.gitHubIssueDraft())
 
         viewModel.retryUpload()
         try await waitUntil {
@@ -175,12 +181,13 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         let viewModel = DiagnosticReportViewModel(
             uploader: nil,
             workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
-            capture: { _ in
+            capture: { _, _ in
                 throw CocoaError(.fileReadNoPermission, userInfo: [NSFilePathErrorKey: "/private/user/path"])
             }
         )
 
         viewModel.begin()
+        viewModel.beginCapture()
         try await waitUntil {
             if case .failed = viewModel.phase { return true }
             return false
@@ -194,6 +201,244 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.artifact)
     }
 
+    @MainActor
+    func testBeginEntersComposingBeforeAnyCaptureRuns() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let captureRan = LockedFlag()
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, _ in
+                captureRan.set()
+                return try Self.makeArtifact(in: directory, data: Data("d".utf8))
+            }
+        )
+
+        viewModel.begin()
+
+        XCTAssertEqual(viewModel.phase, .composing)
+        XCTAssertNil(viewModel.artifact)
+        XCTAssertFalse(captureRan.value)
+    }
+
+    @MainActor
+    func testCancellingCompositionClearsUncapturedDescription() {
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            capture: { _, _ in
+                XCTFail("Cancelling composition must not capture diagnostics")
+                throw CancellationError()
+            }
+        )
+
+        viewModel.begin()
+        viewModel.userDescription = "discard this draft"
+        viewModel.prepareForNewDiagnosticSession()
+
+        XCTAssertEqual(viewModel.phase, .idle)
+        XCTAssertEqual(viewModel.userDescription, "")
+        XCTAssertNil(viewModel.handoffContext)
+        XCTAssertNil(viewModel.artifact)
+    }
+
+    @MainActor
+    func testCancellingCaptureRemovesPartialArtifactAndReturnsToIdle() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let captureStarted = expectation(description: "capture started")
+        let workspace = DiagnosticArtifactWorkspace(rootDirectory: rootDirectory)
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            workspace: workspace,
+            capture: { directory, _ in
+                let partialURL = directory.appendingPathComponent("partial.zip")
+                try Data("partial".utf8).write(to: partialURL)
+                captureStarted.fulfill()
+                try await Task.sleep(nanoseconds: 60_000_000_000)
+                return try Self.makeArtifact(in: directory, data: Data("complete".utf8))
+            }
+        )
+
+        viewModel.userDescription = "temporary details"
+        viewModel.begin()
+        viewModel.beginCapture()
+        await fulfillment(of: [captureStarted], timeout: 2)
+        viewModel.cancelCapture()
+        try await waitUntil { viewModel.phase == .idle }
+
+        XCTAssertNil(viewModel.artifact)
+        XCTAssertEqual(viewModel.userDescription, "")
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: rootDirectory.path)).isEmpty)
+    }
+
+    @MainActor
+    func testCapturePassesNormalizedDescriptionWithoutExposingHandoffBeforeUpload() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let recorded = LockedComment()
+        let handoff = DiagnosticReportHandoffContext(
+            appVersion: "1.2.3",
+            appBuild: "456",
+            capturedStage: "converting",
+            redactedDescription: "playback failed"
+        )
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, comment in
+                recorded.set(comment)
+                return try Self.makeArtifact(
+                    in: directory,
+                    data: Data("d".utf8),
+                    handoff: handoff,
+                    userDescription: "playback failed"
+                )
+            }
+        )
+
+        viewModel.userDescription = "  playback failed\r\n  "
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+
+        XCTAssertEqual(recorded.value?.text, "playback failed")
+        XCTAssertEqual(viewModel.artifact?.preview.userDescription, "playback failed")
+        XCTAssertEqual(viewModel.userDescription, "")
+        XCTAssertNil(viewModel.handoffContext)
+        XCTAssertNil(viewModel.gitHubIssueDraft())
+    }
+
+    @MainActor
+    func testSuccessfulUploadOffersGitHubDraftWithAllowlistedFields() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let receipt = DiagnosticReportReceipt(
+            supportCode: "BDAVP-0123456789ABCDEF",
+            expiresAt: Date(timeIntervalSince1970: 1_790_000_000)
+        )
+        let handoff = DiagnosticReportHandoffContext(
+            appVersion: "1.2.3",
+            appBuild: "456",
+            capturedStage: "converting",
+            redactedDescription: "audio missing"
+        )
+        let viewModel = DiagnosticReportViewModel(
+            uploader: ScriptedDiagnosticUploader(outcomes: [.success(receipt)]),
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, _ in
+                try Self.makeArtifact(in: directory, data: Data("d".utf8), handoff: handoff)
+            }
+        )
+
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+        viewModel.uploadCapturedArtifact()
+        try await waitUntil {
+            if case .success = viewModel.phase { return true }
+            return false
+        }
+
+        let draft = try XCTUnwrap(viewModel.gitHubIssueDraft())
+        XCTAssertEqual(draft.supportCode, receipt.supportCode)
+        XCTAssertEqual(draft.redactedDescription, "audio missing")
+        let url = try XCTUnwrap(draft.url())
+        XCTAssertEqual(url.host, "github.com")
+        XCTAssertEqual(url.path, "/cbusillo/BD_to_AVP/issues/new")
+    }
+
+    @MainActor
+    func testSuccessfulUploadWithIncompleteHandoffDoesNotOfferGitHubDraft() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let receipt = DiagnosticReportReceipt(
+            supportCode: "BDAVP-0123456789ABCDEF",
+            expiresAt: Date(timeIntervalSince1970: 1_790_000_000)
+        )
+        let viewModel = DiagnosticReportViewModel(
+            uploader: ScriptedDiagnosticUploader(outcomes: [.success(receipt)]),
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, _ in
+                try Self.makeArtifact(in: directory, data: Data("d".utf8))
+            }
+        )
+
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+        viewModel.uploadCapturedArtifact()
+        try await waitUntil {
+            if case .success = viewModel.phase { return true }
+            return false
+        }
+
+        XCTAssertNil(viewModel.gitHubIssueDraft())
+    }
+
+    @MainActor
+    func testLocalOnlyReachesReviewWithoutSuccessOrHandoff() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, _ in
+                try Self.makeArtifact(
+                    in: directory,
+                    data: Data("d".utf8),
+                    userDescription: "note kept locally"
+                )
+            }
+        )
+
+        viewModel.userDescription = "note kept locally"
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+
+        XCTAssertFalse(viewModel.isUploadAvailable)
+        XCTAssertEqual(viewModel.artifact?.preview.userDescription, "note kept locally")
+        XCTAssertEqual(viewModel.userDescription, "")
+        XCTAssertNil(viewModel.handoffContext)
+        XCTAssertNil(viewModel.gitHubIssueDraft())
+        if case .success = viewModel.phase {
+            XCTFail("Local-only capture must not claim a linked private report")
+        }
+    }
+
+    @MainActor
+    func testDiscardClearsDescriptionAndHandoffBeforeNextCapture() async throws {
+        let rootDirectory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let viewModel = DiagnosticReportViewModel(
+            uploader: nil,
+            workspace: DiagnosticArtifactWorkspace(rootDirectory: rootDirectory),
+            capture: { directory, comment in
+                try Self.makeArtifact(
+                    in: directory,
+                    data: Data("d".utf8),
+                    userDescription: comment?.text
+                )
+            }
+        )
+
+        viewModel.userDescription = "first report"
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+        XCTAssertTrue(viewModel.discardLocalCopy())
+
+        XCTAssertEqual(viewModel.phase, .idle)
+        XCTAssertEqual(viewModel.userDescription, "")
+        XCTAssertNil(viewModel.handoffContext)
+
+        viewModel.begin()
+        viewModel.beginCapture()
+        try await waitUntil { viewModel.phase == .review }
+        XCTAssertNil(viewModel.artifact?.preview.userDescription)
+    }
+
     private func makeDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -201,7 +446,12 @@ final class DiagnosticReportViewModelTests: XCTestCase {
         return directory
     }
 
-    private static func makeArtifact(in directory: URL, data: Data) throws -> DiagnosticBundleArtifact {
+    private static func makeArtifact(
+        in directory: URL,
+        data: Data,
+        handoff: DiagnosticReportHandoffContext = .empty,
+        userDescription: String? = nil
+    ) throws -> DiagnosticBundleArtifact {
         let archiveURL = directory.appendingPathComponent("diagnostics.zip", isDirectory: false)
         try data.write(to: archiveURL)
         return DiagnosticBundleArtifact(
@@ -221,8 +471,10 @@ final class DiagnosticReportViewModelTests: XCTestCase {
                 ],
                 truncationNotices: [],
                 archiveBytes: data.count,
-                maximumArchiveBytes: 2 * 1_024 * 1_024
-            )
+                maximumArchiveBytes: 2 * 1_024 * 1_024,
+                userDescription: userDescription
+            ),
+            handoff: handoff
         )
     }
 
@@ -240,6 +492,22 @@ final class DiagnosticReportViewModelTests: XCTestCase {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
     }
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+
+    var value: Bool { lock.withLock { flag } }
+    func set() { lock.withLock { flag = true } }
+}
+
+private final class LockedComment: @unchecked Sendable {
+    private let lock = NSLock()
+    private var comment: DiagnosticUserComment??
+
+    var value: DiagnosticUserComment? { lock.withLock { comment ?? nil } }
+    func set(_ newValue: DiagnosticUserComment?) { lock.withLock { comment = .some(newValue) } }
 }
 
 private actor ScriptedDiagnosticUploader: DiagnosticReportUploading {

--- a/macos/BluRayToVisionProTests/DiagnosticUserCommentTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticUserCommentTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class DiagnosticUserCommentTests: XCTestCase {
+    func testEmptyInputReturnsNil() {
+        XCTAssertNil(DiagnosticUserComment.normalize(""))
+    }
+
+    func testWhitespaceOnlyInputReturnsNil() {
+        XCTAssertNil(DiagnosticUserComment.normalize("   \n\t  \r\n "))
+    }
+
+    func testNormalizesLineEndingsToLineFeed() {
+        let comment = DiagnosticUserComment.normalize("first\r\nsecond\rthird")
+        XCTAssertEqual(comment?.text, "first\nsecond\nthird")
+        XCTAssertEqual(comment?.truncated, false)
+    }
+
+    func testStripsControlAndFormatCharactersButKeepsTabsAndNewlines() {
+        let raw = "line\u{0000}one\u{0007}\ttwo\u{007F}\u{0085}\u{200B}\u{202E}\nthree"
+        let comment = DiagnosticUserComment.normalize(raw)
+        XCTAssertEqual(comment?.text, "lineone\ttwo\nthree")
+    }
+
+    func testTrimsLeadingAndTrailingWhitespace() {
+        let comment = DiagnosticUserComment.normalize("\n\n  hello world  \n")
+        XCTAssertEqual(comment?.text, "hello world")
+    }
+
+    func testOversizedCharacterCountIsBoundedAndFlagged() {
+        let raw = String(repeating: "a", count: DiagnosticUserComment.maximumCharacterCount + 500)
+        let comment = DiagnosticUserComment.normalize(raw)
+        XCTAssertEqual(comment?.text.count, DiagnosticUserComment.maximumCharacterCount)
+        XCTAssertEqual(comment?.truncated, true)
+    }
+
+    func testOversizedByteCountIsBoundedWithoutSplittingScalars() throws {
+        let multiScalarCharacter = "e\u{0301}\u{0302}\u{0303}\u{0304}"
+        let raw = String(repeating: multiScalarCharacter, count: 1_200)
+        XCTAssertLessThan(raw.count, DiagnosticUserComment.maximumCharacterCount)
+        XCTAssertGreaterThan(raw.utf8.count, DiagnosticUserComment.maximumByteCount)
+        let comment = try XCTUnwrap(DiagnosticUserComment.normalize(raw))
+        XCTAssertLessThanOrEqual(comment.text.utf8.count, DiagnosticUserComment.maximumByteCount)
+        XCTAssertTrue(comment.truncated)
+        // Valid UTF-8 round-trip proves no scalar was split.
+        XCTAssertEqual(String(decoding: Array(comment.text.utf8), as: UTF8.self), comment.text)
+    }
+}

--- a/macos/BluRayToVisionProTests/GitHubIssueDraftTests.swift
+++ b/macos/BluRayToVisionProTests/GitHubIssueDraftTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class GitHubIssueDraftTests: XCTestCase {
+    private func sampleDraft(
+        supportCode: String = "BDAVP-0123456789ABCDEF",
+        description: String? = "playback failed after stage two"
+    ) -> GitHubIssueDraft {
+        GitHubIssueDraft(
+            supportCode: supportCode,
+            appVersion: "1.2.3",
+            appBuild: "456",
+            capturedStage: "converting",
+            redactedDescription: description
+        )
+    }
+
+    func testURLTargetsOnlyThePublicRepositoryNewIssueEndpoint() throws {
+        let url = try XCTUnwrap(sampleDraft().url())
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, "github.com")
+        XCTAssertEqual(components.path, "/cbusillo/BD_to_AVP/issues/new")
+    }
+
+    func testQueryContainsOnlyTitleAndBodyParameters() throws {
+        let url = try XCTUnwrap(sampleDraft().url())
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let names = Set((components.percentEncodedQueryItems ?? []).map(\.name))
+        XCTAssertEqual(names, ["title", "body"])
+    }
+
+    func testBodyContainsAllowlistedFieldsOnly() {
+        let draft = sampleDraft()
+        let body = draft.body
+        XCTAssertTrue(body.contains(draft.supportCode))
+        XCTAssertTrue(body.contains("1.2.3"))
+        XCTAssertTrue(body.contains("456"))
+        XCTAssertTrue(body.contains("converting"))
+        XCTAssertTrue(body.contains("playback failed after stage two"))
+        XCTAssertTrue(body.lowercased().contains("public"))
+    }
+
+    func testDraftNeverExposesSecretBearingFieldNames() throws {
+        let draft = sampleDraft()
+        let url = try XCTUnwrap(draft.url())
+        let haystack = (url.absoluteString + draft.title + draft.body).lowercased()
+        for forbidden in ["report_id", "report-id", "reportid", "bearer", "object_key", "objectkey", "token=", "authorization", "/var/folders", "/users/"] {
+            XCTAssertFalse(haystack.contains(forbidden), "URL/body must not contain \(forbidden)")
+        }
+    }
+
+    func testSpecialCharactersInDescriptionCannotInjectExtraParameters() throws {
+        // A description crafted to look like extra query parameters must be encoded.
+        let draft = sampleDraft(description: "a&title=evil&body=evil#frag ?x=y")
+        let url = try XCTUnwrap(draft.url())
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual((components.percentEncodedQueryItems ?? []).count, 2)
+        XCTAssertFalse(url.absoluteString.contains("title=evil"))
+        XCTAssertFalse(url.absoluteString.contains("body=evil"))
+        XCTAssertNil(url.fragment)
+    }
+
+    func testDecodedQueryPreservesExactlyOneSafeTitleAndBody() throws {
+        let draft = sampleDraft(description: "a&title=evil\nsecond line")
+        let url = try XCTUnwrap(draft.url())
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = try XCTUnwrap(components.queryItems)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(items.first { $0.name == "title" }?.value, draft.title)
+        XCTAssertEqual(items.first { $0.name == "body" }?.value, draft.body)
+    }
+
+    func testTitleAndBodyAreBounded() {
+        let draft = sampleDraft(description: String(repeating: "z", count: 20_000))
+        XCTAssertLessThanOrEqual(draft.title.count, GitHubIssueDraft.maximumTitleCharacterCount)
+        XCTAssertLessThanOrEqual(draft.body.count, GitHubIssueDraft.maximumBodyCharacterCount)
+    }
+
+    func testMissingDescriptionStillProducesSafeURL() throws {
+        let draft = sampleDraft(description: nil)
+        let url = try XCTUnwrap(draft.url())
+        XCTAssertEqual(url.host, "github.com")
+        XCTAssertTrue(draft.body.contains(draft.supportCode))
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional, auto-focused **What went wrong?** step before immutable diagnostic capture
- normalize, bound, redact, preview, and archive the user description without changing the four-entry upload envelope
- offer a public/editable GitHub issue draft only after a successful private upload, linked solely by the non-secret support code
- harden Unicode control/format stripping, state cleanup, cancellation, and URL/query handling

## Validation
- `uv run python -m scripts.native_app test` — 257 tests passed
- `npm run check` in `support-diagnostics` — typecheck + 18 tests passed
- targeted cancellation, redaction, local-only, failure, upload-success, and URL-injection tests passed
- native visual review covered empty/filled composition, autofocus, privacy warning, capture, and exact reviewed description in the ZIP
- independent privacy/security and lifecycle reviews completed; blockers fixed

Closes #321