### PR TITLE
Prototype direct decoded-stereo MV-HEVC encoding

### DIFF
--- a/docs/direct-mv-hevc-feasibility.md
+++ b/docs/direct-mv-hevc-feasibility.md
@@ -1,0 +1,170 @@
+# Direct decoded-stereo to MV-HEVC feasibility
+
+Issue #347 asks whether the decoded stereo stream can become a final Apple-compatible MV-HEVC movie without first
+writing left and right HEVC eye movies. The bounded prototype proves that this boundary is viable on Apple Silicon,
+but it is not yet qualified as the production default.
+
+## Decision
+
+Use a native Swift helper built on `AVAssetWriter` and tagged pixel-buffer groups. The helper accepts normalized,
+progressive, side-by-side 8-bit 4:2:0 Y4M on standard input and writes one MV-HEVC MOV. Keep FFmpeg immediately
+upstream for the existing crop, deinterlace, eye-swap, resolution, and frame-rate transforms.
+
+The proposed normal path is:
+
+```text
+source FFmpeg -> edge264_test -> FFmpeg geometry normalizer -> mv-hevc-encoder -> <name>_MV-HEVC.mov
+```
+
+This removes the two eye HEVC movies and their merge encode. It does not replace the later optional upscale or final
+MP4Box audio/subtitle mux.
+
+## Encoder boundary inventory
+
+| Candidate | Result | Reason |
+| --- | --- | --- |
+| `AVAssetWriter` tagged pixel-buffer groups | Selected | Accepts synchronized left/right pixel buffers, emits MV-HEVC layer/view metadata, owns MOV finalization, and requires no seekable input. |
+| Direct `VTCompressionSession` plus a custom MOV writer | Rejected for the first implementation | The codec boundary is viable, but recreating multiview sample grouping and Apple spatial container metadata adds avoidable muxing risk. |
+| FFmpeg as the final MV-HEVC writer | Rejected | The bundled FFmpeg remains useful for normalization but does not expose the required Apple tagged multiview writer boundary. |
+| `spatial-media-kit-tool merge` | Retained as fallback | It is proven in the current product, but it requires two materialized eye movies and therefore cannot satisfy the direct-streaming objective. |
+| File-backed side-by-side input through `AVAssetReader` | Rejected for the normal path | It follows Apple's sample topology but adds a large decoded or packed intermediate that the existing Y4M pipe already avoids. |
+
+The selected API is available from macOS 26. The prototype builds as an arm64 executable targeting macOS 26.0 and
+links only Apple AVFoundation, CoreMedia, CoreVideo, and VideoToolbox frameworks plus system Swift libraries.
+
+## Prototype contract
+
+`native/mv_hevc_encoder/MVHEVCEncoder.swift` implements the bounded encoder.
+
+- Input is progressive `C420`, `C420jpeg`, `C420mpeg2`, or `C420paldv` Y4M. Unknown interlace and high-bit-depth
+  formats fail before output replacement.
+- The left and right halves become IOSurface-backed, video-range NV12 pixel buffers tagged with video layer IDs `0`
+  and `1` and left/right stereo-view tags.
+- The writer declares both stereo eyes, a left hero eye, rectilinear projection, horizontal field of view, disparity,
+  and optional camera baseline.
+- BT.709 primaries, transfer function, matrix, limited range, source frame rate, per-eye dimensions, and eye order are
+  preserved by the bounded fixture.
+- The final file is written under a private partial name and moved into place only after `AVAssetWriter` completes.
+  A failed `--overwrite` attempt preserves the prior destination.
+- Standard error carries bounded JSONL `encoder.ready` and `encoder.progress` records. The first accepted frame and
+  each subsequent 120-frame boundary produce progress without depending on MOV file growth.
+- Standard output contains one completion summary. `SIGINT` and `SIGTERM` cancel with exit status 130.
+
+The synthetic fixture supplies a 64 mm baseline only to prove metadata serialization. A product route must not invent
+a camera baseline for Blu-ray content; omit it unless a calibrated source value exists. Existing FOV and zero-disparity
+policy can be passed directly.
+
+## Bounded comparison
+
+The qualification command generated one two-second, 48-frame, 24 fps stereo source with a 16-pixel disparity. Both
+paths received the same per-eye images and a 4 Mbps aggregate bitrate budget. The current path used two 2 Mbps
+VideoToolbox eye encodes followed by merge quality 75; the direct path used one 4 Mbps MV-HEVC encode.
+
+| Measurement | Current path | Direct path |
+| --- | ---: | ---: |
+| Elapsed time | 0.830280 s | 0.378381 s |
+| Child user CPU | 0.435242 s | 0.216164 s |
+| Child system CPU | 0.113633 s | 0.063091 s |
+| Final movie size | 165,650 bytes | 399,675 bytes |
+| Peak eye-intermediate bytes | 534,869 bytes | 0 bytes |
+| Left-eye matched SSIM | 0.912566 | 0.914648 |
+| Right-eye matched SSIM | 0.909273 | 0.915010 |
+
+The direct run took 45.6% of the current path's elapsed time and eliminated both eye intermediates. Its final file was
+234,025 bytes larger under these non-equivalent quality controls. That size delta is descriptive only: the current
+merge performs a second lossy encode governed by quality 75, so this fixture cannot establish a like-for-like size
+regression threshold. The direct result slightly exceeded the current path's decoded per-eye SSIM, and each same-eye
+score remained clearly above its crossed-eye score.
+
+Both paths use VideoToolbox hardware HEVC encoders, and the host reports stereo MV-HEVC encode support. The bounded
+CLI probe does not have a trustworthy per-process GPU counter, so numeric GPU utilization remains unproven. A release
+qualification should add an approved Instruments or equivalent measurement rather than infer GPU load from codec
+selection.
+
+## Container and playback validation
+
+The direct fixture passed all locally automatable checks:
+
+- FFprobe reports one `hvc1` HEVC stream, 320x180 per eye, 24 fps, 48 decoded frames, limited-range BT.709 signaling.
+- MP4Box reports `hvcC`, `lhvC`, `vexu`, `eyes`, `proj`, and `hfov`. The current toolkit baseline does not emit a
+  separate `proj` box; the direct candidate does.
+- `spatial-media-kit-tool split` produces one 48-frame left movie and one 48-frame right movie with the expected eye
+  order and dimensions.
+- `scripts/verify_apple_media.py` passes its AVFoundation/`avconvert` compatibility check.
+- FFmpeg decodes frames after beginning, middle, and near-end seeks.
+
+These checks do not prove stereoscopic presentation in the headset. The physical Apple Vision Pro workflow in
+`docs/visionos-playback-validator.md` remains mandatory before the route can be declared production-ready.
+
+## Failure, cancellation, and backpressure
+
+The receiver uses nonblocking append attempts and waits asynchronously when `AVAssetWriter` applies backpressure.
+POSIX reads consume pipe bytes as soon as they arrive instead of waiting for a large Foundation read buffer. Tests
+cover successful encoding, unsupported chroma, truncated input, excess frames, destination preservation, signal
+cancellation, and partial-file removal.
+
+The qualification harness waits for both producer and consumer, kills and reaps both on timeout, and distinguishes an
+upstream truncation from a consumer rejection. When a consumer rejection causes upstream SIGPIPE, the consumer error
+wins. Product integration should continue using the existing `ProcessPipelineRunner`, process groups, cancellation
+token, and splitter-signal prioritization rather than introducing a second supervision model.
+
+## Restart and fallback
+
+The direct route is eligible only for a normal MV-HEVC run that starts no later than `create_left_right_files`, does not
+request `--keep-files`, does not request the software encoder, and does not require an external eye-file workflow.
+
+- Keep the existing left/right-plus-merge path for explicit fallback and compatibility.
+- Keep `combine_to_mv_hevc` restart behavior file-backed; it requires durable eye movies and cannot enter the direct
+  path.
+- A missing helper or failed capability preflight may select the legacy path before input is consumed. A mid-encode
+  failure must remain a visible failure; silently restarting through another lossy path would hide cost and quality
+  changes.
+- Do not reuse `left_right_bitrate` for the new route. Product integration needs one visible final MV-HEVC bitrate or
+  quality control, while the legacy route retains its existing per-eye bitrate and merge-quality controls.
+- Keep existing native splitter retry behavior. A direct-encoder failure is not evidence that the splitter should be
+  retried in single-threaded mode.
+
+The existing stage enum should not be renumbered. A product implementation can execute the direct helper during
+`create_left_right_files`, produce the existing `_MV-HEVC.mov` boundary, skip `combine_to_mv_hevc` for that run, and
+continue through upscale and final mux without changing later artifact names.
+
+## Packaging and release implications
+
+- Build the helper with the release Xcode toolchain for arm64 and minimum macOS 26.0.
+- Bundle it as a nested executable, sign it before signing the containing app, and include it in notarization and
+  bundled-tool deployment-target checks.
+- No third-party runtime, source archive, or additional license notice is required; the implementation uses Apple SDK
+  frameworks.
+- No production routing or app-bundle change is included in this prototype. Those changes should occur only after the
+  remaining device and GPU evidence is recorded.
+
+## Reproduction
+
+```bash
+uv run python scripts/build_mv_hevc_encoder_macos.py \
+  --output build/mv-hevc-encoder/mv-hevc-encoder
+
+uv run python scripts/qualify_direct_mv_hevc.py \
+  --encoder build/mv-hevc-encoder/mv-hevc-encoder \
+  --output build/direct-mv-hevc/direct.mov \
+  --json-output build/direct-mv-hevc/qualification.json
+
+uv run python -m unittest tests.test_mv_hevc_encoder -v
+```
+
+## Acceptance status
+
+| Issue #347 criterion | Status |
+| --- | --- |
+| Encoder-boundary inventory | Passed |
+| Final MV-HEVC fixture without eye HEVC movies | Passed |
+| Eye order, dimensions, timing, color, FOV, disparity, and multiview metadata | Passed for the bounded fixture |
+| Quality, size, elapsed time, CPU, GPU, and peak disk comparison | Partial: numeric GPU utilization and a like-for-like final-size threshold remain unproven |
+| AVFoundation and beginning/middle/end seeks | Passed |
+| Physical Apple Vision Pro validation | Pending |
+| Cancellation, backpressure, failure attribution, and cleanup | Passed for the bounded prototype |
+| Restart and fallback behavior | Defined |
+| Runtime, license, macOS, architecture, signing, notarization, and bundle implications | Recorded |
+
+The prototype establishes a viable architecture. It must remain non-default until numeric GPU evidence and physical
+Apple Vision Pro playback evidence close the two remaining qualification gaps.

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -149,6 +149,11 @@ artifacts. Default mode removes consumed intermediates after the final output
 is complete; `--keep-files` retains them. Disc/ISO inputs retain their MakeMKV
 materialization.
 
+The [direct MV-HEVC feasibility prototype](direct-mv-hevc-feasibility.md)
+demonstrates a candidate replacement for the normal MV-HEVC eye-file boundary.
+It is not yet part of this production contract; the current file-backed route
+remains authoritative until device and performance qualification completes.
+
 The reused source is user-owned. Automatic cleanup never deletes it.
 `--remove-original` is the explicit exception and removes the source only after
 the complete conversion succeeds. With `--keep-files`, the source is copied

--- a/native/mv_hevc_encoder/MVHEVCEncoder.swift
+++ b/native/mv_hevc_encoder/MVHEVCEncoder.swift
@@ -1,0 +1,666 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import CoreVideo
+import Darwin
+import VideoToolbox
+
+private let videoLayerIDs = [0, 1]
+private let viewIDs = [0, 1]
+private let leftAndRightViewIDs = [0, 1]
+
+private enum EncoderFailure: Error, CustomStringConvertible {
+    case invalidArguments(String)
+    case invalidInput(String)
+    case unsupported(String)
+    case writer(String)
+    case cancelled
+
+    var description: String {
+        switch self {
+        case let .invalidArguments(message), let .invalidInput(message), let .unsupported(message), let .writer(message):
+            return message
+        case .cancelled:
+            return "Encoding cancelled."
+        }
+    }
+}
+
+private struct EncoderOptions {
+    let outputURL: URL
+    let bitrateMbps: Double
+    let fieldOfViewDegrees: Double
+    let baselineMillimeters: Double?
+    let disparityAdjustment: Double
+    let expectedFrameCount: Int?
+    let swapEyes: Bool
+    let overwrite: Bool
+
+    static func parse(arguments: [String]) throws -> EncoderOptions {
+        var outputPath: String?
+        var bitrateMbps = 8.0
+        var fieldOfViewDegrees = 90.0
+        var baselineMillimeters: Double?
+        var disparityAdjustment = 0.0
+        var expectedFrameCount: Int?
+        var swapEyes = false
+        var overwrite = false
+
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--output":
+                outputPath = try value(after: argument, arguments: arguments, index: &index)
+            case "--bitrate-mbps":
+                bitrateMbps = try doubleValue(after: argument, arguments: arguments, index: &index)
+            case "--fov":
+                fieldOfViewDegrees = try doubleValue(after: argument, arguments: arguments, index: &index)
+            case "--baseline-mm":
+                baselineMillimeters = try doubleValue(after: argument, arguments: arguments, index: &index)
+            case "--disparity-adjustment":
+                disparityAdjustment = try doubleValue(after: argument, arguments: arguments, index: &index)
+            case "--expected-frames":
+                expectedFrameCount = try integerValue(after: argument, arguments: arguments, index: &index)
+            case "--swap-eyes":
+                swapEyes = true
+            case "--overwrite":
+                overwrite = true
+            case "--help", "-h":
+                printUsage()
+                exit(0)
+            default:
+                throw EncoderFailure.invalidArguments("Unknown argument: \(argument)")
+            }
+            index += 1
+        }
+
+        guard let outputPath, !outputPath.isEmpty else {
+            throw EncoderFailure.invalidArguments("--output is required.")
+        }
+        guard bitrateMbps.isFinite, bitrateMbps > 0, bitrateMbps <= 500 else {
+            throw EncoderFailure.invalidArguments("--bitrate-mbps must be greater than 0 and at most 500.")
+        }
+        guard fieldOfViewDegrees.isFinite, fieldOfViewDegrees > 0, fieldOfViewDegrees <= 180 else {
+            throw EncoderFailure.invalidArguments("--fov must be greater than 0 and at most 180 degrees.")
+        }
+        if let baselineMillimeters,
+           (!baselineMillimeters.isFinite || baselineMillimeters <= 0 || baselineMillimeters > 1_000)
+        {
+            throw EncoderFailure.invalidArguments("--baseline-mm must be greater than 0 and at most 1000.")
+        }
+        guard disparityAdjustment.isFinite, (-1 ... 1).contains(disparityAdjustment) else {
+            throw EncoderFailure.invalidArguments("--disparity-adjustment must be between -1 and 1.")
+        }
+        if let expectedFrameCount, expectedFrameCount <= 0 {
+            throw EncoderFailure.invalidArguments("--expected-frames must be greater than 0.")
+        }
+
+        return EncoderOptions(
+            outputURL: URL(fileURLWithPath: outputPath).standardizedFileURL,
+            bitrateMbps: bitrateMbps,
+            fieldOfViewDegrees: fieldOfViewDegrees,
+            baselineMillimeters: baselineMillimeters,
+            disparityAdjustment: disparityAdjustment,
+            expectedFrameCount: expectedFrameCount,
+            swapEyes: swapEyes,
+            overwrite: overwrite
+        )
+    }
+
+    private static func value(
+        after option: String,
+        arguments: [String],
+        index: inout Int
+    ) throws -> String {
+        index += 1
+        guard index < arguments.count else {
+            throw EncoderFailure.invalidArguments("\(option) requires a value.")
+        }
+        return arguments[index]
+    }
+
+    private static func doubleValue(
+        after option: String,
+        arguments: [String],
+        index: inout Int
+    ) throws -> Double {
+        let rawValue = try value(after: option, arguments: arguments, index: &index)
+        guard let parsed = Double(rawValue) else {
+            throw EncoderFailure.invalidArguments("\(option) requires a number.")
+        }
+        return parsed
+    }
+
+    private static func integerValue(
+        after option: String,
+        arguments: [String],
+        index: inout Int
+    ) throws -> Int {
+        let rawValue = try value(after: option, arguments: arguments, index: &index)
+        guard let parsed = Int(rawValue) else {
+            throw EncoderFailure.invalidArguments("\(option) requires an integer.")
+        }
+        return parsed
+    }
+
+    private static func printUsage() {
+        print(
+            """
+            Usage: mv-hevc-encoder --output FILE [options]
+
+            Reads progressive, 8-bit 4:2:0 side-by-side Y4M from standard input and writes MV-HEVC MOV.
+
+              --output FILE                  Required output MOV path.
+              --bitrate-mbps VALUE           Final MV-HEVC average bitrate (default: 8).
+              --fov DEGREES                   Horizontal field of view (default: 90).
+              --baseline-mm VALUE             Optional constant camera baseline.
+              --disparity-adjustment VALUE    Fraction of image width, -1 through 1 (default: 0).
+              --expected-frames COUNT         Fail unless exactly this many frames are received.
+              --swap-eyes                     Treat the right half as the left eye.
+              --overwrite                     Replace an existing output file.
+            """
+        )
+    }
+}
+
+private struct Y4MHeader {
+    let frameWidth: Int
+    let frameHeight: Int
+    let frameRateNumerator: Int32
+    let frameRateDenominator: Int32
+    let chromaLocation: CFString
+
+    var eyeWidth: Int { frameWidth / 2 }
+    var lumaBytes: Int { frameWidth * frameHeight }
+    var chromaWidth: Int { frameWidth / 2 }
+    var chromaHeight: Int { frameHeight / 2 }
+    var chromaBytes: Int { chromaWidth * chromaHeight }
+    var frameBytes: Int { lumaBytes + (2 * chromaBytes) }
+    var frameRate: Double { Double(frameRateNumerator) / Double(frameRateDenominator) }
+
+    static func parse(_ line: String) throws -> Y4MHeader {
+        let fields = line.split(separator: " ")
+        guard fields.first == "YUV4MPEG2" else {
+            throw EncoderFailure.invalidInput("Input is not a YUV4MPEG2 stream.")
+        }
+
+        var width: Int?
+        var height: Int?
+        var frameRate: (Int32, Int32)?
+        var interlace = "?"
+        var chroma = ""
+
+        for field in fields.dropFirst() {
+            guard let prefix = field.first else { continue }
+            let value = String(field.dropFirst())
+            switch prefix {
+            case "W":
+                width = Int(value)
+            case "H":
+                height = Int(value)
+            case "F":
+                let components = value.split(separator: ":", maxSplits: 1)
+                if components.count == 2,
+                   let numerator = Int32(components[0]),
+                   let denominator = Int32(components[1])
+                {
+                    frameRate = (numerator, denominator)
+                }
+            case "I":
+                interlace = value
+            case "C":
+                chroma = value.lowercased()
+            default:
+                continue
+            }
+        }
+
+        guard let width, let height, width > 0, height > 0 else {
+            throw EncoderFailure.invalidInput("Y4M width and height are required.")
+        }
+        guard width.isMultiple(of: 4), height.isMultiple(of: 2) else {
+            throw EncoderFailure.invalidInput("Side-by-side Y4M dimensions must be divisible by 4x2.")
+        }
+        guard let frameRate, frameRate.0 > 0, frameRate.1 > 0 else {
+            throw EncoderFailure.invalidInput("Y4M frame rate is required.")
+        }
+        guard interlace == "p" else {
+            throw EncoderFailure.unsupported("Interlaced Y4M must be deinterlaced before direct MV-HEVC encoding.")
+        }
+        let supportedChromaModes = ["420", "420jpeg", "420mpeg2", "420paldv"]
+        guard supportedChromaModes.contains(chroma) else {
+            throw EncoderFailure.unsupported("Direct MV-HEVC encoding currently requires 8-bit 4:2:0 Y4M.")
+        }
+        let chromaLocation = chroma.hasPrefix("420mpeg2")
+            ? kCVImageBufferChromaLocation_Left
+            : kCVImageBufferChromaLocation_Center
+
+        return Y4MHeader(
+            frameWidth: width,
+            frameHeight: height,
+            frameRateNumerator: frameRate.0,
+            frameRateDenominator: frameRate.1,
+            chromaLocation: chromaLocation
+        )
+    }
+}
+
+private final class BufferedStandardInput {
+    private var buffer = Data()
+    private var offset = 0
+    private var reachedEOF = false
+
+    func readLine(maximumBytes: Int = 4_096) throws -> String? {
+        while true {
+            if let newlineIndex = buffer[offset...].firstIndex(of: 0x0A) {
+                let lineData = buffer[offset ..< newlineIndex]
+                offset = buffer.index(after: newlineIndex)
+                compactIfNeeded()
+                guard let line = String(data: lineData, encoding: .utf8) else {
+                    throw EncoderFailure.invalidInput("Y4M header is not valid UTF-8.")
+                }
+                return line
+            }
+            if buffer.count - offset > maximumBytes {
+                throw EncoderFailure.invalidInput("Y4M header line exceeds the supported limit.")
+            }
+            if reachedEOF {
+                if buffer.count == offset {
+                    return nil
+                }
+                throw EncoderFailure.invalidInput("Y4M stream ended in an incomplete header line.")
+            }
+            try readMore()
+        }
+    }
+
+    func readExactly(_ count: Int) throws -> Data {
+        while buffer.count - offset < count, !reachedEOF {
+            try readMore()
+        }
+        guard buffer.count - offset >= count else {
+            throw EncoderFailure.invalidInput("Y4M stream ended in an incomplete frame.")
+        }
+        let end = offset + count
+        let data = Data(buffer[offset ..< end])
+        offset = end
+        compactIfNeeded()
+        return data
+    }
+
+    private func readMore() throws {
+        var data = Data(count: 65_536)
+        while true {
+            let bytesRead = data.withUnsafeMutableBytes { bytes in
+                Darwin.read(STDIN_FILENO, bytes.baseAddress, bytes.count)
+            }
+            if bytesRead == 0 {
+                reachedEOF = true
+                return
+            }
+            if bytesRead > 0 {
+                data.removeSubrange(bytesRead ..< data.count)
+                buffer.append(data)
+                return
+            }
+            if errno != EINTR {
+                throw EncoderFailure.invalidInput("Failed to read Y4M input from standard input.")
+            }
+        }
+    }
+
+    private func compactIfNeeded() {
+        if offset > 1_048_576 || offset == buffer.count {
+            buffer.removeSubrange(0 ..< offset)
+            offset = 0
+        }
+    }
+}
+
+private final class CancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func request() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    var isRequested: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+private final class SignalCancellation {
+    private let sources: [DispatchSourceSignal]
+
+    init(flag: CancellationFlag) {
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, SIG_IGN)
+        sources = [SIGINT, SIGTERM].map { signalNumber in
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler {
+                flag.request()
+                emitStatus(["event": "encoder.cancellation_requested", "schema_version": 1])
+            }
+            source.resume()
+            return source
+        }
+    }
+}
+
+private func makeCompressionProperties(options: EncoderOptions, header: Y4MHeader) throws -> [String: Any] {
+    var properties: [String: Any] = [
+        kVTCompressionPropertyKey_MVHEVCVideoLayerIDs as String: videoLayerIDs,
+        kVTCompressionPropertyKey_MVHEVCViewIDs as String: viewIDs,
+        kVTCompressionPropertyKey_MVHEVCLeftAndRightViewIDs as String: leftAndRightViewIDs,
+        kVTCompressionPropertyKey_HasLeftStereoEyeView as String: true,
+        kVTCompressionPropertyKey_HasRightStereoEyeView as String: true,
+        kVTCompressionPropertyKey_HeroEye as String: kVTHeroEye_Left,
+        kVTCompressionPropertyKey_ProjectionKind as String: kCMFormatDescriptionProjectionKind_Rectilinear,
+        kVTCompressionPropertyKey_HorizontalFieldOfView as String: UInt32((options.fieldOfViewDegrees * 1_000).rounded()),
+        kVTCompressionPropertyKey_HorizontalDisparityAdjustment as String: Int32(
+            (options.disparityAdjustment * 10_000).rounded()
+        ),
+        kVTCompressionPropertyKey_AverageBitRate as String: Int((options.bitrateMbps * 1_000_000).rounded()),
+        kVTCompressionPropertyKey_ExpectedFrameRate as String: header.frameRate,
+        kVTCompressionPropertyKey_ProfileLevel as String: kVTProfileLevel_HEVC_Main_AutoLevel,
+        kVTCompressionPropertyKey_AllowFrameReordering as String: true,
+    ]
+    if let baselineMillimeters = options.baselineMillimeters {
+        properties[kVTCompressionPropertyKey_StereoCameraBaseline as String] = UInt32(
+            (baselineMillimeters * 1_000).rounded()
+        )
+    }
+    return properties
+}
+
+private func makeOutputSettings(options: EncoderOptions, header: Y4MHeader) throws -> [String: Any] {
+    [
+        AVVideoCodecKey: AVVideoCodecType.hevc,
+        AVVideoWidthKey: header.eyeWidth,
+        AVVideoHeightKey: header.frameHeight,
+        AVVideoCompressionPropertiesKey: try makeCompressionProperties(options: options, header: header),
+        AVVideoColorPropertiesKey: [
+            AVVideoColorPrimariesKey: AVVideoColorPrimaries_ITU_R_709_2,
+            AVVideoTransferFunctionKey: AVVideoTransferFunction_ITU_R_709_2,
+            AVVideoYCbCrMatrixKey: AVVideoYCbCrMatrix_ITU_R_709_2,
+        ],
+    ]
+}
+
+private func fillPixelBuffer(
+    _ pixelBuffer: inout CVMutablePixelBuffer,
+    header: Y4MHeader,
+    frame: Data,
+    eyeIndex: Int
+) throws {
+    pixelBuffer.withUnsafeBuffer { unsafeBuffer in
+        CVBufferSetAttachment(
+            unsafeBuffer,
+            kCVImageBufferColorPrimariesKey,
+            kCVImageBufferColorPrimaries_ITU_R_709_2,
+            .shouldPropagate
+        )
+        CVBufferSetAttachment(
+            unsafeBuffer,
+            kCVImageBufferTransferFunctionKey,
+            kCVImageBufferTransferFunction_ITU_R_709_2,
+            .shouldPropagate
+        )
+        CVBufferSetAttachment(
+            unsafeBuffer,
+            kCVImageBufferYCbCrMatrixKey,
+            kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+            .shouldPropagate
+        )
+        CVBufferSetAttachment(
+            unsafeBuffer,
+            kCVImageBufferChromaLocationTopFieldKey,
+            header.chromaLocation,
+            .shouldPropagate
+        )
+    }
+
+    let lumaEyeOffset = eyeIndex * header.eyeWidth
+    let chromaEyeOffset = eyeIndex * (header.eyeWidth / 2)
+    try pixelBuffer.accessUnsafeMutableRawPlaneBytes { planes in
+        guard planes.count == 2 else {
+            throw EncoderFailure.writer("Allocated pixel buffer has an unexpected plane layout.")
+        }
+        let lumaDestination = planes[0].bytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+        let chromaDestination = planes[1].bytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+        let lumaDestinationStride = planes[0].properties.bytesPerRow
+        let chromaDestinationStride = planes[1].properties.bytesPerRow
+
+        try frame.withUnsafeBytes { rawFrame in
+            guard let frameBase = rawFrame.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                throw EncoderFailure.invalidInput("Y4M frame has no readable bytes.")
+            }
+            let lumaSource = frameBase
+            let uSource = frameBase.advanced(by: header.lumaBytes)
+            let vSource = uSource.advanced(by: header.chromaBytes)
+
+            for row in 0 ..< header.frameHeight {
+                memcpy(
+                    lumaDestination.advanced(by: row * lumaDestinationStride),
+                    lumaSource.advanced(by: (row * header.frameWidth) + lumaEyeOffset),
+                    header.eyeWidth
+                )
+            }
+            let eyeChromaWidth = header.eyeWidth / 2
+            for row in 0 ..< header.chromaHeight {
+                let destinationRow = chromaDestination.advanced(by: row * chromaDestinationStride)
+                let sourceRowOffset = (row * header.chromaWidth) + chromaEyeOffset
+                for column in 0 ..< eyeChromaWidth {
+                    destinationRow[column * 2] = uSource[sourceRowOffset + column]
+                    destinationRow[(column * 2) + 1] = vSource[sourceRowOffset + column]
+                }
+            }
+        }
+    }
+}
+
+private func makePixelBuffer(
+    header: Y4MHeader,
+    frame: Data,
+    eyeIndex: Int
+) throws -> CVReadOnlyPixelBuffer {
+    var attributes = CVPixelBufferCreationAttributes(
+        pixelFormatType: CVPixelFormatType(rawValue: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange),
+        size: CVImageSize(width: header.eyeWidth, height: header.frameHeight)
+    )
+    attributes.backing = .ioSurface
+    var pixelBuffer = try CVMutablePixelBuffer(attributes)
+    try fillPixelBuffer(&pixelBuffer, header: header, frame: frame, eyeIndex: eyeIndex)
+    return CVReadOnlyPixelBuffer(pixelBuffer)
+}
+
+private func makeTaggedBuffers(
+    header: Y4MHeader,
+    frame: Data,
+    swapEyes: Bool
+) throws -> [CMTaggedDynamicBuffer] {
+    let sourceIndices = swapEyes ? [1, 0] : [0, 1]
+    let eyes: [CMStereoViewComponents] = [.leftEye, .rightEye]
+    return try zip(videoLayerIDs, zip(eyes, sourceIndices)).map { layerID, eyeAndIndex in
+        let (eye, sourceIndex) = eyeAndIndex
+        let pixelBuffer = try makePixelBuffer(header: header, frame: frame, eyeIndex: sourceIndex)
+        return CMTaggedDynamicBuffer(
+            tags: [.videoLayerID(Int64(layerID)), .stereoView(eye)],
+            content: pixelBuffer
+        )
+    }
+}
+
+private func writerFailure(_ writer: AVAssetWriter, fallback: String) -> EncoderFailure {
+    .writer(writer.error?.localizedDescription ?? fallback)
+}
+
+private func emitStatus(_ values: [String: Any]) {
+    guard var data = try? JSONSerialization.data(withJSONObject: values, options: [.sortedKeys]) else {
+        return
+    }
+    data.append(0x0A)
+    try? FileHandle.standardError.write(contentsOf: data)
+}
+
+private func encode(options: EncoderOptions, cancellationFlag: CancellationFlag) async throws -> (Y4MHeader, Int) {
+    guard VTIsStereoMVHEVCEncodeSupported() else {
+        throw EncoderFailure.unsupported("This Mac does not report stereo MV-HEVC encode support.")
+    }
+    if cancellationFlag.isRequested || Task.isCancelled {
+        throw EncoderFailure.cancelled
+    }
+
+    let fileManager = FileManager.default
+    let outputExists = fileManager.fileExists(atPath: options.outputURL.path)
+    if outputExists {
+        guard options.overwrite else {
+            throw EncoderFailure.invalidArguments("Output already exists; pass --overwrite to replace it.")
+        }
+    }
+    try fileManager.createDirectory(
+        at: options.outputURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+
+    let partialURL = options.outputURL.deletingLastPathComponent().appendingPathComponent(
+        ".\(options.outputURL.lastPathComponent).partial-\(UUID().uuidString)"
+    )
+    var completed = false
+    defer {
+        if !completed {
+            try? fileManager.removeItem(at: partialURL)
+        }
+    }
+
+    let input = BufferedStandardInput()
+    guard let headerLine = try input.readLine() else {
+        throw EncoderFailure.invalidInput("Y4M input is empty.")
+    }
+    let header = try Y4MHeader.parse(headerLine)
+    let outputSettings = try makeOutputSettings(options: options, header: header)
+    let writer = try AVAssetWriter(outputURL: partialURL, fileType: .mov)
+    guard writer.canApply(outputSettings: outputSettings, forMediaType: .video) else {
+        throw EncoderFailure.unsupported("The MV-HEVC output settings are not supported on this Mac.")
+    }
+    let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: outputSettings)
+    writerInput.expectsMediaDataInRealTime = false
+    let receiver = writer.inputTaggedPixelBufferGroupReceiver(for: writerInput, pixelBufferAttributes: nil)
+
+    do {
+        try writer.start()
+        writer.startSession(atSourceTime: .zero)
+        emitStatus(["event": "encoder.ready", "schema_version": 1])
+        var frameCount = 0
+        while let frameHeader = try input.readLine() {
+            guard frameHeader == "FRAME" || frameHeader.hasPrefix("FRAME ") else {
+                throw EncoderFailure.invalidInput("Expected a Y4M FRAME header.")
+            }
+            if cancellationFlag.isRequested || Task.isCancelled {
+                throw EncoderFailure.cancelled
+            }
+            if let expectedFrameCount = options.expectedFrameCount, frameCount >= expectedFrameCount {
+                throw EncoderFailure.invalidInput(
+                    "Expected \(expectedFrameCount) frames but received more."
+                )
+            }
+            let frame = try input.readExactly(header.frameBytes)
+            let taggedBuffers = try makeTaggedBuffers(header: header, frame: frame, swapEyes: options.swapEyes)
+            let presentationTime = CMTime(
+                value: CMTimeValue(frameCount) * CMTimeValue(header.frameRateDenominator),
+                timescale: CMTimeScale(header.frameRateNumerator)
+            )
+
+            while try !receiver.appendImmediately(taggedBuffers, with: presentationTime) {
+                if cancellationFlag.isRequested || Task.isCancelled {
+                    throw EncoderFailure.cancelled
+                }
+                if writer.status == .failed {
+                    throw writerFailure(writer, fallback: "MV-HEVC writer failed while waiting for input capacity.")
+                }
+                try await Task.sleep(for: .milliseconds(2))
+            }
+            frameCount += 1
+            if frameCount == 1 || frameCount.isMultiple(of: 120) {
+                emitStatus([
+                    "event": "encoder.progress",
+                    "frame_count": frameCount,
+                    "schema_version": 1,
+                ])
+            }
+        }
+
+        if let expectedFrameCount = options.expectedFrameCount, frameCount != expectedFrameCount {
+            throw EncoderFailure.invalidInput(
+                "Expected \(expectedFrameCount) frames but received \(frameCount)."
+            )
+        }
+        guard frameCount > 0 else {
+            throw EncoderFailure.invalidInput("Y4M input contains no frames.")
+        }
+
+        receiver.finish()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writerFailure(writer, fallback: "MV-HEVC writer did not complete successfully.")
+        }
+        if !options.overwrite, fileManager.fileExists(atPath: options.outputURL.path) {
+            throw EncoderFailure.writer("Output appeared while encoding; refusing to replace it without --overwrite.")
+        }
+        let renameStatus = partialURL.path.withCString { sourcePath in
+            options.outputURL.path.withCString { destinationPath in
+                Darwin.rename(sourcePath, destinationPath)
+            }
+        }
+        guard renameStatus == 0 else {
+            throw EncoderFailure.writer("Failed to atomically finalize the MV-HEVC output.")
+        }
+        completed = true
+        return (header, frameCount)
+    } catch {
+        writer.cancelWriting()
+        throw error
+    }
+}
+
+@main
+private struct MVHEVCEncoder {
+    static func main() async {
+        let cancellationFlag = CancellationFlag()
+        let signalCancellation = SignalCancellation(flag: cancellationFlag)
+        defer { _ = signalCancellation }
+        do {
+            let options = try EncoderOptions.parse(arguments: Array(CommandLine.arguments.dropFirst()))
+            let (header, frameCount) = try await encode(
+                options: options,
+                cancellationFlag: cancellationFlag
+            )
+            let summary: [String: Any] = [
+                "bitrate_mbps": options.bitrateMbps,
+                "eye_height": header.frameHeight,
+                "eye_width": header.eyeWidth,
+                "field_of_view_degrees": options.fieldOfViewDegrees,
+                "frame_count": frameCount,
+                "frame_rate_denominator": header.frameRateDenominator,
+                "frame_rate_numerator": header.frameRateNumerator,
+                "has_camera_baseline": options.baselineMillimeters != nil,
+                "schema_version": 1,
+                "swapped_eyes": options.swapEyes,
+            ]
+            let data = try JSONSerialization.data(withJSONObject: summary, options: [.sortedKeys])
+            print(String(decoding: data, as: UTF8.self))
+        } catch EncoderFailure.cancelled {
+            fputs("error: Encoding cancelled.\n", stderr)
+            exit(130)
+        } catch {
+            fputs("error: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/scripts/build_mv_hevc_encoder_macos.py
+++ b/scripts/build_mv_hevc_encoder_macos.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = REPOSITORY_ROOT / "native/mv_hevc_encoder/MVHEVCEncoder.swift"
+MINIMUM_MACOS = "26.0"
+COMMAND_TIMEOUT_SECONDS = 180
+
+
+def sdk_path() -> Path:
+    xcrun = shutil.which("xcrun")
+    if xcrun is None:
+        raise RuntimeError("xcrun is required to build the MV-HEVC encoder")
+    value = subprocess.check_output(
+        [xcrun, "--sdk", "macosx", "--show-sdk-path"],
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    ).strip()
+    path = Path(value)
+    if not path.is_dir():
+        raise RuntimeError("xcrun returned an invalid macOS SDK path")
+    return path
+
+
+def swift_compiler() -> str:
+    xcrun = shutil.which("xcrun")
+    if xcrun is None:
+        raise RuntimeError("xcrun is required to build the MV-HEVC encoder")
+    value = subprocess.check_output(
+        [xcrun, "--find", "swiftc"],
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    ).strip()
+    if not value:
+        raise RuntimeError("swiftc is required to build the MV-HEVC encoder")
+    return value
+
+
+def build_command(compiler: str, source_path: Path, output_path: Path, sdk: Path) -> list[str]:
+    return [
+        compiler,
+        "-swift-version",
+        "6",
+        "-parse-as-library",
+        "-O",
+        "-whole-module-optimization",
+        "-warnings-as-errors",
+        "-target",
+        f"arm64-apple-macosx{MINIMUM_MACOS}",
+        "-sdk",
+        str(sdk),
+        str(source_path),
+        "-o",
+        str(output_path),
+        "-framework",
+        "AVFoundation",
+        "-framework",
+        "CoreMedia",
+        "-framework",
+        "CoreVideo",
+        "-framework",
+        "VideoToolbox",
+    ]
+
+
+def build_encoder(output_path: Path) -> None:
+    compiler = swift_compiler()
+    sdk = sdk_path()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="mv-hevc-encoder-build-") as temporary_directory:
+        environment = os.environ.copy()
+        environment["TMPDIR"] = temporary_directory
+        subprocess.run(
+            build_command(compiler, SOURCE_PATH, output_path, sdk),
+            check=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+            env=environment,
+        )
+
+    architecture = subprocess.check_output(
+        ["file", str(output_path)],
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if "arm64" not in architecture:
+        raise RuntimeError("MV-HEVC encoder is not an arm64 executable")
+    build_version = subprocess.check_output(
+        ["vtool", "-show-build", str(output_path)],
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if f"minos {MINIMUM_MACOS}" not in build_version:
+        raise RuntimeError(f"MV-HEVC encoder minimum macOS version is not {MINIMUM_MACOS}")
+    linked_libraries = subprocess.check_output(
+        ["otool", "-L", str(output_path)],
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    for framework in ("AVFoundation", "CoreMedia", "CoreVideo", "VideoToolbox"):
+        if f"/{framework}.framework/" not in linked_libraries:
+            raise RuntimeError(f"MV-HEVC encoder is not linked to {framework}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the native direct MV-HEVC prototype encoder.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/mv-hevc-encoder/mv-hevc-encoder"),
+        help="Destination for the prototype executable.",
+    )
+    args = parser.parse_args()
+
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        parser.error("this build script requires macOS arm64")
+
+    output_path = args.output.resolve()
+    build_encoder(output_path)
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_direct_mv_hevc.py
+++ b/scripts/qualify_direct_mv_hevc.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import re
+import resource
+import shutil
+import subprocess
+import tempfile
+import time
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts import build_mv_hevc_encoder_macos
+from scripts.verify_apple_media import verify_apple_media_compatible
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SPATIAL_MEDIA_TOOL = REPOSITORY_ROOT / "bd_to_avp/bin/spatial-media-kit-tool"
+MP4BOX = REPOSITORY_ROOT / "bd_to_avp/bin/MP4Box"
+DIRECT_REQUIRED_BOX_TYPES = {"eyes", "hfov", "hvcC", "lhvC", "proj", "vexu"}
+CURRENT_REQUIRED_BOX_TYPES = DIRECT_REQUIRED_BOX_TYPES - {"proj"}
+BOX_TYPE_PATTERN = re.compile(r'Type="([A-Za-z0-9 ]{4})"')
+SSIM_PATTERN = re.compile(r"All:([0-9.]+)")
+COMMAND_TIMEOUT_SECONDS = 180
+
+
+class QualificationFailure(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class FixtureOptions:
+    eye_width: int
+    eye_height: int
+    frame_rate: int
+    duration_seconds: int
+    disparity_pixels: int
+    bitrate_mbps: float
+
+    @property
+    def frame_count(self) -> int:
+        return self.frame_rate * self.duration_seconds
+
+    @property
+    def source_width(self) -> int:
+        return self.eye_width + self.disparity_pixels
+
+
+@dataclass(frozen=True)
+class ProcessMetrics:
+    elapsed_seconds: float
+    user_cpu_seconds: float
+    system_cpu_seconds: float
+
+
+def command_path(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise QualificationFailure(f"Required command is unavailable: {name}")
+    return path
+
+
+def run(
+    command: list[str | Path],
+    *,
+    timeout: int = COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [str(item) for item in command],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as error:
+        output = (error.stderr or error.stdout or "").strip()
+        raise QualificationFailure(f"Command failed: {' '.join(map(str, command))}\n{output}") from error
+
+
+def measure(command_runner) -> tuple[object, ProcessMetrics]:
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    started = time.monotonic()
+    result = command_runner()
+    elapsed = time.monotonic() - started
+    after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return result, ProcessMetrics(
+        elapsed_seconds=elapsed,
+        user_cpu_seconds=after.ru_utime - before.ru_utime,
+        system_cpu_seconds=after.ru_stime - before.ru_stime,
+    )
+
+
+def source_filter(options: FixtureOptions) -> str:
+    return (
+        "[0:v]split=2[left_source][right_source];"
+        f"[left_source]crop={options.eye_width}:{options.eye_height}:0:0[left];"
+        f"[right_source]crop={options.eye_width}:{options.eye_height}:{options.disparity_pixels}:0[right]"
+    )
+
+
+def generate_reference(
+    ffmpeg: str,
+    output_path: Path,
+    options: FixtureOptions,
+    *,
+    right_eye: bool,
+) -> None:
+    horizontal_offset = options.disparity_pixels if right_eye else 0
+    run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            (
+                f"testsrc2=size={options.source_width}x{options.eye_height}:"
+                f"rate={options.frame_rate}:duration={options.duration_seconds}"
+            ),
+            "-vf",
+            f"crop={options.eye_width}:{options.eye_height}:{horizontal_offset}:0,format=yuv420p",
+            "-c:v",
+            "ffv1",
+            "-y",
+            output_path,
+        ]
+    )
+
+
+def direct_generator_command(ffmpeg: str, options: FixtureOptions) -> list[str]:
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        (
+            f"testsrc2=size={options.source_width}x{options.eye_height}:"
+            f"rate={options.frame_rate}:duration={options.duration_seconds}"
+        ),
+        "-filter_complex",
+        f"{source_filter(options)};[left][right]hstack=inputs=2,format=yuv420p[stereo]",
+        "-map",
+        "[stereo]",
+        "-f",
+        "yuv4mpegpipe",
+        "-",
+    ]
+
+
+def encoder_command(encoder: Path, output_path: Path, options: FixtureOptions) -> list[str | Path]:
+    return [
+        encoder,
+        "--output",
+        output_path,
+        "--bitrate-mbps",
+        str(options.bitrate_mbps),
+        "--fov",
+        "90",
+        "--baseline-mm",
+        "64",
+        "--disparity-adjustment",
+        "0",
+        "--expected-frames",
+        str(options.frame_count),
+        "--overwrite",
+    ]
+
+
+def select_pipeline_failure(
+    generator_status: int,
+    generator_stderr: str,
+    encoder_status: int,
+    encoder_stderr: str,
+) -> str | None:
+    generator_error = generator_stderr.strip()
+    encoder_error = encoder_stderr.strip()
+    if generator_status == 0 and encoder_status == 0:
+        return None
+    if encoder_status != 0 and generator_status != 0:
+        upstream_eof_markers = (
+            "input is empty",
+            "incomplete frame",
+            "incomplete header line",
+        )
+        if any(marker in encoder_error.lower() for marker in upstream_eof_markers):
+            return f"Fixture generator failed:\n{generator_error or 'no diagnostic output'}"
+        return f"Direct MV-HEVC encoder failed:\n{encoder_error or 'no diagnostic output'}"
+    if encoder_status != 0:
+        return f"Direct MV-HEVC encoder failed:\n{encoder_error or 'no diagnostic output'}"
+    return f"Fixture generator failed:\n{generator_error or 'no diagnostic output'}"
+
+
+def kill_and_reap(*processes: subprocess.Popen) -> None:
+    for process in processes:
+        if process.poll() is None:
+            process.kill()
+
+    unreaped = 0
+    for process in processes:
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            unreaped += 1
+        for stream in (process.stdin, process.stdout, process.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+
+    if unreaped:
+        raise QualificationFailure(f"Failed to reap {unreaped} timed-out qualification process(es).")
+
+
+def encode_direct(
+    ffmpeg: str,
+    encoder: Path,
+    output_path: Path,
+    options: FixtureOptions,
+) -> tuple[dict[str, object], ProcessMetrics]:
+    def execute() -> dict[str, object]:
+        generator = subprocess.Popen(
+            direct_generator_command(ffmpeg, options),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert generator.stdout is not None
+        encoder_process = subprocess.Popen(
+            [str(item) for item in encoder_command(encoder, output_path, options)],
+            stdin=generator.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        generator.stdout.close()
+        try:
+            encoder_stdout, encoder_stderr = encoder_process.communicate(timeout=COMMAND_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as error:
+            try:
+                kill_and_reap(encoder_process, generator)
+            except QualificationFailure as cleanup_error:
+                raise cleanup_error from error
+            raise QualificationFailure("Direct MV-HEVC encoding timed out.") from error
+        try:
+            generator_status = generator.wait(timeout=30)
+        except subprocess.TimeoutExpired as error:
+            try:
+                kill_and_reap(generator)
+            except QualificationFailure as cleanup_error:
+                raise cleanup_error from error
+            raise QualificationFailure("Fixture generator did not exit after the encoder completed.") from error
+        generator_stderr = generator.stderr.read().decode("utf-8", errors="replace") if generator.stderr else ""
+        for stream in (generator.stderr, encoder_process.stdout, encoder_process.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+        failure = select_pipeline_failure(
+            generator_status,
+            generator_stderr,
+            encoder_process.returncode,
+            encoder_stderr,
+        )
+        if failure:
+            raise QualificationFailure(failure)
+        try:
+            summary = json.loads(encoder_stdout)
+        except json.JSONDecodeError as error:
+            raise QualificationFailure("Direct MV-HEVC encoder returned invalid JSON.") from error
+        if not isinstance(summary, dict) or summary.get("schema_version") != 1:
+            raise QualificationFailure("Direct MV-HEVC encoder returned an unsupported summary.")
+        return summary
+
+    summary, metrics = measure(execute)
+    return summary, metrics
+
+
+def encode_current(
+    ffmpeg: str,
+    output_path: Path,
+    work_directory: Path,
+    options: FixtureOptions,
+) -> tuple[ProcessMetrics, int]:
+    left_path = work_directory / "current-left.mov"
+    right_path = work_directory / "current-right.mov"
+
+    def execute() -> None:
+        run(
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                (
+                    f"testsrc2=size={options.source_width}x{options.eye_height}:"
+                    f"rate={options.frame_rate}:duration={options.duration_seconds}"
+                ),
+                "-filter_complex",
+                source_filter(options),
+                "-map",
+                "[left]",
+                "-c:v",
+                "hevc_videotoolbox",
+                "-tag:v",
+                "hvc1",
+                "-b:v",
+                f"{options.bitrate_mbps / 2:g}M",
+                "-y",
+                left_path,
+                "-map",
+                "[right]",
+                "-c:v",
+                "hevc_videotoolbox",
+                "-tag:v",
+                "hvc1",
+                "-b:v",
+                f"{options.bitrate_mbps / 2:g}M",
+                "-y",
+                right_path,
+            ]
+        )
+        run(
+            [
+                SPATIAL_MEDIA_TOOL,
+                "merge",
+                "--left-file",
+                left_path,
+                "--right-file",
+                right_path,
+                "--quality",
+                "75",
+                "--left-is-primary",
+                "--horizontal-field-of-view",
+                "90",
+                "--horizontal-disparity-adjustment",
+                "0",
+                "--output-file",
+                output_path,
+            ]
+        )
+
+    _, metrics = measure(execute)
+    peak_intermediate_bytes = left_path.stat().st_size + right_path.stat().st_size
+    return metrics, peak_intermediate_bytes
+
+
+def ffprobe_stream(ffprobe: str, path: Path) -> dict[str, object]:
+    completed = run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-count_frames",
+            "-show_entries",
+            (
+                "stream=codec_name,codec_tag_string,width,height,avg_frame_rate,nb_read_frames,"
+                "color_range,color_space,color_transfer,color_primaries"
+            ),
+            "-of",
+            "json",
+            path,
+        ]
+    )
+    data = json.loads(completed.stdout)
+    streams = data.get("streams")
+    if not isinstance(streams, list) or len(streams) != 1 or not isinstance(streams[0], dict):
+        raise QualificationFailure(f"Expected one video stream in {path.name}.")
+    return streams[0]
+
+
+def box_types(path: Path) -> set[str]:
+    completed = run([MP4BOX, "-diso", path, "-std"])
+    return set(BOX_TYPE_PATTERN.findall(completed.stdout))
+
+
+def split_mv_hevc(path: Path, output_directory: Path) -> tuple[Path, Path]:
+    output_directory.mkdir(parents=True, exist_ok=True)
+    run([SPATIAL_MEDIA_TOOL, "split", "--input-file", path, "--output-dir", output_directory])
+    left = sorted(output_directory.glob("*LEFT*.mov"))
+    right = sorted(output_directory.glob("*RIGHT*.mov"))
+    if len(left) != 1 or len(right) != 1:
+        raise QualificationFailure("Spatial Media Toolkit did not produce one left and one right output.")
+    return left[0], right[0]
+
+
+def ssim(ffmpeg: str, candidate: Path, reference: Path) -> float:
+    process = subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-i",
+            candidate,
+            "-i",
+            reference,
+            "-lavfi",
+            "[0:v][1:v]ssim",
+            "-f",
+            "null",
+            "-",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if process.returncode != 0:
+        raise QualificationFailure(f"SSIM comparison failed:\n{process.stderr.strip()}")
+    matches = SSIM_PATTERN.findall(process.stderr)
+    if not matches:
+        raise QualificationFailure("SSIM comparison did not report an aggregate score.")
+    return float(matches[-1])
+
+
+def verify_seeks(ffmpeg: str, path: Path, duration_seconds: int) -> None:
+    for position in (0, duration_seconds / 2, max(0, duration_seconds - 0.1)):
+        run(
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-ss",
+                str(position),
+                "-i",
+                path,
+                "-frames:v",
+                "1",
+                "-f",
+                "null",
+                "-",
+            ]
+        )
+
+
+def validate_output(
+    ffmpeg: str,
+    ffprobe: str,
+    path: Path,
+    reference_left: Path,
+    reference_right: Path,
+    split_directory: Path,
+    options: FixtureOptions,
+    *,
+    label: str,
+    required_box_types: set[str],
+) -> dict[str, object]:
+    stream = ffprobe_stream(ffprobe, path)
+    if stream.get("codec_name") != "hevc" or stream.get("codec_tag_string") != "hvc1":
+        raise QualificationFailure(f"{label} output is not an hvc1 HEVC stream.")
+    if stream.get("width") != options.eye_width or stream.get("height") != options.eye_height:
+        raise QualificationFailure(f"{label} output has unexpected per-eye dimensions.")
+    if stream.get("nb_read_frames") != str(options.frame_count):
+        raise QualificationFailure(f"{label} output has an unexpected decoded frame count.")
+    expected_color = {
+        "color_primaries": "bt709",
+        "color_range": "tv",
+        "color_space": "bt709",
+        "color_transfer": "bt709",
+    }
+    if any(stream.get(field) != value for field, value in expected_color.items()):
+        raise QualificationFailure(f"{label} output does not preserve limited-range BT.709 signaling.")
+
+    observed_boxes = box_types(path)
+    missing_boxes = sorted(required_box_types - observed_boxes)
+    if missing_boxes:
+        raise QualificationFailure(f"{label} output is missing required boxes: {', '.join(missing_boxes)}")
+
+    left, right = split_mv_hevc(path, split_directory)
+    left_stream = ffprobe_stream(ffprobe, left)
+    right_stream = ffprobe_stream(ffprobe, right)
+    for split_stream in (left_stream, right_stream):
+        if split_stream.get("nb_read_frames") != str(options.frame_count):
+            raise QualificationFailure("A split eye output has an unexpected frame count.")
+        if split_stream.get("width") != options.eye_width or split_stream.get("height") != options.eye_height:
+            raise QualificationFailure("A split eye output has unexpected dimensions.")
+
+    left_match = ssim(ffmpeg, left, reference_left)
+    left_cross = ssim(ffmpeg, left, reference_right)
+    right_match = ssim(ffmpeg, right, reference_right)
+    right_cross = ssim(ffmpeg, right, reference_left)
+    if min(left_match, right_match) < 0.85:
+        raise QualificationFailure(f"{label} output eye quality fell below the bounded fixture threshold.")
+    if left_match <= left_cross + 0.15 or right_match <= right_cross + 0.15:
+        raise QualificationFailure(f"{label} output eye order is not distinguishable from the crossed comparison.")
+
+    verify_apple_media_compatible(path)
+    verify_seeks(ffmpeg, path, options.duration_seconds)
+    return {
+        "box_types": sorted(observed_boxes & DIRECT_REQUIRED_BOX_TYPES),
+        "left_cross_ssim": left_cross,
+        "left_match_ssim": left_match,
+        "right_cross_ssim": right_cross,
+        "right_match_ssim": right_match,
+        "stream": stream,
+    }
+
+
+def metric_dict(metrics: ProcessMetrics) -> dict[str, float]:
+    return {
+        "elapsed_seconds": round(metrics.elapsed_seconds, 6),
+        "system_cpu_seconds": round(metrics.system_cpu_seconds, 6),
+        "user_cpu_seconds": round(metrics.user_cpu_seconds, 6),
+    }
+
+
+def qualify(output_path: Path, encoder_path: Path, options: FixtureOptions) -> dict[str, object]:
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        raise QualificationFailure("Direct MV-HEVC qualification requires macOS arm64.")
+    ffmpeg = command_path("ffmpeg")
+    ffprobe = command_path("ffprobe")
+    for tool in (SPATIAL_MEDIA_TOOL, MP4BOX):
+        if not tool.is_file() or not tool.stat().st_mode & 0o111:
+            raise QualificationFailure(f"Required bundled tool is unavailable: {tool.name}")
+
+    if not encoder_path.is_file():
+        build_mv_hevc_encoder_macos.build_encoder(encoder_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="direct-mv-hevc-qualification-") as temporary_directory:
+        work_directory = Path(temporary_directory)
+        reference_left = work_directory / "left-reference.mkv"
+        reference_right = work_directory / "right-reference.mkv"
+        current_output = work_directory / "current.mov"
+        direct_output = work_directory / "direct.mov"
+
+        generate_reference(ffmpeg, reference_left, options, right_eye=False)
+        generate_reference(ffmpeg, reference_right, options, right_eye=True)
+        direct_summary, direct_metrics = encode_direct(ffmpeg, encoder_path, direct_output, options)
+        current_metrics, current_intermediate_bytes = encode_current(
+            ffmpeg,
+            current_output,
+            work_directory,
+            options,
+        )
+        direct_validation = validate_output(
+            ffmpeg,
+            ffprobe,
+            direct_output,
+            reference_left,
+            reference_right,
+            work_directory / "direct-split",
+            options,
+            label="Direct",
+            required_box_types=DIRECT_REQUIRED_BOX_TYPES,
+        )
+        current_validation = validate_output(
+            ffmpeg,
+            ffprobe,
+            current_output,
+            reference_left,
+            reference_right,
+            work_directory / "current-split",
+            options,
+            label="Current",
+            required_box_types=CURRENT_REQUIRED_BOX_TYPES,
+        )
+        shutil.copy2(direct_output, output_path)
+
+        direct_size = direct_output.stat().st_size
+        current_size = current_output.stat().st_size
+        return {
+            "capabilities": {
+                "gpu_measurement": "not_available_in_bounded_cli_probe",
+                "physical_vision_pro_validation": "required_before_production_default",
+                "stereo_mv_hevc_encode": True,
+            },
+            "comparison": {
+                "direct_to_current_elapsed_ratio": round(
+                    direct_metrics.elapsed_seconds / current_metrics.elapsed_seconds,
+                    6,
+                ),
+                "eliminated_eye_intermediate_bytes": current_intermediate_bytes,
+                "final_size_delta_bytes": direct_size - current_size,
+            },
+            "current_path": {
+                **metric_dict(current_metrics),
+                "final_bytes": current_size,
+                "peak_eye_intermediate_bytes": current_intermediate_bytes,
+                "validation": current_validation,
+            },
+            "direct_path": {
+                **metric_dict(direct_metrics),
+                "encoder_summary": direct_summary,
+                "final_bytes": direct_size,
+                "peak_eye_intermediate_bytes": 0,
+                "validation": direct_validation,
+            },
+            "fixture": {
+                "disparity_pixels": options.disparity_pixels,
+                "duration_seconds": options.duration_seconds,
+                "eye_height": options.eye_height,
+                "eye_width": options.eye_width,
+                "frame_count": options.frame_count,
+                "frame_rate": options.frame_rate,
+            },
+            "schema_version": 1,
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build and qualify the decoded-stereo-to-direct-MV-HEVC prototype.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/direct-mv-hevc/direct.mov"),
+        help="Destination for the validated direct MV-HEVC fixture.",
+    )
+    parser.add_argument(
+        "--encoder",
+        type=Path,
+        default=Path("build/mv-hevc-encoder/mv-hevc-encoder"),
+        help="Prototype encoder executable; it is built when missing.",
+    )
+    parser.add_argument("--eye-width", type=int, default=320)
+    parser.add_argument("--eye-height", type=int, default=180)
+    parser.add_argument("--frame-rate", type=int, default=24)
+    parser.add_argument("--duration", type=int, default=2)
+    parser.add_argument("--disparity-pixels", type=int, default=16)
+    parser.add_argument("--bitrate-mbps", type=float, default=4.0)
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+
+    if args.eye_width <= 0 or args.eye_height <= 0 or args.eye_width % 2 or args.eye_height % 2:
+        parser.error("eye dimensions must be positive even integers")
+    if args.frame_rate <= 0 or args.duration <= 0:
+        parser.error("frame rate and duration must be positive")
+    if args.disparity_pixels < 0 or args.disparity_pixels % 2:
+        parser.error("disparity pixels must be a non-negative even integer")
+    if args.bitrate_mbps <= 0:
+        parser.error("bitrate must be positive")
+
+    options = FixtureOptions(
+        eye_width=args.eye_width,
+        eye_height=args.eye_height,
+        frame_rate=args.frame_rate,
+        duration_seconds=args.duration,
+        disparity_pixels=args.disparity_pixels,
+        bitrate_mbps=args.bitrate_mbps,
+    )
+    try:
+        result = qualify(args.output.resolve(), args.encoder.resolve(), options)
+    except QualificationFailure as error:
+        parser.exit(1, f"error: {error}\n")
+
+    text = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mv_hevc_encoder.py
+++ b/tests/test_mv_hevc_encoder.py
@@ -127,24 +127,31 @@ class MVHEVCEncoderBuilderTests(unittest.TestCase):
 class MVHEVCEncoderIntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        support = subprocess.run(
-            [
-                "xcrun",
-                "swift",
-                "-e",
-                'import VideoToolbox; print(VTIsStereoMVHEVCEncodeSupported() ? "yes" : "no")',
-            ],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=60,
-        )
-        if support.stdout.strip() != "yes":
-            raise unittest.SkipTest("this Mac does not report stereo MV-HEVC encode support")
         cls.temporary_directory = tempfile.TemporaryDirectory(prefix="mv-hevc-encoder-tests-")
         cls.encoder = Path(cls.temporary_directory.name) / "mv-hevc-encoder"
-        build_mv_hevc_encoder_macos.build_encoder(cls.encoder)
+        try:
+            build_mv_hevc_encoder_macos.build_encoder(cls.encoder)
+            probe_output = Path(cls.temporary_directory.name) / "capability.mov"
+            probe = subprocess.run(
+                [str(cls.encoder), "--output", str(probe_output), "--expected-frames", "2"],
+                input=y4m_header() + y4m_frame(0) + y4m_frame(1),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+            if probe.returncode != 0:
+                diagnostic = probe.stderr.decode(errors="replace")
+                unavailable_messages = (
+                    "does not report stereo MV-HEVC encode support",
+                    "MV-HEVC output settings are not supported",
+                )
+                if any(message in diagnostic for message in unavailable_messages):
+                    raise unittest.SkipTest("this Mac cannot create the bounded MV-HEVC fixture")
+                raise RuntimeError(f"MV-HEVC capability probe failed:\n{diagnostic}")
+            probe_output.unlink()
+        except BaseException:
+            cls.temporary_directory.cleanup()
+            raise
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/tests/test_mv_hevc_encoder.py
+++ b/tests/test_mv_hevc_encoder.py
@@ -1,0 +1,302 @@
+import json
+import platform
+import select
+import shutil
+import signal
+import subprocess
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from scripts import build_mv_hevc_encoder_macos, qualify_direct_mv_hevc
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+MP4BOX = REPOSITORY_ROOT / "bd_to_avp/bin/MP4Box"
+
+
+def y4m_header(*, chroma: str = "420jpeg") -> bytes:
+    return f"YUV4MPEG2 W128 H64 F24:1 Ip A0:0 C{chroma}\n".encode()
+
+
+def y4m_frame(frame_index: int = 0) -> bytes:
+    width = 128
+    height = 64
+    eye_width = width // 2
+    luma = bytearray(width * height)
+    for row in range(height):
+        offset = row * width
+        luma[offset : offset + eye_width] = bytes([48 + frame_index]) * eye_width
+        luma[offset + eye_width : offset + width] = bytes([176 - frame_index]) * eye_width
+    chroma_plane_bytes = (width // 2) * (height // 2)
+    return b"FRAME\n" + bytes(luma) + (bytes([96]) * chroma_plane_bytes) + (bytes([160]) * chroma_plane_bytes)
+
+
+class MVHEVCEncoderBuilderTests(unittest.TestCase):
+    def test_build_command_pins_swift_target_and_frameworks(self) -> None:
+        command = build_mv_hevc_encoder_macos.build_command(
+            "/toolchain/swiftc",
+            Path("MVHEVCEncoder.swift"),
+            Path("mv-hevc-encoder"),
+            Path("/SDKs/MacOSX.sdk"),
+        )
+
+        self.assertEqual(
+            command[:7],
+            [
+                "/toolchain/swiftc",
+                "-swift-version",
+                "6",
+                "-parse-as-library",
+                "-O",
+                "-whole-module-optimization",
+                "-warnings-as-errors",
+            ],
+        )
+        self.assertIn(
+            f"arm64-apple-macosx{build_mv_hevc_encoder_macos.MINIMUM_MACOS}",
+            command,
+        )
+        self.assertIn("/SDKs/MacOSX.sdk", command)
+        self.assertEqual(
+            command[-8:],
+            [
+                "-framework",
+                "AVFoundation",
+                "-framework",
+                "CoreMedia",
+                "-framework",
+                "CoreVideo",
+                "-framework",
+                "VideoToolbox",
+            ],
+        )
+
+    def test_box_requirements_distinguish_candidate_from_current_baseline(self) -> None:
+        self.assertIn("proj", qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES)
+        self.assertNotIn("proj", qualify_direct_mv_hevc.CURRENT_REQUIRED_BOX_TYPES)
+        self.assertEqual(
+            qualify_direct_mv_hevc.CURRENT_REQUIRED_BOX_TYPES,
+            qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES - {"proj"},
+        )
+
+    def test_pipeline_failure_prefers_generator_for_truncated_input(self) -> None:
+        failure = qualify_direct_mv_hevc.select_pipeline_failure(
+            1,
+            "generator root cause",
+            1,
+            "error: Y4M stream ended in an incomplete frame.",
+        )
+
+        self.assertEqual(failure, "Fixture generator failed:\ngenerator root cause")
+
+    def test_pipeline_failure_prefers_encoder_over_upstream_sigpipe(self) -> None:
+        failure = qualify_direct_mv_hevc.select_pipeline_failure(
+            141,
+            "broken pipe",
+            1,
+            "error: unsupported output settings",
+        )
+
+        self.assertEqual(failure, "Direct MV-HEVC encoder failed:\nerror: unsupported output settings")
+
+    def test_kill_and_reap_attempts_every_process_after_wait_timeout(self) -> None:
+        first = Mock(stdin=None, stdout=None, stderr=None)
+        first.poll.return_value = None
+        first.wait.side_effect = subprocess.TimeoutExpired("first", 30)
+        second = Mock(stdin=None, stdout=None, stderr=None)
+        second.poll.return_value = None
+        second.wait.return_value = 0
+
+        with self.assertRaisesRegex(qualify_direct_mv_hevc.QualificationFailure, "Failed to reap 1"):
+            qualify_direct_mv_hevc.kill_and_reap(first, second)
+
+        first.kill.assert_called_once_with()
+        second.kill.assert_called_once_with()
+        first.wait.assert_called_once_with(timeout=30)
+        second.wait.assert_called_once_with(timeout=30)
+
+
+@unittest.skipUnless(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and shutil.which("xcrun"),
+    "native MV-HEVC encoder tests require macOS arm64 and Xcode",
+)
+class MVHEVCEncoderIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        support = subprocess.run(
+            [
+                "xcrun",
+                "swift",
+                "-e",
+                'import VideoToolbox; print(VTIsStereoMVHEVCEncodeSupported() ? "yes" : "no")',
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+        if support.stdout.strip() != "yes":
+            raise unittest.SkipTest("this Mac does not report stereo MV-HEVC encode support")
+        cls.temporary_directory = tempfile.TemporaryDirectory(prefix="mv-hevc-encoder-tests-")
+        cls.encoder = Path(cls.temporary_directory.name) / "mv-hevc-encoder"
+        build_mv_hevc_encoder_macos.build_encoder(cls.encoder)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary_directory.cleanup()
+
+    def output_path(self, name: str) -> Path:
+        path = Path(self.temporary_directory.name) / name
+        path.unlink(missing_ok=True)
+        for partial in path.parent.glob(f".{path.name}.partial-*"):
+            partial.unlink()
+        return path
+
+    def run_encoder(
+        self,
+        output_path: Path,
+        input_bytes: bytes,
+        *,
+        expected_frames: int | None = None,
+        overwrite: bool = False,
+    ) -> subprocess.CompletedProcess[bytes]:
+        command = [str(self.encoder), "--output", str(output_path)]
+        if expected_frames is not None:
+            command.extend(["--expected-frames", str(expected_frames)])
+        if overwrite:
+            command.append("--overwrite")
+        return subprocess.run(
+            command,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+
+    def assert_no_partial_output(self, output_path: Path) -> None:
+        self.assertEqual(list(output_path.parent.glob(f".{output_path.name}.partial-*")), [])
+
+    def test_encodes_bounded_mv_hevc_and_spatial_metadata(self) -> None:
+        output_path = self.output_path("valid.mov")
+
+        completed = self.run_encoder(
+            output_path,
+            y4m_header() + y4m_frame(0) + y4m_frame(1),
+            expected_frames=2,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr.decode())
+        summary = json.loads(completed.stdout)
+        self.assertEqual(summary["frame_count"], 2)
+        self.assertEqual(summary["eye_width"], 64)
+        self.assertEqual(summary["eye_height"], 64)
+        self.assertTrue(output_path.is_file())
+        boxes = subprocess.run(
+            [str(MP4BOX), "-diso", str(output_path), "-std"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        ).stdout
+        observed = set(qualify_direct_mv_hevc.BOX_TYPE_PATTERN.findall(boxes))
+        self.assertTrue(qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES <= observed)
+        self.assert_no_partial_output(output_path)
+
+    def test_rejects_high_bit_depth_y4m_before_writing_output(self) -> None:
+        output_path = self.output_path("high-bit-depth.mov")
+
+        completed = self.run_encoder(output_path, y4m_header(chroma="420p10"))
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(b"requires 8-bit 4:2:0 Y4M", completed.stderr)
+        self.assertFalse(output_path.exists())
+        self.assert_no_partial_output(output_path)
+
+    def test_failed_overwrite_preserves_existing_output(self) -> None:
+        output_path = self.output_path("preserve.mov")
+        output_path.write_bytes(b"existing output")
+
+        completed = self.run_encoder(
+            output_path,
+            y4m_header() + b"FRAME\ntruncated",
+            expected_frames=1,
+            overwrite=True,
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(b"incomplete frame", completed.stderr)
+        self.assertEqual(output_path.read_bytes(), b"existing output")
+        self.assert_no_partial_output(output_path)
+
+    def test_rejects_frames_beyond_expected_count_and_cleans_up(self) -> None:
+        output_path = self.output_path("too-many.mov")
+
+        completed = self.run_encoder(
+            output_path,
+            y4m_header() + y4m_frame(0) + y4m_frame(1),
+            expected_frames=1,
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(b"received more", completed.stderr)
+        self.assertFalse(output_path.exists())
+        self.assert_no_partial_output(output_path)
+
+    def test_sigterm_cancels_and_removes_partial_output(self) -> None:
+        output_path = self.output_path("cancelled.mov")
+        process = subprocess.Popen(
+            [str(self.encoder), "--output", str(output_path), "--expected-frames", "2"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert process.stdin is not None
+        assert process.stderr is not None
+        process.stdin.write(y4m_header())
+        process.stdin.flush()
+        readable, _, _ = select.select([process.stderr], [], [], 5)
+        if not readable:
+            process.kill()
+            process.wait(timeout=5)
+            self.fail("encoder did not emit readiness within five seconds")
+        ready_line = process.stderr.readline()
+        self.assertEqual(json.loads(ready_line)["event"], "encoder.ready")
+        process.send_signal(signal.SIGTERM)
+        readable, _, _ = select.select([process.stderr], [], [], 5)
+        if not readable:
+            process.kill()
+            process.wait(timeout=5)
+            self.fail("encoder did not acknowledge cancellation within five seconds")
+        cancellation_line = process.stderr.readline()
+        self.assertEqual(
+            json.loads(cancellation_line)["event"],
+            "encoder.cancellation_requested",
+        )
+        try:
+            process.stdin.write(b"FRAME\n")
+            process.stdin.flush()
+        except BrokenPipeError:
+            pass
+        try:
+            process.stdin.close()
+        except BrokenPipeError:
+            pass
+        status = process.wait(timeout=10)
+        stderr = ready_line + cancellation_line + process.stderr.read()
+        process.stderr.close()
+        if process.stdout:
+            process.stdout.close()
+
+        self.assertEqual(status, 130, stderr.decode())
+        self.assertIn(b"Encoding cancelled", stderr)
+        self.assertFalse(output_path.exists())
+        self.assert_no_partial_output(output_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mv_hevc_encoder.py
+++ b/tests/test_mv_hevc_encoder.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import unittest
 
+from contextlib import suppress
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -204,7 +205,7 @@ class MVHEVCEncoderIntegrationTests(unittest.TestCase):
             timeout=30,
         ).stdout
         observed = set(qualify_direct_mv_hevc.BOX_TYPE_PATTERN.findall(boxes))
-        self.assertTrue(qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES <= observed)
+        self.assertLessEqual(qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES, observed)
         self.assert_no_partial_output(output_path)
 
     def test_rejects_high_bit_depth_y4m_before_writing_output(self) -> None:
@@ -277,15 +278,11 @@ class MVHEVCEncoderIntegrationTests(unittest.TestCase):
             json.loads(cancellation_line)["event"],
             "encoder.cancellation_requested",
         )
-        try:
+        with suppress(BrokenPipeError):
             process.stdin.write(b"FRAME\n")
             process.stdin.flush()
-        except BrokenPipeError:
-            pass
-        try:
+        with suppress(BrokenPipeError):
             process.stdin.close()
-        except BrokenPipeError:
-            pass
         status = process.wait(timeout=10)
         stderr = ready_line + cancellation_line + process.stderr.read()
         process.stderr.close()


### PR DESCRIPTION
## Summary
- add a Swift 6 AVFoundation helper that streams normalized side-by-side Y4M into one final MV-HEVC MOV
- add a reproducible arm64/macOS 26 build helper, bounded current-vs-direct qualification harness, and failure/cancellation coverage
- document encoder candidates, metadata, performance, restart/fallback, packaging, and the remaining production-readiness gaps

## Qualification
- direct fixture: 48 frames at 24 fps, per-eye 320x180, limited-range BT.709
- spatial metadata: `hvcC`, `lhvC`, `vexu`, `eyes`, `proj`, and `hfov`
- direct path used 45.6% of current-path elapsed time in the recorded bounded run and eliminated 534,869 bytes of eye intermediates
- AVFoundation compatibility, beginning/middle/end seeks, split-eye frame counts, eye order, and decoded SSIM passed

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` — 821 passed, 2 skipped
- `uv run python scripts/native_app.py test` — 272 passed
- `uv build`
- `uv run python scripts/qualify_direct_mv_hevc.py ...`

## Review notes
- This is a large but self-contained prototype/evidence PR; it does not route production conversions through the helper or change app packaging.
- JetBrains inspection was clean only for project metadata because the configured IntelliJ module does not semantically cover the new Swift/Python paths; repository gates and independent review provide the code evidence.
- Physical Apple Vision Pro playback, numeric GPU measurement, and a like-for-like final-size threshold remain required before declaring the route production-ready.

Refs #347
