### PR TITLE
Fix stalled MVC decoding with bounded fallback

### DIFF
--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -16,16 +16,14 @@ from bd_to_avp.modules.disc import DiscInfo
 from bd_to_avp.modules.command import combined_process_output, run_ffmpeg_capture, run_ffprobe, run_process_capture
 from bd_to_avp.process_runner import (
     CaptureOverflowPolicy,
-    ChildProcessRunner,
+    ProcessArtifactNoProgressError,
     ProcessArtifactProbe,
     ProcessCancelled,
-    ProcessExecutionError,
     ProcessPipelineError,
     ProcessPipelineRunner,
     ProcessPipelineStage,
     ProcessRunnerError,
     ProcessSpec,
-    ProcessTimeoutError,
 )
 from bd_to_avp.presentation import cli_message
 from bd_to_avp.runtime import RunContext
@@ -66,7 +64,7 @@ class NativeMvcSplitError(RuntimeError):
     pass
 
 
-NATIVE_MVC_PROBE_TIMEOUT_SECONDS = 30
+NATIVE_MVC_ARTIFACT_NO_GROWTH_TIMEOUT_SECONDS = 120
 NATIVE_MVC_RETRY_SIGNALS = {
     signal.SIGABRT,
     signal.SIGBUS,
@@ -118,13 +116,6 @@ def generate_mvc_annex_b_stream_command(video_input_path: Path) -> list[str | Pa
         "h264",
         "-",
     ]
-
-
-def should_probe_native_multithread_splitter() -> bool:
-    source_path = config.source_path
-    if not source_path:
-        return False
-    return source_path.suffix.lower() in config.IMAGE_EXTENSIONS
 
 
 def prepare_native_mvc_input(video_input_path: Path) -> Path:
@@ -309,57 +300,32 @@ def run_native_mvc_encoding(
     producer_command = generate_mvc_annex_b_stream_command(video_input_path) if stream_from_container else None
     native_input_path = Path("-") if stream_from_container else prepare_native_mvc_input(video_input_path)
     try:
-        skip_multithreaded_attempt = False
-        if not stream_from_container and should_probe_native_multithread_splitter():
-            cli_message(
-                "Checking native MVC splitter with a short multi-threaded probe.",
-                run_context=run_context,
-            )
-            skip_multithreaded_attempt = native_multithread_splitter_probe_crashed(
+        single_threaded = False
+        try:
+            run_native_mvc_split_attempt(
                 native_input_path,
+                ffmpeg_command,
+                output_paths,
+                producer_command=producer_command,
+                single_threaded=single_threaded,
                 run_context=run_context,
                 cancellation_event=cancellation_event,
                 observability_context=observability_context,
             )
-            if not skip_multithreaded_attempt:
-                cli_message(
-                    "Native MVC splitter probe passed; proceeding with multi-threaded mode.",
-                    run_context=run_context,
-                )
-
-        try:
-            if skip_multithreaded_attempt:
-                cli_message(
-                    "Native MVC splitter probe crashed; using slower single-threaded mode.",
-                    run_context=run_context,
-                )
-                run_native_mvc_split_attempt(
-                    native_input_path,
-                    ffmpeg_command,
-                    output_paths,
-                    producer_command=producer_command,
-                    single_threaded=True,
-                    run_context=run_context,
-                    cancellation_event=cancellation_event,
-                    observability_context=observability_context,
-                )
-            else:
-                run_native_mvc_split_attempt(
-                    native_input_path,
-                    ffmpeg_command,
-                    output_paths,
-                    producer_command=producer_command,
-                    single_threaded=False,
-                    run_context=run_context,
-                    cancellation_event=cancellation_event,
-                    observability_context=observability_context,
-                )
-        except subprocess.CalledProcessError as error:
-            if not native_splitter_died_by_signal(error):
+        except (ProcessArtifactNoProgressError, subprocess.CalledProcessError) as error:
+            retry_after_stall = isinstance(error, ProcessArtifactNoProgressError)
+            retry_after_crash = isinstance(error, subprocess.CalledProcessError) and native_splitter_died_by_signal(
+                error
+            )
+            if single_threaded or not (retry_after_stall or retry_after_crash):
                 raise
 
             cli_message(
-                "Native MVC splitter crashed; retrying once in single-threaded mode.",
+                (
+                    "Native MVC splitter stopped making progress; retrying once in single-threaded mode."
+                    if retry_after_stall
+                    else "Native MVC splitter crashed; retrying once in single-threaded mode."
+                ),
                 run_context=run_context,
             )
             for output_path in output_paths:
@@ -374,6 +340,8 @@ def run_native_mvc_encoding(
                 cancellation_event=cancellation_event,
                 observability_context=observability_context,
             )
+    except ProcessArtifactNoProgressError as error:
+        raise NativeMvcSplitError(build_native_splitter_stall_message(error)) from error
     except subprocess.CalledProcessError as error:
         if native_splitter_should_report_crash(error):
             raise NativeMvcSplitError(build_native_splitter_failure_message(error)) from error
@@ -381,39 +349,6 @@ def run_native_mvc_encoding(
     finally:
         if not stream_from_container and native_input_path != video_input_path:
             native_input_path.unlink(missing_ok=True)
-
-
-def native_multithread_splitter_probe_crashed(
-    native_input_path: Path,
-    *,
-    run_context: RunContext | None = None,
-    cancellation_event: threading.Event | None = None,
-    observability_context: ObservabilityContext | None = None,
-) -> bool:
-    splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=False)
-    try:
-        ChildProcessRunner().run(
-            ProcessSpec(
-                argv=tuple(splitter_command),
-                tool_id="edge264",
-                display_name="Native MVC splitter probe",
-                env=os.environ.copy(),
-                stdout=subprocess.DEVNULL,
-                merge_stderr=False,
-                event_context=observability_context or ObservabilityContext(),
-                timeout_seconds=NATIVE_MVC_PROBE_TIMEOUT_SECONDS,
-                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
-            ),
-            run_context=run_context,
-            cancellation_event=cancellation_event,
-        )
-    except ProcessTimeoutError:
-        return False
-    except ProcessExecutionError as error:
-        if native_splitter_returncode_is_retry_signal(error.returncode):
-            return True
-        raise
-    return False
 
 
 def run_native_mvc_split_attempt(
@@ -480,6 +415,8 @@ def run_native_mvc_split_attempt(
                             output_artifact_roles(len(output_paths)), output_paths, strict=True
                         )
                     ),
+                    artifact_no_growth_timeout_seconds=NATIVE_MVC_ARTIFACT_NO_GROWTH_TIMEOUT_SECONDS,
+                    artifact_no_growth_retryable=not single_threaded,
                     capture_overflow=CaptureOverflowPolicy.TRUNCATE,
                 )
             ),
@@ -510,10 +447,8 @@ def select_native_pipeline_error(
     splitter_stage = stages[splitter_index]
     ffmpeg_stage = stages[ffmpeg_index]
 
-    if (
-        isinstance(splitter_stage.error, subprocess.CalledProcessError)
-        and splitter_stage.completed_before_final
-        and native_splitter_died_by_signal(splitter_stage.error)
+    if isinstance(splitter_stage.error, subprocess.CalledProcessError) and native_splitter_died_by_signal(
+        splitter_stage.error
     ):
         return splitter_stage.error
     if (
@@ -572,6 +507,15 @@ def build_native_splitter_failure_message(error: subprocess.CalledProcessError) 
         f"({signal_name}). This usually means the bundled native decoder hit a Blu-ray MVC bitstream it does not "
         "currently support. The source may need a splitter update or a future fallback path. "
         "Please submit a diagnostic report so the bounded splitter and encoder evidence can be reviewed."
+    )
+
+
+def build_native_splitter_stall_message(error: ProcessArtifactNoProgressError) -> str:
+    return (
+        "The native MVC splitter stopped producing video in both multi-threaded and single-threaded modes. "
+        "The conversion was stopped instead of waiting indefinitely. This usually means the bundled native decoder "
+        "hit damaged or unsupported MVC data. Please submit a diagnostic report so the bounded splitter and encoder "
+        f"evidence can be reviewed. ({error})"
     )
 
 

--- a/bd_to_avp/process_runner.py
+++ b/bd_to_avp/process_runner.py
@@ -95,6 +95,10 @@ class ProcessTimeoutError(ProcessRunnerError):
     pass
 
 
+class ProcessArtifactNoProgressError(ProcessRunnerError):
+    pass
+
+
 class ProcessPipeDrainError(ProcessRunnerError):
     pass
 
@@ -139,6 +143,8 @@ class ProcessSpec:
     capture_overflow: CaptureOverflowPolicy = CaptureOverflowPolicy.FAIL
     activity_interval_seconds: float = DEFAULT_ACTIVITY_INTERVAL_SECONDS
     artifact_interval_seconds: float = DEFAULT_ARTIFACT_INTERVAL_SECONDS
+    artifact_no_growth_timeout_seconds: float | None = None
+    artifact_no_growth_retryable: bool = False
     timeout_seconds: float | None = None
     termination_grace_seconds: float = DEFAULT_TERMINATION_GRACE_SECONDS
     kill_wait_seconds: float = DEFAULT_KILL_WAIT_SECONDS
@@ -180,6 +186,15 @@ class ProcessSpec:
                 raise ValueError(f"{duration_name} must be positive")
         if self.timeout_seconds is not None and self.timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
+        if self.artifact_no_growth_timeout_seconds is not None:
+            if self.artifact_no_growth_timeout_seconds <= 0:
+                raise ValueError("artifact_no_growth_timeout_seconds must be positive")
+            if not self.artifacts:
+                raise ValueError("artifact_no_growth_timeout_seconds requires at least one artifact")
+        if type(self.artifact_no_growth_retryable) is not bool:
+            raise TypeError("artifact_no_growth_retryable must be a bool")
+        if self.artifact_no_growth_retryable and self.artifact_no_growth_timeout_seconds is None:
+            raise ValueError("artifact_no_growth_retryable requires artifact_no_growth_timeout_seconds")
 
 
 @dataclass(frozen=True)
@@ -539,7 +554,9 @@ class _LineFramer:
 class _ArtifactState:
     path: Path | None = None
     size_bytes: int | None = None
+    modified_at_ns: int | None = None
     observed_at: float | None = None
+    last_progress_at: float | None = None
     resolver_failed: bool = False
 
 
@@ -639,7 +656,7 @@ class ChildProcessRunner:
             expected_streams.add(ProcessStream.STDERR)
         closed_streams: set[ProcessStream] = set()
         framers = {stream: _LineFramer(spec.line_limit_bytes) for stream in expected_streams}
-        artifact_states = [_ArtifactState(path=probe.path) for probe in spec.artifacts]
+        artifact_states = [_ArtifactState(path=probe.path, last_progress_at=started_at) for probe in spec.artifacts]
 
         pending_error: BaseException | None = None
         failure_code: str | None = None
@@ -824,6 +841,23 @@ class ChildProcessRunner:
                         now=now,
                     )
                     last_artifact_event_at = now
+                    stalled_artifact_roles = (
+                        [
+                            probe.role
+                            for probe, artifact_state in zip(spec.artifacts, artifact_states, strict=True)
+                            if artifact_state.last_progress_at is not None
+                            and now - artifact_state.last_progress_at >= spec.artifact_no_growth_timeout_seconds
+                        ]
+                        if spec.artifact_no_growth_timeout_seconds is not None
+                        else []
+                    )
+                    if pending_error is None and returncode is None and stalled_artifact_roles:
+                        pending_error = ProcessArtifactNoProgressError(
+                            f"{spec.display_name} produced no artifact growth for "
+                            f"{spec.artifact_no_growth_timeout_seconds:g} seconds: "
+                            f"{', '.join(stalled_artifact_roles)}"
+                        )
+                        failure_code = "artifact_no_growth"
 
                 if (
                     returncode is not None
@@ -945,7 +979,13 @@ class ChildProcessRunner:
                 context=final_context,
                 data=replace(
                     final_data,
-                    failure=ObservabilityFailure(code=failure_code or "runner_failed", retryable=False),
+                    failure=ObservabilityFailure(
+                        code=failure_code or "runner_failed",
+                        retryable=(
+                            isinstance(pending_error, ProcessArtifactNoProgressError)
+                            and spec.artifact_no_growth_retryable
+                        ),
+                    ),
                 ),
                 terminal=True,
             )
@@ -1199,7 +1239,9 @@ class ChildProcessRunner:
             if artifact_state.path != path:
                 artifact_state.path = path
                 artifact_state.size_bytes = None
+                artifact_state.modified_at_ns = None
                 artifact_state.observed_at = None
+                artifact_state.last_progress_at = now
             if path is None:
                 artifact = ObservabilityArtifact(role=probe.role, state="missing")
                 emitter.emit(
@@ -1218,11 +1260,20 @@ class ChildProcessRunner:
                 )
             else:
                 growth = None
+                previous_size = artifact_state.size_bytes
+                previous_modified_at_ns = artifact_state.modified_at_ns
                 if artifact_state.size_bytes is not None and artifact_state.observed_at is not None:
                     elapsed = now - artifact_state.observed_at
                     if elapsed > 0:
                         growth = max(0, int((status.st_size - artifact_state.size_bytes) / elapsed))
+                if (
+                    previous_modified_at_ns is None
+                    or status.st_size > (previous_size or 0)
+                    or status.st_mtime_ns > previous_modified_at_ns
+                ):
+                    artifact_state.last_progress_at = now
                 artifact_state.size_bytes = status.st_size
+                artifact_state.modified_at_ns = status.st_mtime_ns
                 artifact_state.observed_at = now
                 artifact = ObservabilityArtifact(
                     role=probe.role,
@@ -1338,7 +1389,12 @@ class ProcessPipelineRunner:
         ):
             internal_cancellation.set()
 
-        forced_cleanup = self._join_upstream_stages(states[:-1], internal_cancellation)
+        cleanup_error: ProcessRunnerError | None = None
+        try:
+            forced_cleanup = self._join_upstream_stages(states[:-1], internal_cancellation)
+        except ProcessRunnerError as error:
+            cleanup_error = error
+            forced_cleanup = True
         result = ProcessPipelineResult(
             stages=tuple(
                 ProcessPipelineStageResult(
@@ -1361,7 +1417,11 @@ class ProcessPipelineRunner:
                 raise cancellation_error
             raise ProcessCancelled("process pipeline was cancelled")
         if any(self._is_substantive_error(stage.error) for stage in result.stages):
+            if cleanup_error is not None:
+                raise ProcessPipelineError(result) from cleanup_error
             raise ProcessPipelineError(result)
+        if cleanup_error is not None:
+            raise cleanup_error
         if final_state.result is None:
             raise ProcessRunnerError("process pipeline ended without a final-stage result")
         return result

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -12,6 +12,7 @@ from bd_to_avp.modules import video
 from bd_to_avp.modules.disc import DiscInfo
 from bd_to_avp.observability import ObservabilityContext
 from bd_to_avp.process_runner import (
+    ProcessArtifactNoProgressError,
     ProcessCancelled,
     ProcessExecutionError,
     ProcessOutputSnapshot,
@@ -19,7 +20,6 @@ from bd_to_avp.process_runner import (
     ProcessPipelineResult,
     ProcessPipelineStageResult,
     ProcessResult,
-    ProcessTimeoutError,
 )
 
 
@@ -279,6 +279,11 @@ class NativeMvcSelectionTests(unittest.TestCase):
             [probe.role for probe in stages[-1].spec.artifacts],
             ["left_eye_video_output", "right_eye_video_output"],
         )
+        self.assertEqual(
+            stages[-1].spec.artifact_no_growth_timeout_seconds,
+            video.NATIVE_MVC_ARTIFACT_NO_GROWTH_TIMEOUT_SECONDS,
+        )
+        self.assertTrue(stages[-1].spec.artifact_no_growth_retryable)
         self.assertTrue(all(stage.spec.event_context is event_context for stage in stages))
         self.assertIs(run.call_args.kwargs["run_context"], run_context)
         self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
@@ -365,7 +370,6 @@ class NativeMvcSelectionTests(unittest.TestCase):
         with (
             patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
             patch.object(video, "should_stream_mvc_from_container", return_value=False),
-            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
             patch.object(
                 video.ProcessPipelineRunner,
                 "run",
@@ -386,108 +390,54 @@ class NativeMvcSelectionTests(unittest.TestCase):
         second_stages = run.call_args_list[1].args[0]
         self.assertEqual(first_stages[0].spec.argv[-1], "-Omk")
         self.assertEqual(second_stages[0].spec.argv[-1], "-Osk")
+        self.assertTrue(first_stages[-1].spec.artifact_no_growth_retryable)
+        self.assertFalse(second_stages[-1].spec.artifact_no_growth_retryable)
+
+    def test_native_split_retries_single_threaded_when_outputs_stop_growing(self) -> None:
+        stall = ProcessArtifactNoProgressError("encoder outputs stopped growing")
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(
+                video.ProcessPipelineRunner,
+                "run",
+                side_effect=[pipeline_failure(ffmpeg_error=stall), pipeline_success(False)],
+            ) as run,
+            redirect_stdout(StringIO()),
+        ):
+            video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
+
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[0].args[0][0].spec.argv[-1], "-Omk")
+        self.assertEqual(run.call_args_list[1].args[0][0].spec.argv[-1], "-Osk")
+
+    def test_native_split_reports_stall_after_single_thread_retry(self) -> None:
+        stall = ProcessArtifactNoProgressError("encoder outputs stopped growing")
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(
+                video.ProcessPipelineRunner,
+                "run",
+                side_effect=[pipeline_failure(ffmpeg_error=stall), pipeline_failure(ffmpeg_error=stall)],
+            ) as run,
+            redirect_stdout(StringIO()),
+            self.assertRaisesRegex(video.NativeMvcSplitError, "stopped producing video.*waiting indefinitely"),
+        ):
+            video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
+
+        self.assertEqual(run.call_count, 2)
 
     def test_native_split_does_not_retry_when_pipeline_is_cancelled(self) -> None:
         cancellation = ProcessCancelled("cancelled")
         with (
             patch.object(video, "should_stream_mvc_from_container", return_value=False),
-            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
             patch.object(video.ProcessPipelineRunner, "run", side_effect=cancellation) as run,
             self.assertRaises(ProcessCancelled),
         ):
             video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
 
         run.assert_called_once()
-
-    def test_native_split_probe_crash_skips_multithreaded_attempt(self) -> None:
-        with (
-            patch.object(video, "should_stream_mvc_from_container", return_value=False),
-            patch.object(video, "should_probe_native_multithread_splitter", return_value=True),
-            patch.object(video, "native_multithread_splitter_probe_crashed", return_value=True),
-            patch.object(video, "run_native_mvc_split_attempt") as run_attempt,
-            redirect_stdout(StringIO()),
-        ):
-            video.run_native_mvc_encoding(Path("movie.264"), (Path("output.mov"),), ["encode-ffmpeg"])
-
-        run_attempt.assert_called_once()
-        self.assertTrue(run_attempt.call_args.kwargs["single_threaded"])
-
-    def test_native_split_probe_pass_uses_multithreaded_attempt(self) -> None:
-        stdout = StringIO()
-        with (
-            patch.object(video, "should_stream_mvc_from_container", return_value=False),
-            patch.object(video, "should_probe_native_multithread_splitter", return_value=True),
-            patch.object(video, "native_multithread_splitter_probe_crashed", return_value=False),
-            patch.object(video, "run_native_mvc_split_attempt") as run_attempt,
-            redirect_stdout(stdout),
-        ):
-            video.run_native_mvc_encoding(Path("movie.264"), (Path("output.mov"),), ["encode-ffmpeg"])
-
-        self.assertFalse(run_attempt.call_args.kwargs["single_threaded"])
-        self.assertIn("Native MVC splitter probe passed", stdout.getvalue())
-
-    def test_native_split_does_not_probe_mkv_sources(self) -> None:
-        with (
-            patch.object(video, "should_stream_mvc_from_container", return_value=True),
-            patch.object(video, "native_multithread_splitter_probe_crashed") as probe,
-            patch.object(video, "run_native_mvc_split_attempt"),
-        ):
-            video.run_native_mvc_encoding(Path("movie.mkv"), (Path("output.mov"),), ["encode-ffmpeg"])
-
-        probe.assert_not_called()
-
-    def test_native_multithread_probe_returns_true_when_splitter_dies_by_signal(self) -> None:
-        with (
-            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
-            patch.object(
-                video.ChildProcessRunner,
-                "run",
-                side_effect=process_error(-signal.SIGABRT, ["edge264_test"]),
-            ),
-        ):
-            self.assertTrue(video.native_multithread_splitter_probe_crashed(Path("movie.264")))
-
-    def test_native_multithread_probe_does_not_treat_sigterm_as_crash(self) -> None:
-        error = process_error(-signal.SIGTERM, ["edge264_test"])
-        with (
-            patch.object(video.ChildProcessRunner, "run", side_effect=error),
-            self.assertRaises(ProcessExecutionError) as raised,
-        ):
-            video.native_multithread_splitter_probe_crashed(Path("movie.264"))
-
-        self.assertIs(raised.exception, error)
-
-    def test_native_multithread_probe_returns_false_after_timeout(self) -> None:
-        with patch.object(
-            video.ChildProcessRunner,
-            "run",
-            side_effect=ProcessTimeoutError("probe timed out"),
-        ):
-            self.assertFalse(video.native_multithread_splitter_probe_crashed(Path("movie.264")))
-
-    def test_native_multithread_probe_uses_bounded_runner_contract(self) -> None:
-        run_context = Mock()
-        cancellation_event = threading.Event()
-        event_context = ObservabilityContext()
-        with (
-            patch.object(video, "generate_native_mvc_splitter_command", return_value=["edge264_test"]),
-            patch.object(video.ChildProcessRunner, "run", return_value=process_result("edge264")) as run,
-        ):
-            result = video.native_multithread_splitter_probe_crashed(
-                Path("movie.264"),
-                run_context=run_context,
-                cancellation_event=cancellation_event,
-                observability_context=event_context,
-            )
-
-        self.assertFalse(result)
-        spec = run.call_args.args[0]
-        self.assertEqual(spec.stdout, subprocess.DEVNULL)
-        self.assertFalse(spec.merge_stderr)
-        self.assertEqual(spec.timeout_seconds, video.NATIVE_MVC_PROBE_TIMEOUT_SECONDS)
-        self.assertIs(spec.event_context, event_context)
-        self.assertIs(run.call_args.kwargs["run_context"], run_context)
-        self.assertIs(run.call_args.kwargs["cancellation_event"], cancellation_event)
 
     def test_native_split_raises_clear_error_when_single_thread_retry_sigaborts(self) -> None:
         crash = pipeline_failure(
@@ -497,11 +447,24 @@ class NativeMvcSelectionTests(unittest.TestCase):
         with (
             patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
             patch.object(video, "should_stream_mvc_from_container", return_value=False),
-            patch.object(video, "should_probe_native_multithread_splitter", return_value=False),
             patch.object(video.ProcessPipelineRunner, "run", side_effect=[crash, crash]),
             self.assertRaisesRegex(video.NativeMvcSplitError, "SIGABRT.*diagnostic report"),
         ):
             video.split_mvc_to_stereo_native(Path("movie.264"), Path("left.mov"), Path("right.mov"), DiscInfo(), "")
+
+    def test_signal_crash_is_prioritized_even_when_final_stage_completes_first(self) -> None:
+        splitter_error = process_error(-signal.SIGABRT, ["edge264_test"])
+        ffmpeg_error = process_error(1, ["encode-ffmpeg"])
+        error = ProcessPipelineError(
+            ProcessPipelineResult(
+                (
+                    ProcessPipelineStageResult("edge264", None, splitter_error, completed_before_final=False),
+                    ProcessPipelineStageResult("ffmpeg", None, ffmpeg_error, completed_before_final=True),
+                )
+            )
+        )
+
+        self.assertIs(video.select_native_pipeline_error(error, producer_present=False), splitter_error)
 
 
 def process_result(tool_id: str) -> ProcessResult:

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -20,6 +20,7 @@ from bd_to_avp.process_runner import (
     EVENT_QUEUE_LIMIT,
     CaptureOverflowPolicy,
     ChildProcessRunner,
+    ProcessArtifactNoProgressError,
     ProcessArtifactProbe,
     ProcessCancelled,
     ProcessExecutionError,
@@ -447,6 +448,200 @@ class ChildProcessRunnerTests(unittest.TestCase):
         self.assertGreaterEqual(len(artifact_events), 2)
         self.assertEqual(artifact_events[-1].data.artifact.state, "complete")
         self.assertEqual(artifact_events[-1].data.artifact.size_bytes, 131072)
+
+    def test_artifact_no_growth_timeout_ignores_continuing_diagnostics(self) -> None:
+        sink = RecordingSink()
+        context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink))
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            started = time.monotonic()
+            with self.assertRaises(ProcessArtifactNoProgressError):
+                ChildProcessRunner().run(
+                    self.spec(
+                        "import pathlib, sys, time; path = pathlib.Path(sys.argv[1]); "
+                        "path.write_bytes(b'x' * 70000); "
+                        "[(print('progress', index, file=sys.stderr, flush=True), time.sleep(0.02)) "
+                        "for index in range(1000)]",
+                        artifact,
+                        merge_stderr=False,
+                        artifacts=(ProcessArtifactProbe("intermediate", artifact),),
+                        artifact_interval_seconds=0.02,
+                        artifact_no_growth_timeout_seconds=0.25,
+                        artifact_no_growth_retryable=True,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    ),
+                    run_context=context,
+                )
+
+        self.assertLess(time.monotonic() - started, 3)
+        failures = [event for event in sink.snapshot().events if event.kind == "tool.failed"]
+        self.assertEqual(failures[-1].data.failure.code, "artifact_no_growth")
+        self.assertTrue(failures[-1].data.failure.retryable)
+
+    def test_artifact_growth_resets_no_growth_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            result = ChildProcessRunner().run(
+                self.spec(
+                    "import pathlib, sys, time; path = pathlib.Path(sys.argv[1]); "
+                    "file = path.open('wb'); "
+                    "[(file.write(b'x' * 70000), file.flush(), time.sleep(0.05)) for _ in range(4)]; "
+                    "file.close()",
+                    artifact,
+                    artifacts=(ProcessArtifactProbe("intermediate", artifact),),
+                    artifact_interval_seconds=0.02,
+                    artifact_no_growth_timeout_seconds=0.25,
+                )
+            )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_artifact_rewrite_resets_no_growth_timeout_without_size_change(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            result = ChildProcessRunner().run(
+                self.spec(
+                    "import os, pathlib, sys, time; path = pathlib.Path(sys.argv[1]); "
+                    "path.write_bytes(b'x' * 70000); "
+                    "[(os.utime(path, None), time.sleep(0.05)) for _ in range(4)]",
+                    artifact,
+                    artifacts=(ProcessArtifactProbe("intermediate", artifact),),
+                    artifact_interval_seconds=0.02,
+                    artifact_no_growth_timeout_seconds=0.25,
+                )
+            )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_each_artifact_must_continue_making_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            growing = Path(directory) / "growing.bin"
+            stalled = Path(directory) / "stalled.bin"
+            with self.assertRaisesRegex(ProcessArtifactNoProgressError, "stalled_output"):
+                ChildProcessRunner().run(
+                    self.spec(
+                        "import pathlib, sys, time; growing = pathlib.Path(sys.argv[1]); "
+                        "stalled = pathlib.Path(sys.argv[2]); stalled.write_bytes(b'x' * 70000); "
+                        "file = growing.open('wb'); "
+                        "[(file.write(b'x' * 70000), file.flush(), time.sleep(0.04)) for _ in range(1000)]",
+                        growing,
+                        stalled,
+                        artifacts=(
+                            ProcessArtifactProbe("growing_output", growing),
+                            ProcessArtifactProbe("stalled_output", stalled),
+                        ),
+                        artifact_interval_seconds=0.02,
+                        artifact_no_growth_timeout_seconds=0.25,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                )
+
+    def test_pipeline_final_artifact_stall_cancels_blocked_producer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "output.bin"
+            stages = (
+                ProcessPipelineStage(
+                    self.spec(
+                        "import os\nwhile True: os.write(1, b'x' * 65536)",
+                        tool_id="producer",
+                        display_name="producer",
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                ),
+                ProcessPipelineStage(
+                    self.spec(
+                        "import pathlib, sys, time; pathlib.Path(sys.argv[1]).write_bytes(b'x' * 70000); "
+                        "time.sleep(30)",
+                        artifact,
+                        tool_id="consumer",
+                        display_name="consumer",
+                        artifacts=(ProcessArtifactProbe("output", artifact),),
+                        artifact_interval_seconds=0.02,
+                        artifact_no_growth_timeout_seconds=0.25,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                ),
+            )
+
+            started = time.monotonic()
+            with self.assertRaises(ProcessPipelineError) as raised:
+                ProcessPipelineRunner(exit_grace_seconds=0.1).run(stages)
+
+        self.assertLess(time.monotonic() - started, 3)
+        self.assertIsInstance(raised.exception.result.stages[0].error, ProcessCancelled)
+        self.assertIsInstance(raised.exception.result.stages[1].error, ProcessArtifactNoProgressError)
+
+    def test_three_stage_artifact_plateau_preserves_final_error_and_cleans_up_splitter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            left_artifact = Path(directory) / "left.bin"
+            right_artifact = Path(directory) / "right.bin"
+            stages = (
+                ProcessPipelineStage(
+                    self.spec(
+                        "import os; os.write(1, b'x' * 1048576)",
+                        tool_id="producer",
+                        display_name="producer",
+                    )
+                ),
+                ProcessPipelineStage(
+                    self.spec(
+                        "import os, sys, time; sys.stdin.buffer.read(); os.write(1, b'x' * 131072); time.sleep(30)",
+                        tool_id="splitter",
+                        display_name="splitter",
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                ),
+                ProcessPipelineStage(
+                    self.spec(
+                        "import pathlib, sys; payload = sys.stdin.buffer.read(65536); "
+                        "pathlib.Path(sys.argv[1]).write_bytes(payload); "
+                        "pathlib.Path(sys.argv[2]).write_bytes(payload); sys.stdin.buffer.read()",
+                        left_artifact,
+                        right_artifact,
+                        tool_id="encoder",
+                        display_name="encoder",
+                        artifacts=(
+                            ProcessArtifactProbe("left_output", left_artifact),
+                            ProcessArtifactProbe("right_output", right_artifact),
+                        ),
+                        artifact_interval_seconds=0.02,
+                        artifact_no_growth_timeout_seconds=0.25,
+                        termination_grace_seconds=0.1,
+                        kill_wait_seconds=0.1,
+                    )
+                ),
+            )
+
+            started = time.monotonic()
+            with self.assertRaises(ProcessPipelineError) as raised:
+                ProcessPipelineRunner(exit_grace_seconds=0.1).run(stages)
+
+        self.assertLess(time.monotonic() - started, 3)
+        self.assertIsNone(raised.exception.result.stages[0].error)
+        self.assertIsInstance(raised.exception.result.stages[1].error, ProcessCancelled)
+        self.assertIsInstance(raised.exception.result.stages[2].error, ProcessArtifactNoProgressError)
+
+    def test_pipeline_preserves_stage_error_when_cleanup_monitor_fails(self) -> None:
+        stages = (
+            ProcessPipelineStage(self.spec("print('done')", tool_id="producer", display_name="producer")),
+            ProcessPipelineStage(self.spec("raise SystemExit(4)", tool_id="consumer", display_name="consumer")),
+        )
+        cleanup_error = ProcessRunnerError("pipeline monitor did not stop")
+        runner = ProcessPipelineRunner(exit_grace_seconds=0.1)
+
+        with (
+            unittest.mock.patch.object(runner, "_join_upstream_stages", side_effect=cleanup_error),
+            self.assertRaises(ProcessPipelineError) as raised,
+        ):
+            runner.run(stages)
+
+        self.assertIs(raised.exception.__cause__, cleanup_error)
+        self.assertIsInstance(raised.exception.result.stages[1].error, subprocess.CalledProcessError)
 
     def test_cancellation_emits_terminal_incomplete_artifact_snapshot(self) -> None:
         sink = RecordingSink()


### PR DESCRIPTION
## Summary
- bound MVC output no-progress by tracking each expected artifact's size and write activity
- terminate a stalled multithread pipeline, remove partial outputs, and retry once in single-thread mode
- remove the redundant 30-second ISO probe and preserve the root stage error even if pipeline cleanup also fails
- report a bounded diagnostic failure if the single-thread fallback also stops making progress

## Validation
- `uv run python -m unittest discover -s tests` — 799 passed, 2 skipped
- `uv run ruff check bd_to_avp/process_runner.py bd_to_avp/modules/video.py tests/test_process_runner.py tests/test_native_mvc_split.py`
- JetBrains changed-files closeout inspection — clean
- all 4 required PR checks passed on `09dc1683f7b5b43bc3f89bf747c1052c802eeab7`
- private field ISO reproduced the deterministic two-output plateau, automatically retried single-threaded, and completed both HEVC eye outputs
- both outputs: 1920×1080, 24000/1001 fps, 5,630.875250 seconds, 135,006 frames; final 10-second decode passed for each

Closes #334
