### PR TITLE
release: prepare Beta 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ and RC exclude it. Existing Stable or RC selections remain in place until you
 explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
 
-Beta 4 metadata (`0.3.0b4`, build `149`) is prepared and authorized for the
-guarded Prerelease workflow after production diagnostics qualification. There
-is no Beta 4 tag, DMG, release, or updater item until issue #316 completes
-exact-SHA signing, publication, and public verification.
+Beta 4 (`0.3.0b4`, build `149`) is published and immutable. Beta 5 metadata
+(`0.3.0b5`, build `150`) is prepared and authorized for the guarded Prerelease
+workflow in issue #338. There is no Beta 5 tag, DMG, release, or updater item
+until exact-SHA signing, publication, and public verification complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.
@@ -180,7 +180,7 @@ warning. Titles are not used to guess audio language.
 
 Audio-language filtering can reduce output payload when tracks are omitted,
 but this feature does not establish the cause of the output-size report in
-issue #202 and does not claim to fix the separately reported Ship's *Top Gun*
+issue #202 and does not claim to fix any separately reported media-specific
 stall. Those observations remain separate diagnostic work.
 
 ## Terminal Usage

--- a/docs/0.3.0-beta.5-cut-packet.md
+++ b/docs/0.3.0-beta.5-cut-packet.md
@@ -1,0 +1,102 @@
+# 0.3.0 Beta 5 Cut Packet
+
+> **Authorized metadata; publication pending.** Issue #338 owns the repository
+> preparation, exact-SHA Prerelease dispatch, signing approval, notarization,
+> artifact construction, publication, appcast deployment, and installed-field
+> qualification recorded here. This packet does not assert that a Beta 5 tag,
+> draft, DMG, release, or appcast item exists.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 5 metadata was prepared from
+protected `main` after the MVC no-progress recovery and its post-merge test
+correction landed and exact-merge CI and CodeQL completed successfully. This
+packet intentionally does not name a dispatch SHA: issue #338 must record and
+verify the new protected `main` SHA after this metadata PR merges.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b5` |
+| Public version | `0.3.0-beta.5` |
+| Bundle and Sparkle build | `150` |
+| GitHub tag and release title | `v0.3.0-beta.5` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4` |
+
+Build `150` is globally newer than immutable published Beta 4 build `149`.
+The live audit before preparation found published Beta 4 with the expected DMG,
+`SHA256SUMS`, and `appcast.xml` assets, no `v0.3.0-beta.5` release, and an
+appcast state still rooted at Beta 4.
+
+## Included Product Changes
+
+- PR #335 keeps generated temporary MVC filenames strictly redacted in private
+  diagnostic archives while preserving useful file-role and growth evidence.
+- PR #336 bounds a native MVC pipeline that remains alive but stops producing
+  either eye. The app terminates the stalled pipeline, removes partial outputs,
+  and retries once through the existing single-thread decoder. A second stall
+  becomes an actionable bounded error instead of an indefinite wait.
+- PR #336 also removes the redundant 30-second ISO probe, tracks size and write
+  activity independently for every expected output, and preserves the
+  substantive stage failure even when cleanup also encounters an error.
+- PR #337 accepts both cancellation and the expected broken-pipe race when a
+  stalled downstream stage closes, restoring deterministic exact-merge CI
+  without changing production behavior.
+
+## Cumulative Update Contract
+
+Publication must append Beta 5 above the immutable production history:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b5` | `150` | `beta` |
+| 2 | `0.3.0b4` | `149` | `beta` |
+| 3 | `0.3.0b3` | `148` | `beta` |
+| 4 | `0.2.143` | `146` | Stable / no channel |
+
+Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3,
+Beta 4, and Beta 5, and an installed earlier Beta on either route may update
+forward to build `150`. Moving to a safer route never downgrades an installed
+prerelease.
+
+## Reviewed Release-Note Seed
+
+Use this text only inside issue #338's authorized publication flow:
+
+> BD_to_AVP `v0.3.0-beta.5` fixes a native MVC conversion stall that could occur
+> on some 3D streams. If multithreaded decoding stops producing either
+> eye, the app now terminates the stalled pipeline, removes partial output, and
+> retries once in single-threaded mode. Diagnostic temporary filenames also
+> remain strictly redacted. The app now fails clearly instead of waiting
+> indefinitely if the bounded fallback cannot make progress.
+
+Do not describe Beta 5 as downloadable, signed, published, or
+Sparkle-discoverable until issue #338 completes the guarded release and verifies
+the immutable public state.
+
+## Authorization Boundary
+
+Issue #338 and the explicit Beta 5 request authorize the metadata preparation,
+protected-main review, and exact-SHA Prerelease dispatch. The repository has no
+freeze entry for `v0.3.0-beta.5`.
+
+The workflow must be dispatched only from the exact protected `main` SHA that
+contains the reviewed metadata PR. `main` must remain fixed while the workflow
+is nonterminal. The `macos-signing` environment remains a separate human
+authorization boundary: approval requires current-conversation authorization,
+the active `cbusillo` identity, and the run-bound fingerprint emitted by
+`scripts.github_release_run watch`.
+
+Publication and installed-field qualification remain separate evidence states.
+After publication, issue #338 must verify the public release, attestation, live
+appcast, updater route, and the corrected private diagnostic lifecycle owned by
+issue #278.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -84,13 +84,12 @@ document it as an external dependency with preflight behavior.
   production GUI path. The protected-main release workflow builds that app with
   the production name and bundle identifier on a pinned GitHub-hosted macOS 26
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
-- The next prepared production-identity field build is `v0.3.0-beta.4`, internal
-  version `0.3.0b4`, build `149`. Issue #314 has completed the authorized
-  production diagnostics admission deployment and issue #316 has removed the
-  committed freeze through protected-main review. Beta 4 is authorized for the
-  guarded exact-SHA Prerelease workflow but remains unpublished until signing
-  and public verification complete. Beta 3 build `148` remains the published
-  manual-download seed and immutable appcast history below it.
+- Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`) is published
+  and immutable. The next prepared production-identity field build is Beta 5
+  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`). Issue #338 owns
+  its guarded exact-SHA Prerelease workflow; Beta 5 remains unpublished until
+  signing and public verification complete. Beta 3 build `148` remains the
+  manual-download seed and immutable appcast history below both releases.
 - Stable, RC, Beta, and Alpha are routes for the same product, bundle identifier,
   feed, Sparkle key, signing team, and diagnostics endpoint. Stable is default;
   broader routes include progressively earlier stages without permitting

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -95,10 +95,11 @@ missing or unknown values fail closed to Stable. Choosing a safer route affects
 only future newer builds and never downgrades the installed app. Published Beta
 3 (`0.3.0b3`, build `148`) is the one-time manual-download production seed:
 older Stable and RC installations cannot discover it, while an installed Beta
-3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) is the next prepared
-target and is authorized for the guarded exact-SHA Prerelease workflow. Its
-future cumulative item must sit above Beta 3 and remain visible only to Beta and
-Alpha until a later newer Stable supersedes it.
+3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) is published and
+immutable. Beta 5 (`0.3.0b5`, build `150`) is the next prepared target and is
+authorized for the guarded exact-SHA Prerelease workflow. Its future cumulative
+item must sit above Beta 4 and Beta 3 and remain visible only to Beta and Alpha
+until a later newer Stable supersedes it.
 
 ## Release Workflow
 
@@ -150,16 +151,14 @@ behavior and engine architecture rather than release branding.
 
 ## Remaining Field Evidence
 
-Beta 3 publication and route qualification are complete. Beta 4 field evidence
-remains pending issue #316's guarded Prerelease workflow and installed-app
-qualification. The committed freeze is removed after the production diagnostics
-service admitted and qualified privacy-rules-v4 clients. The signed installed-app
-qualification must prove that:
+Beta 3 and Beta 4 publication are complete. Beta 5 field evidence remains
+pending issue #338's guarded Prerelease workflow and installed-app
+qualification. The signed installed-app qualification must prove that:
 
-- Beta 3 updates forward to Beta 4 on Beta and Alpha without changing the saved
+- Beta 4 updates forward to Beta 5 on Beta and Alpha without changing the saved
   route;
-- Stable and RC continue to exclude both Beta items;
-- the production service rejects pre-v4 clients and accepts the signed Beta 4
+- Stable and RC continue to exclude every Beta item;
+- the production service rejects pre-v4 clients and accepts the signed Beta 5
   client; and
 - a deliberate report can be submitted, retrieved by support code, assessed
   for privacy and diagnostic sufficiency, and deleted.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,19 +4,20 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The repository carries published, immutable Beta 3 history at internal version
-`0.3.0b3`, build `148`, and a prepared Beta 4 target at `0.3.0b4`, build `149`.
-The failed, unpublished `0.3.0rc1` build `147` attempt is preserved in the
-checked-in recovery evidence and its build number is permanently burned. The
-reviewed [Beta 4 cut packet](0.3.0-beta.4-cut-packet.md) records metadata only;
-it does not assert that any Beta 4 public artifact exists.
+The repository carries published, immutable Beta 3 and Beta 4 history at
+internal versions `0.3.0b3` and `0.3.0b4`, builds `148` and `149`, and a
+prepared Beta 5 target at `0.3.0b5`, build `150`. The failed, unpublished
+`0.3.0rc1` build `147` attempt is preserved in the checked-in recovery evidence
+and its build number is permanently burned. The reviewed
+[Beta 5 cut packet](0.3.0-beta.5-cut-packet.md) records metadata only; it does
+not assert that any Beta 5 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issue #314 has completed the authorized
-production diagnostics admission deployment. Issue #316 owns the reviewed
-unfreeze, exact-SHA dispatch, approval, signing, publication, and verification.
+implemented and regression-covered. Issue #338 owns the reviewed Beta 5
+exact-SHA dispatch, approval, signing, publication, verification, and
+installed-field qualification.
 
 ## Release Preparation
 
@@ -32,9 +33,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b4` maps to public `0.3.0-beta.4`, tag/title
-`v0.3.0-beta.4`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg`. The numeric
+example, internal `0.3.0b5` maps to public `0.3.0-beta.5`, tag/title
+`v0.3.0-beta.5`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -75,13 +76,12 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 4 is authorized but not yet published.** Issue #316 removed the
-> `v0.3.0-beta.4` freeze through protected-main review after issue #314 recorded
-> the authorized production diagnostics deployment and live admission evidence.
-> Dispatch only from the exact protected `main` commit containing that removal,
-> keep `main` fixed while the workflow is nonterminal, and do not describe Beta
-> 4 as public until signing, notarization, appcast publication, and route
-> verification complete.
+> **Beta 5 is authorized but not yet published.** Issue #338 owns the guarded
+> `v0.3.0-beta.5` release, and the repository contains no freeze entry for that
+> exact tag. Dispatch only from the exact protected `main` commit containing the
+> reviewed Beta 5 metadata, keep `main` fixed while the workflow is nonterminal,
+> and do not describe Beta 5 as public until signing, notarization, appcast
+> publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,12 +6,11 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. Beta 3 is published and immutable at `0.3.0b3` build
-`148`, with build `147` permanently burned. The next prepared target is Beta 4
-at `0.3.0b4` build `149`. Issue #314 completed the authorized production
-diagnostics admission gate, and issue #316 exclusively owns the reviewed
-unfreeze, exact-SHA dispatch, approval, signing, publication, and public
-verification.
+this four-route contract. Beta 3 and Beta 4 are published and immutable at
+`0.3.0b3` build `148` and `0.3.0b4` build `149`, with build `147` permanently
+burned. The next prepared target is Beta 5 at `0.3.0b5` build `150`. Issue #338
+owns the reviewed exact-SHA dispatch, approval, signing, publication, public
+verification, and installed-field qualification.
 
 ## Production Identity
 
@@ -52,7 +51,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -139,32 +138,31 @@ prereleases. Beta 3 remains immutable production/feed history in the cumulative
 appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
-client waits for a newer eligible Stable build. Beta 4 reserves the next global
-build, `149`.
+client waits for a newer eligible Stable build. Beta 4 is immutable production
+history, and Beta 5 reserves the next global build, `150`.
 
-## Beta 4 Authorized Target
+## Beta 5 Authorized Target
 
-The repository is prepared for the guarded `v0.3.0-beta.4` Prerelease workflow:
+The repository is prepared for the guarded `v0.3.0-beta.5` Prerelease workflow:
 
-- internal version `0.3.0b4`;
-- public tag and title `v0.3.0-beta.4`;
-- global build `149`;
+- internal version `0.3.0b5`;
+- public tag and title `v0.3.0-beta.5`;
+- global build `150`;
 - Sparkle channel `beta`;
 - GitHub prerelease, never Latest, PyPI, or Homebrew; and
 - the same production product, bundle, feed, key, signing team, and diagnostics
-  endpoint as Beta 3.
+  endpoint as Beta 4.
 
-The cumulative appcast must place Beta 4 above immutable Beta 3 build `148` and
-Stable build `146`. Stable and RC exclude both Beta items; Beta and Alpha admit
-them, allowing an installed Beta 3 to update forward to Beta 4 without changing
-the saved route.
+The cumulative appcast must place Beta 5 above immutable Beta 4 build `149`,
+Beta 3 build `148`, and Stable build `146`. Stable and RC exclude all Beta
+items; Beta and Alpha admit them, allowing an installed earlier Beta to update
+forward to Beta 5 without changing the saved route.
 
-Issue #316 removed this exact tag from `.github/release-freezes.json` through
-protected-main review after #314 completed the explicitly authorized production
-diagnostics deployment. Absence of the freeze authorizes workflow preflight; it
-does not assert that a tag, draft, DMG, release, or appcast item exists. The
-reviewed metadata and release-note seed are in
-[the Beta 4 cut packet](0.3.0-beta.4-cut-packet.md).
+Issue #338 owns this cut. The repository has no freeze entry for this exact tag;
+that absence authorizes workflow preflight but does not assert that a tag,
+draft, DMG, release, or appcast item exists. The reviewed metadata and
+release-note seed are in
+[the Beta 5 cut packet](0.3.0-beta.5-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -267,24 +267,24 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 4 Authorization Smoke
+### Beta 5 Authorization Smoke
 
-Run these checks after the issue #316 unfreeze lands and before workflow
-dispatch. They prove the committed target and authorization boundary, not a
-signed or published app.
+Run these checks after issue #338's metadata preparation lands and before
+workflow dispatch. They prove the committed target and authorization boundary,
+not a signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b4`, public `0.3.0-beta.4`, build `149`, Beta channel, prerelease,
+   `0.3.0b5`, public `0.3.0-beta.5`, build `150`, Beta channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 4 freeze is absent while all route, identity, and existing-release
+   Beta 5 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 4 build `149`, Beta 3
-   build `148`, then Stable build `146`; Stable and RC must exclude both Beta
-   items while Beta and Alpha admit them.
-4. Confirm the live repository has no Beta 4 tag, release, draft, or asset and
-   the public appcast still ends at Beta 3 build `148`.
-5. Continue only through issue #316's exact-SHA Prerelease workflow. Signed-app,
+3. Validate a cumulative appcast fixture ordered Beta 5 build `150`, Beta 4
+   build `149`, Beta 3 build `148`, then Stable build `146`; Stable and RC must
+   exclude every Beta item while Beta and Alpha admit them.
+4. Confirm the live repository has no Beta 5 tag, release, draft, or asset and
+   the public appcast still ends at Beta 4 build `149`.
+5. Continue only through issue #338's exact-SHA Prerelease workflow. Signed-app,
    update-route, and diagnostic-lifecycle qualification remain incomplete until
    the guarded workflow and installed-field checks finish.
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -265,12 +265,13 @@ select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 `v0.3.0-beta.2` Preview identities remain separate, immutable, and unable to
 Sparkle-upgrade into Beta 3.
 
-The next prepared item is authorized `v0.3.0-beta.4` (`0.3.0b4`, build `149`).
-Issue #316 removed the committed freeze after production diagnostics
-qualification. Publication must append Beta 4 above Beta 3 in the same
-cumulative feed, remain excluded from Stable and RC, and be eligible to Beta and
-Alpha. The exact-SHA Prerelease workflow, signing approval, notarization, and
-public verification remain separate fail-closed boundaries.
+Published `v0.3.0-beta.4` (`0.3.0b4`, build `149`) is the immutable head of the
+current cumulative feed above Beta 3. The next prepared item is authorized
+`v0.3.0-beta.5` (`0.3.0b5`, build `150`) under issue #338. Publication must
+append Beta 5 above Beta 4 and Beta 3, remain excluded from Stable and RC, and
+be eligible to Beta and Alpha. The exact-SHA Prerelease workflow, signing
+approval, notarization, and public verification remain separate fail-closed
+boundaries.
 
 ## Runtime Integration and UX
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,13 +37,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 149
+        CURRENT_PROJECT_VERSION: 150
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b4
+        MARKETING_VERSION: 0.3.0b5
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b4"
+version = "0.3.0b5"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "149"
+CFBundleVersion = "150"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -92,8 +92,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b4")
-        self.assertEqual(NATIVE_BUILD_VERSION, "149")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b5")
+        self.assertEqual(NATIVE_BUILD_VERSION, "150")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,29 +156,30 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_and_authorized_for_beta4(self) -> None:
+    def test_repository_is_prepared_and_authorized_for_beta5(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b4")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.4")
-        self.assertEqual(metadata.build_version, "149")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.4")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.4")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.4.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b5")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.5")
+        self.assertEqual(metadata.build_version, "150")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.5")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.5")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.4", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-beta.5", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.4-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b4`", cut_packet)
-        self.assertIn("Build `149`", cut_packet)
-        self.assertIn("PR #313", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.5-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b5`", cut_packet)
+        self.assertIn("Build `150`", cut_packet)
+        self.assertIn("PR #335", cut_packet)
+        self.assertIn("PR #336", cut_packet)
         self.assertIn("Privacy rules version `4`", cut_packet)
-        self.assertIn("issue #316", cut_packet)
+        self.assertIn("issue #338", cut_packet)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
         evidence = release.validate_beta3_recovery_evidence()

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,13 +188,14 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
-    def test_beta4_appends_above_beta3_in_cumulative_production_history(self) -> None:
+    def test_beta5_appends_above_existing_betas_in_cumulative_production_history(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             empty_feed = root / "empty.xml"
             stable_feed = root / "stable.xml"
             beta3_feed = root / "beta3.xml"
             beta4_feed = root / "beta4.xml"
+            beta5_feed = root / "beta5.xml"
             make_empty_feed(empty_feed)
 
             sparkle_appcast.append_item(
@@ -212,23 +213,28 @@ class SparkleAppcastTests(unittest.TestCase):
                 beta4_feed,
                 item("149", "0.3.0b4", "beta", minimum_system_version="26.0"),
             )
+            sparkle_appcast.append_item(
+                beta4_feed,
+                beta5_feed,
+                item("150", "0.3.0b5", "beta", minimum_system_version="26.0"),
+            )
 
-            sparkle_appcast.validate_release_snapshot(beta4_feed, "0.3.0b4")
-            sparkle_appcast.validate_release_tag_snapshot(beta4_feed, "v0.3.0-beta.4")
-            _, channel = sparkle_appcast.load_appcast(beta4_feed)
+            sparkle_appcast.validate_release_snapshot(beta5_feed, "0.3.0b5")
+            sparkle_appcast.validate_release_tag_snapshot(beta5_feed, "v0.3.0-beta.5")
+            _, channel = sparkle_appcast.load_appcast(beta5_feed)
             items = channel.findall("item")
 
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
-            ["149", "148", "146"],
+            ["150", "149", "148", "146"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
-            ["0.3.0b4", "0.3.0b3", "0.2.143"],
+            ["0.3.0b5", "0.3.0b4", "0.3.0b3", "0.2.143"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
-            ["beta", "beta", None],
+            ["beta", "beta", "beta", None],
         )
 
     def test_rejects_non_monotonic_build(self) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "149")
+        self.assertEqual(info["CFBundleVersion"], "150")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b4"
+version = "0.3.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- prepare internal `0.3.0b5`, public `v0.3.0-beta.5`, and global build `150`
- update cumulative Sparkle history and release documentation for immutable Beta 4 → Beta 5
- include the bounded MVC stall recovery and diagnostic privacy improvements from PRs #335–#337
- keep publication fail-closed: no Beta 5 tag, artifact, release, or feed item exists until the guarded Prerelease workflow completes

## Validation
- `uv run python -m scripts.release validate`
- 133 focused release/native/Sparkle tests
- 799 Python tests (2 skipped)
- 268 native Swift tests
- scoped Ruff format/lint, mypy, import and CLI smokes
- `uv build`
- Briefcase create/build
- independent post-fix reviews: no findings

Refs #338