### PR TITLE
chore: prepare and freeze Beta 4 metadata

### DIFF
--- a/.github/release-freezes.json
+++ b/.github/release-freezes.json
@@ -1,5 +1,10 @@
 {
   "schema": "bd_to_avp.release_freezes",
   "schema_version": 1,
-  "frozen_release_tags": {}
+  "frozen_release_tags": {
+    "v0.3.0-beta.4": {
+      "issue": 316,
+      "reason": "Beta 4 signing, publication, appcast mutation, and field qualification require explicit authorization after the production diagnostics admission gate is deployed."
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ feasibility record before choosing it for headset delivery.
 
 ## GUI install
 
-For a normal Stable install of `Blu-ray to Vision Pro`, download GitHub Latest
+For a normal Stable install of `3D Blu-ray to Vision Pro`, download GitHub Latest
 from the [releases page]. Open the DMG file and drag the app to your Applications
 folder. Beta 3 is a prerelease rather than GitHub Latest; use only its exact
 tagged release as described below.
@@ -37,7 +37,7 @@ for macOS 14 through 25.
 
 ### Beta 3 manual bootstrap
 
-When published, `v0.3.0-beta.3` is a one-time manual-download seed, not an
+Published `v0.3.0-beta.3` is a one-time manual-download seed, not an
 update that currently shipped Stable or RC clients can discover. Those clients
 can select only Stable or RC, so they cannot select the Beta route or receive
 Beta 3 through Sparkle. Download that exact GitHub Release DMG, drag it into
@@ -60,6 +60,11 @@ and Alpha. The Beta 3 appcast item is eligible only on Beta and Alpha; Stable
 and RC exclude it. Existing Stable or RC selections remain in place until you
 explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
+
+Beta 4 metadata (`0.3.0b4`, build `149`) is prepared but release-frozen. There
+is no Beta 4 tag, DMG, release, or updater item until the guarded publication
+issue completes the production diagnostics admission gate, explicit release
+authorization, signing, and public verification.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.

--- a/docs/0.3.0-beta.4-cut-packet.md
+++ b/docs/0.3.0-beta.4-cut-packet.md
@@ -1,0 +1,97 @@
+# 0.3.0 Beta 4 Cut Packet
+
+> **Frozen metadata only.** Issue #315 owns the repository preparation recorded
+> here. Issue #316 exclusively owns removal of the release freeze, exact-SHA
+> workflow dispatch, signing approval, notarization, artifact construction,
+> release/appcast publication, and installed-field qualification. This packet
+> does not assert that a Beta 4 tag, draft, DMG, release, or appcast item exists.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 4 is prepared from protected `main`
+commit `51dd2979c6d5dc4d13a1f78b4b63b5f96ea6589d`, after the three field-feedback
+PRs merged and their post-merge CI and CodeQL completed successfully.
+
+## Exact Metadata
+
+| Field | Frozen value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b4` |
+| Public version | `0.3.0-beta.4` |
+| Bundle and Sparkle build | `149` |
+| GitHub tag and release title | `v0.3.0-beta.4` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4`, rooted in PR #313 |
+
+Build `149` is globally newer than the production appcast, whose newest item is
+immutable Beta 3 build `148`. The live remote audit found no
+`v0.3.0-beta.4` tag, release, draft, appcast item, or PyPI `0.3.0b4` project
+version before preparation.
+
+## Included Product Changes
+
+- PR #313 removes raw process and thread identifiers from privacy-rules-v4
+  diagnostic capture. PR #317 makes the service reject missing or pre-v4
+  clients before upload authorization; production deployment remains gated by
+  explicit Cloudflare authorization in issue #314.
+- PR #323 adds an optional bounded, redacted problem description to the support
+  bundle and offers a GitHub issue draft only after a successful private upload.
+  The browser draft contains the support code, app/build, captured stage, and
+  redacted user description; it does not contain report credentials, object
+  keys, raw ZIP data, local paths, or GitHub credentials.
+- PR #324 retains left-eye and right-eye artifact samples independently and
+  distinguishes quiet tool output with continuing file growth from a true
+  no-output/no-growth stall. It improves Ship's next report but does not claim
+  to fix or explain a media-specific encoder deadlock.
+- PR #325 adds independent **All Languages** and **Preferred Language Only**
+  audio controls. Preferred-only keeps every canonical metadata-language match
+  in source order, with visible source-default/first-track fallback; audio and
+  subtitle policies remain independent.
+
+## Cumulative Update Contract
+
+Publication must append Beta 4 above Beta 3 without rewriting production
+history:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b4` | `149` | `beta` |
+| 2 | `0.3.0b3` | `148` | `beta` |
+| 3 | `0.2.143` | `146` | Stable / no channel |
+
+Stable and RC continue to exclude Beta items. Beta and Alpha admit both Beta 3
+and Beta 4, and an installed Beta 3 on either route may update forward to build
+`149`. Moving to a safer route never downgrades an installed prerelease.
+
+## Reviewed Release-Note Seed
+
+Use this text only inside issue #316's authorized publication flow:
+
+> BD_to_AVP `v0.3.0-beta.4` adds independent audio-language selection,
+> privacy-rules-v4 diagnostic comments with a safe GitHub issue handoff, and
+> clearer left/right output-growth status for apparent stalls. All Languages
+> remains the audio default. This build improves future stall reports but does
+> not claim to fix Ship's media-specific encoder plateau.
+
+Do not describe Beta 4 as downloadable, signed, published, or
+Sparkle-discoverable until issue #316 completes the guarded release and verifies
+the immutable public state.
+
+## Freeze Boundary
+
+`.github/release-freezes.json` binds `v0.3.0-beta.4` to issue #316. The guarded
+Prerelease workflow must fail before packaging or signing while that entry is
+present. Only issue #316 may remove it through a protected-main pull request,
+and only after issue #314 records an explicitly authorized production service
+deployment and exact live admission evidence.
+
+Issue #315 performs no workflow dispatch, environment approval, signing,
+notarization, tag or draft creation, artifact construction, appcast mutation,
+Pages deployment, or publication.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -84,10 +84,12 @@ document it as an external dependency with preflight behavior.
   production GUI path. The protected-main release workflow builds that app with
   the production name and bundle identifier on a pinned GitHub-hosted macOS 26
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
-- The next planned production-identity field build is `v0.3.0-beta.3`, internal
-  version `0.3.0b3`, build `148`. It is a manual-download seed because currently
-  shipped clients cannot select Beta or Alpha, but its immutable appcast item is
-  visible to those routes after the new selector is installed.
+- The next prepared production-identity field build is `v0.3.0-beta.4`, internal
+  version `0.3.0b4`, build `149`. It is frozen against release dispatch until
+  issue #314 records an explicitly authorized production diagnostics admission
+  deployment and issue #316 removes the committed freeze through protected-main
+  review. Beta 3 build `148` remains the published manual-download seed and
+  immutable appcast history below it.
 - Stable, RC, Beta, and Alpha are routes for the same product, bundle identifier,
   feed, Sparkle key, signing team, and diagnostics endpoint. Stable is default;
   broader routes include progressively earlier stages without permitting

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -87,23 +87,18 @@ identity differs. Release metadata separately derives the dotted public tag,
 title, and DMG name instead of treating the internal PEP 440 version as a public
 identifier.
 
-Stable is the default unchanneled Sparkle route. The application now persists
+Stable is the default unchanneled Sparkle route. The application persists
 Stable `{}`, RC `{rc}`, Beta `{beta, rc}`, and Alpha `{alpha, beta, rc}` as exact
 additional-channel sets. Existing `stable`, `rc`, and legacy
 `releaseCandidate` preferences migrate without selecting a less stable route;
 missing or unknown values fail closed to Stable. Choosing a safer route affects
-only future newer builds and never downgrades the installed app. The next
-production-identity field build is `0.3.0b3` build `148`. It will be published
-as `v0.3.0-beta.3`. It is a manual-download seed: currently shipped Stable and RC
-installations cannot select Beta, so they cannot discover it with Sparkle. Before
-installing it, quit the production app and all retired Preview variants, then
-copy `~/Library/Application Support/3D Blu-ray to Vision Pro/profiles.json` to a
-safe location outside that folder if it exists. Bundle separation does not
-isolate this shared profile path; do not edit it from a retired Preview app after
-Beta 3 installation. The manual DMG replaces the production
-`com.shinycomputers.bd-to-avp` app; after launch, it exposes all four routes.
-Its Beta 3 item is visible only to Beta and Alpha, while persisted Stable and RC
-remain unchanged until explicit selection and never downgrade an installed Beta.
+only future newer builds and never downgrades the installed app. Published Beta
+3 (`0.3.0b3`, build `148`) is the one-time manual-download production seed:
+older Stable and RC installations cannot discover it, while an installed Beta
+3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) is the next prepared
+target and is committed with a release freeze. Its future cumulative item must
+sit above Beta 3 and remain visible only to Beta and Alpha until a later newer
+Stable supersedes it.
 
 ## Release Workflow
 
@@ -155,12 +150,15 @@ behavior and engine architecture rather than release branding.
 
 ## Remaining Field Evidence
 
-The accepted physical-disc result allows the production line to proceed with
-Beta 3 so the merged observability and diagnostics can classify the reported
-follow-on issues. The signed installed-app tests must prove that:
+Beta 3 publication and route qualification are complete. Beta 4 field evidence
+is intentionally blocked until its committed freeze is lifted through issue
+#316 and the production diagnostics service admits privacy-rules-v4 clients.
+The signed installed-app qualification must prove that:
 
-- existing Stable and RC preferences migrate without silently selecting Beta;
-- Beta 3 installs with the production identity and exposes all four routes;
-- Stable and RC exclude Beta 3 while Beta and Alpha admit it; and
-- a newer unchanneled Stable can later supersede prereleases for every route
-  without changing the saved preference.
+- Beta 3 updates forward to Beta 4 on Beta and Alpha without changing the saved
+  route;
+- Stable and RC continue to exclude both Beta items;
+- the production service rejects pre-v4 clients and accepts the signed Beta 4
+  client; and
+- a deliberate report can be submitted, retrieved by support code, assessed
+  for privacy and diagnostic sufficiency, and deleted.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,20 +4,19 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The repository now carries the reviewed `v0.3.0-beta.3` metadata: internal
-version `0.3.0b3`, build `148`. The failed, unpublished `0.3.0rc1` build `147`
-attempt is preserved in the checked-in recovery evidence and its build number
-is permanently burned. The exact recovery and
-[Beta 3 cut packet](0.3.0-beta.3-cut-packet.md) are complete; they do not assert
-that any Beta 3 public artifact exists.
+The repository carries published, immutable Beta 3 history at internal version
+`0.3.0b3`, build `148`, and a frozen Beta 4 target at `0.3.0b4`, build `149`.
+The failed, unpublished `0.3.0rc1` build `147` attempt is preserved in the
+checked-in recovery evidence and its build number is permanently burned. The
+reviewed [Beta 4 cut packet](0.3.0-beta.4-cut-packet.md) records metadata only;
+it does not assert that any Beta 4 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issue #294 has authorized publication by
-removing the Beta 3 release-freeze entry through protected-main review and now
-exclusively owns the exact-SHA dispatch, approval, signing, publication, and
-verification work.
+implemented and regression-covered. Issue #316 owns Beta 4 unfreeze, exact-SHA
+dispatch, approval, signing, publication, and verification after issue #314
+records an explicitly authorized production diagnostics admission deployment.
 
 ## Release Preparation
 
@@ -33,9 +32,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b3` maps to public `0.3.0-beta.3`, tag/title
-`v0.3.0-beta.3`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg`. The numeric
+example, internal `0.3.0b4` maps to public `0.3.0-beta.4`, tag/title
+`v0.3.0-beta.4`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -76,13 +75,14 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 3 publication is authorized only through issue #294.** The repository
-> metadata is the reviewed `0.3.0b3` build `148` target and build `147` remains
-> permanently burned. The Beta 3 entry has been removed from
-> `.github/release-freezes.json` through protected-main review. Do not dispatch
-> until the exact unfreeze merge SHA has green post-merge CI and CodeQL. Only
-> the guarded `Prerelease` workflow may request `macos-signing` approval, sign,
-> publish, append the cumulative appcast, or deploy Pages for this release.
+> **Beta 4 is not authorized for release.** The repository metadata is the
+> reviewed `0.3.0b4` build `149` target, and
+> `.github/release-freezes.json` binds `v0.3.0-beta.4` to issue #316. Do not
+> dispatch, request `macos-signing` approval, sign, publish, append the
+> cumulative appcast, or deploy Pages while that entry is present. Only #316 may
+> remove the freeze through protected-main review after #314 records an
+> explicitly authorized production diagnostics deployment and live admission
+> evidence.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,
@@ -272,8 +272,8 @@ Sparkle implicitly includes default Stable items for every route. Moving to a
 safer route affects only future newer builds and never downgrades the installed
 application.
 
-When published, `v0.3.0-beta.3` (`0.3.0b3`, build `148`) is appended to the
-cumulative feed on channel `beta`, but currently shipped Stable and RC clients
+Published `v0.3.0-beta.3` (`0.3.0b3`, build `148`) is appended to the cumulative
+feed on channel `beta`, but currently shipped Stable and RC clients
 cannot select that channel. It is therefore a manual-download seed, not a
 Sparkle-discoverable update from those installations. Testers download the exact
 GitHub Release DMG, replace the production

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,12 +6,12 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. The exact Beta 3 metadata migration and bootstrap are
-complete at `0.3.0b3` build `148`, with build `147` permanently burned. Issue
-#294 has removed the Beta 3 release-freeze entry through protected-main review
-and exclusively owns exact-SHA dispatch, approval, signing, publication, and
-public verification. No public-artifact claim exists until that guarded flow
-completes and its public state is independently verified.
+this four-route contract. Beta 3 is published and immutable at `0.3.0b3` build
+`148`, with build `147` permanently burned. The next prepared target is frozen
+Beta 4 at `0.3.0b4` build `149`. Issue #316 exclusively owns removing that
+freeze, exact-SHA dispatch, approval, signing, publication, and public
+verification after the production diagnostics admission gate in issue #314 is
+deployed with explicit authorization.
 
 ## Production Identity
 
@@ -52,7 +52,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -107,7 +107,7 @@ prerelease must not silently change an existing route preference.
 
 ## Beta 3 Manual-Download Seed
 
-When published, `v0.3.0-beta.3` is the first Beta on the production identity
+Published `v0.3.0-beta.3` is the first Beta on the production identity
 and the one-time manual-download seed:
 
 - internal version `0.3.0b3`;
@@ -139,8 +139,32 @@ prereleases. Beta 3 remains immutable production/feed history in the cumulative
 appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
-client waits for a newer eligible Stable build. The next production build is at
-least `149`.
+client waits for a newer eligible Stable build. Beta 4 reserves the next global
+build, `149`.
+
+## Beta 4 Frozen Target
+
+The repository is prepared for `v0.3.0-beta.4` without authorizing a release:
+
+- internal version `0.3.0b4`;
+- public tag and title `v0.3.0-beta.4`;
+- global build `149`;
+- Sparkle channel `beta`;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta 3.
+
+The cumulative appcast must place Beta 4 above immutable Beta 3 build `148` and
+Stable build `146`. Stable and RC exclude both Beta items; Beta and Alpha admit
+them, allowing an installed Beta 3 to update forward to Beta 4 without changing
+the saved route.
+
+`.github/release-freezes.json` binds this exact tag to issue #316. No tag,
+draft, DMG, release, or appcast item may be created while the freeze is present.
+Only #316 may remove it through protected-main review after #314 records an
+explicitly authorized production diagnostics deployment. The reviewed metadata
+and release-note seed are in
+[the Beta 4 cut packet](0.3.0-beta.4-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -267,6 +267,25 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
+### Beta 4 Frozen-Preparation Smoke
+
+Run these checks before any unfreeze or release authorization. They prove only
+the committed target and fail-closed boundary, not a signed or published app.
+
+1. Run `uv run python -m scripts.release validate` and confirm internal
+   `0.3.0b4`, public `0.3.0-beta.4`, build `149`, Beta channel, prerelease,
+   non-Latest, and no PyPI publication.
+2. Run the Prerelease metadata policy with the committed target and confirm it
+   rejects `v0.3.0-beta.4` as frozen by issue #316 before packaging or signing.
+3. Validate a cumulative appcast fixture ordered Beta 4 build `149`, Beta 3
+   build `148`, then Stable build `146`; Stable and RC must exclude both Beta
+   items while Beta and Alpha admit them.
+4. Confirm the live repository has no Beta 4 tag, release, draft, or asset and
+   the public appcast still ends at Beta 3 build `148`.
+5. Stop. Signed-app, update-route, and diagnostic-lifecycle qualification belong
+   to issue #316 after issue #314 records an explicitly authorized production
+   diagnostics deployment and the release freeze is removed through review.
+
 ## Follow-Up Routing
 
 - Missing bundled GUI dependency: file or update the relevant #88 child issue.

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -254,9 +254,9 @@ One appcast serves all four routes:
 
 Sparkle continues to include default Stable items automatically. The updater
 selects the greatest eligible global build, so choosing a safer route affects
-future updates only and never downgrades the installed application. When
-published, `v0.3.0-beta.3` (`0.3.0b3`, build `148`) is an immutable `beta` item
-in the cumulative feed and a manual-download seed. Currently shipped Stable and
+future updates only and never downgrades the installed application. Published
+`v0.3.0-beta.3` (`0.3.0b3`, build `148`) is an immutable `beta` item in the
+cumulative feed and a manual-download seed. Currently shipped Stable and
 RC clients cannot select Beta, so they cannot discover it through Sparkle; do
 not claim otherwise. Its `beta` item is eligible only to Beta and Alpha, not
 Stable or RC. After manually installing the production
@@ -264,6 +264,12 @@ Stable or RC. After manually installing the production
 select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 `v0.3.0-beta.2` Preview identities remain separate, immutable, and unable to
 Sparkle-upgrade into Beta 3.
+
+The next prepared item is frozen `v0.3.0-beta.4` (`0.3.0b4`, build `149`). If
+issue #316 later authorizes publication, it must append above Beta 3 in the same
+cumulative feed, remain excluded from Stable and RC, and be eligible to Beta and
+Alpha. The committed freeze prevents the Prerelease workflow from packaging or
+signing that target today.
 
 ## Runtime Integration and UX
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,13 +37,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 148
+        CURRENT_PROJECT_VERSION: 149
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b3
+        MARKETING_VERSION: 0.3.0b4
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b3"
+version = "0.3.0b4"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "148"
+CFBundleVersion = "149"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -92,8 +92,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b3")
-        self.assertEqual(NATIVE_BUILD_VERSION, "148")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b4")
+        self.assertEqual(NATIVE_BUILD_VERSION, "149")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,5 +1,6 @@
 import hashlib
 import importlib
+import json
 import re
 import stat
 import subprocess
@@ -155,19 +156,29 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_for_beta3(self) -> None:
+    def test_repository_is_prepared_and_frozen_for_beta4(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b3")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.3")
-        self.assertEqual(metadata.build_version, "148")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.3")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b4")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.4")
+        self.assertEqual(metadata.build_version, "149")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.4")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.4")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
+
+        freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
+        self.assertEqual(freeze_policy["frozen_release_tags"]["v0.3.0-beta.4"]["issue"], 316)
+
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.4-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b4`", cut_packet)
+        self.assertIn("Build `149`", cut_packet)
+        self.assertIn("PR #313", cut_packet)
+        self.assertIn("Privacy rules version `4`", cut_packet)
+        self.assertIn("issue #316", cut_packet)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
         evidence = release.validate_beta3_recovery_evidence()

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -293,8 +293,8 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
         self.assertIn("| GitHub Latest | No |", summary)
         self.assertIn("| PyPI publication | No |", summary)
 
-    def test_beta3_unfreeze_allows_metadata_while_freeze_entries_fail_closed(self) -> None:
-        environment = valid_metadata_environment(
+    def test_beta3_unfreeze_and_beta4_freeze_fail_closed(self) -> None:
+        beta3_environment = valid_metadata_environment(
             PRERELEASE_WORKFLOW_NAME,
             release_tag="v0.3.0-beta.3",
             channel="beta",
@@ -303,8 +303,19 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
             publish_pypi="false",
         )
 
-        metadata = validate_release_metadata(environment)
+        metadata = validate_release_metadata(beta3_environment)
         self.assertEqual(metadata.release_tag, "v0.3.0-beta.3")
+
+        beta4_environment = valid_metadata_environment(
+            PRERELEASE_WORKFLOW_NAME,
+            release_tag="v0.3.0-beta.4",
+            channel="beta",
+            prerelease="true",
+            make_latest="false",
+            publish_pypi="false",
+        )
+        with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #316"):
+            validate_release_metadata(beta4_environment)
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             freezes_path = Path(temporary_directory) / "release-freezes.json"
@@ -325,7 +336,7 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #294"):
-                validate_release_metadata(environment, freezes_path=freezes_path)
+                validate_release_metadata(beta3_environment, freezes_path=freezes_path)
 
     @patch("scripts.release_workflow_policy.urlopen")
     def test_engine_identity_is_loaded_from_github_oidc_claims(self, urlopen_mock: Mock) -> None:

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,6 +188,49 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
+    def test_beta4_appends_above_beta3_in_cumulative_production_history(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            empty_feed = root / "empty.xml"
+            stable_feed = root / "stable.xml"
+            beta3_feed = root / "beta3.xml"
+            beta4_feed = root / "beta4.xml"
+            make_empty_feed(empty_feed)
+
+            sparkle_appcast.append_item(
+                empty_feed,
+                stable_feed,
+                item("146", "0.2.143", None, minimum_system_version="14.0"),
+            )
+            sparkle_appcast.append_item(
+                stable_feed,
+                beta3_feed,
+                item("148", "0.3.0b3", "beta", minimum_system_version="26.0"),
+            )
+            sparkle_appcast.append_item(
+                beta3_feed,
+                beta4_feed,
+                item("149", "0.3.0b4", "beta", minimum_system_version="26.0"),
+            )
+
+            sparkle_appcast.validate_release_snapshot(beta4_feed, "0.3.0b4")
+            sparkle_appcast.validate_release_tag_snapshot(beta4_feed, "v0.3.0-beta.4")
+            _, channel = sparkle_appcast.load_appcast(beta4_feed)
+            items = channel.findall("item")
+
+        self.assertEqual(
+            [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
+            ["149", "148", "146"],
+        )
+        self.assertEqual(
+            [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
+            ["0.3.0b4", "0.3.0b3", "0.2.143"],
+        )
+        self.assertEqual(
+            [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
+            ["beta", "beta", None],
+        )
+
     def test_rejects_non_monotonic_build(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "148")
+        self.assertEqual(info["CFBundleVersion"], "149")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -250,14 +250,25 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('--release-tag "$BASE_SNAPSHOT_TAG"', str(prepare))
         self.assertIn('--release-tag "$LATEST_SNAPSHOT_TAG"', str(prepare))
 
-    def test_beta3_unfreeze_retains_release_preflight_guards(self) -> None:
+    def test_beta4_freeze_retains_release_preflight_guards(self) -> None:
         workflow = load_release_engine()
         prepare_steps = workflow["jobs"]["prepare"]["steps"]
         step_names = [step["name"] for step in prepare_steps]
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
 
         self.assertEqual(freeze_policy["schema"], "bd_to_avp.release_freezes")
-        self.assertEqual(freeze_policy["frozen_release_tags"], {})
+        self.assertEqual(
+            freeze_policy["frozen_release_tags"],
+            {
+                "v0.3.0-beta.4": {
+                    "issue": 316,
+                    "reason": (
+                        "Beta 4 signing, publication, appcast mutation, and field qualification require explicit "
+                        "authorization after the production diagnostics admission gate is deployed."
+                    ),
+                }
+            },
+        )
         self.assertLess(
             step_names.index("Validate route and summarize publication effects"),
             step_names.index("Reject existing release identity"),

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b3"
+version = "0.3.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- atomically prepare internal `0.3.0b4`, public `0.3.0-beta.4`, build `149`
- bind `v0.3.0-beta.4` to issue #316 in the committed release-freeze policy
- add the Beta 4 cut packet and current-target release documentation
- add cumulative appcast coverage for Beta 4 above immutable Beta 3
- update native/package metadata assertions to the frozen target

## Safety boundary
This PR does **not** dispatch a workflow, request signing approval, sign or notarize, create a tag/draft/release, build a public artifact, mutate the public appcast, deploy Pages, or publish anything. The guarded Prerelease metadata policy rejects this exact target as frozen by issue #316. Production diagnostics deployment remains separately gated by explicit Cloudflare authorization in #314.

## Live audit
Before preparation:
- production appcast newest item: Beta 3 build `148`
- no `v0.3.0-beta.4` tag or GitHub release
- no PyPI `0.3.0b4`
- build `149` passed the appcast `check-release` monotonicity gate

## Validation
- `uv run python -m scripts.release validate`
- committed freeze policy rejects `v0.3.0-beta.4` as issue #316
- `uv run python -m unittest discover -s tests -t .` — **796 passed, 2 skipped**
- `uv run python scripts/native_app.py test` — **267 passed**
- local ad-hoc Release package with approved non-secret diagnostics endpoint — passed bundle/signature/worker smoke
- `uv build` — sdist and wheel for `0.3.0b4`
- Actionlint, targeted Ruff format/lint, mypy, `uv lock --check`, Markdown-link check, and `git diff --check` — passed
- independent release-safety and documentation reviews completed; the one confirmed authorization-boundary gap was corrected

Closes #315