### PR TITLE
Fix Worker stdout backpressure during progress floods

### DIFF
--- a/macos/BluRayToVisionPro/Worker/WorkerProcessClient.swift
+++ b/macos/BluRayToVisionPro/Worker/WorkerProcessClient.swift
@@ -137,6 +137,26 @@ final class WorkerProcessClient: WorkerProcessRunning, @unchecked Sendable {
     }
 
     func run(job: WorkerJobSpec, onEvent: @escaping EventHandler) async throws -> WorkerRunResult {
+        do {
+            let result = try await withTaskCancellationHandler(
+                operation: {
+                    try await runProcess(job: job, onEvent: onEvent)
+                },
+                onCancel: {
+                    self.cancel()
+                }
+            )
+            try Task.checkCancellation()
+            return result
+        } catch {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
+            throw error
+        }
+    }
+
+    private func runProcess(job: WorkerJobSpec, onEvent: @escaping EventHandler) async throws -> WorkerRunResult {
         let process = Process()
         let standardInput = Pipe()
         let standardOutput = Pipe()
@@ -367,12 +387,19 @@ final class WorkerProcessClient: WorkerProcessRunning, @unchecked Sendable {
         process: Process,
         onEvent: @escaping EventHandler
     ) async throws -> WorkerEvent? {
+        let reader = try PullDrivenFileReader(
+            fileHandle: fileHandle,
+            queue: Self.ioQueue
+        )
+        defer {
+            reader.close()
+        }
         var framer = JSONLFramer()
         var terminalEvent: WorkerEvent?
         var expectedSequence = 0
         let decoder = JSONDecoder()
 
-        for try await chunk in Self.chunks(from: fileHandle) {
+        while let chunk = try await reader.read(maximumBytes: Self.stdoutChunkBytes) {
             for line in try framer.append(chunk) {
                 guard terminalEvent == nil else {
                     throw WorkerLifecycleError.eventAfterTerminal
@@ -416,65 +443,75 @@ final class WorkerProcessClient: WorkerProcessRunning, @unchecked Sendable {
     }
 
     private static let stdoutChunkBytes = 64 * 1_024
-    private static let stdoutQueueChunkLimit = 128
 
-    private static func chunks(from fileHandle: FileHandle) -> AsyncThrowingStream<Data, Error> {
-        AsyncThrowingStream(bufferingPolicy: .bufferingOldest(stdoutQueueChunkLimit)) { continuation in
-            let fileDescriptor = dup(fileHandle.fileDescriptor)
-            guard fileDescriptor >= 0 else {
-                continuation.finish(
-                    throwing: NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
-                )
-                return
-            }
-            let channel = DispatchIO(
-                type: .stream,
-                fileDescriptor: fileDescriptor,
-                queue: ioQueue
-            ) { _ in
-                close(fileDescriptor)
-            }
-            channel.setLimit(lowWater: 1)
-            channel.setLimit(highWater: stdoutChunkBytes)
-            channel.read(offset: 0, length: Int.max, queue: ioQueue) { done, dispatchData, errorCode in
-                if let dispatchData, !dispatchData.isEmpty {
-                    switch continuation.yield(Data(dispatchData)) {
-                    case .enqueued:
-                        break
-                    case .dropped:
-                        continuation.finish(
-                            throwing: NSError(
-                                domain: NSPOSIXErrorDomain,
-                                code: Int(ENOBUFS),
-                                userInfo: [NSLocalizedDescriptionKey: "Worker stdout overflow: event processing fell behind."]
-                            )
-                        )
-                        channel.close(flags: .stop)
-                        return
-                    case .terminated:
-                        channel.close(flags: .stop)
-                        return
-                    @unknown default:
-                        channel.close(flags: .stop)
-                        return
+}
+
+private final class PullDrivenFileReader: @unchecked Sendable {
+    private let fileDescriptor: Int32
+    private let queue: DispatchQueue
+    private let lock = NSLock()
+    private var closed = false
+
+    init(fileHandle: FileHandle, queue: DispatchQueue) throws {
+        let fileDescriptor = dup(fileHandle.fileDescriptor)
+        guard fileDescriptor >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        self.fileDescriptor = fileDescriptor
+        self.queue = queue
+    }
+
+    deinit {
+        close()
+    }
+
+    func read(maximumBytes: Int) async throws -> Data? {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async { [self] in
+                continuation.resume(
+                    with: Result {
+                        try readSynchronously(maximumBytes: maximumBytes)
                     }
-                }
-                if errorCode != 0 {
-                    continuation.finish(
-                        throwing: NSError(domain: NSPOSIXErrorDomain, code: Int(errorCode))
-                    )
-                    channel.close(flags: .stop)
-                } else if done {
-                    continuation.finish()
-                    channel.close()
-                }
-            }
-            continuation.onTermination = { _ in
-                channel.close(flags: .stop)
+                )
             }
         }
     }
 
+    func close() {
+        let shouldClose = lock.withLock {
+            guard !closed else {
+                return false
+            }
+            closed = true
+            return true
+        }
+        if shouldClose {
+            Darwin.close(fileDescriptor)
+        }
+    }
+
+    private func readSynchronously(maximumBytes: Int) throws -> Data? {
+        guard maximumBytes > 0 else {
+            return nil
+        }
+        var buffer = [UInt8](repeating: 0, count: maximumBytes)
+        while true {
+            let byteCount = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(fileDescriptor, bytes.baseAddress, bytes.count)
+            }
+            if byteCount > 0 {
+                return Data(buffer.prefix(Int(byteCount)))
+            }
+            if byteCount == 0 {
+                return nil
+            }
+            let errorCode = errno
+            if errorCode == EINTR {
+                continue
+            }
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorCode))
+        }
+    }
 }
 
 private final class DiagnosticPipeDrainer: @unchecked Sendable {

--- a/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
@@ -42,6 +42,132 @@ final class WorkerProcessClientTests: XCTestCase {
         XCTAssertEqual(result.terminalEvent.type, .jobCompleted)
     }
 
+    func testBackpressuresHighVolumeStdoutUntilSlowHandlerCatchesUp() async throws {
+        let eventCount = 260
+        let payloadBytes = 48 * 1_024
+        let client = fixtureClient(body: """
+        \(readyEvent())
+        sys.stderr.write("WRITER-STARTED\\n")
+        sys.stderr.flush()
+        message = "x" * \(payloadBytes)
+        for sequence in range(1, \(eventCount + 1)):
+            print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "log", "job_id": job_id, "sequence": sequence, "payload": {"level": "info", "message": message}}), flush=True)
+        sys.stderr.write("WRITER-COMPLETED\\n")
+        sys.stderr.flush()
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": \(eventCount + 1), "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        """)
+        let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
+        let slowHandlerStarted = expectation(description: "slow handler started")
+        let gate = AsyncGate()
+        var sequences: [Int] = []
+        let task = Task {
+            try await client.run(job: job) { event in
+                sequences.append(event.sequence)
+                if event.sequence == 1 {
+                    slowHandlerStarted.fulfill()
+                    await gate.wait()
+                }
+            }
+        }
+
+        await fulfillment(of: [slowHandlerStarted], timeout: 5)
+        let writerStarted = await waitForDiagnosticMarker("WRITER-STARTED", client: client)
+        XCTAssertTrue(writerStarted)
+        guard writerStarted else {
+            await gate.open()
+            _ = await task.result
+            return
+        }
+        try await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertFalse(client.diagnosticSnapshot().toolOutput.text.contains("WRITER-COMPLETED"))
+        await gate.open()
+        let result = try await task.value
+
+        XCTAssertEqual(sequences, Array(0 ... (eventCount + 1)))
+        XCTAssertEqual(result.terminalEvent.type, .jobCompleted)
+        XCTAssertEqual(result.exitStatus, 0)
+        XCTAssertTrue(result.diagnostics.contains("WRITER-COMPLETED"))
+    }
+
+    func testHandlesProductionShapedProgressBurst() async throws {
+        let progressEventCount = 400
+        let client = fixtureClient(body: """
+        \(readyEvent())
+        for sequence in range(1, \(progressEventCount + 1)):
+            observability = {"schema": "bd_to_avp.observability", "schema_version": 1, "emitter": "worker", "stream_id": job_id, "sequence": sequence - 1, "occurred_at": "2026-07-22T00:00:00Z", "elapsed_ms": sequence, "kind": "tool.progress", "severity": "info", "privacy": "private", "redaction": "raw", "context": {"correlation": {}}, "data": {"progress": {"completed_units": sequence, "total_units": \(progressEventCount), "unit": "ticks"}}}
+            print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "observability", "job_id": job_id, "sequence": sequence, "payload": {"event": observability}}), flush=True)
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": \(progressEventCount + 1), "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        """)
+        let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
+        var sequences: [Int] = []
+        var progressEvents = 0
+
+        let result = try await client.run(job: job) { event in
+            sequences.append(event.sequence)
+            if event.type == .observability {
+                progressEvents += 1
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+        }
+
+        XCTAssertEqual(sequences, Array(0 ... (progressEventCount + 1)))
+        XCTAssertEqual(progressEvents, progressEventCount)
+        XCTAssertEqual(result.terminalEvent.type, .jobCompleted)
+        XCTAssertEqual(result.exitStatus, 0)
+    }
+
+    func testCancellationWhileStdoutIsBackpressuredReapsWorker() async throws {
+        let payloadBytes = 48 * 1_024
+        let client = fixtureClient(body: """
+        \(readyEvent())
+        sys.stderr.write("WRITER-STARTED\\n")
+        sys.stderr.flush()
+        message = "x" * \(payloadBytes)
+        for sequence in range(1, 10_000):
+            print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "log", "job_id": job_id, "sequence": sequence, "payload": {"level": "info", "message": message}}), flush=True)
+        sys.stderr.write("WRITER-COMPLETED\\n")
+        sys.stderr.flush()
+        """)
+        let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
+        let slowHandlerStarted = expectation(description: "slow handler started")
+        let runFinished = expectation(description: "run finished")
+        let gate = AsyncGate()
+        let task = Task {
+            defer {
+                runFinished.fulfill()
+            }
+            return try await client.run(job: job) { event in
+                if event.sequence == 1 {
+                    slowHandlerStarted.fulfill()
+                    await gate.wait()
+                }
+            }
+        }
+
+        await fulfillment(of: [slowHandlerStarted], timeout: 5)
+        let writerStarted = await waitForDiagnosticMarker("WRITER-STARTED", client: client)
+        XCTAssertTrue(writerStarted)
+        guard writerStarted else {
+            task.cancel()
+            await gate.open()
+            _ = await task.result
+            return
+        }
+        try await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertFalse(client.diagnosticSnapshot().toolOutput.text.contains("WRITER-COMPLETED"))
+        task.cancel()
+        await gate.open()
+        await fulfillment(of: [runFinished], timeout: 5)
+
+        switch await task.result {
+        case .failure(let error):
+            XCTAssertTrue(error is CancellationError, "Unexpected cancellation error: \(error)")
+        case .success:
+            XCTFail("Expected cancellation before a terminal event to fail the run")
+        }
+        XCTAssertFalse(client.diagnosticSnapshot().isRunning)
+    }
+
     func testStreamsAndBoundsDiagnosticsWhileWorkerIsActive() async throws {
         let diagnosticPayloadBytes = 4 * 1_024 * 1_024
         let client = fixtureClient(body: """
@@ -205,6 +331,41 @@ final class WorkerProcessClientTests: XCTestCase {
         XCTAssertNotEqual(result.exitStatus, 0)
     }
 
+    func testTaskCancellationAfterTerminalDeliveryReturnsCancellationError() async throws {
+        let client = fixtureClient(body: """
+        \(readyEvent())
+        print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "job.completed", "job_id": job_id, "sequence": 1, "payload": {"result": {"name": "movie", "resolution": "1920x1080", "frame_rate": "24/1", "interlaced": False, "size_bytes": 10, "titles": []}}}), flush=True)
+        """)
+        let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
+        let terminalHandlerStarted = expectation(description: "terminal handler started")
+        let runFinished = expectation(description: "run finished")
+        let gate = AsyncGate()
+        let task = Task {
+            defer {
+                runFinished.fulfill()
+            }
+            return try await client.run(job: job) { event in
+                if event.type.isTerminal {
+                    terminalHandlerStarted.fulfill()
+                    await gate.wait()
+                }
+            }
+        }
+
+        await fulfillment(of: [terminalHandlerStarted], timeout: 5)
+        task.cancel()
+        await gate.open()
+        await fulfillment(of: [runFinished], timeout: 5)
+
+        switch await task.result {
+        case .failure(let error):
+            XCTAssertTrue(error is CancellationError, "Unexpected cancellation error: \(error)")
+        case .success:
+            XCTFail("Expected task cancellation after terminal delivery to fail the run")
+        }
+        XCTAssertFalse(client.diagnosticSnapshot().isRunning)
+    }
+
     func testCancellationRequestedBeforeLaunchIsNotLost() async throws {
         let client = fixtureClient(body: "time.sleep(30)")
         let job = WorkerJobSpec(sourceURL: URL(fileURLWithPath: "/tmp/movie.m2ts"), jobID: jobID)
@@ -223,6 +384,21 @@ final class WorkerProcessClientTests: XCTestCase {
         """
         print(json.dumps({"protocol_version": \(WorkerJobSpec.protocolVersion), "type": "worker.ready", "job_id": job_id, "sequence": 0, "payload": {"worker_version": "test", "process_group_id": os.getpid()}}), flush=True)
         """
+    }
+
+    private func waitForDiagnosticMarker(
+        _ marker: String,
+        client: WorkerProcessClient,
+        timeout: TimeInterval = 2
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if client.diagnosticSnapshot().toolOutput.text.contains(marker) {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        return false
     }
 
     private func fixtureClient(body: String) -> WorkerProcessClient {
@@ -257,5 +433,35 @@ private actor TerminalEventState {
 
     func record() {
         wasReceived = true
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                continuations.append(continuation)
+            }
+        }
+    }
+
+    func open() {
+        guard !isOpen else {
+            return
+        }
+        isOpen = true
+        let waitingContinuations = continuations
+        continuations.removeAll()
+        for continuation in waitingContinuations {
+            continuation.resume()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the push-buffered Worker stdout stream with a pull-driven reader
- apply kernel pipe backpressure instead of dropping valid JSONL protocol chunks
- preserve explicit cancellation and raw `Task.cancel()` lifecycle semantics
- cover sustained progress bursts, blocked handlers, process reaping, and terminal cancellation races

## Validation
- `uv run python scripts/native_app.py test` (272 tests)
- `uv run python scripts/validate_observability_migration.py`
- JetBrains changed-files closeout inspection: clean
- independent lifecycle/backpressure review: approved

Fixes #342