### PR TITLE
Package the direct MV-HEVC helper for production

### DIFF
--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -174,6 +174,7 @@ class Config:
     EDGE264_TEST_PATH = SCRIPT_PATH_BIN / "edge264_test"
     SPATIAL_MEDIA_PATH = SCRIPT_PATH_BIN / "spatial-media-kit-tool"
     FX_UPSCALE_PATH = SCRIPT_PATH_BIN / "fx-upscale"
+    MV_HEVC_ENCODER_PATH = SCRIPT_PATH_BIN / "mv-hevc-encoder"
 
     FINAL_FILE_TAG = "_AVP"
     AV1_FINAL_FILE_TAG = "_AV1_Stereo"

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -37,10 +37,14 @@ Required app-local tools today:
 - `ffprobe`
 - `MP4Box`
 - `edge264_test`
+- `fx-upscale`
+- `mv-hevc-encoder`
 - `spatial-media-kit-tool`
 
 The release gate should fail if a required bundled executable is missing, not
 executable, or linked to Homebrew paths such as `/opt/homebrew` or `/usr/local`.
+The native MV-HEVC encoder is packaged and capability-probeable before product
+routing is enabled; its presence alone does not select the direct route.
 
 Apple Vision OCR is the GUI subtitle OCR path. The clean-machine smoke should
 verify that the packaged app runtime can import and run the Apple Vision OCR

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -44,7 +44,9 @@ Required app-local tools today:
 The release gate should fail if a required bundled executable is missing, not
 executable, or linked to Homebrew paths such as `/opt/homebrew` or `/usr/local`.
 The native MV-HEVC encoder is packaged and capability-probeable before product
-routing is enabled; its presence alone does not select the direct route.
+routing is enabled; its presence alone does not select the direct route. Package
+verification accepts either valid supported or unavailable capability output so
+hosted build environments do not override the later runtime fallback decision.
 
 Apple Vision OCR is the GUI subtitle OCR path. The clean-machine smoke should
 verify that the packaged app runtime can import and run the Apple Vision OCR

--- a/native/mv_hevc_encoder/MVHEVCEncoder.swift
+++ b/native/mv_hevc_encoder/MVHEVCEncoder.swift
@@ -159,6 +159,7 @@ private struct EncoderOptions {
               --expected-frames COUNT         Fail unless exactly this many frames are received.
               --swap-eyes                     Treat the right half as the left eye.
               --overwrite                     Replace an existing output file.
+              --capability-probe              Report stereo MV-HEVC encode support and exit.
             """
         )
     }
@@ -636,7 +637,23 @@ private struct MVHEVCEncoder {
         let signalCancellation = SignalCancellation(flag: cancellationFlag)
         defer { _ = signalCancellation }
         do {
-            let options = try EncoderOptions.parse(arguments: Array(CommandLine.arguments.dropFirst()))
+            let arguments = Array(CommandLine.arguments.dropFirst())
+            if arguments == ["--capability-probe"] {
+                let supported = VTIsStereoMVHEVCEncodeSupported()
+                let data = try JSONSerialization.data(
+                    withJSONObject: [
+                        "schema_version": 1,
+                        "stereo_mv_hevc_encode_supported": supported,
+                    ],
+                    options: [.sortedKeys]
+                )
+                print(String(decoding: data, as: UTF8.self))
+                if !supported {
+                    exit(2)
+                }
+                return
+            }
+            let options = try EncoderOptions.parse(arguments: arguments)
             let (header, frameCount) = try await encode(
                 options: options,
                 cancellationFlag: cancellationFlag

--- a/native/mv_hevc_encoder/MVHEVCEncoder.swift
+++ b/native/mv_hevc_encoder/MVHEVCEncoder.swift
@@ -394,6 +394,36 @@ private func makeOutputSettings(options: EncoderOptions, header: Y4MHeader) thro
     ]
 }
 
+private func isStereoMVHEVCOutputConfigurationSupported() throws -> Bool {
+    guard VTIsStereoMVHEVCEncodeSupported() else {
+        return false
+    }
+    let probeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        ".mv-hevc-capability-\(UUID().uuidString).mov"
+    )
+    defer { try? FileManager.default.removeItem(at: probeURL) }
+    let options = EncoderOptions(
+        outputURL: probeURL,
+        bitrateMbps: 8.0,
+        fieldOfViewDegrees: 90.0,
+        baselineMillimeters: nil,
+        disparityAdjustment: 0.0,
+        expectedFrameCount: nil,
+        swapEyes: false,
+        overwrite: true
+    )
+    let header = Y4MHeader(
+        frameWidth: 3_840,
+        frameHeight: 1_080,
+        frameRateNumerator: 24_000,
+        frameRateDenominator: 1_001,
+        chromaLocation: kCVImageBufferChromaLocation_Center
+    )
+    let outputSettings = try makeOutputSettings(options: options, header: header)
+    let writer = try AVAssetWriter(outputURL: probeURL, fileType: .mov)
+    return writer.canApply(outputSettings: outputSettings, forMediaType: .video)
+}
+
 private func fillPixelBuffer(
     _ pixelBuffer: inout CVMutablePixelBuffer,
     header: Y4MHeader,
@@ -639,7 +669,7 @@ private struct MVHEVCEncoder {
         do {
             let arguments = Array(CommandLine.arguments.dropFirst())
             if arguments == ["--capability-probe"] {
-                let supported = VTIsStereoMVHEVCEncodeSupported()
+                let supported = try isStereoMVHEVCOutputConfigurationSupported()
                 let data = try JSONSerialization.data(
                     withJSONObject: [
                         "schema_version": 1,

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -585,14 +585,16 @@ def smoke_packaged_mv_hevc_encoder(app_path: Path) -> None:
         text=True,
         timeout=30,
     )
-    validate_mv_hevc_capability_probe(completed, description="Packaged MV-HEVC encoder")
+    supported = validate_mv_hevc_capability_probe(completed, description="Packaged MV-HEVC encoder")
+    if not supported:
+        print("Packaged MV-HEVC encoder is valid but unavailable on this build host.")
 
 
 def validate_mv_hevc_capability_probe(
     completed: subprocess.CompletedProcess[str],
     *,
     description: str,
-) -> None:
+) -> bool:
     try:
         payload = json.loads(completed.stdout)
     except json.JSONDecodeError as error:
@@ -605,16 +607,17 @@ def validate_mv_hevc_capability_probe(
         "stereo_mv_hevc_encode_supported": False,
     }
     if completed.returncode == 2 and payload == unsupported_payload:
-        raise RuntimeError(f"{description} reports that stereo MV-HEVC encoding is unavailable on this Mac.")
+        return False
     expected_payload = {
         "schema_version": 1,
         "stereo_mv_hevc_encode_supported": True,
     }
-    if completed.returncode != 0 or payload != expected_payload:
-        raise RuntimeError(
-            f"{description} capability probe failed.\n"
-            f"exit: {completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
-        )
+    if completed.returncode == 0 and payload == expected_payload:
+        return True
+    raise RuntimeError(
+        f"{description} capability probe failed.\n"
+        f"exit: {completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
 
 
 def smoke_packaged_worker(app_path: Path) -> None:

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from bd_to_avp.observability import ObservabilityEvent
 from bd_to_avp.worker.protocol import PROTOCOL_VERSION
+from scripts.build_mv_hevc_encoder_macos import build_encoder as build_mv_hevc_encoder
 from scripts.production_identity import (
     PRODUCTION_BUNDLE_IDENTIFIER,
     PRODUCTION_DISTRIBUTION_CHANNEL,
@@ -53,6 +54,8 @@ NATIVE_APP_NAME = f"{NATIVE_PRODUCT_NAME}.app"
 BRIEFCASE_APP = REPO_ROOT / "build" / "bd-to-avp" / "macos" / "app" / "3D Blu-ray to Vision Pro.app"
 PACKAGE_ROOT = MACOS_ROOT / "build" / "package"
 PACKAGED_APP = PACKAGE_ROOT / NATIVE_APP_NAME
+MV_HEVC_ENCODER_NAME = "mv-hevc-encoder"
+PACKAGED_MV_HEVC_ENCODER = PACKAGE_ROOT / "native-tools" / MV_HEVC_ENCODER_NAME
 WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
 WORKER_PROTOCOL_VERSION = PROTOCOL_VERSION
 WORKER_ENTITLEMENTS = MACOS_ROOT / "BluRayToVisionPro" / "Worker.entitlements"
@@ -267,7 +270,24 @@ def prepare_briefcase_runtime() -> None:
         raise RuntimeError(f"Briefcase did not create the expected runtime at {BRIEFCASE_APP}")
 
 
-def assemble_package() -> Path:
+def build_packaged_mv_hevc_encoder(output_path: Path = PACKAGED_MV_HEVC_ENCODER) -> Path:
+    output_path.unlink(missing_ok=True)
+    build_mv_hevc_encoder(output_path)
+    output_path.chmod(output_path.stat().st_mode | 0o111)
+    return output_path
+
+
+def install_mv_hevc_encoder(app_path: Path, source_path: Path) -> Path:
+    if not source_path.is_file():
+        raise RuntimeError(f"MV-HEVC encoder build product is missing at {source_path}")
+    destination = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, destination)
+    destination.chmod(destination.stat().st_mode | 0o111)
+    return destination
+
+
+def assemble_package(mv_hevc_encoder_path: Path) -> Path:
     source_app = DERIVED_DATA / "Build" / "Products" / NATIVE_PACKAGE_CONFIGURATION / NATIVE_APP_NAME
     if not source_app.is_dir():
         raise RuntimeError(f"macOS build product is missing at {source_app}")
@@ -291,6 +311,7 @@ def assemble_package() -> Path:
     for internal_document in ("README.md", "pyproject.toml"):
         (destination_contents / "Resources" / "app" / internal_document).unlink(missing_ok=True)
     shutil.rmtree(destination_contents / "Resources" / "app_packages" / "bin", ignore_errors=True)
+    install_mv_hevc_encoder(PACKAGED_APP, mv_hevc_encoder_path)
 
     source_launcher = source_contents / "MacOS" / "3D Blu-ray to Vision Pro"
     worker_launcher = destination_contents / "MacOS" / WORKER_EXECUTABLE_NAME
@@ -322,6 +343,7 @@ def verify_layout(app_path: Path, *, environment: Mapping[str, str] | None = Non
     native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
     worker_executable = app_path / "Contents" / "MacOS" / WORKER_EXECUTABLE_NAME
     ffprobe_executable = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / "ffprobe"
+    mv_hevc_encoder = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME
     required_paths = [
         native_executable,
         worker_executable,
@@ -331,14 +353,16 @@ def verify_layout(app_path: Path, *, environment: Mapping[str, str] | None = Non
         app_path / "Contents" / "Resources" / "app_packages",
         app_path / "Contents" / "Resources" / "app_icon.icns",
         ffprobe_executable,
+        mv_hevc_encoder,
     ]
     missing = [path for path in required_paths if not path.exists()]
     if missing:
         raise RuntimeError("Packaged macOS app is missing:\n" + "\n".join(str(path) for path in missing))
-    for executable in (native_executable, worker_executable, ffprobe_executable):
+    for executable in (native_executable, worker_executable, ffprobe_executable, mv_hevc_encoder):
         if executable_architectures(executable) != {"arm64"}:
             raise RuntimeError(f"Packaged executable must be arm64-only: {executable}")
     verify_mach_o_minimum_system_versions(app_path, native_executable)
+    verify_exact_minimum_system_version(mv_hevc_encoder, "MV-HEVC encoder")
     verify_native_binary_paths(native_executable)
     verify_package_paths(app_path)
 
@@ -431,12 +455,7 @@ def minimum_macos_versions(path: Path) -> set[str]:
 
 def verify_mach_o_minimum_system_versions(app_path: Path, native_executable: Path) -> None:
     expected_version = normalized_version(NATIVE_MINIMUM_SYSTEM_VERSION)
-    native_versions = minimum_macos_versions(native_executable)
-    if {normalized_version(version) for version in native_versions} != {expected_version}:
-        found = ", ".join(sorted(native_versions))
-        raise RuntimeError(
-            f"Swift executable must target macOS {NATIVE_MINIMUM_SYSTEM_VERSION}; found {found}: {native_executable}"
-        )
+    verify_exact_minimum_system_version(native_executable, "Swift executable")
 
     incompatible: list[str] = []
     for path in sorted(app_path.rglob("*")):
@@ -451,6 +470,14 @@ def verify_mach_o_minimum_system_versions(app_path: Path, native_executable: Pat
             "Packaged Mach-O requires a newer macOS version than "
             f"{NATIVE_MINIMUM_SYSTEM_VERSION}:\n" + "\n".join(incompatible)
         )
+
+
+def verify_exact_minimum_system_version(path: Path, description: str) -> None:
+    expected_version = normalized_version(NATIVE_MINIMUM_SYSTEM_VERSION)
+    versions = minimum_macos_versions(path)
+    if {normalized_version(version) for version in versions} != {expected_version}:
+        found = ", ".join(sorted(versions))
+        raise RuntimeError(f"{description} must target macOS {NATIVE_MINIMUM_SYSTEM_VERSION}; found {found}: {path}")
 
 
 def normalized_version(version: str) -> tuple[int, int, int]:
@@ -545,6 +572,49 @@ def smoke_packaged_native_app(app_path: Path) -> None:
     app_path = app_path.resolve()
     native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
     run([str(native_executable), "--startup-smoke"], cwd=app_path)
+
+
+def smoke_packaged_mv_hevc_encoder(app_path: Path) -> None:
+    app_path = app_path.resolve()
+    encoder = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME
+    completed = subprocess.run(
+        [str(encoder), "--capability-probe"],
+        cwd=app_path,
+        capture_output=True,
+        env=smoke_environment(),
+        text=True,
+        timeout=30,
+    )
+    validate_mv_hevc_capability_probe(completed, description="Packaged MV-HEVC encoder")
+
+
+def validate_mv_hevc_capability_probe(
+    completed: subprocess.CompletedProcess[str],
+    *,
+    description: str,
+) -> None:
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            f"{description} capability probe returned invalid JSON.\n"
+            f"exit: {completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        ) from error
+    unsupported_payload = {
+        "schema_version": 1,
+        "stereo_mv_hevc_encode_supported": False,
+    }
+    if completed.returncode == 2 and payload == unsupported_payload:
+        raise RuntimeError(f"{description} reports that stereo MV-HEVC encoding is unavailable on this Mac.")
+    expected_payload = {
+        "schema_version": 1,
+        "stereo_mv_hevc_encode_supported": True,
+    }
+    if completed.returncode != 0 or payload != expected_payload:
+        raise RuntimeError(
+            f"{description} capability probe failed.\n"
+            f"exit: {completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
 
 
 def smoke_packaged_worker(app_path: Path) -> None:
@@ -661,11 +731,13 @@ def validate_smoke_events(events: list[object], job_id: str) -> None:
 
 
 def package(identity: str, keychain: str | None = None) -> None:
+    mv_hevc_encoder_path = build_packaged_mv_hevc_encoder()
     prepare_briefcase_runtime()
     xcodebuild("build", NATIVE_PACKAGE_CONFIGURATION)
-    app_path = assemble_package()
+    app_path = assemble_package(mv_hevc_encoder_path)
     sign_package(app_path, identity, keychain)
     smoke_packaged_native_app(app_path)
+    smoke_packaged_mv_hevc_encoder(app_path)
     smoke_packaged_worker(app_path)
     verify_codesign(app_path)
     print(app_path)

--- a/scripts/verify_app_tools.py
+++ b/scripts/verify_app_tools.py
@@ -5,7 +5,13 @@ import plistlib
 import subprocess
 from pathlib import Path
 
-from scripts.native_app import is_mach_o, minimum_macos_versions, normalized_version
+from scripts.native_app import (
+    MV_HEVC_ENCODER_NAME,
+    is_mach_o,
+    minimum_macos_versions,
+    normalized_version,
+    validate_mv_hevc_capability_probe,
+)
 
 
 APP_PATH = Path("build/bd-to-avp/macos/app/3D Blu-ray to Vision Pro.app")
@@ -18,15 +24,16 @@ CORE_TOOLS = {
 GUI_RUNTIME_TOOLS = {
     "edge264_test": ["--help"],
     "fx-upscale": ["--help"],
+    "mv-hevc-encoder": ["--capability-probe"],
     "spatial-media-kit-tool": ["--help"],
 }
 REQUIRED_TOOLS = CORE_TOOLS | GUI_RUNTIME_TOOLS
 
 
-def run(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
+def run(command: list[str | Path], *, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(item) for item in command],
-        check=True,
+        check=check,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -40,7 +47,11 @@ def verify_tool(tool_path: Path, probe_args: list[str]) -> None:
     if not tool_path.stat().st_mode & 0o111:
         raise PermissionError(f"Bundled tool is not executable: {tool_path}")
 
-    run([tool_path, *probe_args])
+    if tool_path.name == MV_HEVC_ENCODER_NAME:
+        completed = run([tool_path, *probe_args], check=False)
+        validate_mv_hevc_capability_probe(completed, description="Bundled MV-HEVC encoder")
+    else:
+        run([tool_path, *probe_args])
     linked_libraries = run(["otool", "-L", tool_path]).stdout
     for forbidden_path in ["/opt/homebrew", "/usr/local"]:
         if forbidden_path in linked_libraries:

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -140,7 +140,15 @@ class MacOSReleaseArtifactTests(unittest.TestCase):
         tool_names = {call.args[0].name for call in verify_tool.call_args_list}
         self.assertEqual(
             tool_names,
-            {"MP4Box", "edge264_test", "ffmpeg", "ffprobe", "fx-upscale", "spatial-media-kit-tool"},
+            {
+                "MP4Box",
+                "edge264_test",
+                "ffmpeg",
+                "ffprobe",
+                "fx-upscale",
+                "mv-hevc-encoder",
+                "spatial-media-kit-tool",
+            },
         )
 
     def test_refuses_to_replace_an_existing_dmg(self) -> None:

--- a/tests/test_mv_hevc_encoder.py
+++ b/tests/test_mv_hevc_encoder.py
@@ -131,24 +131,26 @@ class MVHEVCEncoderIntegrationTests(unittest.TestCase):
         cls.encoder = Path(cls.temporary_directory.name) / "mv-hevc-encoder"
         try:
             build_mv_hevc_encoder_macos.build_encoder(cls.encoder)
-            probe_output = Path(cls.temporary_directory.name) / "capability.mov"
             probe = subprocess.run(
-                [str(cls.encoder), "--output", str(probe_output), "--expected-frames", "2"],
-                input=y4m_header() + y4m_frame(0) + y4m_frame(1),
+                [str(cls.encoder), "--capability-probe"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 timeout=30,
             )
+            probe_payload = json.loads(probe.stdout)
+            if probe.returncode == 2 and probe_payload == {
+                "schema_version": 1,
+                "stereo_mv_hevc_encode_supported": False,
+            }:
+                raise unittest.SkipTest("this Mac cannot create the bounded MV-HEVC fixture")
             if probe.returncode != 0:
                 diagnostic = probe.stderr.decode(errors="replace")
-                unavailable_messages = (
-                    "does not report stereo MV-HEVC encode support",
-                    "MV-HEVC output settings are not supported",
-                )
-                if any(message in diagnostic for message in unavailable_messages):
-                    raise unittest.SkipTest("this Mac cannot create the bounded MV-HEVC fixture")
                 raise RuntimeError(f"MV-HEVC capability probe failed:\n{diagnostic}")
-            probe_output.unlink()
+            if probe_payload != {
+                "schema_version": 1,
+                "stereo_mv_hevc_encode_supported": True,
+            }:
+                raise RuntimeError(f"unexpected MV-HEVC capability probe output: {probe_payload!r}")
         except BaseException:
             cls.temporary_directory.cleanup()
             raise
@@ -187,6 +189,23 @@ class MVHEVCEncoderIntegrationTests(unittest.TestCase):
 
     def assert_no_partial_output(self, output_path: Path) -> None:
         self.assertEqual(list(output_path.parent.glob(f".{output_path.name}.partial-*")), [])
+
+    def test_capability_probe_reports_support_without_input(self) -> None:
+        completed = subprocess.run(
+            [str(self.encoder), "--capability-probe"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr.decode())
+        self.assertEqual(
+            json.loads(completed.stdout),
+            {
+                "schema_version": 1,
+                "stereo_mv_hevc_encode_supported": True,
+            },
+        )
 
     def test_encodes_bounded_mv_hevc_and_spatial_metadata(self) -> None:
         output_path = self.output_path("valid.mov")

--- a/tests/test_mv_hevc_encoder.py
+++ b/tests/test_mv_hevc_encoder.py
@@ -75,6 +75,17 @@ class MVHEVCEncoderBuilderTests(unittest.TestCase):
             ],
         )
 
+    def test_capability_probe_checks_the_real_asset_writer_settings(self) -> None:
+        source = build_mv_hevc_encoder_macos.SOURCE_PATH.read_text(encoding="utf-8")
+        probe_start = source.index("private func isStereoMVHEVCOutputConfigurationSupported()")
+        probe_end = source.index("private func fillPixelBuffer", probe_start)
+        probe_source = source[probe_start:probe_end]
+
+        self.assertIn("VTIsStereoMVHEVCEncodeSupported()", probe_source)
+        self.assertIn("makeOutputSettings(options: options, header: header)", probe_source)
+        self.assertIn("writer.canApply(outputSettings: outputSettings, forMediaType: .video)", probe_source)
+        self.assertIn("let supported = try isStereoMVHEVCOutputConfigurationSupported()", source)
+
     def test_box_requirements_distinguish_candidate_from_current_baseline(self) -> None:
         self.assertIn("proj", qualify_direct_mv_hevc.DIRECT_REQUIRED_BOX_TYPES)
         self.assertNotIn("proj", qualify_direct_mv_hevc.CURRENT_REQUIRED_BOX_TYPES)

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -813,7 +813,7 @@ Load command 3
         )
         environment.assert_called_once_with()
 
-    def test_mv_hevc_encoder_smoke_rejects_unsupported_hardware(self) -> None:
+    def test_mv_hevc_encoder_smoke_accepts_valid_unsupported_hardware_result(self) -> None:
         completed = subprocess.CompletedProcess(
             args=[],
             returncode=2,
@@ -823,9 +823,11 @@ Load command 3
         with (
             patch("scripts.native_app.smoke_environment", return_value={}),
             patch("scripts.native_app.subprocess.run", return_value=completed),
-            self.assertRaisesRegex(RuntimeError, "stereo MV-HEVC encoding is unavailable"),
+            patch("builtins.print") as print_mock,
         ):
             smoke_packaged_mv_hevc_encoder(Path("/tmp") / NATIVE_APP_NAME)
+
+        print_mock.assert_called_once_with("Packaged MV-HEVC encoder is valid but unavailable on this build host.")
 
     def test_rejects_wrong_job_or_result(self) -> None:
         events: list[object] = [

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from bd_to_avp.worker.protocol import PROTOCOL_VERSION
 from scripts.native_app import (
+    MV_HEVC_ENCODER_NAME,
     NATIVE_APP_NAME,
     NATIVE_BUNDLE_IDENTIFIER,
     NATIVE_BUILD_VERSION,
@@ -28,15 +29,20 @@ from scripts.native_app import (
     PROJECT_PATH,
     REPO_ROOT,
     SCHEME,
+    build_packaged_mv_hevc_encoder,
+    install_mv_hevc_encoder,
     native_build_settings,
     minimum_macos_versions,
+    package,
     parse_args,
     sign_package,
+    smoke_packaged_mv_hevc_encoder,
     smoke_packaged_native_app,
     smoke_packaged_worker,
     validate_smoke_events,
     verify_native_binary_paths,
     verify_mach_o_minimum_system_versions,
+    verify_exact_minimum_system_version,
     verify_package_paths,
     verify_product_identity,
     verify_product_source_copy,
@@ -95,6 +101,39 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b6")
         self.assertEqual(NATIVE_BUILD_VERSION, "151")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
+        self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
+
+    def test_builds_packaged_mv_hevc_encoder_at_requested_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "tools" / MV_HEVC_ENCODER_NAME
+
+            def build(path: Path) -> None:
+                path.parent.mkdir(parents=True)
+                path.write_bytes(b"\xcf\xfa\xed\xfe")
+
+            with patch("scripts.native_app.build_mv_hevc_encoder", side_effect=build) as build_mock:
+                result = build_packaged_mv_hevc_encoder(output_path)
+
+            self.assertEqual(result, output_path)
+            self.assertTrue(output_path.stat().st_mode & 0o111)
+            build_mock.assert_called_once_with(output_path)
+
+    def test_installs_mv_hevc_encoder_in_app_runtime_tool_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_path = root / NATIVE_APP_NAME
+            source_path = root / "built" / MV_HEVC_ENCODER_NAME
+            source_path.parent.mkdir(parents=True)
+            source_path.write_bytes(b"\xcf\xfa\xed\xfe")
+
+            installed_path = install_mv_hevc_encoder(app_path, source_path)
+
+            self.assertEqual(
+                installed_path,
+                app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME,
+            )
+            self.assertEqual(installed_path.read_bytes(), source_path.read_bytes())
+            self.assertTrue(installed_path.stat().st_mode & 0o111)
 
     def test_uses_one_native_settings_scene_and_release_grade_source_groups(self) -> None:
         project_spec = (MACOS_ROOT / "project.yml").read_text(encoding="utf-8")
@@ -355,6 +394,14 @@ Load command 3
 
             versions.assert_called_once_with(native_executable)
 
+    def test_rejects_mv_hevc_encoder_with_wrong_minimum_macos(self) -> None:
+        encoder = Path("/tmp/mv-hevc-encoder")
+        with (
+            patch("scripts.native_app.minimum_macos_versions", return_value={"25.0"}),
+            self.assertRaisesRegex(RuntimeError, "MV-HEVC encoder must target macOS 26.0"),
+        ):
+            verify_exact_minimum_system_version(encoder, "MV-HEVC encoder")
+
     def test_package_accepts_an_explicit_signing_keychain(self) -> None:
         args = parse_args(
             [
@@ -368,6 +415,33 @@ Load command 3
 
         self.assertEqual(args.sign_identity, "Developer ID Application: Example")
         self.assertEqual(args.sign_keychain, "/tmp/release.keychain-db")
+
+    def test_package_builds_installs_signs_and_smokes_mv_hevc_encoder(self) -> None:
+        encoder_path = Path("/tmp/native-tools/mv-hevc-encoder")
+        app_path = Path("/tmp") / NATIVE_APP_NAME
+        with (
+            patch("scripts.native_app.build_packaged_mv_hevc_encoder", return_value=encoder_path) as build_encoder,
+            patch("scripts.native_app.prepare_briefcase_runtime") as prepare_runtime,
+            patch("scripts.native_app.xcodebuild") as xcodebuild_mock,
+            patch("scripts.native_app.assemble_package", return_value=app_path) as assemble,
+            patch("scripts.native_app.sign_package") as sign,
+            patch("scripts.native_app.smoke_packaged_native_app") as smoke_native,
+            patch("scripts.native_app.smoke_packaged_mv_hevc_encoder") as smoke_encoder,
+            patch("scripts.native_app.smoke_packaged_worker") as smoke_worker,
+            patch("scripts.native_app.verify_codesign") as verify,
+            patch("builtins.print"),
+        ):
+            package("Developer ID Application: Example", "/tmp/release.keychain-db")
+
+        build_encoder.assert_called_once_with()
+        prepare_runtime.assert_called_once_with()
+        xcodebuild_mock.assert_called_once_with("build", NATIVE_PACKAGE_CONFIGURATION)
+        assemble.assert_called_once_with(encoder_path)
+        sign.assert_called_once_with(app_path, "Developer ID Application: Example", "/tmp/release.keychain-db")
+        smoke_native.assert_called_once_with(app_path)
+        smoke_encoder.assert_called_once_with(app_path)
+        smoke_worker.assert_called_once_with(app_path)
+        verify.assert_called_once_with(app_path)
 
     def test_package_signing_uses_the_explicit_keychain(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -410,6 +484,28 @@ Load command 3
             self.assertNotIn("--options", command)
             self.assertNotIn("runtime", command)
             self.assertIn("--timestamp=none", command)
+
+    def test_package_signs_mv_hevc_encoder_before_the_containing_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / NATIVE_APP_NAME
+            encoder = app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME
+            encoder.parent.mkdir(parents=True)
+            encoder.write_bytes(b"\xcf\xfa\xed\xfe")
+            (app_path / "Contents" / "MacOS").mkdir(parents=True)
+            with (
+                patch("scripts.native_app.is_mach_o", side_effect=lambda path: path == encoder),
+                patch("scripts.native_app.run") as run_mock,
+            ):
+                sign_package(app_path, "-")
+
+        commands = [call.args[0] for call in run_mock.call_args_list]
+        encoder_sign_index = next(
+            index for index, command in enumerate(commands) if "--sign" in command and command[-1] == str(encoder)
+        )
+        app_sign_index = next(
+            index for index, command in enumerate(commands) if "--sign" in command and command[-1] == str(app_path)
+        )
+        self.assertLess(encoder_sign_index, app_sign_index)
 
     def test_product_copy_has_no_internal_labels(self) -> None:
         verify_product_source_copy()
@@ -683,6 +779,53 @@ Load command 3
             ],
             cwd=resolved_app_path,
         )
+
+    def test_mv_hevc_encoder_smoke_uses_the_signed_packaged_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            relative_app_path = Path("package") / NATIVE_APP_NAME
+            absolute_app_path = temporary_path / relative_app_path
+            absolute_app_path.mkdir(parents=True)
+            resolved_app_path = absolute_app_path.resolve()
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"schema_version":1,"stereo_mv_hevc_encode_supported":true}\n',
+                stderr="",
+            )
+            with (
+                chdir(temporary_path),
+                patch("scripts.native_app.smoke_environment", return_value={"PATH": "/usr/bin"}) as environment,
+                patch("scripts.native_app.subprocess.run", return_value=completed) as run_mock,
+            ):
+                smoke_packaged_mv_hevc_encoder(relative_app_path)
+
+        run_mock.assert_called_once_with(
+            [
+                str(resolved_app_path / "Contents" / "Resources" / "app" / "bd_to_avp" / "bin" / MV_HEVC_ENCODER_NAME),
+                "--capability-probe",
+            ],
+            cwd=resolved_app_path,
+            capture_output=True,
+            env={"PATH": "/usr/bin"},
+            text=True,
+            timeout=30,
+        )
+        environment.assert_called_once_with()
+
+    def test_mv_hevc_encoder_smoke_rejects_unsupported_hardware(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=2,
+            stdout='{"schema_version":1,"stereo_mv_hevc_encode_supported":false}\n',
+            stderr="",
+        )
+        with (
+            patch("scripts.native_app.smoke_environment", return_value={}),
+            patch("scripts.native_app.subprocess.run", return_value=completed),
+            self.assertRaisesRegex(RuntimeError, "stereo MV-HEVC encoding is unavailable"),
+        ):
+            smoke_packaged_mv_hevc_encoder(Path("/tmp") / NATIVE_APP_NAME)
 
     def test_rejects_wrong_job_or_result(self) -> None:
         events: list[object] = [

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -25,6 +25,7 @@ class VerifyAppToolsTests(unittest.TestCase):
                 "ffprobe",
                 "edge264_test",
                 "fx-upscale",
+                "mv-hevc-encoder",
                 "MP4Box",
                 "spatial-media-kit-tool",
             },
@@ -34,6 +35,7 @@ class VerifyAppToolsTests(unittest.TestCase):
         self.assertLess(set(verify_app_tools.CORE_TOOLS), set(verify_app_tools.REQUIRED_TOOLS))
         self.assertIn("edge264_test", verify_app_tools.REQUIRED_TOOLS)
         self.assertNotIn("edge264_test", verify_app_tools.CORE_TOOLS)
+        self.assertEqual(verify_app_tools.REQUIRED_TOOLS["mv-hevc-encoder"], ["--capability-probe"])
 
     def test_verify_tool_uses_probe_args_and_rejects_usr_local_linkage(self) -> None:
         with tempfile.NamedTemporaryFile() as tool_file:
@@ -53,6 +55,40 @@ class VerifyAppToolsTests(unittest.TestCase):
             with patch.object(verify_app_tools, "run", side_effect=fake_run):
                 with self.assertRaisesRegex(RuntimeError, "/usr/local"):
                     verify_app_tools.verify_tool(tool_path, ["-version"])
+
+    def test_mv_hevc_encoder_probe_requires_the_supported_capability_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tool_path = Path(temp_dir) / "mv-hevc-encoder"
+            tool_path.write_text("tool")
+            tool_path.chmod(0o755)
+            malformed_probe = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"schema_version":1}\n',
+            )
+            with (
+                patch.object(verify_app_tools, "run", return_value=malformed_probe) as run_mock,
+                self.assertRaisesRegex(RuntimeError, "capability probe failed"),
+            ):
+                verify_app_tools.verify_tool(tool_path, ["--capability-probe"])
+
+        run_mock.assert_called_once_with([tool_path, "--capability-probe"], check=False)
+
+    def test_mv_hevc_encoder_probe_reports_unsupported_hardware(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tool_path = Path(temp_dir) / "mv-hevc-encoder"
+            tool_path.write_text("tool")
+            tool_path.chmod(0o755)
+            unsupported_probe = subprocess.CompletedProcess(
+                args=[],
+                returncode=2,
+                stdout='{"schema_version":1,"stereo_mv_hevc_encode_supported":false}\n',
+            )
+            with (
+                patch.object(verify_app_tools, "run", return_value=unsupported_probe),
+                self.assertRaisesRegex(RuntimeError, "stereo MV-HEVC encoding is unavailable"),
+            ):
+                verify_app_tools.verify_tool(tool_path, ["--capability-probe"])
 
     def test_verify_ffmpeg_requires_libsvtav1(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_verify_app_tools.py
+++ b/tests/test_verify_app_tools.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from scripts import verify_app_tools
 
@@ -74,7 +74,7 @@ class VerifyAppToolsTests(unittest.TestCase):
 
         run_mock.assert_called_once_with([tool_path, "--capability-probe"], check=False)
 
-    def test_mv_hevc_encoder_probe_reports_unsupported_hardware(self) -> None:
+    def test_mv_hevc_encoder_probe_accepts_valid_unsupported_hardware_result(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             tool_path = Path(temp_dir) / "mv-hevc-encoder"
             tool_path.write_text("tool")
@@ -84,11 +84,21 @@ class VerifyAppToolsTests(unittest.TestCase):
                 returncode=2,
                 stdout='{"schema_version":1,"stereo_mv_hevc_encode_supported":false}\n',
             )
-            with (
-                patch.object(verify_app_tools, "run", return_value=unsupported_probe),
-                self.assertRaisesRegex(RuntimeError, "stereo MV-HEVC encoding is unavailable"),
-            ):
+            linked_libraries = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+            with patch.object(
+                verify_app_tools,
+                "run",
+                side_effect=[unsupported_probe, linked_libraries],
+            ) as run_mock:
                 verify_app_tools.verify_tool(tool_path, ["--capability-probe"])
+
+        self.assertEqual(
+            run_mock.call_args_list,
+            [
+                call([tool_path, "--capability-probe"], check=False),
+                call(["otool", "-L", tool_path]),
+            ],
+        )
 
     def test_verify_ffmpeg_requires_libsvtav1(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- build the qualified arm64/macOS-26 native MV-HEVC helper during app packaging
- install it at the stable packaged runtime path and expose the matching config path without activating routing
- add a bounded JSON capability probe with explicit unsupported-hardware semantics
- sign the helper before the containing app and include it in layout, target, signature, and release-tool verification
- extend focused package, probe, signing-order, and release-smoke coverage

## Validation

- `uv run python -m unittest discover -s tests -t .` — 846 tests passed, 2 skipped
- `uv run python scripts/native_app.py test` — 279 tests passed after merging current `main`
- `uv run mypy bd_to_avp` — passed
- targeted Ruff format/check — passed
- `uv build` — source distribution and wheel built
- `uv run python scripts/native_app.py package` — complete app build, install, ad-hoc nested signing, native startup smoke, packaged helper capability smoke, worker smoke, and final codesign verification passed
- `uv run python scripts/verify_app_tools.py --app-path "macos/build/package/3D Blu-ray to Vision Pro.app" --profile release` — passed
- packaged helper reported schema v1 support, arm64, macOS 26.0 minimum, and a valid embedded signature
- independent multi-model review plus final post-fix review — clean

## Routing Safety

No production conversion code consumes `Config.MV_HEVC_ENCODER_PATH`; existing generated MV-HEVC routing remains unchanged.

Closes #351
Parent workstream: #348
