### PR TITLE
fix: expose left-right encode liveness

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -79,6 +79,14 @@ AV1_STEREO_VEXU_CONTENT_HEX = (
 )
 
 
+def output_artifact_roles(output_count: int) -> tuple[str, ...]:
+    if output_count == 1:
+        return ("stereo_video_output",)
+    if output_count == 2:
+        return ("left_eye_video_output", "right_eye_video_output")
+    return tuple(f"video_output_{index}" for index in range(1, output_count + 1))
+
+
 def generate_native_mvc_splitter_command(video_input_path: Path, *, single_threaded: bool = False) -> list[str | Path]:
     options = "-Osk" if single_threaded else "-Omk"
     return [
@@ -467,8 +475,8 @@ def run_native_mvc_split_attempt(
                     env=os.environ.copy(),
                     event_context=event_context,
                     artifacts=tuple(
-                        ProcessArtifactProbe(f"video_output_{index}", path=output_path)
-                        for index, output_path in enumerate(output_paths, start=1)
+                        ProcessArtifactProbe(role, path=output_path)
+                        for role, output_path in zip(output_artifact_roles(len(output_paths)), output_paths, strict=True)
                     ),
                     capture_overflow=CaptureOverflowPolicy.TRUNCATE,
                 )

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -476,7 +476,9 @@ def run_native_mvc_split_attempt(
                     event_context=event_context,
                     artifacts=tuple(
                         ProcessArtifactProbe(role, path=output_path)
-                        for role, output_path in zip(output_artifact_roles(len(output_paths)), output_paths, strict=True)
+                        for role, output_path in zip(
+                            output_artifact_roles(len(output_paths)), output_paths, strict=True
+                        )
                     ),
                     capture_overflow=CaptureOverflowPolicy.TRUNCATE,
                 )

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,6 +47,12 @@ the worker transport sequence without changing lifecycle progress, and projects
 their stable kind, stage, severity, message, detail, and failure fields into the
 existing bounded diagnostic history. Unsupported schemas, secret privacy, and
 oversized text fail decoding rather than falling back to unredacted strings.
+For multi-artifact stages such as `create_left_right_files`, the live status view
+retains the current left-eye and right-eye artifact samples separately. A quiet
+helper process with recently growing artifacts is therefore classified as active
+work rather than as an immediate stall. The technical-details panel reserves the
+stall warning for runs that have neither recent tool output nor recent expected
+artifact growth.
 
 Worker conversion stages pass the same `RunContext` and cancellation token into
 every child-tool wrapper. Canonical child-process events therefore retain the

--- a/macos/BluRayToVisionPro/Models/LiveObservabilityStatus.swift
+++ b/macos/BluRayToVisionPro/Models/LiveObservabilityStatus.swift
@@ -13,36 +13,117 @@ struct LiveObservabilityStatus: Equatable, Sendable {
         }
     }
 
+    enum ActivityState: Equatable, Sendable {
+        case active
+        case toolQuietArtifactsActive
+        case stalled
+    }
+
+    struct ArtifactStatus: Equatable, Sendable {
+        let role: String
+        let state: String?
+        let sizeBytes: Int64?
+        let modificationAgeSeconds: Int64?
+        let growthBytesPerSecond: Int64?
+        let sampledAt: Date
+
+        func currentModificationAgeSeconds(at date: Date) -> Int64? {
+            guard let modificationAgeSeconds else {
+                return nil
+            }
+            let hostElapsed = max(0, Int64(date.timeIntervalSince(sampledAt).rounded(.down)))
+            return modificationAgeSeconds + hostElapsed
+        }
+
+        func isRecentlyActive(at date: Date, thresholdSeconds: Int64) -> Bool {
+            guard state == "growing" else {
+                return false
+            }
+            let sampleAgeSeconds = max(0, Int64(date.timeIntervalSince(sampledAt).rounded(.down)))
+            if let growthBytesPerSecond,
+               growthBytesPerSecond > 0,
+               sampleAgeSeconds < thresholdSeconds
+            {
+                return true
+            }
+            guard let modificationAgeSeconds = currentModificationAgeSeconds(at: date) else {
+                return false
+            }
+            return modificationAgeSeconds < thresholdSeconds
+        }
+    }
+
     private(set) var stageID: String?
     private(set) var toolID: String?
+    private(set) var toolRunID: String?
     private(set) var processState: ProcessState?
     private(set) var lastOutputAgeSeconds: Int64?
     private(set) var lastOutputAgeSampledAt: Date?
-    private(set) var artifactRole: String?
-    private(set) var artifactState: String?
-    private(set) var artifactSizeBytes: Int64?
-    private(set) var artifactModificationAgeSeconds: Int64?
-    private(set) var artifactGrowthBytesPerSecond: Int64?
+    private var artifactSamples: [ArtifactStatus] = []
+    private var mostRecentArtifactRole: String?
     private(set) var updatedAt: Date?
 
     static let empty = LiveObservabilityStatus()
+
+    var artifacts: [ArtifactStatus] {
+        artifactSamples.sorted { left, right in
+            let leftPriority = Self.artifactPriority(left.role)
+            let rightPriority = Self.artifactPriority(right.role)
+            if leftPriority != rightPriority {
+                return leftPriority < rightPriority
+            }
+            return left.role < right.role
+        }
+    }
+
+    var artifactRole: String? {
+        focusedArtifact?.role
+    }
+
+    var artifactState: String? {
+        focusedArtifact?.state
+    }
+
+    var artifactSizeBytes: Int64? {
+        focusedArtifact?.sizeBytes
+    }
+
+    var artifactModificationAgeSeconds: Int64? {
+        focusedArtifact?.modificationAgeSeconds
+    }
+
+    var artifactGrowthBytesPerSecond: Int64? {
+        focusedArtifact?.growthBytesPerSecond
+    }
 
     var hasDetails: Bool {
         stageID != nil
             || toolID != nil
             || processState != nil
             || lastOutputAgeSeconds != nil
-            || artifactRole != nil
-            || artifactState != nil
-            || artifactSizeBytes != nil
-            || artifactGrowthBytesPerSecond != nil
+            || !artifactSamples.isEmpty
     }
 
     mutating func receive(_ event: ObservabilityEvent, receivedAt: Date) {
         let incomingToolID = Self.safeIdentifier(event.context.tool?.id)
-        let belongsToCurrentTool = incomingToolID == nil || incomingToolID == toolID
+        let incomingToolRunID = Self.safeIdentifier(event.context.tool?.runID)
+        let belongsToCurrentTool = incomingToolRunID != nil
+            ? incomingToolRunID == toolRunID
+            : incomingToolID == nil || incomingToolID == toolID
+        let toolDidChange: Bool
+        if let incomingToolRunID {
+            toolDidChange = incomingToolRunID != toolRunID
+        } else if let incomingToolID {
+            toolDidChange = incomingToolID != toolID
+        } else {
+            toolDidChange = false
+        }
         if let stageID = Self.safeIdentifier(event.context.stage?.id) {
             self.stageID = stageID
+        }
+        if toolDidChange {
+            artifactSamples.removeAll(keepingCapacity: true)
+            mostRecentArtifactRole = nil
         }
         if let processState = Self.processState(for: event) {
             let wouldRegressTerminalState = self.processState?.isTerminal == true
@@ -56,16 +137,15 @@ struct LiveObservabilityStatus: Equatable, Sendable {
         if let incomingToolID {
             toolID = incomingToolID
         }
+        if let incomingToolRunID {
+            toolRunID = incomingToolRunID
+        }
         if let age = event.data.activity?.lastOutputAgeSeconds {
             lastOutputAgeSeconds = age
             lastOutputAgeSampledAt = receivedAt
         }
         if let artifact = event.data.artifact {
-            artifactRole = Self.safeIdentifier(artifact.role)
-            artifactState = Self.safeIdentifier(artifact.state)
-            artifactSizeBytes = Self.nonNegative(artifact.sizeBytes)
-            artifactModificationAgeSeconds = Self.nonNegative(artifact.modificationAgeSeconds)
-            artifactGrowthBytesPerSecond = Self.nonNegative(artifact.growthBytesPerSecond)
+            updateArtifact(artifact, receivedAt: receivedAt)
         }
         updatedAt = receivedAt
     }
@@ -86,13 +166,21 @@ struct LiveObservabilityStatus: Equatable, Sendable {
         return lastOutputAgeSeconds + hostElapsed
     }
 
-    func isStalled(at date: Date, thresholdSeconds: Int64 = 60) -> Bool {
-        guard processState == .running || processState == .cancelling,
-              let age = currentLastOutputAgeSeconds(at: date)
-        else {
-            return false
+    func activityState(at date: Date, thresholdSeconds: Int64 = 60) -> ActivityState {
+        guard processState == .running || processState == .cancelling else {
+            return .active
         }
-        return age >= thresholdSeconds
+        guard let age = currentLastOutputAgeSeconds(at: date), age >= thresholdSeconds else {
+            return .active
+        }
+        if artifacts.contains(where: { $0.isRecentlyActive(at: date, thresholdSeconds: thresholdSeconds) }) {
+            return .toolQuietArtifactsActive
+        }
+        return .stalled
+    }
+
+    func isStalled(at date: Date, thresholdSeconds: Int64 = 60) -> Bool {
+        activityState(at: date, thresholdSeconds: thresholdSeconds) == .stalled
     }
 
     static func processState(for event: ObservabilityEvent) -> ProcessState? {
@@ -128,6 +216,48 @@ struct LiveObservabilityStatus: Equatable, Sendable {
             return nil
         }
         return value
+    }
+
+    private var focusedArtifact: ArtifactStatus? {
+        if let mostRecentArtifactRole,
+           let artifact = artifactSamples.first(where: { $0.role == mostRecentArtifactRole })
+        {
+            return artifact
+        }
+        return artifacts.first
+    }
+
+    private mutating func updateArtifact(_ artifact: ObservabilityArtifact, receivedAt: Date) {
+        guard let role = Self.safeIdentifier(artifact.role) else {
+            return
+        }
+        let snapshot = ArtifactStatus(
+            role: role,
+            state: Self.safeIdentifier(artifact.state),
+            sizeBytes: Self.nonNegative(artifact.sizeBytes),
+            modificationAgeSeconds: Self.nonNegative(artifact.modificationAgeSeconds),
+            growthBytesPerSecond: Self.nonNegative(artifact.growthBytesPerSecond),
+            sampledAt: receivedAt
+        )
+        if let existingIndex = artifactSamples.firstIndex(where: { $0.role == role }) {
+            artifactSamples[existingIndex] = snapshot
+        } else {
+            artifactSamples.append(snapshot)
+        }
+        mostRecentArtifactRole = role
+    }
+
+    private static func artifactPriority(_ role: String) -> Int {
+        switch role {
+        case "left_eye_video_output":
+            return 0
+        case "right_eye_video_output":
+            return 1
+        case "stereo_video_output":
+            return 2
+        default:
+            return 100
+        }
     }
 
     private static func safeIdentifier(_ value: String?) -> String? {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1024,6 +1024,10 @@ private struct LiveObservabilityStatusView: View {
     @State private var now = Date()
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+    private var activityState: LiveObservabilityStatus.ActivityState {
+        status.activityState(at: now)
+    }
+
     private var processState: String? {
         status.processState?.rawValue.capitalized
     }
@@ -1032,18 +1036,24 @@ private struct LiveObservabilityStatusView: View {
         status.currentLastOutputAgeSeconds(at: now).map { "\($0)s ago" }
     }
 
+    private var statusSummary: String {
+        switch activityState {
+        case .active:
+            return "Recent tool output or heartbeat"
+        case .toolQuietArtifactsActive:
+            return "Tool output quiet; artifact growth continues"
+        case .stalled:
+            return "No recent tool output or artifact growth"
+        }
+    }
+
+    private var artifactLabel: String {
+        status.artifacts.count == 1 ? "Artifact" : "Artifacts"
+    }
+
     private var artifactDescription: String? {
-        let identity = [status.artifactRole, status.artifactState]
-            .compactMap { $0 }
-            .joined(separator: " · ")
-        let size = status.artifactSizeBytes.map {
-            ByteCountFormatter.string(fromByteCount: $0, countStyle: .file)
-        }
-        let growth = status.artifactGrowthBytesPerSecond.map {
-            "+\(ByteCountFormatter.string(fromByteCount: $0, countStyle: .file))/s"
-        }
-        let values = [identity.isEmpty ? nil : identity, size, growth].compactMap { $0 }
-        return values.isEmpty ? nil : values.joined(separator: " · ")
+        let descriptions = status.artifacts.map(artifactDescription(_:))
+        return descriptions.isEmpty ? nil : descriptions.joined(separator: "\n")
     }
 
     var body: some View {
@@ -1052,8 +1062,12 @@ private struct LiveObservabilityStatusView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
 
-            if status.isStalled(at: now) {
-                Label("No recent tool output", systemImage: "clock.badge.exclamationmark")
+            if activityState == .toolQuietArtifactsActive {
+                Label("Artifact growth continues while the tool stays quiet", systemImage: "clock.badge.checkmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            } else if activityState == .stalled {
+                Label("No recent tool output or artifact growth", systemImage: "clock.badge.exclamationmark")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.orange)
             }
@@ -1061,15 +1075,46 @@ private struct LiveObservabilityStatusView: View {
             statusRow("Stage", value: status.stageID)
             statusRow("Tool", value: status.toolID)
             statusRow("Process", value: processState)
+            statusRow("Status", value: statusSummary)
             statusRow("Last output", value: lastOutput)
-            statusRow("Artifact", value: artifactDescription)
+            statusRow(artifactLabel, value: artifactDescription)
         }
         .font(.caption.monospaced())
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Live tool status")
-        .accessibilityValue(status.isStalled(at: now) ? "No recent tool output" : "Active")
+        .accessibilityValue(statusSummary)
         .onReceive(timer) { now = $0 }
+    }
+
+    private func artifactDescription(_ artifact: LiveObservabilityStatus.ArtifactStatus) -> String {
+        let identity = [friendlyArtifactRole(artifact.role), artifact.state]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+        let size = artifact.sizeBytes.map {
+            ByteCountFormatter.string(fromByteCount: $0, countStyle: .file)
+        }
+        let growth = artifact.growthBytesPerSecond.map {
+            $0 > 0
+                ? "+\(ByteCountFormatter.string(fromByteCount: $0, countStyle: .file))/s"
+                : "no growth"
+        }
+        let age = artifact.currentModificationAgeSeconds(at: now).map { "mtime \($0)s ago" }
+        let values = [identity.isEmpty ? nil : identity, size, growth, age].compactMap { $0 }
+        return values.joined(separator: " · ")
+    }
+
+    private func friendlyArtifactRole(_ role: String) -> String {
+        switch role {
+        case "left_eye_video_output":
+            return "Left eye"
+        case "right_eye_video_output":
+            return "Right eye"
+        case "stereo_video_output":
+            return "Stereo video"
+        default:
+            return role
+        }
     }
 
     @ViewBuilder

--- a/macos/BluRayToVisionProTests/LiveObservabilityStatusTests.swift
+++ b/macos/BluRayToVisionProTests/LiveObservabilityStatusTests.swift
@@ -70,6 +70,239 @@ final class LiveObservabilityStatusTests: XCTestCase {
         )
     }
 
+    func testGrowingArtifactKeepsQuietToolOutOfStalledState() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.activity",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                activityAge: 58
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                stageID: "create_left_right_files",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                artifact: [
+                    "role": "left_eye_video_output",
+                    "state": "growing",
+                    "size_bytes": 1_572_864_000,
+                    "modification_age_seconds": 4,
+                    "growth_bytes_per_second": 8_388_608,
+                ]
+            ),
+            receivedAt: receivedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(
+            status.activityState(at: receivedAt.addingTimeInterval(3)),
+            .toolQuietArtifactsActive
+        )
+        XCTAssertFalse(status.isStalled(at: receivedAt.addingTimeInterval(3)))
+    }
+
+    func testStalePositiveGrowthSampleEventuallyBecomesStalled() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.activity",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                activityAge: 60
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                stageID: "create_left_right_files",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                artifact: [
+                    "role": "left_eye_video_output",
+                    "state": "growing",
+                    "size_bytes": 1_572_864_000,
+                    "modification_age_seconds": 4,
+                    "growth_bytes_per_second": 8_388_608,
+                ]
+            ),
+            receivedAt: receivedAt
+        )
+
+        XCTAssertEqual(
+            status.activityState(at: receivedAt.addingTimeInterval(60)),
+            .stalled
+        )
+    }
+
+    func testUnknownArtifactStateDoesNotMaskAStall() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.activity",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                activityAge: 60
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                toolRunID: "run-a",
+                process: ["pid": 42],
+                artifact: [
+                    "role": "left_eye_video_output",
+                    "state": "future/state",
+                    "modification_age_seconds": 1,
+                    "growth_bytes_per_second": 8_388_608,
+                ]
+            ),
+            receivedAt: receivedAt
+        )
+
+        XCTAssertNil(status.artifactState)
+        XCTAssertEqual(status.activityState(at: receivedAt), .stalled)
+    }
+
+    func testRetainsBothLeftAndRightArtifactSnapshots() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                stageID: "create_left_right_files",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                artifact: [
+                    "role": "left_eye_video_output",
+                    "state": "growing",
+                    "size_bytes": 1_048_576,
+                    "modification_age_seconds": 2,
+                    "growth_bytes_per_second": 262_144,
+                ]
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                stageID: "create_left_right_files",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42, "process_group_id": 42],
+                artifact: [
+                    "role": "right_eye_video_output",
+                    "state": "growing",
+                    "size_bytes": 2_097_152,
+                    "modification_age_seconds": 3,
+                    "growth_bytes_per_second": 524_288,
+                ]
+            ),
+            receivedAt: receivedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(status.artifacts.map(\.role), ["left_eye_video_output", "right_eye_video_output"])
+        XCTAssertEqual(status.artifacts.map(\.growthBytesPerSecond), [262_144, 524_288])
+        XCTAssertEqual(status.artifactRole, "right_eye_video_output")
+        XCTAssertEqual(status.artifactGrowthBytesPerSecond, 524_288)
+    }
+
+    func testToolRunChangeResetsArtifactSnapshotState() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42],
+                artifact: [
+                    "role": "left_eye_video_output",
+                    "state": "growing",
+                ]
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.started",
+                toolID: "ffmpeg",
+                toolRunID: "run-b",
+                process: ["pid": 43, "process_group_id": 43]
+            ),
+            receivedAt: receivedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(status.toolRunID, "run-b")
+        XCTAssertTrue(status.artifacts.isEmpty)
+    }
+
+    func testSameToolRunRetainsArtifactsWhenToolLabelChanges() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        status.receive(
+            try makeEvent(
+                kind: "tool.artifact",
+                toolID: "ffmpeg",
+                toolRunID: "run-a",
+                process: ["pid": 42],
+                artifact: ["role": "left_eye_video_output", "state": "growing"]
+            ),
+            receivedAt: receivedAt
+        )
+        status.receive(
+            try makeEvent(
+                kind: "tool.activity",
+                toolID: "ffmpeg-helper",
+                toolRunID: "run-a",
+                process: ["pid": 42],
+                activityAge: 1
+            ),
+            receivedAt: receivedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(status.toolID, "ffmpeg-helper")
+        XCTAssertEqual(status.toolRunID, "run-a")
+        XCTAssertEqual(status.artifacts.map(\.role), ["left_eye_video_output"])
+    }
+
+    func testSharedLeftRightFixturesKeepQuietEncoderActive() throws {
+        let receivedAt = Date(timeIntervalSince1970: 100)
+        var status = LiveObservabilityStatus.empty
+        for fixtureName in [
+            "observability_left_eye_growing_v1.json",
+            "observability_right_eye_growing_v1.json",
+        ] {
+            status.receive(
+                try JSONDecoder().decode(
+                    ObservabilityEvent.self,
+                    from: try sharedFixtureData(named: fixtureName)
+                ),
+                receivedAt: receivedAt
+            )
+        }
+
+        XCTAssertEqual(status.activityState(at: receivedAt), .toolQuietArtifactsActive)
+        XCTAssertEqual(
+            status.artifacts.map(\.role),
+            ["left_eye_video_output", "right_eye_video_output"]
+        )
+        XCTAssertEqual(status.artifacts.map(\.sizeBytes), [884_998_144, 1_589_137_900])
+    }
+
     func testSharedLongRunningFixturesDistinguishHealthyWorkFromStall() throws {
         let receivedAt = Date(timeIntervalSince1970: 100)
         var active = LiveObservabilityStatus.empty
@@ -156,6 +389,7 @@ final class LiveObservabilityStatusTests: XCTestCase {
         kind: String,
         stageID: String = "encode",
         toolID: String = "ffmpeg",
+        toolRunID: String = "tool-run-1",
         process: [String: Any]? = nil,
         activityAge: Int64? = nil,
         artifact: [String: Any]? = nil
@@ -166,7 +400,7 @@ final class LiveObservabilityStatusTests: XCTestCase {
         fixture["kind"] = kind
         var context = try XCTUnwrap(fixture["context"] as? [String: Any])
         context["stage"] = ["id": stageID]
-        context["tool"] = ["id": toolID]
+        context["tool"] = ["id": toolID, "run_id": toolRunID]
         context["process"] = process
         fixture["context"] = context
         var data = try XCTUnwrap(fixture["data"] as? [String: Any])

--- a/tests/fixtures/observability_left_eye_growing_v1.json
+++ b/tests/fixtures/observability_left_eye_growing_v1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "bd_to_avp.observability",
+  "schema_version": 1,
+  "emitter": "worker",
+  "stream_id": "38f64c27-a1cf-43e8-92d7-021cc5f9b315",
+  "sequence": 80,
+  "occurred_at": "2026-07-21T00:00:00.000Z",
+  "elapsed_ms": 7200000,
+  "kind": "tool.artifact",
+  "severity": "info",
+  "privacy": "private",
+  "redaction": "raw",
+  "context": {
+    "correlation": {
+      "job_id": "c555d6b5-c20f-42cb-bf91-21433459b1de"
+    },
+    "stage": {
+      "id": "create_left_right_files",
+      "index": 8,
+      "count": 14
+    },
+    "tool": {
+      "id": "ffmpeg",
+      "run_id": "4a9ba245-a370-40a4-8b85-00b03531f46e"
+    },
+    "process": {
+      "pid": 9134,
+      "process_group_id": 9134
+    }
+  },
+  "data": {
+    "artifact": {
+      "role": "left_eye_video_output",
+      "state": "growing",
+      "location": {
+        "value": "/Users/example/Movies/Feature/temp_files/left.mp4",
+        "privacy": "private",
+        "truncated": false
+      },
+      "size_bytes": 884998144,
+      "modification_age_seconds": 2,
+      "growth_bytes_per_second": 8388608
+    },
+    "activity": {
+      "last_output_age_seconds": 75
+    }
+  }
+}

--- a/tests/fixtures/observability_right_eye_growing_v1.json
+++ b/tests/fixtures/observability_right_eye_growing_v1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "bd_to_avp.observability",
+  "schema_version": 1,
+  "emitter": "worker",
+  "stream_id": "38f64c27-a1cf-43e8-92d7-021cc5f9b315",
+  "sequence": 81,
+  "occurred_at": "2026-07-21T00:00:05.000Z",
+  "elapsed_ms": 7205000,
+  "kind": "tool.artifact",
+  "severity": "info",
+  "privacy": "private",
+  "redaction": "raw",
+  "context": {
+    "correlation": {
+      "job_id": "c555d6b5-c20f-42cb-bf91-21433459b1de"
+    },
+    "stage": {
+      "id": "create_left_right_files",
+      "index": 8,
+      "count": 14
+    },
+    "tool": {
+      "id": "ffmpeg",
+      "run_id": "4a9ba245-a370-40a4-8b85-00b03531f46e"
+    },
+    "process": {
+      "pid": 9134,
+      "process_group_id": 9134
+    }
+  },
+  "data": {
+    "artifact": {
+      "role": "right_eye_video_output",
+      "state": "growing",
+      "location": {
+        "value": "/Users/example/Movies/Feature/temp_files/right.mp4",
+        "privacy": "private",
+        "truncated": false
+      },
+      "size_bytes": 1589137900,
+      "modification_age_seconds": 3,
+      "growth_bytes_per_second": 6291456
+    },
+    "activity": {
+      "last_output_age_seconds": 80
+    }
+  }
+}

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -64,6 +64,17 @@ class NativeMvcCommandTests(unittest.TestCase):
             ],
         )
 
+    def test_output_artifact_roles_distinguish_left_and_right_outputs(self) -> None:
+        self.assertEqual(video.output_artifact_roles(1), ("stereo_video_output",))
+        self.assertEqual(
+            video.output_artifact_roles(2),
+            ("left_eye_video_output", "right_eye_video_output"),
+        )
+        self.assertEqual(
+            video.output_artifact_roles(3),
+            ("video_output_1", "video_output_2", "video_output_3"),
+        )
+
     def test_native_ffmpeg_command_splits_side_by_side_stream(self) -> None:
         with (
             patch.object(video.config, "left_right_bitrate", 12),
@@ -264,6 +275,10 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertEqual([stage.spec.tool_id for stage in stages], ["ffmpeg", "edge264", "ffmpeg"])
         self.assertEqual([stage.spec.argv[0] for stage in stages], ["source-ffmpeg", "edge264_test", "encode-ffmpeg"])
         self.assertEqual([probe.path for probe in stages[-1].spec.artifacts], [left_output, right_output])
+        self.assertEqual(
+            [probe.role for probe in stages[-1].spec.artifacts],
+            ["left_eye_video_output", "right_eye_video_output"],
+        )
         self.assertTrue(all(stage.spec.event_context is event_context for stage in stages))
         self.assertIs(run.call_args.kwargs["run_context"], run_context)
         self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
@@ -494,7 +509,7 @@ def process_result(tool_id: str) -> ProcessResult:
     return ProcessResult(tool_run_id=f"{tool_id}-run", returncode=0, elapsed_ms=1, stdout=empty, stderr=empty)
 
 
-def process_error(returncode: int, command: list[str]) -> ProcessExecutionError:
+def process_error(returncode: int, command: list[str | bytes]) -> ProcessExecutionError:
     empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
     return ProcessExecutionError(returncode, command, empty, empty)
 
@@ -538,7 +553,7 @@ def pipeline_failure(
                 "ffmpeg",
                 None if ffmpeg_error else process_result("encoder"),
                 ffmpeg_error,
-                completed_before_final=True,
+                completed_before_final=ffmpeg_error is not None,
             ),
         )
     )

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -448,6 +448,39 @@ class ChildProcessRunnerTests(unittest.TestCase):
         self.assertEqual(artifact_events[-1].data.artifact.state, "complete")
         self.assertEqual(artifact_events[-1].data.artifact.size_bytes, 131072)
 
+    def test_cancellation_emits_terminal_incomplete_artifact_snapshot(self) -> None:
+        sink = RecordingSink()
+        cancellation_event = threading.Event()
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            timer = threading.Timer(0.1, cancellation_event.set)
+            timer.start()
+            try:
+                with self.assertRaises(ProcessCancelled):
+                    ChildProcessRunner().run(
+                        self.spec(
+                            "import pathlib, sys, time; path = pathlib.Path(sys.argv[1]); "
+                            "path.write_bytes(b'x' * 70000); time.sleep(30)",
+                            artifact,
+                            artifacts=(ProcessArtifactProbe("intermediate", artifact),),
+                            artifact_interval_seconds=0.04,
+                            termination_grace_seconds=0.1,
+                            kill_wait_seconds=0.1,
+                        ),
+                        run_context=context,
+                        cancellation_event=cancellation_event,
+                    )
+            finally:
+                timer.cancel()
+
+        artifact_events = [event for event in sink.snapshot().events if event.kind == "tool.artifact"]
+        self.assertGreaterEqual(len(artifact_events), 1)
+        self.assertEqual(artifact_events[-1].data.artifact.state, "incomplete")
+        self.assertEqual(artifact_events[-1].data.artifact.size_bytes, 65536)
+        terminal = sink.snapshot().events[-1]
+        self.assertEqual(terminal.kind, "tool.cancelled")
+
     def test_blocked_event_sink_does_not_block_output_draining(self) -> None:
         release_sink = threading.Event()
 


### PR DESCRIPTION
## Summary
- label and retain left-eye and right-eye artifact samples independently
- distinguish quiet tool output with continuing file growth from a true stall
- emit a final incomplete artifact snapshot on cancellation
- add production-scale shared fixtures and native/Python regression coverage

## Scope
This improves diagnosis of the Create Left/Right Files plateau reported in #319. It does not claim to fix a media-specific encoder deadlock without the original source/report.

## Validation
- `uv run python -m unittest discover -s tests -t .` (767 passed, 2 skipped)
- `uv run python scripts/native_app.py test` after merging current `main` (264 passed)
- `git diff --check`

Closes #319