### PR TITLE
Default new audio profiles to preferred language

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,13 @@ selection. Multi-title selections run serially and preserve completed outputs
 if a later video needs attention. For source-folder jobs, accepted MKV or subtitle error
 continuations resume the failed source and then continue through the original
 batch queue. Audio and subtitle language choices are independent. The native
-app defaults every existing, migrated, built-in, and new profile to **All
-Languages** for audio. **Preferred Language Only** retains every audio stream
-whose metadata language matches the selected language; if none match, the app
-keeps the source-default audio stream or the first stream and shows a warning.
-Titles are not used to guess audio language.
+app defaults built-in and new profile options to **Preferred Language Only**
+with English selected. Existing version-4 custom profiles retain their stored
+choice, while version-1 through version-3 profiles migrate to **All Languages**
+to preserve their historical behavior. Preferred-only mode retains every audio
+stream whose metadata language matches the selected language; if none match,
+the app keeps the source-default audio stream or the first stream and shows a
+warning. Titles are not used to guess audio language.
 
 Audio-language filtering can reduce output payload when tracks are omitted,
 but this feature does not establish the cause of the output-size report in

--- a/docs/0.3.0-beta.4-cut-packet.md
+++ b/docs/0.3.0-beta.4-cut-packet.md
@@ -7,9 +7,11 @@
 > does not assert that a Beta 4 tag, draft, DMG, release, or appcast item exists.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 4 is prepared from protected `main`
-commit `51dd2979c6d5dc4d13a1f78b4b63b5f96ea6589d`, after the three field-feedback
-PRs merged and their post-merge CI and CodeQL completed successfully.
+[release-routes.md](release-routes.md). Beta 4 metadata was initially prepared
+from protected `main` commit `51dd2979c6d5dc4d13a1f78b4b63b5f96ea6589d`,
+after the field-feedback PRs merged and their post-merge CI and CodeQL completed
+successfully. Issue #327 is the only post-freeze product-default adjustment and
+remains covered by the same release freeze.
 
 ## Exact Metadata
 
@@ -53,7 +55,9 @@ version before preparation.
 - PR #325 adds independent **All Languages** and **Preferred Language Only**
   audio controls. Preferred-only keeps every canonical metadata-language match
   in source order, with visible source-default/first-track fallback; audio and
-  subtitle policies remain independent.
+  subtitle policies remain independent. Issue #327 makes preferred-only English
+  the built-in/new-profile default while preserving explicit version-4 choices
+  and all-languages migration for version-1 through version-3 profiles.
 
 ## Cumulative Update Contract
 
@@ -76,9 +80,10 @@ Use this text only inside issue #316's authorized publication flow:
 
 > BD_to_AVP `v0.3.0-beta.4` adds independent audio-language selection,
 > privacy-rules-v4 diagnostic comments with a safe GitHub issue handoff, and
-> clearer left/right output-growth status for apparent stalls. All Languages
-> remains the audio default. This build improves future stall reports but does
-> not claim to fix Ship's media-specific encoder plateau.
+> clearer left/right output-growth status for apparent stalls. Preferred
+> Language Only with English selected is the audio default; All Languages
+> remains available. This build improves future stall reports but does not claim
+> to fix Ship's media-specific encoder plateau.
 
 Do not describe Beta 4 as downloadable, signed, published, or
 Sparkle-discoverable until issue #316 completes the guarded release and verifies

--- a/docs/macos-ui-acceptance.md
+++ b/docs/macos-ui-acceptance.md
@@ -17,9 +17,9 @@ baseline for `0.3.0` and later.
 | Area | Result | Evidence |
 | --- | --- | --- |
 | Deployment floor | Pass | XcodeGen and `MACOSX_DEPLOYMENT_TARGET` remain 26.0; package compatibility is enforced separately. |
-| Profiles | Pass | Built-ins are immutable; custom profiles support create, duplicate, rename, edit, reorder, delete, default selection, atomic persistence, and corruption recovery. Profile document v4 stores the independent audio-language policy, while v1-v3 migrations retain all audio languages. |
+| Profiles | Pass | Built-ins are immutable; custom profiles support create, duplicate, rename, edit, reorder, delete, default selection, atomic persistence, and corruption recovery. Built-in and new profile options default to preferred-only English audio. Profile document v4 stores explicit choices, while v1-v3 migrations retain all audio languages. |
 | Current-job isolation | Pass | Profile writes contain only reusable encoding settings. Source, destination, preview intent, and job/recovery options remain outside the stored profile. |
-| Audio and subtitle languages | Pass | Audio exposes `All Languages` and `Preferred Language Only` with an `Audio language` picker; subtitles retain separate handling and `Subtitle language` controls. Job and profile summaries label Video, Audio, and Subtitles independently. |
+| Audio and subtitle languages | Pass | Audio defaults to `Preferred Language Only` with English selected and also exposes `All Languages`; subtitles retain separate handling and `Subtitle language` controls. Job and profile summaries label Video, Audio, and Subtitles independently. |
 | Standard platform controls | Pass | The application uses platform windows, toolbar/menu roles, forms, pickers, lists, split views, materials, and AVKit playback rather than custom replicas. |
 | Structural chrome | Pass | Footers use system material normally and switch to an opaque window background for Reduce Transparency or Increase Contrast. No explicit `glassEffect` is applied to dense content. |
 | Readability | Pass | Forms and metadata remain opaque; video keeps a black backing; diagnostics use the platform text background. |

--- a/docs/native-worker-protocol-v9.md
+++ b/docs/native-worker-protocol-v9.md
@@ -1,8 +1,10 @@
 # Native Worker Protocol v9
 
-Protocol v9 adds an explicit audio-language selection field while preserving
-all-language behavior by default. The native app and bundled Python worker ship
-atomically and both require version 9.
+Protocol v9 adds an explicit audio-language selection field. The native app
+defaults built-in and new profile options to preferred-only English, while an
+explicit all-languages selection and legacy profile migrations preserve the v8
+behavior. The native app and bundled Python worker ship atomically and both
+require version 9.
 
 Observability events, lifecycle rules, ownership, heartbeats, request size
 limits, and terminal behavior are unchanged from
@@ -17,7 +19,7 @@ with exactly these keys:
 {
   "mode": "automatic",
   "bitrate": 384,
-  "preferred_language": null
+  "preferred_language": "eng"
 }
 ```
 
@@ -25,12 +27,13 @@ with exactly these keys:
 - `bitrate` remains the AAC conversion or Automatic fallback bitrate.
 - `preferred_language` is always present. `null` means retain all audio
   languages, which is the v8 behavior. A canonical ISO 639-2/T code such as
-  `eng`, `jpn`, or `nld` enables preferred-language-only selection.
+  `eng`, `jpn`, or `nld` enables preferred-language-only selection. The native
+  app's built-in/new-profile default is `eng`.
 
 The worker accepts supported alpha-2, alpha-3/B, alpha-3/T, and valid base
 language tags, then canonicalizes them to alpha-3/T. It rejects an omitted
 field, unsupported code, non-string/non-null value, or any unknown audio key.
-Swift encodes the all-language value as an explicit JSON `null`; omission is
+Swift encodes an explicit all-languages selection as JSON `null`; omission is
 not equivalent.
 
 ## Selection Policy

--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -349,7 +349,7 @@ private struct LegacyEncodingOptionsV3: Decodable {
             swapEyes: swapEyes,
             audioHandling: audioHandling,
             audioBitrate: audioBitrate,
-            audioLanguages: AudioLanguagePolicy(),
+            audioLanguages: AudioLanguagePolicy(mode: .allLanguages, preferredLanguage: .english),
             subtitles: subtitles
         )
     }
@@ -401,6 +401,7 @@ private struct LegacyEncodingOptionsV2: Decodable {
             swapEyes: swapEyes,
             audioHandling: audioHandling,
             audioBitrate: audioBitrate,
+            audioLanguages: AudioLanguagePolicy(mode: .allLanguages, preferredLanguage: .english),
             subtitles: subtitles
         )
     }
@@ -462,6 +463,7 @@ private struct LegacyEncodingOptionsV1: Decodable {
             swapEyes: swapEyes,
             audioHandling: audioHandling,
             audioBitrate: audioBitrate,
+            audioLanguages: AudioLanguagePolicy(mode: .allLanguages, preferredLanguage: .english),
             subtitles: SubtitlePolicy(mode: mode, preferredLanguage: preferredLanguage)
         )
     }

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -97,7 +97,7 @@ enum AudioLanguageMode: String, CaseIterable, Codable, Identifiable {
 }
 
 struct AudioLanguagePolicy: Codable, Equatable {
-    var mode = AudioLanguageMode.allLanguages
+    var mode = AudioLanguageMode.preferredOnly
     var preferredLanguage = MediaLanguage.english
 
     var summary: String {

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -21,7 +21,7 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
     var summary: String {
         switch self {
         case .balanced:
-            "HEVC 75, source resolution, automatic audio, all audio languages, and subtitles."
+            "HEVC 75, source resolution, automatic audio, English audio only, and subtitles."
         case .originalResolution:
             "Higher quality while preserving the source resolution."
         case .fourKUpscale:

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -165,9 +165,11 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(AudioHandling.pcm.rawValue, "preserve")
         XCTAssertEqual(AudioHandling.pcm.title, "Uncompressed PCM")
         XCTAssertEqual(EncodingOptions().audioHandling, .automatic)
-        XCTAssertEqual(EncodingOptions().audioLanguages.mode, .allLanguages)
+        XCTAssertEqual(EncodingOptions().audioLanguages.mode, .preferredOnly)
+        XCTAssertEqual(EncodingOptions().audioLanguages.preferredLanguage, .english)
         XCTAssertTrue(BuiltInProfile.allCases.allSatisfy { $0.options.audioHandling == .automatic })
-        XCTAssertTrue(BuiltInProfile.allCases.allSatisfy { $0.options.audioLanguages.mode == .allLanguages })
+        XCTAssertTrue(BuiltInProfile.allCases.allSatisfy { $0.options.audioLanguages.mode == .preferredOnly })
+        XCTAssertTrue(BuiltInProfile.allCases.allSatisfy { $0.options.audioLanguages.preferredLanguage == .english })
         XCTAssertEqual(ConversionStage.transcodeAudio.title, "7 — Prepare Audio")
     }
 
@@ -182,17 +184,17 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(AudioHandling.convertAAC.bitrateLabel, "AAC bitrate")
         XCTAssertNil(AudioHandling.pcm.bitrateLabel)
         XCTAssertTrue(EncodingOptions().compactSummary.contains("Audio: automatic audio"))
-        XCTAssertTrue(EncodingOptions().compactSummary.contains("all languages"))
+        XCTAssertTrue(EncodingOptions().compactSummary.contains("English only"))
         XCTAssertTrue(EncodingOptions().compactSummary.contains("Subtitles: English + others"))
         XCTAssertEqual(
             EncodingOptions(audioHandling: .automatic, audioBitrate: 448).compactSummary,
-            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: automatic audio (AAC fallback 448 kbps), all languages · Subtitles: English + others"
+            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: automatic audio (AAC fallback 448 kbps), English only · Subtitles: English + others"
         )
         XCTAssertEqual(
             EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
-            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: AAC 448 kbps, all languages · Subtitles: English + others"
+            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: AAC 448 kbps, English only · Subtitles: English + others"
         )
-        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("all audio languages"))
+        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("English audio only"))
     }
 
     func testSourceInferencePreservesProductHierarchy() throws {
@@ -566,7 +568,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(spec.encoding?.fieldOfView, 120)
         XCTAssertEqual(
             spec.encoding?.audio,
-            WorkerJobSpec.Encoding.Audio(mode: .convertAAC, bitrate: 512, preferredLanguage: nil)
+            WorkerJobSpec.Encoding.Audio(mode: .convertAAC, bitrate: 512, preferredLanguage: "eng")
         )
     }
 
@@ -711,7 +713,7 @@ final class ConversionWorkflowTests: XCTestCase {
         let audio = try XCTUnwrap(encoding["audio"] as? [String: Any])
         XCTAssertEqual(audio["mode"] as? String, "automatic")
         XCTAssertEqual(audio["bitrate"] as? Int, 384)
-        XCTAssertTrue(audio["preferred_language"] is NSNull)
+        XCTAssertEqual(audio["preferred_language"] as? String, "eng")
         XCTAssertEqual(Set(audio.keys), ["mode", "bitrate", "preferred_language"])
         XCTAssertNil(encoding["transcode_audio"])
         XCTAssertNil(encoding["audio_bitrate"])
@@ -788,7 +790,7 @@ final class ConversionWorkflowTests: XCTestCase {
 
             XCTAssertEqual(audio["mode"] as? String, expectedMode)
             XCTAssertEqual(audio["bitrate"] as? Int, 448)
-            XCTAssertTrue(audio["preferred_language"] is NSNull)
+            XCTAssertEqual(audio["preferred_language"] as? String, "eng")
             XCTAssertEqual(Set(audio.keys), ["mode", "bitrate", "preferred_language"])
         }
     }

--- a/macos/README.md
+++ b/macos/README.md
@@ -54,8 +54,10 @@ package gate launches the signed Swift host with `--startup-smoke`, smokes the
 embedded conversion worker, and then performs strict deep signature validation.
 
 The app and engine use worker protocol v9. Audio and subtitle language controls
-are independent: profiles retain all audio languages by default, while
-preferred-only audio keeps every metadata-language match and visibly falls
+are independent: built-in and new profile options default to preferred-only
+English audio, while existing version-4 custom choices remain unchanged and
+version-1 through version-3 profiles migrate to all-languages behavior.
+Preferred-only audio keeps every metadata-language match and visibly falls
 back to the source-default or first audio stream when no match exists. MKV,
 MTS, M2TS, and ISO
 sources can create an isolated beginning, middle, or end preview child job with

--- a/tests/fixtures/native_worker_convert_physical_disc_v9.json
+++ b/tests/fixtures/native_worker_convert_physical_disc_v9.json
@@ -15,7 +15,7 @@
     "audio": {
       "mode": "automatic",
       "bitrate": 384,
-      "preferred_language": null
+      "preferred_language": "eng"
     },
     "video_mode": "mv_hevc",
     "av1_crf": 32,

--- a/tests/fixtures/native_worker_convert_v9.json
+++ b/tests/fixtures/native_worker_convert_v9.json
@@ -14,7 +14,7 @@
     "audio": {
       "mode": "automatic",
       "bitrate": 384,
-      "preferred_language": null
+      "preferred_language": "eng"
     },
     "video_mode": "mv_hevc",
     "av1_crf": 32,

--- a/tests/fixtures/native_worker_preview_v9.json
+++ b/tests/fixtures/native_worker_preview_v9.json
@@ -14,7 +14,7 @@
     "audio": {
       "mode": "automatic",
       "bitrate": 384,
-      "preferred_language": null
+      "preferred_language": "eng"
     },
     "video_mode": "mv_hevc",
     "av1_crf": 32,

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -249,7 +249,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
         self.assertEqual(job.encoding.video_mode if job.encoding else None, VideoMode.MV_HEVC)
         self.assertEqual(job.encoding.av1_crf if job.encoding else None, 32)
-        self.assertIsNone(job.encoding.audio.preferred_language if job.encoding else "missing")
+        self.assertEqual(job.encoding.audio.preferred_language if job.encoding else None, "eng")
 
     def test_retains_protocol_v8_fixture_as_rejected_historical_evidence(self) -> None:
         fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v8.json"
@@ -283,6 +283,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.source.kind, WorkerSourceKind.PHYSICAL_DISC)
         self.assertEqual(job.source.path, Path("/dev/disk9"))
         self.assertEqual(job.source.title_id, "makemkv:0")
+        self.assertEqual(job.encoding.audio.preferred_language if job.encoding else None, "eng")
         self.assertFalse(job.job.remove_original if job.job else True)
 
     def test_parses_shared_swift_preview_fixture(self) -> None:
@@ -291,6 +292,7 @@ class JobSpecTests(unittest.TestCase):
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(job.operation, WorkerOperation.PREVIEW_SOURCE)
+        self.assertEqual(job.encoding.audio.preferred_language if job.encoding else None, "eng")
         self.assertEqual(job.preview.position if job.preview else None, PreviewPosition.MIDDLE)
         self.assertEqual(job.preview.duration_seconds if job.preview else None, 60)
 


### PR DESCRIPTION
## Summary
- default built-in and new native profile options to Preferred Language Only with English selected
- preserve explicit version-4 custom choices and pin version-1 through version-3 migrations to All Languages
- update shared worker fixtures, protocol documentation, UI acceptance evidence, and the frozen Beta 4 release-note seed

## Validation
- `uv run python scripts/native_app.py test` — 267 passed
- `uv run python -m unittest discover -s tests -t .` — 796 passed, 2 skipped
- `uv run python -m unittest tests.test_native_app tests.test_native_worker` — 124 passed
- `uv run ruff check tests/test_native_worker.py`
- `uv run ruff format --check tests/test_native_worker.py`
- `uv run python scripts/native_app.py build`
- `uv run python -m scripts.release validate`
- `uv lock --check`
- visual/accessibility review confirms Preferred Language Only and English (eng) are selected in the Development app
- independent implementation and release-safety reviews completed; the protocol-doc consistency finding was corrected

Beta 4 remains frozen and unpublished; this PR does not dispatch, sign, notarize, deploy, or publish anything.

Closes #327