### PR TITLE
Fix generated filename redaction in diagnostics

### DIFF
--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticRedactor.swift
@@ -94,6 +94,7 @@ final class DiagnosticRedactor {
                 options: [.caseInsensitive]
             )
         }
+        redacted = redactTokenAdjacentFilenameFragments(in: redacted)
         redacted = replaceCapturedMatches(
             pattern: #"[\"'`]((?:(?:file|dev|iso):/{1,3}|/|~/)[^\"'`\r\n]+)[\"'`]"#,
             in: redacted,
@@ -183,6 +184,16 @@ final class DiagnosticRedactor {
             in: redacted
         ) { _ in "<network:redacted>" }
         return Self.removingUnsafeControlCharacters(from: redacted)
+    }
+
+    private func redactTokenAdjacentFilenameFragments(in text: String) -> String {
+        replaceCapturedMatches(
+            pattern: #"(<(?:path|name):[0-9A-F]{8}:[0-9]{3}>)(?:\.[A-Za-z0-9]{1,16}|[._-][A-Za-z0-9][A-Za-z0-9._-]{0,127}\.[A-Za-z0-9]{1,16})(?![A-Za-z0-9_.-])"#,
+            in: text,
+            captureGroup: 1
+        ) { token in
+            token
+        }
     }
 
     private func redactMediaMetadataBlocks(in text: String) -> String {

--- a/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
@@ -159,6 +159,25 @@ final class DiagnosticBundleTests: XCTestCase {
         XCTAssertTrue(output.contains("<identifier:01234567:001>"))
     }
 
+    func testRedactorRemovesGeneratedNativeMVCFilenameAfterSensitiveNameReplacement() {
+        let redactor = DiagnosticRedactor(bundleID: fixedBundleID)
+        redactor.registerSensitiveName("Secret Feature")
+
+        let output = redactor.redact("""
+        Secret Feature_mvc_abcdefgh.264
+        codec=H.264
+        timestamp=16:21:42.264
+        version=1.264
+        """)
+
+        XCTAssertFalse(output.contains("Secret Feature"))
+        XCTAssertFalse(output.contains("_mvc_abcdefgh.264"))
+        XCTAssertTrue(output.contains("codec=H.264"))
+        XCTAssertTrue(output.contains("timestamp=16:21:42.264"))
+        XCTAssertTrue(output.contains("version=1.264"))
+        XCTAssertEqual(output.components(separatedBy: "<name:01234567:").count - 1, 1)
+    }
+
     func testRedactorHandlesEscapedAndSchemePathsTitleArgumentsAndSecretEnvironmentKeys() {
         let redactor = DiagnosticRedactor(bundleID: fixedBundleID)
         let text = """


### PR DESCRIPTION
## Summary

- remove generated filename suffixes that remain adjacent to per-bundle path or name tokens
- preserve useful codec, timestamp, duration, and version text that happens to contain `.264`
- add regression coverage for the sensitive-name replacement ordering found in a signed field bundle

## Validation

- `uv run python scripts/native_app.py test` — 268 tests passed
- JetBrains changed-file inspection — GREEN, 0 actionable findings
- independent review finding for numeric `.264` false positives addressed with token-adjacent matching

Fixes #333
Refs #278
