### PR TITLE
release: prepare 0.3.0 Beta 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ and RC exclude it. Existing Stable or RC selections remain in place until you
 explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
 
-Beta 4 (`0.3.0b4`, build `149`) is published and immutable. Beta 5 metadata
-(`0.3.0b5`, build `150`) is prepared and authorized for the guarded Prerelease
-workflow in issue #338. There is no Beta 5 tag, DMG, release, or updater item
-until exact-SHA signing, publication, and public verification complete.
+Beta 4 (`0.3.0b4`, build `149`) and Beta 5 (`0.3.0b5`, build `150`) are
+published and immutable. Beta 6 metadata (`0.3.0b6`, build `151`) is prepared
+for the guarded Prerelease workflow. There is no Beta 6 tag, DMG, release, or
+updater item until exact-SHA signing, publication, and public verification
+complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.

--- a/docs/0.3.0-beta.5-cut-packet.md
+++ b/docs/0.3.0-beta.5-cut-packet.md
@@ -1,21 +1,19 @@
 # 0.3.0 Beta 5 Cut Packet
 
-> **Authorized metadata; publication pending.** Issue #338 owns the repository
-> preparation, exact-SHA Prerelease dispatch, signing approval, notarization,
-> artifact construction, publication, appcast deployment, and installed-field
-> qualification recorded here. This packet does not assert that a Beta 5 tag,
-> draft, DMG, release, or appcast item exists.
+> **Published and immutable.** Beta 5 was published on July 22, 2026 through
+> the guarded Prerelease workflow. The GitHub release, signed and notarized DMG,
+> `SHA256SUMS`, release `appcast.xml`, and cumulative production appcast are now
+> historical release evidence. Issue #338 retains any remaining installed-field
+> qualification follow-up.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 5 metadata was prepared from
-protected `main` after the MVC no-progress recovery and its post-merge test
-correction landed and exact-merge CI and CodeQL completed successfully. This
-packet intentionally does not name a dispatch SHA: issue #338 must record and
-verify the new protected `main` SHA after this metadata PR merges.
+[release-routes.md](release-routes.md). Beta 5 was released from protected
+`main` commit `cc733a6917c61642ec6ccf2a6b70a7f9044bfabb` after exact-main CI
+and CodeQL completed successfully.
 
 ## Exact Metadata
 
-| Field | Reviewed value |
+| Field | Published value |
 | --- | --- |
 | Package and bundle short version | `0.3.0b5` |
 | Public version | `0.3.0-beta.5` |
@@ -32,10 +30,9 @@ verify the new protected `main` SHA after this metadata PR merges.
 | Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
 | Privacy contract | Privacy rules version `4` |
 
-Build `150` is globally newer than immutable published Beta 4 build `149`.
-The live audit before preparation found published Beta 4 with the expected DMG,
-`SHA256SUMS`, and `appcast.xml` assets, no `v0.3.0-beta.5` release, and an
-appcast state still rooted at Beta 4.
+Build `150` is globally newer than immutable Beta 4 build `149`. The release
+was published at `2026-07-22T08:01:48Z` with the expected DMG,
+`SHA256SUMS`, and `appcast.xml` assets.
 
 ## Included Product Changes
 
@@ -49,12 +46,12 @@ appcast state still rooted at Beta 4.
   activity independently for every expected output, and preserves the
   substantive stage failure even when cleanup also encounters an error.
 - PR #337 accepts both cancellation and the expected broken-pipe race when a
-  stalled downstream stage closes, restoring deterministic exact-merge CI
-  without changing production behavior.
+  stalled downstream stage closes, restoring deterministic CI without changing
+  production behavior.
 
 ## Cumulative Update Contract
 
-Publication must append Beta 5 above the immutable production history:
+Beta 5 was appended above the immutable production history:
 
 | Order | Internal version | Build | Channel |
 | ---: | --- | ---: | --- |
@@ -63,40 +60,21 @@ Publication must append Beta 5 above the immutable production history:
 | 3 | `0.3.0b3` | `148` | `beta` |
 | 4 | `0.2.143` | `146` | Stable / no channel |
 
-Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3,
-Beta 4, and Beta 5, and an installed earlier Beta on either route may update
-forward to build `150`. Moving to a safer route never downgrades an installed
-prerelease.
+Stable and RC exclude every Beta item. Beta and Alpha admit Beta 3, Beta 4,
+and Beta 5. Moving to a safer route never downgrades an installed prerelease.
 
-## Reviewed Release-Note Seed
-
-Use this text only inside issue #338's authorized publication flow:
+## Published Release Notes
 
 > BD_to_AVP `v0.3.0-beta.5` fixes a native MVC conversion stall that could occur
-> on some 3D streams. If multithreaded decoding stops producing either
-> eye, the app now terminates the stalled pipeline, removes partial output, and
-> retries once in single-threaded mode. Diagnostic temporary filenames also
-> remain strictly redacted. The app now fails clearly instead of waiting
-> indefinitely if the bounded fallback cannot make progress.
+> on some 3D streams. If multithreaded decoding stops producing either eye, the
+> app now terminates the stalled pipeline, removes partial output, and retries
+> once in single-threaded mode. Diagnostic temporary filenames also remain
+> strictly redacted. The app now fails clearly instead of waiting indefinitely
+> if the bounded fallback cannot make progress.
 
-Do not describe Beta 5 as downloadable, signed, published, or
-Sparkle-discoverable until issue #338 completes the guarded release and verifies
-the immutable public state.
+## Historical Authorization Boundary
 
-## Authorization Boundary
-
-Issue #338 and the explicit Beta 5 request authorize the metadata preparation,
-protected-main review, and exact-SHA Prerelease dispatch. The repository has no
-freeze entry for `v0.3.0-beta.5`.
-
-The workflow must be dispatched only from the exact protected `main` SHA that
-contains the reviewed metadata PR. `main` must remain fixed while the workflow
-is nonterminal. The `macos-signing` environment remains a separate human
-authorization boundary: approval requires current-conversation authorization,
-the active `cbusillo` identity, and the run-bound fingerprint emitted by
-`scripts.github_release_run watch`.
-
-Publication and installed-field qualification remain separate evidence states.
-After publication, issue #338 must verify the public release, attestation, live
-appcast, updater route, and the corrected private diagnostic lifecycle owned by
-issue #278.
+Issue #338 and the explicit Beta 5 request authorized metadata preparation,
+exact-SHA dispatch, and publication. The separate `macos-signing` approval was
+bound to the published run and protected-main commit. Later release packets may
+refer to Beta 5 only as immutable production history.

--- a/docs/0.3.0-beta.6-cut-packet.md
+++ b/docs/0.3.0-beta.6-cut-packet.md
@@ -1,0 +1,94 @@
+# 0.3.0 Beta 6 Cut Packet
+
+> **Authorized metadata; publication pending.** The explicit Beta 6 request on
+> July 22, 2026 authorizes repository preparation, protected-main review, and
+> exact-SHA Prerelease dispatch. This packet does not assert that a Beta 6 tag,
+> draft, DMG, release, or appcast item exists. The `macos-signing` environment
+> remains a separate run-bound human authorization boundary.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 6 metadata was prepared after the
+diagnostic inventory, Worker stdout backpressure fix, and native MVC decoder
+recovery landed on protected `main` with exact-main CI and CodeQL green.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b6` |
+| Public version | `0.3.0-beta.6` |
+| Bundle and Sparkle build | `151` |
+| GitHub tag and release title | `v0.3.0-beta.6` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.6.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4` |
+
+Build `151` is globally newer than immutable published Beta 5 build `150`.
+The live audit before preparation found published Beta 5 with the expected DMG,
+`SHA256SUMS`, and `appcast.xml` assets and no `v0.3.0-beta.6` release.
+
+## Included Product Changes
+
+- PR #341 adds a maintainer-only diagnostic report inventory with bounded,
+  privacy-preserving metadata for finding field reports without exposing report
+  contents in normal operations.
+- PR #343 makes Worker stdout delivery pull-driven so high-volume diagnostics
+  apply real backpressure instead of accumulating an unbounded in-memory queue.
+  Cancellation and process-reaping behavior remain bounded while reads are
+  backpressured.
+- PR #344 vendors the edge264-mvc terminal dependency recovery from upstream
+  PR #7. A damaged MVC slice can no longer leave every multithreaded task waiting
+  forever on an incomplete reference frame that no task can finish.
+- PR #344 also pins the decoder to Xcode 26.5, SDK 26.5, minimum macOS 14.0,
+  baseline arm64 flags, a reproducible unsigned hash, and a complete upstream
+  `make check` rebuild-and-compare gate. The existing single-thread fallback
+  remains as a separate safety net.
+
+## Cumulative Update Contract
+
+Publication must append Beta 6 above the immutable production history:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b6` | `151` | `beta` |
+| 2 | `0.3.0b5` | `150` | `beta` |
+| 3 | `0.3.0b4` | `149` | `beta` |
+| 4 | `0.3.0b3` | `148` | `beta` |
+| 5 | `0.2.143` | `146` | Stable / no channel |
+
+Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3
+through Beta 6, and an installed earlier Beta on either route may update forward
+to build `151`. Moving to a safer route never downgrades an installed
+prerelease.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.0-beta.6` fixes a multithreaded MVC decoder deadlock found in
+> field testing. Damaged streams that leave an incomplete reference frame now
+> recover instead of waiting forever, while the existing bounded single-thread
+> fallback remains available. The release also fixes high-volume Worker stdout
+> backpressure and improves maintainer access to privacy-preserving diagnostic
+> report metadata.
+
+Do not describe Beta 6 as downloadable, signed, published, or
+Sparkle-discoverable until the guarded release verifies the immutable public
+state.
+
+## Authorization Boundary
+
+The explicit Beta 6 request authorizes metadata preparation, protected-main
+review, and exact-SHA Prerelease dispatch. The repository has no freeze entry
+for `v0.3.0-beta.6`.
+
+The workflow must be dispatched only from the exact protected `main` SHA that
+contains the reviewed metadata PR. `main` must remain fixed while the workflow
+is nonterminal. Before approving `macos-signing`, the run watcher must emit the
+run-bound approval fingerprint and the maintainer must explicitly authorize
+that approval in the active conversation.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -84,12 +84,13 @@ document it as an external dependency with preflight behavior.
   production GUI path. The protected-main release workflow builds that app with
   the production name and bundle identifier on a pinned GitHub-hosted macOS 26
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
-- Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`) is published
-  and immutable. The next prepared production-identity field build is Beta 5
-  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`). Issue #338 owns
-  its guarded exact-SHA Prerelease workflow; Beta 5 remains unpublished until
-  signing and public verification complete. Beta 3 build `148` remains the
-  manual-download seed and immutable appcast history below both releases.
+- Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`) and Beta 5
+  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`) are published and
+  immutable. The next prepared production-identity field build is Beta 6
+  (`v0.3.0-beta.6`, internal version `0.3.0b6`, build `151`). It remains
+  unpublished until exact-SHA signing and public verification complete. Beta 3
+  build `148` remains the manual-download seed and immutable appcast history
+  below the later Beta releases.
 - Stable, RC, Beta, and Alpha are routes for the same product, bundle identifier,
   feed, Sparkle key, signing team, and diagnostics endpoint. Stable is default;
   broader routes include progressively earlier stages without permitting

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -95,11 +95,12 @@ missing or unknown values fail closed to Stable. Choosing a safer route affects
 only future newer builds and never downgrades the installed app. Published Beta
 3 (`0.3.0b3`, build `148`) is the one-time manual-download production seed:
 older Stable and RC installations cannot discover it, while an installed Beta
-3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) is published and
-immutable. Beta 5 (`0.3.0b5`, build `150`) is the next prepared target and is
-authorized for the guarded exact-SHA Prerelease workflow. Its future cumulative
-item must sit above Beta 4 and Beta 3 and remain visible only to Beta and Alpha
-until a later newer Stable supersedes it.
+3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) and Beta 5
+(`0.3.0b5`, build `150`) are published and immutable. Beta 6 (`0.3.0b6`, build
+`151`) is the next prepared target for the guarded exact-SHA Prerelease
+workflow. Its future cumulative item must sit above Beta 5, Beta 4, and Beta 3
+and remain visible only to Beta and Alpha until a later newer Stable supersedes
+it.
 
 ## Release Workflow
 
@@ -151,14 +152,13 @@ behavior and engine architecture rather than release branding.
 
 ## Remaining Field Evidence
 
-Beta 3 and Beta 4 publication are complete. Beta 5 field evidence remains
-pending issue #338's guarded Prerelease workflow and installed-app
-qualification. The signed installed-app qualification must prove that:
+Beta 3, Beta 4, and Beta 5 publication are complete. Beta 6 signed installed-app
+qualification must prove that:
 
-- Beta 4 updates forward to Beta 5 on Beta and Alpha without changing the saved
+- Beta 5 updates forward to Beta 6 on Beta and Alpha without changing the saved
   route;
 - Stable and RC continue to exclude every Beta item;
-- the production service rejects pre-v4 clients and accepts the signed Beta 5
+- the production service rejects pre-v4 clients and accepts the signed Beta 6
   client; and
 - a deliberate report can be submitted, retrieved by support code, assessed
   for privacy and diagnostic sufficiency, and deleted.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,20 +4,21 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The repository carries published, immutable Beta 3 and Beta 4 history at
-internal versions `0.3.0b3` and `0.3.0b4`, builds `148` and `149`, and a
-prepared Beta 5 target at `0.3.0b5`, build `150`. The failed, unpublished
-`0.3.0rc1` build `147` attempt is preserved in the checked-in recovery evidence
-and its build number is permanently burned. The reviewed
-[Beta 5 cut packet](0.3.0-beta.5-cut-packet.md) records metadata only; it does
-not assert that any Beta 5 public artifact exists.
+The repository carries published, immutable Beta 3, Beta 4, and Beta 5 history
+at internal versions `0.3.0b3`, `0.3.0b4`, and `0.3.0b5`, builds `148`, `149`,
+and `150`, and a prepared Beta 6 target at `0.3.0b6`, build `151`. The failed,
+unpublished `0.3.0rc1` build `147` attempt is preserved in the checked-in
+recovery evidence and its build number is permanently burned. The
+[Beta 5 cut packet](0.3.0-beta.5-cut-packet.md) records immutable publication
+history, while the reviewed [Beta 6 cut packet](0.3.0-beta.6-cut-packet.md)
+records metadata only and does not assert that a Beta 6 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issue #338 owns the reviewed Beta 5
-exact-SHA dispatch, approval, signing, publication, verification, and
-installed-field qualification.
+implemented and regression-covered. The explicit Beta 6 request authorizes the
+reviewed metadata preparation and exact-SHA dispatch; run-bound signing approval
+remains a separate authorization boundary.
 
 ## Release Preparation
 
@@ -33,9 +34,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b5` maps to public `0.3.0-beta.5`, tag/title
-`v0.3.0-beta.5`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg`. The numeric
+example, internal `0.3.0b6` maps to public `0.3.0-beta.6`, tag/title
+`v0.3.0-beta.6`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.6.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -76,12 +77,12 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 5 is authorized but not yet published.** Issue #338 owns the guarded
-> `v0.3.0-beta.5` release, and the repository contains no freeze entry for that
-> exact tag. Dispatch only from the exact protected `main` commit containing the
-> reviewed Beta 5 metadata, keep `main` fixed while the workflow is nonterminal,
-> and do not describe Beta 5 as public until signing, notarization, appcast
-> publication, and route verification complete.
+> **Beta 6 is authorized but not yet published.** The explicit Beta 6 request
+> authorizes guarded `v0.3.0-beta.6` dispatch, and the repository contains no
+> freeze entry for that exact tag. Dispatch only from the exact protected `main`
+> commit containing the reviewed Beta 6 metadata, keep `main` fixed while the
+> workflow is nonterminal, and do not describe Beta 6 as public until signing,
+> notarization, appcast publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or
 dispatch `Prerelease` only for reviewed committed Alpha, Beta, or RC metadata,

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,11 +6,11 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. Beta 3 and Beta 4 are published and immutable at
-`0.3.0b3` build `148` and `0.3.0b4` build `149`, with build `147` permanently
-burned. The next prepared target is Beta 5 at `0.3.0b5` build `150`. Issue #338
-owns the reviewed exact-SHA dispatch, approval, signing, publication, public
-verification, and installed-field qualification.
+this four-route contract. Beta 3, Beta 4, and Beta 5 are published and immutable
+at builds `148`, `149`, and `150`, with build `147` permanently burned. The next
+prepared target is Beta 6 at `0.3.0b6` build `151`. The explicit Beta 6 request
+authorizes reviewed exact-SHA dispatch; run-bound signing approval remains a
+separate authorization boundary.
 
 ## Production Identity
 
@@ -51,7 +51,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.6.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -138,12 +138,12 @@ prereleases. Beta 3 remains immutable production/feed history in the cumulative
 appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
-client waits for a newer eligible Stable build. Beta 4 is immutable production
-history, and Beta 5 reserves the next global build, `150`.
+client waits for a newer eligible Stable build. Beta 4 and Beta 5 are immutable
+production history, and Beta 6 reserves the next global build, `151`.
 
-## Beta 5 Authorized Target
+## Beta 5 Published History
 
-The repository is prepared for the guarded `v0.3.0-beta.5` Prerelease workflow:
+Published `v0.3.0-beta.5` is immutable production history:
 
 - internal version `0.3.0b5`;
 - public tag and title `v0.3.0-beta.5`;
@@ -153,16 +153,33 @@ The repository is prepared for the guarded `v0.3.0-beta.5` Prerelease workflow:
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta 4.
 
-The cumulative appcast must place Beta 5 above immutable Beta 4 build `149`,
-Beta 3 build `148`, and Stable build `146`. Stable and RC exclude all Beta
-items; Beta and Alpha admit them, allowing an installed earlier Beta to update
-forward to Beta 5 without changing the saved route.
-
-Issue #338 owns this cut. The repository has no freeze entry for this exact tag;
-that absence authorizes workflow preflight but does not assert that a tag,
-draft, DMG, release, or appcast item exists. The reviewed metadata and
-release-note seed are in
+The cumulative appcast places Beta 5 above immutable Beta 4 build `149`, Beta 3
+build `148`, and Stable build `146`. Stable and RC exclude all Beta items; Beta
+and Alpha admit them. Historical metadata and release evidence are in
 [the Beta 5 cut packet](0.3.0-beta.5-cut-packet.md).
+
+## Beta 6 Authorized Target
+
+The repository is prepared for the guarded `v0.3.0-beta.6` Prerelease workflow:
+
+- internal version `0.3.0b6`;
+- public tag and title `v0.3.0-beta.6`;
+- global build `151`;
+- Sparkle channel `beta`;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta 5.
+
+Publication must place Beta 6 above immutable Beta 5 build `150`, Beta 4 build
+`149`, Beta 3 build `148`, and Stable build `146`. Stable and RC exclude all
+Beta items; Beta and Alpha admit them, allowing an installed earlier Beta to
+update forward to Beta 6 without changing the saved route.
+
+The explicit Beta 6 request authorizes metadata preparation and exact-SHA
+dispatch. The repository has no freeze entry for this exact tag; that absence
+authorizes workflow preflight but does not assert that a tag, draft, DMG,
+release, or appcast item exists. The reviewed metadata and release-note seed are
+in [the Beta 6 cut packet](0.3.0-beta.6-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -267,24 +267,24 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 5 Authorization Smoke
+### Beta 6 Authorization Smoke
 
-Run these checks after issue #338's metadata preparation lands and before
-workflow dispatch. They prove the committed target and authorization boundary,
-not a signed or published app.
+Run these checks after the Beta 6 metadata preparation lands and before workflow
+dispatch. They prove the committed target and authorization boundary, not a
+signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b5`, public `0.3.0-beta.5`, build `150`, Beta channel, prerelease,
+   `0.3.0b6`, public `0.3.0-beta.6`, build `151`, Beta channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 5 freeze is absent while all route, identity, and existing-release
+   Beta 6 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 5 build `150`, Beta 4
-   build `149`, Beta 3 build `148`, then Stable build `146`; Stable and RC must
-   exclude every Beta item while Beta and Alpha admit them.
-4. Confirm the live repository has no Beta 5 tag, release, draft, or asset and
-   the public appcast still ends at Beta 4 build `149`.
-5. Continue only through issue #338's exact-SHA Prerelease workflow. Signed-app,
+3. Validate a cumulative appcast fixture ordered Beta 6 build `151`, Beta 5
+   build `150`, Beta 4 build `149`, Beta 3 build `148`, then Stable build `146`;
+   Stable and RC must exclude every Beta item while Beta and Alpha admit them.
+4. Confirm the live repository has no Beta 6 tag, release, draft, or asset and
+   the public appcast still ends at Beta 5 build `150`.
+5. Continue only through the exact-SHA Prerelease workflow. Signed-app,
    update-route, and diagnostic-lifecycle qualification remain incomplete until
    the guarded workflow and installed-field checks finish.
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -69,8 +69,9 @@ Each new appcast item embeds the digest-bound draft release body as Markdown, so
 Sparkle uses its adaptive native text view without loading GitHub page chrome or
 making a second release-note request. A full-release link remains available for
 downloads and extended context, and historical external-link items remain valid.
-The live feed remains empty until the first enabled release is published. See
-[release-process.md](release-process.md) for the operator sequence.
+The live feed now carries cumulative production history through Beta 5 build
+`150`; prepared Beta 6 metadata does not alter it before guarded publication.
+See [release-process.md](release-process.md) for the operator sequence.
 
 Stable `0.2.143` remains compatible with macOS 14. The production SwiftUI line
 starting with `0.3.0b3` requires Apple Silicon and macOS 26. Sparkle's minimum
@@ -265,13 +266,12 @@ select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 `v0.3.0-beta.2` Preview identities remain separate, immutable, and unable to
 Sparkle-upgrade into Beta 3.
 
-Published `v0.3.0-beta.4` (`0.3.0b4`, build `149`) is the immutable head of the
-current cumulative feed above Beta 3. The next prepared item is authorized
-`v0.3.0-beta.5` (`0.3.0b5`, build `150`) under issue #338. Publication must
-append Beta 5 above Beta 4 and Beta 3, remain excluded from Stable and RC, and
-be eligible to Beta and Alpha. The exact-SHA Prerelease workflow, signing
-approval, notarization, and public verification remain separate fail-closed
-boundaries.
+Published `v0.3.0-beta.5` (`0.3.0b5`, build `150`) is the immutable head of the
+current cumulative feed above Beta 4 and Beta 3. The next prepared item is
+`v0.3.0-beta.6` (`0.3.0b6`, build `151`). Publication must append Beta 6 above
+the existing Betas, remain excluded from Stable and RC, and be eligible to Beta
+and Alpha. The exact-SHA Prerelease workflow, signing approval, notarization,
+and public verification remain separate fail-closed boundaries.
 
 ## Runtime Integration and UX
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,13 +37,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 150
+        CURRENT_PROJECT_VERSION: 151
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b5
+        MARKETING_VERSION: 0.3.0b6
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b5"
+version = "0.3.0b6"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "150"
+CFBundleVersion = "151"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -92,8 +92,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b5")
-        self.assertEqual(NATIVE_BUILD_VERSION, "150")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b6")
+        self.assertEqual(NATIVE_BUILD_VERSION, "151")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,30 +156,31 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_and_authorized_for_beta5(self) -> None:
+    def test_repository_is_prepared_and_authorized_for_beta6(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b5")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.5")
-        self.assertEqual(metadata.build_version, "150")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.5")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.5")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.5.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b6")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.6")
+        self.assertEqual(metadata.build_version, "151")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.6")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.6")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.6.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.5", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-beta.6", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.5-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b5`", cut_packet)
-        self.assertIn("Build `150`", cut_packet)
-        self.assertIn("PR #335", cut_packet)
-        self.assertIn("PR #336", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.6-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b6`", cut_packet)
+        self.assertIn("Build `151`", cut_packet)
+        self.assertIn("PR #341", cut_packet)
+        self.assertIn("PR #343", cut_packet)
+        self.assertIn("PR #344", cut_packet)
         self.assertIn("Privacy rules version `4`", cut_packet)
-        self.assertIn("issue #338", cut_packet)
+        self.assertIn("explicit Beta 6 request", cut_packet)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
         evidence = release.validate_beta3_recovery_evidence()

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,7 +188,7 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
-    def test_beta5_appends_above_existing_betas_in_cumulative_production_history(self) -> None:
+    def test_beta6_appends_above_existing_betas_in_cumulative_production_history(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             empty_feed = root / "empty.xml"
@@ -196,6 +196,7 @@ class SparkleAppcastTests(unittest.TestCase):
             beta3_feed = root / "beta3.xml"
             beta4_feed = root / "beta4.xml"
             beta5_feed = root / "beta5.xml"
+            beta6_feed = root / "beta6.xml"
             make_empty_feed(empty_feed)
 
             sparkle_appcast.append_item(
@@ -218,23 +219,28 @@ class SparkleAppcastTests(unittest.TestCase):
                 beta5_feed,
                 item("150", "0.3.0b5", "beta", minimum_system_version="26.0"),
             )
+            sparkle_appcast.append_item(
+                beta5_feed,
+                beta6_feed,
+                item("151", "0.3.0b6", "beta", minimum_system_version="26.0"),
+            )
 
-            sparkle_appcast.validate_release_snapshot(beta5_feed, "0.3.0b5")
-            sparkle_appcast.validate_release_tag_snapshot(beta5_feed, "v0.3.0-beta.5")
-            _, channel = sparkle_appcast.load_appcast(beta5_feed)
+            sparkle_appcast.validate_release_snapshot(beta6_feed, "0.3.0b6")
+            sparkle_appcast.validate_release_tag_snapshot(beta6_feed, "v0.3.0-beta.6")
+            _, channel = sparkle_appcast.load_appcast(beta6_feed)
             items = channel.findall("item")
 
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
-            ["150", "149", "148", "146"],
+            ["151", "150", "149", "148", "146"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
-            ["0.3.0b5", "0.3.0b4", "0.3.0b3", "0.2.143"],
+            ["0.3.0b6", "0.3.0b5", "0.3.0b4", "0.3.0b3", "0.2.143"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
-            ["beta", "beta", "beta", None],
+            ["beta", "beta", "beta", "beta", None],
         )
 
     def test_rejects_non_monotonic_build(self) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "150")
+        self.assertEqual(info["CFBundleVersion"], "151")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b5"
+version = "0.3.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- advance committed release metadata to internal `0.3.0b6`, public `0.3.0-beta.6`, and global build `151`
- record published Beta 5 as immutable production history and add the Beta 6 cut packet
- extend cumulative Sparkle history tests through Beta 6
- keep Beta 6 as a GitHub prerelease, non-Latest, with no PyPI or Homebrew publication

## Included changes since Beta 5

- PR #341 — maintainer diagnostic report inventory
- PR #343 — pull-driven Worker stdout backpressure and cancellation coverage
- PR #344 — native MVC decoder terminal dependency recovery plus reproducible Xcode 26.5 baseline-arm64 vendoring

## Live boundary

- live appcast head: build `150`, short version `0.3.0b5`, channel `beta`
- Beta 5 release is published and immutable
- no `v0.3.0-beta.6` tag or GitHub Release exists
- `macos-signing` approval remains a separate run-bound human authorization after dispatch

## Validation

- `uv run python -m scripts.release validate`
- focused release/appcast suite — 133 passed
- full Python suite — 811 passed, 2 skipped
- native macOS app suite — 272 passed
- Ruff format/check — clean
- live tag/release/appcast audit — clean
- independent release-contract review — findings resolved
- JetBrains changed-files inspection — zero findings; inconclusive only because `uv.lock` is outside semantic project coverage

This PR prepares metadata only. It does not publish, sign, tag, or alter the live appcast.