### PR TITLE
Activate protocol v10 direct MV-HEVC routing

### DIFF
--- a/bd_to_avp/modules/process.py
+++ b/bd_to_avp/modules/process.py
@@ -25,12 +25,14 @@ from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.modules.video import (
     create_av1_sbs_file,
     create_av1_stereo_file,
+    create_direct_mv_hevc_file,
     create_left_right_files,
     create_mv_hevc_file,
     detect_crop_parameters,
     create_upscaled_file,
     get_video_color_depth,
 )
+from bd_to_avp.modules.video_route import ResolvedVideoRoute, VideoRouteKind, legacy_video_route
 from bd_to_avp.observability import ObservabilityContext, ObservabilityStage
 from bd_to_avp.process_runner import ProcessCancelled
 from bd_to_avp.presentation import cli_message
@@ -101,7 +103,8 @@ def find_batch_sources(source_folder_path: Path) -> tuple[Path, ...]:
     )
 
 
-def conversion_stage_plan() -> tuple[str, ...]:
+def conversion_stage_plan(video_route: ResolvedVideoRoute | None = None) -> tuple[str, ...]:
+    video_route = video_route or legacy_video_route()
     stages = ["configure"]
     if config.start_stage is Stage.MOVE_FILES:
         return (*stages, "move_files")
@@ -121,9 +124,14 @@ def conversion_stage_plan() -> tuple[str, ...]:
     if not config.skip_subtitles and config.start_stage.value <= Stage.EXTRACT_SUBTITLES.value:
         stages.append("extract_subtitles")
     if config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
-        stages.append("encode_av1_stereo" if config.video_mode is VideoMode.AV1_SBS else "create_left_right_files")
+        stages.append(
+            "encode_av1_stereo" if video_route.output_mode is VideoMode.AV1_SBS else "create_left_right_files"
+        )
     if config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
-        stages.append("finalize_av1_stereo" if config.video_mode is VideoMode.AV1_SBS else "combine_to_mv_hevc")
+        if video_route.output_mode is VideoMode.AV1_SBS:
+            stages.append("finalize_av1_stereo")
+        elif video_route.selected is not VideoRouteKind.DIRECT_MV_HEVC:
+            stages.append("combine_to_mv_hevc")
     if config.fx_upscale and config.start_stage.value <= Stage.UPSCALE_VIDEO.value:
         stages.append("upscale_video")
     if config.audio_mode.prepares_m4a and config.start_stage.value <= Stage.TRANSCODE_AUDIO.value:
@@ -144,6 +152,7 @@ def process(
     batch_sources: tuple[Path, ...] | None = None,
     activity: ActivityReporter | None = None,
     run_context: RunContext | None = None,
+    video_route: ResolvedVideoRoute | None = None,
 ) -> Path | None:
     cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     raise_if_cancelled(cancellation_event)
@@ -164,9 +173,14 @@ def process(
             config.start_stage = gui_start_stage if is_resume_source else batch_start_stage
             try:
                 final_output_path = (
-                    process_each(cancellation_event, activity=activity, run_context=run_context)
+                    process_each(
+                        cancellation_event,
+                        activity=activity,
+                        run_context=run_context,
+                        video_route=video_route,
+                    )
                     if activity
-                    else process_each(cancellation_event, run_context=run_context)
+                    else process_each(cancellation_event, run_context=run_context, video_route=video_route)
                 )
                 raise_if_cancelled(cancellation_event)
             except preflight.DependencyPreflightError:
@@ -192,9 +206,14 @@ def process(
     else:
         if selected_title_id is None:
             final_output_path = (
-                process_each(cancellation_event, activity=activity, run_context=run_context)
+                process_each(
+                    cancellation_event,
+                    activity=activity,
+                    run_context=run_context,
+                    video_route=video_route,
+                )
                 if activity
-                else process_each(cancellation_event, run_context=run_context)
+                else process_each(cancellation_event, run_context=run_context, video_route=video_route)
             )
         else:
             final_output_path = (
@@ -203,12 +222,14 @@ def process(
                     activity=activity,
                     selected_title_id=selected_title_id,
                     run_context=run_context,
+                    video_route=video_route,
                 )
                 if activity
                 else process_each(
                     cancellation_event,
                     selected_title_id=selected_title_id,
                     run_context=run_context,
+                    video_route=video_route,
                 )
             )
 
@@ -221,7 +242,9 @@ def process_each(
     *,
     selected_title_id: str | None = None,
     run_context: RunContext | None = None,
+    video_route: ResolvedVideoRoute | None = None,
 ) -> Path:
+    video_route = video_route or legacy_video_route()
     cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     raise_if_cancelled(cancellation_event)
     if config.video_mode is VideoMode.AV1_SBS and config.fx_upscale:
@@ -246,6 +269,7 @@ def process_each(
     if activity:
         activity.stage_started("preflight", "Checking required conversion tools")
     preflight.verify_runtime_ready(
+        video_route=video_route,
         run_context=run_context,
         cancellation_event=cancellation_event,
         observability_context=stage_observability_context("preflight"),
@@ -352,7 +376,7 @@ def process_each(
         observability_context=stage_observability_context("extract_subtitles"),
     )
     raise_if_cancelled(cancellation_event)
-    if config.video_mode is VideoMode.AV1_SBS:
+    if video_route.output_mode is VideoMode.AV1_SBS:
         if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
             activity.stage_started("encode_av1_stereo", "Encoding side-by-side AV1 stereo video")
         av1_sbs_path = create_av1_sbs_file(
@@ -374,6 +398,19 @@ def process_each(
             run_context=run_context,
             cancellation_event=cancellation_event,
             observability_context=stage_observability_context("finalize_av1_stereo"),
+        )
+    elif video_route.selected is VideoRouteKind.DIRECT_MV_HEVC:
+        if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+            activity.stage_started("create_left_right_files", "Encoding direct MV-HEVC video")
+        video_path = create_direct_mv_hevc_file(
+            disc_info,
+            output_folder,
+            video_output_path,
+            crop_params,
+            video_route.direct_bitrate_mbps,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=stage_observability_context("create_left_right_files"),
         )
     else:
         if activity and config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
@@ -527,6 +564,7 @@ def start_process(
     batch_sources: tuple[Path, ...] | None = None,
     activity: ActivityReporter | None = None,
     run_context: RunContext | None = None,
+    video_route: ResolvedVideoRoute | None = None,
 ) -> Path | None:
     cancellation_event = normalized_cancellation_event(cancellation_event, run_context)
     gui_start_stage = gui_start_stage or config.start_stage
@@ -542,6 +580,7 @@ def start_process(
                     batch_sources=batch_sources,
                     activity=activity,
                     run_context=run_context,
+                    video_route=video_route,
                 )
         return process(
             gui_start_stage,
@@ -552,6 +591,7 @@ def start_process(
             batch_sources=batch_sources,
             activity=activity,
             run_context=run_context,
+            video_route=video_route,
         )
     except ProcessCancelled as error:
         raise ProcessingCancelled("Processing was cancelled.") from error

--- a/bd_to_avp/modules/video.py
+++ b/bd_to_avp/modules/video.py
@@ -237,6 +237,64 @@ def generate_native_mvc_av1_command(
     return [arg if arg != "pipe:0" else "-" for arg in command]
 
 
+def generate_direct_mv_hevc_normalizer_command(
+    disc_info: DiscInfo,
+    crop_params: str,
+) -> list[str]:
+    if disc_info.color_depth != 8:
+        raise ValueError("Direct MV-HEVC encoding currently supports 8-bit 4:2:0 Blu-ray MVC sources only.")
+
+    source_width, source_height = parse_resolution(config.resolution or disc_info.resolution)
+    stream = ffmpeg.input(
+        "pipe:0",
+        f="yuv4mpegpipe",
+        r=config.frame_rate or disc_info.frame_rate,
+    )
+    split_streams = ffmpeg.filter_multi_output(stream, "split", 2)
+    left_stream = ffmpeg.filter(split_streams[0], "crop", source_width, source_height, 0, 0)
+    right_stream = ffmpeg.filter(split_streams[1], "crop", source_width, source_height, source_width, 0)
+
+    if crop_params:
+        left_stream = ffmpeg.filter(left_stream, "crop", *crop_params.split(":"))
+        right_stream = ffmpeg.filter(right_stream, "crop", *crop_params.split(":"))
+
+    if disc_info.is_interlaced:
+        left_stream = ffmpeg.filter(left_stream, "bwdif")
+        right_stream = ffmpeg.filter(right_stream, "bwdif")
+
+    if config.swap_eyes:
+        left_stream, right_stream = right_stream, left_stream
+
+    packed_stream = ffmpeg.filter([left_stream, right_stream], "hstack", inputs=2)
+    output = ffmpeg.output(
+        packed_stream,
+        "pipe:1",
+        format="yuv4mpegpipe",
+        pix_fmt="yuv420p",
+        r=config.frame_rate or disc_info.frame_rate,
+    )
+    command = ffmpeg.compile(output, cmd=config.FFMPEG_PATH.as_posix(), overwrite_output=True)
+    return [arg if arg != "pipe:0" else "-" for arg in command]
+
+
+def generate_direct_mv_hevc_encoder_command(
+    output_path: Path,
+    bitrate_mbps: int,
+) -> list[str | Path]:
+    return [
+        config.MV_HEVC_ENCODER_PATH,
+        "--output",
+        output_path,
+        "--bitrate-mbps",
+        str(bitrate_mbps),
+        "--fov",
+        str(config.fov),
+        "--disparity-adjustment",
+        "0",
+        "--overwrite",
+    ]
+
+
 def parse_resolution(resolution: str) -> tuple[int, int]:
     width, height = resolution.lower().split("x", 1)
     return int(width), int(height)
@@ -349,6 +407,213 @@ def run_native_mvc_encoding(
     finally:
         if not stream_from_container and native_input_path != video_input_path:
             native_input_path.unlink(missing_ok=True)
+
+
+def run_direct_mv_hevc_encoding(
+    video_input_path: Path,
+    output_path: Path,
+    normalizer_command: list[str],
+    encoder_command: list[str | Path],
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> None:
+    stream_from_container = should_stream_mvc_from_container(video_input_path)
+    producer_command = generate_mvc_annex_b_stream_command(video_input_path) if stream_from_container else None
+    native_input_path = Path("-") if stream_from_container else prepare_native_mvc_input(video_input_path)
+
+    try:
+        try:
+            run_direct_mv_hevc_attempt(
+                native_input_path,
+                output_path,
+                normalizer_command,
+                encoder_command,
+                producer_command=producer_command,
+                single_threaded=False,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
+            )
+        except (ProcessArtifactNoProgressError, subprocess.CalledProcessError) as error:
+            retry_after_crash = isinstance(error, subprocess.CalledProcessError) and native_splitter_died_by_signal(
+                error
+            )
+            if not isinstance(error, ProcessArtifactNoProgressError) and not retry_after_crash:
+                raise
+            retry_reason = (
+                "Direct MV-HEVC output stopped making progress; retrying once with single-threaded MVC decoding."
+                if isinstance(error, ProcessArtifactNoProgressError)
+                else "Native MVC splitter crashed; retrying direct MV-HEVC once in single-threaded mode."
+            )
+            cli_message(retry_reason, run_context=run_context)
+            remove_direct_mv_hevc_attempt_artifacts(output_path)
+            run_direct_mv_hevc_attempt(
+                native_input_path,
+                output_path,
+                normalizer_command,
+                encoder_command,
+                producer_command=producer_command,
+                single_threaded=True,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
+            )
+    except ProcessArtifactNoProgressError as error:
+        raise NativeMvcSplitError(build_direct_mv_hevc_stall_message(error)) from error
+    except subprocess.CalledProcessError as error:
+        if native_splitter_should_report_crash(error):
+            raise NativeMvcSplitError(build_native_splitter_failure_message(error)) from error
+        raise
+    finally:
+        if not stream_from_container and native_input_path != video_input_path:
+            native_input_path.unlink(missing_ok=True)
+
+
+def run_direct_mv_hevc_attempt(
+    native_input_path: Path,
+    output_path: Path,
+    normalizer_command: list[str],
+    encoder_command: list[str | Path],
+    *,
+    producer_command: list[str | Path] | None,
+    single_threaded: bool,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> None:
+    splitter_command = generate_native_mvc_splitter_command(native_input_path, single_threaded=single_threaded)
+    attempt_name = "single-threaded" if single_threaded else "multi-threaded"
+    cli_message(f"Running direct MVC to MV-HEVC encode ({attempt_name}).", run_context=run_context)
+
+    if config.output_commands and run_context is None:
+        commands: list[list[str | Path]] = [splitter_command, [*normalizer_command], encoder_command]
+        if producer_command:
+            commands.insert(0, producer_command)
+        cli_message(
+            "Running command:\n" + " | ".join(" ".join(str(argument) for argument in command) for command in commands)
+        )
+
+    event_context = observability_context or ObservabilityContext()
+    stages: list[ProcessPipelineStage] = []
+    if producer_command:
+        stages.append(
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(producer_command),
+                    tool_id="ffmpeg",
+                    display_name=f"Extract MVC stream ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            )
+        )
+    stages.extend(
+        (
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(splitter_command),
+                    tool_id="edge264",
+                    display_name=f"Split native MVC stream ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            ),
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(normalizer_command),
+                    tool_id="ffmpeg",
+                    display_name=f"Normalize direct stereo video ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            ),
+            ProcessPipelineStage(
+                ProcessSpec(
+                    argv=tuple(encoder_command),
+                    tool_id="mv_hevc_encoder",
+                    display_name=f"Encode direct MV-HEVC video ({attempt_name})",
+                    env=os.environ.copy(),
+                    event_context=event_context,
+                    artifacts=(
+                        ProcessArtifactProbe(
+                            "stereo_video_output",
+                            resolver=lambda: resolve_direct_mv_hevc_artifact(output_path),
+                        ),
+                    ),
+                    artifact_no_growth_timeout_seconds=NATIVE_MVC_ARTIFACT_NO_GROWTH_TIMEOUT_SECONDS,
+                    artifact_no_growth_retryable=not single_threaded,
+                    capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+                )
+            ),
+        )
+    )
+    try:
+        ProcessPipelineRunner(exit_grace_seconds=5).run(
+            tuple(stages),
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+        )
+    except ProcessPipelineError as error:
+        selected_error = select_direct_mv_hevc_pipeline_error(error, producer_present=producer_command is not None)
+        if selected_error is not None:
+            raise selected_error from error
+
+
+def select_direct_mv_hevc_pipeline_error(
+    pipeline_error: ProcessPipelineError,
+    *,
+    producer_present: bool,
+) -> BaseException | None:
+    stages = pipeline_error.result.stages
+    producer_index = 0 if producer_present else None
+    splitter_index = 1 if producer_present else 0
+    normalizer_index = splitter_index + 1
+    encoder_index = normalizer_index + 1
+    producer_stage = stages[producer_index] if producer_index is not None else None
+    splitter_stage = stages[splitter_index]
+    normalizer_stage = stages[normalizer_index]
+    encoder_stage = stages[encoder_index]
+
+    if isinstance(splitter_stage.error, subprocess.CalledProcessError) and native_splitter_died_by_signal(
+        splitter_stage.error
+    ):
+        return splitter_stage.error
+    for stage in (producer_stage, splitter_stage, normalizer_stage):
+        if (
+            stage is not None
+            and stage.completed_before_final
+            and stage.error is not None
+            and not process_error_is_sigpipe(stage.error)
+        ):
+            return stage.error
+    if encoder_stage.error is not None:
+        return encoder_stage.error
+    for stage in (normalizer_stage, splitter_stage, producer_stage):
+        if stage is not None and stage.error is not None and not process_error_is_sigpipe(stage.error):
+            return stage.error
+    return None
+
+
+def resolve_direct_mv_hevc_artifact(output_path: Path) -> Path | None:
+    candidates: list[tuple[int, Path]] = []
+    for candidate in output_path.parent.glob(f".{output_path.name}.partial-*"):
+        try:
+            candidates.append((candidate.stat().st_mtime_ns, candidate))
+        except OSError:
+            continue
+    if candidates:
+        return max(candidates)[1]
+    return output_path if output_path.exists() else None
+
+
+def remove_direct_mv_hevc_attempt_artifacts(output_path: Path) -> None:
+    for partial_path in output_path.parent.glob(f".{output_path.name}.partial-*"):
+        partial_path.unlink(missing_ok=True)
 
 
 def run_native_mvc_split_attempt(
@@ -516,6 +781,15 @@ def build_native_splitter_stall_message(error: ProcessArtifactNoProgressError) -
         "The conversion was stopped instead of waiting indefinitely. This usually means the bundled native decoder "
         "hit damaged or unsupported MVC data. Please submit a diagnostic report so the bounded splitter and encoder "
         f"evidence can be reviewed. ({error})"
+    )
+
+
+def build_direct_mv_hevc_stall_message(error: ProcessArtifactNoProgressError) -> str:
+    return (
+        "Direct MV-HEVC output stopped making progress during both multi-threaded and single-threaded MVC decoding. "
+        "The conversion was stopped instead of waiting indefinitely. The splitter, geometry normalizer, or direct "
+        "encoder may have stalled. Please submit a diagnostic report so the bounded pipeline evidence can be reviewed. "
+        f"({error})"
     )
 
 
@@ -865,6 +1139,39 @@ def create_mv_hevc_file(
     if not config.keep_files:
         left_video_path.unlink(missing_ok=True)
         right_video_path.unlink(missing_ok=True)
+    return mv_hevc_path
+
+
+def create_direct_mv_hevc_file(
+    disc_info: DiscInfo,
+    output_folder: Path,
+    mvc_video: Path,
+    crop_params: str,
+    bitrate_mbps: int | None,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> Path:
+    mv_hevc_path = output_folder / f"{disc_info.name}_MV-HEVC.mov"
+    if config.start_stage.value <= Stage.CREATE_LEFT_RIGHT_FILES.value:
+        if bitrate_mbps is None:
+            raise ValueError("Direct MV-HEVC encoding requires a resolved bitrate.")
+        if not can_use_native_mvc_splitter(disc_info):
+            raise RuntimeError(explain_native_mvc_unavailable(disc_info))
+        normalizer_command = generate_direct_mv_hevc_normalizer_command(disc_info, crop_params)
+        encoder_command = generate_direct_mv_hevc_encoder_command(mv_hevc_path, bitrate_mbps)
+        run_direct_mv_hevc_encoding(
+            mvc_video,
+            mv_hevc_path,
+            normalizer_command,
+            encoder_command,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+        )
+        if not config.keep_files and not should_stream_mvc_from_container(mvc_video):
+            mvc_video.unlink(missing_ok=True)
     return mv_hevc_path
 
 

--- a/bd_to_avp/modules/video_route.py
+++ b/bd_to_avp/modules/video_route.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Callable, Mapping
+
+from bd_to_avp.modules.command import run_process_capture
+from bd_to_avp.modules.config import Stage, config
+from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.observability import ObservabilityContext
+from bd_to_avp.process_runner import ProcessCancelled, ProcessExecutionError, ProcessRunnerError
+from bd_to_avp.runtime import RunContext
+from bd_to_avp.worker.protocol import BitrateMode, BitrateOptions, EncodingOptions, JobOptions, VideoRouteIntent
+
+AUTOMATIC_DIRECT_BITRATE_MBPS = 40
+AUTOMATIC_GENERATED_EYE_BITRATE_MBPS = 20
+AUTOMATIC_GENERATED_MERGE_QUALITY = 75
+DIRECT_CAPABILITY_TIMEOUT_SECONDS = 15
+
+
+class VideoRouteKind(StrEnum):
+    DIRECT_MV_HEVC = "direct_mv_hevc"
+    GENERATED_MV_HEVC = "generated_mv_hevc"
+    AV1 = "av1"
+    EXISTING_ARTIFACT = "existing_artifact"
+
+
+@dataclass(frozen=True)
+class DirectMVHEVCCapability:
+    supported: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class ResolvedVideoRoute:
+    intent: VideoRouteIntent
+    selected: VideoRouteKind
+    reason: str
+    output_mode: VideoMode
+    direct_bitrate_mbps: int | None = None
+    generated_eye_bitrate_mbps: int | None = None
+    generated_merge_quality: int | None = None
+    av1_crf: int | None = None
+    fallback_reason: str | None = None
+
+    def report(self) -> dict[str, object]:
+        report: dict[str, object] = {
+            "intent": self.intent.value,
+            "selected": self.selected.value,
+            "reason": self.reason,
+        }
+        if self.direct_bitrate_mbps is not None:
+            report["bitrate_mbps"] = self.direct_bitrate_mbps
+        if self.generated_eye_bitrate_mbps is not None:
+            report["eye_bitrate_mbps"] = self.generated_eye_bitrate_mbps
+        if self.generated_merge_quality is not None:
+            report["merge_quality"] = self.generated_merge_quality
+        if self.av1_crf is not None:
+            report["crf"] = self.av1_crf
+        if self.fallback_reason is not None:
+            report["fallback_reason"] = self.fallback_reason
+            report["fallback_timing"] = "pre_input"
+        return report
+
+
+class VideoRoutePreflightError(RuntimeError):
+    pass
+
+
+CapabilityProbe = Callable[[], DirectMVHEVCCapability]
+
+
+def resolve_video_route(
+    encoding: EncodingOptions,
+    job: JobOptions,
+    *,
+    capability_probe: CapabilityProbe | None = None,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> ResolvedVideoRoute:
+    video = encoding.video
+    start_stage = Stage.get_stage(job.start_stage)
+
+    if start_stage.value > Stage.COMBINE_TO_MV_HEVC.value:
+        return ResolvedVideoRoute(
+            intent=video.route_intent,
+            selected=VideoRouteKind.EXISTING_ARTIFACT,
+            reason="resume_uses_existing_video_artifact",
+            output_mode=video.mode,
+        )
+    if video.route_intent is VideoRouteIntent.EXISTING_ARTIFACT:
+        raise VideoRoutePreflightError("The existing video artifact route requires a start stage after stage 5.")
+
+    if video.mode is VideoMode.AV1_SBS:
+        if video.av1_crf is None:
+            raise VideoRoutePreflightError("AV1 encoding requires an active CRF value.")
+        return ResolvedVideoRoute(
+            intent=video.route_intent,
+            selected=VideoRouteKind.AV1,
+            reason="av1_output_requested",
+            output_mode=video.mode,
+            av1_crf=video.av1_crf,
+        )
+
+    if video.route_intent is VideoRouteIntent.GENERATED:
+        return _generated_route(encoding, reason="generated_route_requested")
+
+    generated_reason = _generated_constraint_reason(encoding, job, start_stage)
+    if generated_reason is not None:
+        return _generated_route(encoding, reason=generated_reason, use_requested_settings=False)
+
+    if video.route_intent is not VideoRouteIntent.AUTOMATIC:
+        raise VideoRoutePreflightError(
+            f"MV-HEVC stage {start_stage.value} cannot use route intent {video.route_intent.value!r}."
+        )
+    if video.direct_bitrate is None:
+        raise VideoRoutePreflightError("Automatic MV-HEVC routing requires an active direct bitrate policy.")
+
+    probe = capability_probe or (
+        lambda: probe_direct_mv_hevc_capability(
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+        )
+    )
+    capability = probe()
+    if not capability.supported:
+        return _generated_route(
+            encoding,
+            reason="direct_capability_unavailable",
+            fallback_reason=capability.reason,
+            use_requested_settings=False,
+        )
+
+    return ResolvedVideoRoute(
+        intent=video.route_intent,
+        selected=VideoRouteKind.DIRECT_MV_HEVC,
+        reason="direct_eligible",
+        output_mode=video.mode,
+        direct_bitrate_mbps=_resolve_bitrate(video.direct_bitrate, AUTOMATIC_DIRECT_BITRATE_MBPS),
+    )
+
+
+def legacy_video_route() -> ResolvedVideoRoute:
+    if config.start_stage.value > Stage.COMBINE_TO_MV_HEVC.value:
+        return ResolvedVideoRoute(
+            intent=VideoRouteIntent.EXISTING_ARTIFACT,
+            selected=VideoRouteKind.EXISTING_ARTIFACT,
+            reason="legacy_resume_uses_existing_video_artifact",
+            output_mode=config.video_mode,
+        )
+    if config.video_mode is VideoMode.AV1_SBS:
+        return ResolvedVideoRoute(
+            intent=VideoRouteIntent.ENCODE,
+            selected=VideoRouteKind.AV1,
+            reason="legacy_av1_route",
+            output_mode=config.video_mode,
+            av1_crf=config.av1_crf,
+        )
+    return ResolvedVideoRoute(
+        intent=VideoRouteIntent.GENERATED,
+        selected=VideoRouteKind.GENERATED_MV_HEVC,
+        reason="legacy_generated_route",
+        output_mode=config.video_mode,
+        generated_eye_bitrate_mbps=config.left_right_bitrate,
+        generated_merge_quality=config.mv_hevc_quality,
+    )
+
+
+def probe_direct_mv_hevc_capability(
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> DirectMVHEVCCapability:
+    helper_path = config.MV_HEVC_ENCODER_PATH
+    if not helper_path.is_file():
+        return DirectMVHEVCCapability(False, "helper_missing")
+    if not os.access(helper_path, os.X_OK):
+        return DirectMVHEVCCapability(False, "helper_not_executable")
+
+    try:
+        result = run_process_capture(
+            [helper_path, "--capability-probe"],
+            "Probe direct MV-HEVC capability",
+            tool_id="mv_hevc_encoder",
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+            timeout_seconds=DIRECT_CAPABILITY_TIMEOUT_SECONDS,
+            show_command=False,
+        )
+        return _parse_capability_payload(result.stdout.text(), returncode=result.returncode)
+    except ProcessCancelled:
+        raise
+    except ProcessExecutionError as error:
+        if error.returncode == 2:
+            return _parse_capability_payload(error.stdout_snapshot.text(), returncode=error.returncode)
+        raise VideoRoutePreflightError(
+            f"The direct MV-HEVC capability probe failed with exit code {error.returncode}."
+        ) from error
+    except (OSError, subprocess.SubprocessError, ProcessRunnerError) as error:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe could not be completed.") from error
+
+
+def _parse_capability_payload(payload: str, *, returncode: int) -> DirectMVHEVCCapability:
+    try:
+        raw = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe returned invalid JSON.") from error
+    if not isinstance(raw, Mapping) or set(raw) != {"schema_version", "stereo_mv_hevc_encode_supported"}:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe returned an invalid contract.")
+    if type(raw["schema_version"]) is not int or raw["schema_version"] != 1:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe returned an invalid contract.")
+    if type(raw["stereo_mv_hevc_encode_supported"]) is not bool:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe returned an invalid contract.")
+
+    supported = raw["stereo_mv_hevc_encode_supported"]
+    if supported and returncode != 0:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe contradicted its exit status.")
+    if not supported and returncode != 2:
+        raise VideoRoutePreflightError("The direct MV-HEVC capability probe contradicted its exit status.")
+    return DirectMVHEVCCapability(
+        supported=supported,
+        reason="direct_capability_supported" if supported else "stereo_mv_hevc_encode_unavailable",
+    )
+
+
+def _generated_constraint_reason(
+    encoding: EncodingOptions,
+    job: JobOptions,
+    start_stage: Stage,
+) -> str | None:
+    if start_stage.value >= Stage.CREATE_LEFT_RIGHT_FILES.value:
+        return "restart_stage_requires_generated_artifacts"
+    if job.keep_files:
+        return "reusable_intermediates_requested"
+    if job.software_encoder:
+        return "software_encoder_requested"
+    if encoding.upscale.enabled:
+        return "upscale_requires_generated_artifacts"
+    if not 1 <= encoding.fov <= 180:
+        return "field_of_view_requires_generated_route"
+    return None
+
+
+def _generated_route(
+    encoding: EncodingOptions,
+    *,
+    reason: str,
+    fallback_reason: str | None = None,
+    use_requested_settings: bool = True,
+) -> ResolvedVideoRoute:
+    video = encoding.video
+    if use_requested_settings:
+        if video.generated_eye_bitrate is None or video.generated_merge_quality is None:
+            raise VideoRoutePreflightError("Generated MV-HEVC routing requires active generated settings.")
+        eye_bitrate = _resolve_bitrate(video.generated_eye_bitrate, AUTOMATIC_GENERATED_EYE_BITRATE_MBPS)
+        merge_quality = video.generated_merge_quality
+    else:
+        eye_bitrate = AUTOMATIC_GENERATED_EYE_BITRATE_MBPS
+        merge_quality = AUTOMATIC_GENERATED_MERGE_QUALITY
+    return ResolvedVideoRoute(
+        intent=video.route_intent,
+        selected=VideoRouteKind.GENERATED_MV_HEVC,
+        reason=reason,
+        output_mode=video.mode,
+        generated_eye_bitrate_mbps=eye_bitrate,
+        generated_merge_quality=merge_quality,
+        fallback_reason=fallback_reason,
+    )
+
+
+def _resolve_bitrate(bitrate: BitrateOptions, automatic_mbps: int) -> int:
+    if bitrate.mode is BitrateMode.AUTOMATIC:
+        return automatic_mbps
+    if bitrate.mbps is None:
+        raise VideoRoutePreflightError("Custom bitrate mode requires an Mbps value.")
+    return bitrate.mbps

--- a/bd_to_avp/preflight.py
+++ b/bd_to_avp/preflight.py
@@ -8,6 +8,7 @@ from bd_to_avp.vendor.pgsrip.ocr import AppleVisionOcr, OcrError
 from bd_to_avp.modules.command import run_process_capture
 from bd_to_avp.modules.config import Stage, config
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import ResolvedVideoRoute, VideoRouteKind, legacy_video_route
 from bd_to_avp.observability import ObservabilityContext
 from bd_to_avp.process_runner import ProcessCancelled, ProcessRunnerError
 from bd_to_avp.runtime import RunContext
@@ -19,11 +20,13 @@ class DependencyPreflightError(RuntimeError):
 
 def verify_runtime_ready(
     *,
+    video_route: ResolvedVideoRoute | None = None,
     run_context: RunContext | None = None,
     cancellation_event: Event | None = None,
     observability_context: ObservabilityContext | None = None,
 ) -> None:
-    missing_binaries = get_missing_dependency_binaries_for_current_job()
+    video_route = video_route or legacy_video_route()
+    missing_binaries = get_missing_dependency_binaries_for_current_job(video_route)
     if not missing_binaries:
         verify_av1_encoder_ready(
             run_context=run_context,
@@ -37,8 +40,11 @@ def verify_runtime_ready(
     raise DependencyPreflightError(message)
 
 
-def get_missing_dependency_binaries_for_current_job() -> list[Path]:
-    required_paths = get_required_dependency_binaries_for_current_job()
+def get_missing_dependency_binaries_for_current_job(
+    video_route: ResolvedVideoRoute | None = None,
+) -> list[Path]:
+    video_route = video_route or legacy_video_route()
+    required_paths = get_required_dependency_binaries_for_current_job(video_route)
     missing_binaries = [path for path in required_paths if not path.exists()]
     if (
         needs_native_mvc_splitter()
@@ -46,17 +52,28 @@ def get_missing_dependency_binaries_for_current_job() -> list[Path]:
         and not ensure_native_mvc_splitter_executable()
     ):
         missing_binaries.append(config.EDGE264_TEST_PATH)
+    if (
+        video_route.selected is VideoRouteKind.DIRECT_MV_HEVC
+        and config.MV_HEVC_ENCODER_PATH not in missing_binaries
+        and not os.access(config.MV_HEVC_ENCODER_PATH, os.X_OK)
+    ):
+        missing_binaries.append(config.MV_HEVC_ENCODER_PATH)
     return missing_binaries
 
 
-def get_required_dependency_binaries_for_current_job() -> list[Path]:
+def get_required_dependency_binaries_for_current_job(
+    video_route: ResolvedVideoRoute | None = None,
+) -> list[Path]:
+    video_route = video_route or legacy_video_route()
     required_paths = [config.FFMPEG_PATH, config.FFPROBE_PATH]
 
     if needs_makemkv():
         required_paths.append(config.MAKEMKVCON_PATH)
     if needs_native_mvc_splitter():
         required_paths.append(config.EDGE264_TEST_PATH)
-    if config.video_mode is VideoMode.MV_HEVC and config.start_stage.value <= Stage.COMBINE_TO_MV_HEVC.value:
+    if video_route.selected is VideoRouteKind.DIRECT_MV_HEVC:
+        required_paths.append(config.MV_HEVC_ENCODER_PATH)
+    if video_route.selected is VideoRouteKind.GENERATED_MV_HEVC:
         required_paths.append(config.SPATIAL_MEDIA_PATH)
     if config.start_stage.value <= Stage.CREATE_FINAL_FILE.value:
         required_paths.append(config.MP4BOX_PATH)
@@ -129,6 +146,7 @@ def get_dependency_name(path: Path) -> str:
         config.MAKEMKVCON_PATH: "MakeMKV",
         config.MP4BOX_PATH: "MP4Box",
         config.EDGE264_TEST_PATH: "Native MVC helper",
+        config.MV_HEVC_ENCODER_PATH: "Direct MV-HEVC encoder",
         config.SPATIAL_MEDIA_PATH: "Spatial media tool",
         config.FX_UPSCALE_PATH: "FX Upscale",
     }

--- a/bd_to_avp/worker/operations.py
+++ b/bd_to_avp/worker/operations.py
@@ -23,6 +23,12 @@ from bd_to_avp.modules.process import (
     start_process,
 )
 from bd_to_avp.modules.sub import SRTCreationError
+from bd_to_avp.modules.video_route import (
+    ResolvedVideoRoute,
+    VideoRouteKind,
+    VideoRoutePreflightError,
+    resolve_video_route,
+)
 from bd_to_avp.process_runner import ProcessCancelled
 from bd_to_avp.runtime import RunContext
 from bd_to_avp.worker.ownership import WorkerCancelled, WorkerProcessOwner
@@ -226,6 +232,18 @@ def preview_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActi
     if preview is None:
         raise WorkerOperationError("invalid_request", "Preview requests require preview options.")
 
+    try:
+        resolved_video_route = resolve_job_video_route(job, owner, activity)
+    except VideoRoutePreflightError as error:
+        if owner.cancellation_event.is_set():
+            raise WorkerCancelled("The preview was cancelled.") from error
+        raise WorkerOperationError(
+            "video_route_preflight_failed",
+            "The video route could not be prepared safely.",
+            str(error),
+        ) from error
+    report_video_route(activity, resolved_video_route)
+
     activity.stage_started("inspect_source", "Reading video metadata")
     inspection = inspect_source(job.source, owner, run_context=activity.run_context)
     try:
@@ -250,6 +268,8 @@ def preview_source(job: JobSpec, owner: WorkerProcessOwner, activity: WorkerActi
         activity,
         preview_range=preview_range,
         allow_recovery=False,
+        resolved_video_route=resolved_video_route,
+        route_already_reported=True,
     )
     artifact = {
         **result,
@@ -267,6 +287,8 @@ def _convert_source(
     *,
     preview_range: PreviewRange | None = None,
     allow_recovery: bool = True,
+    resolved_video_route: ResolvedVideoRoute | None = None,
+    route_already_reported: bool = False,
 ) -> dict[str, object]:
     source_path = validate_source(job.source)
     destination = job.destination
@@ -287,15 +309,20 @@ def _convert_source(
     owner.check_cancelled()
     with configured_conversion(job, source_path, preview_range=preview_range):
         try:
-            activity.set_stage_plan(conversion_stage_plan())
-            activity.stage_started("configure", "Preparing conversion settings")
             config.configure_tool_environment()
+            resolved_video_route = resolved_video_route or resolve_job_video_route(job, owner, activity)
+            apply_video_route_to_config(resolved_video_route)
+            activity.set_stage_plan(conversion_stage_plan(resolved_video_route))
+            activity.stage_started("configure", "Preparing conversion settings")
             activity.log("Tool environment configured", stage="configure")
+            if not route_already_reported:
+                report_video_route(activity, resolved_video_route)
             final_output_path = start_process(
                 cancellation_event=owner.cancellation_event,
                 activity=activity,
                 selected_title_id=job.source.title_id,
                 run_context=activity.run_context,
+                video_route=resolved_video_route,
             )
             resolved_preview_range = config.preview_range
             owner.check_cancelled()
@@ -338,6 +365,14 @@ def _convert_source(
             raise WorkerOperationError(
                 "dependency_preflight_failed",
                 "A required conversion helper is missing or unavailable.",
+                str(error),
+            ) from error
+        except VideoRoutePreflightError as error:
+            if owner.cancellation_event.is_set():
+                raise WorkerCancelled("The conversion was cancelled.") from error
+            raise WorkerOperationError(
+                "video_route_preflight_failed",
+                "The video route could not be prepared safely.",
                 str(error),
             ) from error
         except FileExistsError as error:
@@ -386,6 +421,8 @@ def _convert_source(
         "output_path": final_output_path.as_posix(),
         "size_bytes": final_output_path.stat().st_size,
     }
+    assert resolved_video_route is not None
+    result["video_route"] = resolved_video_route.report()
     if job.source.title_id is not None:
         result["title_id"] = job.source.title_id
     if resolved_preview_range is not None:
@@ -437,11 +474,8 @@ def configured_conversion(
         config.audio_bitrate = job.encoding.audio.bitrate
         config.audio_preferred_language = job.encoding.audio.preferred_language
         config.video_mode = job.encoding.video_mode
-        config.av1_crf = job.encoding.av1_crf
-        config.left_right_bitrate = job.encoding.left_right_bitrate
-        config.link_quality = job.encoding.link_quality
-        config.mv_hevc_quality = job.encoding.mv_hevc_quality
-        config.upscale_quality = job.encoding.upscale_quality
+        if job.encoding.upscale.quality is not None:
+            config.upscale_quality = job.encoding.upscale.quality
         config.fov = job.encoding.fov
         config.frame_rate = job.encoding.frame_rate
         config.resolution = job.encoding.resolution
@@ -453,7 +487,7 @@ def configured_conversion(
         config.crop_black_bars = job.encoding.crop_black_bars
         config.output_commands = job.job.output_commands
         config.software_encoder = job.job.software_encoder
-        config.fx_upscale = job.encoding.fx_upscale
+        config.fx_upscale = job.encoding.upscale.enabled
         config.continue_on_error = job.job.continue_on_error
         config.language_code = job.encoding.subtitles.preferred_language or "eng"
         config.remove_extra_languages = job.encoding.subtitles.mode is SubtitleMode.PREFERRED_ONLY
@@ -468,6 +502,60 @@ def configured_conversion(
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+
+def apply_video_route_to_config(video_route: ResolvedVideoRoute) -> None:
+    config.video_mode = video_route.output_mode
+    if video_route.av1_crf is not None:
+        config.av1_crf = video_route.av1_crf
+    if video_route.generated_eye_bitrate_mbps is not None:
+        config.left_right_bitrate = video_route.generated_eye_bitrate_mbps
+    if video_route.generated_merge_quality is not None:
+        config.mv_hevc_quality = video_route.generated_merge_quality
+
+
+def resolve_job_video_route(
+    job: JobSpec,
+    owner: WorkerProcessOwner,
+    activity: WorkerActivityReporter,
+) -> ResolvedVideoRoute:
+    if job.encoding is None or job.job is None:
+        raise WorkerOperationError("invalid_request", "Conversion requests require encoding and job options.")
+    return resolve_video_route(
+        job.encoding,
+        job.job,
+        run_context=activity.run_context,
+        cancellation_event=owner.cancellation_event,
+        observability_context=stage_observability_context("configure"),
+    )
+
+
+def report_video_route(activity: WorkerActivityReporter, video_route: ResolvedVideoRoute) -> None:
+    report = video_route.report()
+    if video_route.fallback_reason is not None:
+        activity.warning(
+            "Direct MV-HEVC is unavailable on this Mac. Continuing with generated MV-HEVC.",
+            stage="configure",
+            code="video_route_fallback",
+            video_route=report,
+        )
+        return
+    activity.log(
+        route_message(video_route),
+        stage="configure",
+        code="video_route_selected",
+        video_route=report,
+    )
+
+
+def route_message(video_route: ResolvedVideoRoute) -> str:
+    messages = {
+        VideoRouteKind.DIRECT_MV_HEVC: "Using direct MV-HEVC encoding.",
+        VideoRouteKind.GENERATED_MV_HEVC: "Using generated MV-HEVC encoding.",
+        VideoRouteKind.AV1: "Using AV1 stereo encoding.",
+        VideoRouteKind.EXISTING_ARTIFACT: "Using the existing encoded video artifact.",
+    }
+    return messages[video_route.selected]
 
 
 def validate_source(source: JobSource) -> Path:

--- a/bd_to_avp/worker/protocol.py
+++ b/bd_to_avp/worker/protocol.py
@@ -16,7 +16,7 @@ from bd_to_avp.modules.video_mode import VideoMode
 from bd_to_avp.observability import ObservabilityEvent
 from bd_to_avp.runtime import RunContext
 
-PROTOCOL_VERSION = 9
+PROTOCOL_VERSION = 10
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_EVENT_BYTES = 1024 * 1024
 MAX_DETAIL_BYTES = 64 * 1024
@@ -49,6 +49,18 @@ class SubtitleMode(StrEnum):
     OFF = "off"
     PREFERRED_ONLY = "preferred_only"
     PREFERRED_PLUS_OTHERS = "preferred_plus_others"
+
+
+class BitrateMode(StrEnum):
+    AUTOMATIC = "automatic"
+    CUSTOM = "custom"
+
+
+class VideoRouteIntent(StrEnum):
+    AUTOMATIC = "automatic"
+    GENERATED = "generated"
+    ENCODE = "encode"
+    EXISTING_ARTIFACT = "existing_artifact"
 
 
 class WorkerEventType(StrEnum):
@@ -109,21 +121,42 @@ class SubtitleOptions:
 
 
 @dataclass(frozen=True)
+class BitrateOptions:
+    mode: BitrateMode
+    mbps: int | None = None
+
+
+@dataclass(frozen=True)
+class VideoOptions:
+    mode: VideoMode
+    route_intent: VideoRouteIntent
+    direct_bitrate: BitrateOptions | None = None
+    generated_eye_bitrate: BitrateOptions | None = None
+    generated_merge_quality: int | None = None
+    av1_crf: int | None = None
+
+
+@dataclass(frozen=True)
+class UpscaleOptions:
+    enabled: bool
+    quality: int | None = None
+
+
+@dataclass(frozen=True)
 class EncodingOptions:
     audio: AudioOptions
-    video_mode: VideoMode
-    av1_crf: int
-    left_right_bitrate: int
-    link_quality: bool
-    mv_hevc_quality: int
-    upscale_quality: int
+    video: VideoOptions
+    upscale: UpscaleOptions
     fov: int
     frame_rate: str
     resolution: str
     crop_black_bars: bool
     swap_eyes: bool
-    fx_upscale: bool
     subtitles: SubtitleOptions
+
+    @property
+    def video_mode(self) -> VideoMode:
+        return self.video.mode
 
 
 @dataclass(frozen=True)
@@ -295,6 +328,7 @@ class JobSpec:
             encoding = cls._parse_encoding(raw.get("encoding"), job_id)
             job_options = cls._parse_job_options(raw.get("job"), job_id)
             assert job_options is not None
+            cls._validate_video_route_for_job(encoding, job_options, job_id)
         if operation is WorkerOperation.CONVERT_SOURCE:
             assert job_options is not None
             if source_kind is WorkerSourceKind.PHYSICAL_DISC and job_options.remove_original:
@@ -335,6 +369,48 @@ class JobSpec:
             job=job_options,
             preview=preview_options,
         )
+
+    @staticmethod
+    def _validate_video_route_for_job(
+        encoding: EncodingOptions,
+        job: JobOptions,
+        job_id: str,
+    ) -> None:
+        video = encoding.video
+        if job.start_stage > 5:
+            if video.route_intent is not VideoRouteIntent.EXISTING_ARTIFACT:
+                raise WorkerProtocolError(
+                    "invalid_encoding_options",
+                    "Jobs starting after stage 5 must request the existing video artifact route.",
+                    job_id=job_id,
+                )
+            return
+        if video.route_intent is VideoRouteIntent.EXISTING_ARTIFACT:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "The existing video artifact route requires a start stage after stage 5.",
+                job_id=job_id,
+            )
+        if video.mode is VideoMode.AV1_SBS:
+            return
+
+        generated_requirement: str | None = None
+        if job.start_stage >= 4:
+            generated_requirement = "Stage 4 and stage 5 restarts require"
+        elif job.keep_files:
+            generated_requirement = "Reusable intermediates require"
+        elif job.software_encoder:
+            generated_requirement = "Software HEVC requires"
+        elif encoding.upscale.enabled:
+            generated_requirement = "FX upscale requires"
+        elif not 1 <= encoding.fov <= 180:
+            generated_requirement = "The selected field of view requires"
+        if generated_requirement is not None and video.route_intent is not VideoRouteIntent.GENERATED:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"{generated_requirement} the generated MV-HEVC route.",
+                job_id=job_id,
+            )
 
     @staticmethod
     def _parse_job_id(value: Any) -> str:
@@ -395,38 +471,28 @@ class JobSpec:
             )
         required_keys = {
             "audio",
-            "video_mode",
-            "av1_crf",
-            "left_right_bitrate",
-            "link_quality",
-            "mv_hevc_quality",
-            "upscale_quality",
+            "video",
+            "upscale",
             "fov",
             "frame_rate",
             "resolution",
             "crop_black_bars",
             "swap_eyes",
-            "fx_upscale",
             "subtitles",
         }
         cls._require_exact_keys(value, required_keys, "encoding", job_id)
         encoding = EncodingOptions(
             audio=cls._parse_audio_options(value.get("audio"), job_id),
-            video_mode=cls._parse_video_mode(value.get("video_mode"), job_id),
-            av1_crf=cls._parse_int(value, "av1_crf", "encoding", job_id, minimum=0, maximum=63),
-            left_right_bitrate=cls._parse_int(value, "left_right_bitrate", "encoding", job_id, minimum=1, maximum=500),
-            link_quality=cls._parse_bool(value, "link_quality", "encoding", job_id),
-            mv_hevc_quality=cls._parse_int(value, "mv_hevc_quality", "encoding", job_id, minimum=0, maximum=100),
-            upscale_quality=cls._parse_int(value, "upscale_quality", "encoding", job_id, minimum=0, maximum=100),
+            video=cls._parse_video_options(value.get("video"), job_id),
+            upscale=cls._parse_upscale_options(value.get("upscale"), job_id),
             fov=cls._parse_int(value, "fov", "encoding", job_id, minimum=0, maximum=360),
             frame_rate=cls._parse_string(value, "frame_rate", "encoding", job_id),
             resolution=cls._parse_string(value, "resolution", "encoding", job_id),
             crop_black_bars=cls._parse_bool(value, "crop_black_bars", "encoding", job_id),
             swap_eyes=cls._parse_bool(value, "swap_eyes", "encoding", job_id),
-            fx_upscale=cls._parse_bool(value, "fx_upscale", "encoding", job_id),
             subtitles=cls._parse_subtitle_options(value.get("subtitles"), job_id),
         )
-        if encoding.video_mode is VideoMode.AV1_SBS and encoding.fx_upscale:
+        if encoding.video_mode is VideoMode.AV1_SBS and encoding.upscale.enabled:
             raise WorkerProtocolError(
                 "invalid_encoding_options",
                 "AV1 stereo export does not support AI FX upscale.",
@@ -439,6 +505,189 @@ class JobSpec:
                 job_id=job_id,
             )
         return encoding
+
+    @classmethod
+    def _parse_video_options(cls, value: Any, job_id: str) -> VideoOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.video must be an object.",
+                job_id=job_id,
+            )
+
+        mode = cls._parse_video_mode(value.get("mode"), job_id)
+        route_intent = cls._parse_video_route_intent(value.get("route_intent"), job_id)
+        if mode is VideoMode.MV_HEVC and route_intent is VideoRouteIntent.AUTOMATIC:
+            cls._require_exact_keys(
+                value,
+                {"mode", "route_intent", "direct_bitrate"},
+                "encoding.video",
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return VideoOptions(
+                mode=mode,
+                route_intent=route_intent,
+                direct_bitrate=cls._parse_bitrate_options(
+                    value.get("direct_bitrate"),
+                    "encoding.video.direct_bitrate",
+                    job_id,
+                ),
+            )
+        if mode is VideoMode.MV_HEVC and route_intent is VideoRouteIntent.GENERATED:
+            cls._require_exact_keys(
+                value,
+                {"mode", "route_intent", "generated_eye_bitrate", "generated_merge_quality"},
+                "encoding.video",
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return VideoOptions(
+                mode=mode,
+                route_intent=route_intent,
+                generated_eye_bitrate=cls._parse_bitrate_options(
+                    value.get("generated_eye_bitrate"),
+                    "encoding.video.generated_eye_bitrate",
+                    job_id,
+                ),
+                generated_merge_quality=cls._parse_int(
+                    value,
+                    "generated_merge_quality",
+                    "encoding.video",
+                    job_id,
+                    minimum=0,
+                    maximum=100,
+                    error_code="invalid_encoding_options",
+                ),
+            )
+        if mode is VideoMode.AV1_SBS and route_intent is VideoRouteIntent.ENCODE:
+            cls._require_exact_keys(
+                value,
+                {"mode", "route_intent", "crf"},
+                "encoding.video",
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return VideoOptions(
+                mode=mode,
+                route_intent=route_intent,
+                av1_crf=cls._parse_int(
+                    value,
+                    "crf",
+                    "encoding.video",
+                    job_id,
+                    minimum=0,
+                    maximum=63,
+                    error_code="invalid_encoding_options",
+                ),
+            )
+        if route_intent is VideoRouteIntent.EXISTING_ARTIFACT:
+            cls._require_exact_keys(
+                value,
+                {"mode", "route_intent"},
+                "encoding.video",
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return VideoOptions(mode=mode, route_intent=route_intent)
+
+        raise WorkerProtocolError(
+            "invalid_encoding_options",
+            f"encoding.video route {route_intent.value!r} is not valid for {mode.value!r} output.",
+            job_id=job_id,
+        )
+
+    @classmethod
+    def _parse_bitrate_options(cls, value: Any, label: str, job_id: str) -> BitrateOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"{label} must be an object.",
+                job_id=job_id,
+            )
+        raw_mode = value.get("mode")
+        if not isinstance(raw_mode, str):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"{label}.mode must be a string.",
+                job_id=job_id,
+            )
+        try:
+            mode = BitrateMode(raw_mode)
+        except ValueError as error:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"Unsupported {label}.mode: {raw_mode!r}.",
+                job_id=job_id,
+            ) from error
+        if mode is BitrateMode.AUTOMATIC:
+            cls._require_exact_keys(
+                value,
+                {"mode"},
+                label,
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return BitrateOptions(mode=mode)
+
+        cls._require_exact_keys(
+            value,
+            {"mode", "mbps"},
+            label,
+            job_id,
+            error_code="invalid_encoding_options",
+        )
+        return BitrateOptions(
+            mode=mode,
+            mbps=cls._parse_int(
+                value,
+                "mbps",
+                label,
+                job_id,
+                minimum=1,
+                maximum=500,
+                error_code="invalid_encoding_options",
+            ),
+        )
+
+    @classmethod
+    def _parse_upscale_options(cls, value: Any, job_id: str) -> UpscaleOptions:
+        if not isinstance(value, Mapping):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.upscale must be an object.",
+                job_id=job_id,
+            )
+        enabled = cls._parse_bool(value, "enabled", "encoding.upscale", job_id)
+        if not enabled:
+            cls._require_exact_keys(
+                value,
+                {"enabled"},
+                "encoding.upscale",
+                job_id,
+                error_code="invalid_encoding_options",
+            )
+            return UpscaleOptions(enabled=False)
+
+        cls._require_exact_keys(
+            value,
+            {"enabled", "quality"},
+            "encoding.upscale",
+            job_id,
+            error_code="invalid_encoding_options",
+        )
+        return UpscaleOptions(
+            enabled=True,
+            quality=cls._parse_int(
+                value,
+                "quality",
+                "encoding.upscale",
+                job_id,
+                minimum=0,
+                maximum=100,
+                error_code="invalid_encoding_options",
+            ),
+        )
 
     @staticmethod
     def _parse_video_mode(value: Any, job_id: str) -> VideoMode:
@@ -454,6 +703,23 @@ class JobSpec:
             raise WorkerProtocolError(
                 "invalid_encoding_options",
                 f"Unsupported encoding.video_mode: {value!r}.",
+                job_id=job_id,
+            ) from error
+
+    @staticmethod
+    def _parse_video_route_intent(value: Any, job_id: str) -> VideoRouteIntent:
+        if not isinstance(value, str):
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                "encoding.video.route_intent must be a string.",
+                job_id=job_id,
+            )
+        try:
+            return VideoRouteIntent(value)
+        except ValueError as error:
+            raise WorkerProtocolError(
+                "invalid_encoding_options",
+                f"Unsupported encoding.video.route_intent: {value!r}.",
                 job_id=job_id,
             ) from error
 

--- a/docs/direct-mv-hevc-feasibility.md
+++ b/docs/direct-mv-hevc-feasibility.md
@@ -2,8 +2,9 @@
 
 Issue #347 asks whether the decoded stereo stream can become a final Apple-compatible MV-HEVC movie without first
 writing left and right HEVC eye movies. The bounded prototype proves that this boundary is viable on Apple Silicon,
-and the completed qualification clears it for product integration. The current product remains on the legacy path
-until that integration is implemented and shipped.
+and the completed qualification clears it for product integration. Protocol v10 now activates the qualified route for
+eligible native-app conversions while preserving the generated path for explicit workflow constraints and preflight
+fallback.
 
 ## Decision
 
@@ -96,6 +97,19 @@ Every direct run exceeded the required quality floor of 0.911273. At that matche
 metrics. Their file hashes differed, so the result makes no byte-for-byte determinism claim about container metadata.
 The like-for-like size gate therefore passes for the bounded fixture without inferring equivalence from encoder input
 controls.
+
+### Initial 1080p automatic-policy check
+
+Protocol-v10 integration also ran a one-second, 1920x1080-per-eye, 24 fps synthetic check with 128 pixels of disparity
+against the product's default generated budget of 20 Mbps per eye plus merge quality 75. At a 40 Mbps direct target,
+the direct minimum same-eye SSIM was 0.961318 versus 0.961768 for the generated path, a difference of 0.000450. Raising
+the direct ceiling to 500 Mbps reduced but did not eliminate that fixture-specific gap: 0.961567 versus 0.961755.
+
+The initial worker-owned automatic target is therefore the conservative 40 Mbps aggregate generated-eye budget, not
+the 20 Mbps value inferred by scaling only the small fixture. This one-run synthetic check is integration evidence, not
+the representative-corpus release gate. Issue #354 retains the prerelease quality, size, and physical-playback gate
+before direct is promoted in a stable release. The quality matcher accepts `--direct-max-bitrate-mbps` so future corpus
+runs can test a direct search ceiling independently from the generated path's aggregate eye target.
 
 ### GPU time
 
@@ -206,8 +220,8 @@ continue through upscale and final mux without changing later artifact names.
   bundled-tool deployment-target checks.
 - No third-party runtime, source archive, or additional license notice is required; the implementation uses Apple SDK
   frameworks.
-- No production routing or app-bundle change is included in this prototype. The completed qualification now allows
-  those changes to proceed in the generated-intermediate and mode-specific-control integration workstream.
+- The packaged helper is consumed only through `Config.MV_HEVC_ENCODER_PATH`. Protocol v10 resolves capability before
+  input, executes direct output during stage 4, and preserves the generated route for restart and reusable artifacts.
 
 ## Reproduction
 
@@ -258,5 +272,5 @@ uv run python -m unittest \
 | Restart and fallback behavior | Defined |
 | Runtime, license, macOS, architecture, signing, notarization, and bundle implications | Recorded |
 
-The prototype is fully qualified for product integration. It remains non-default only because the runtime, UI,
-profile, protocol, fallback, packaging, and migration changes belong to the follow-on implementation plan.
+The prototype is fully qualified and its runtime route is active under protocol v10. Route-aware UI diagnostics and
+rollout remain in issue #354; streamed 4K upscale and live conversion imagery remain separate follow-up issues.

--- a/docs/direct-pipeline-contracts.md
+++ b/docs/direct-pipeline-contracts.md
@@ -141,18 +141,20 @@ source path, AAC transcoding reads audio from that source without an
 intermediate PCM MOV, and MVC video is demuxed as Annex B into the native
 splitter without an intermediate `.h264` file.
 
-The MVC path is a bounded three-process pipeline: source FFmpeg to
-`edge264_test` to encoding FFmpeg. MV-HEVC materializes left/right eye files;
-AV1 directly materializes one packed software-encoded video. Subtitles, AAC,
+The MVC path uses the shared bounded process supervisor. Generated MV-HEVC and
+AV1 use source FFmpeg to `edge264_test` to encoding FFmpeg. Eligible protocol-v10
+MV-HEVC jobs add the packaged `mv-hevc-encoder` after an FFmpeg geometry
+normalizer and write `_MV-HEVC.mov` directly during stage 4. Subtitles, AAC,
 the mode-specific finalized video, and the final movie remain named stage
 artifacts. Default mode removes consumed intermediates after the final output
 is complete; `--keep-files` retains them. Disc/ISO inputs retain their MakeMKV
 materialization.
 
-The [direct MV-HEVC feasibility prototype](direct-mv-hevc-feasibility.md)
-demonstrates a candidate replacement for the normal MV-HEVC eye-file boundary.
-It is not yet part of this production contract; the current file-backed route
-remains authoritative until device and performance qualification completes.
+The [direct MV-HEVC feasibility evidence](direct-mv-hevc-feasibility.md)
+qualifies that production route. Reusable intermediates, software HEVC,
+external eye workflows, upscaling, stage-4/5 restarts, and valid unavailable
+capability remain generated/file-backed. A failure after direct input starts is
+never replayed through the generated route.
 
 The reused source is user-owned. Automatic cleanup never deletes it.
 `--remove-original` is the explicit exception and removes the source only after

--- a/docs/native-worker-protocol-v1.md
+++ b/docs/native-worker-protocol-v1.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v1
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 The native macOS prototype communicates with the existing Python engine over a
 bounded JSON Lines (JSONL) protocol. The boundary is intentionally independent

--- a/docs/native-worker-protocol-v10.md
+++ b/docs/native-worker-protocol-v10.md
@@ -1,0 +1,167 @@
+# Native Worker Protocol v10
+
+Protocol v10 activates deterministic direct MV-HEVC routing. The native app
+projects one route intent and only the video controls that intent can use; the
+worker resolves one immutable execution route before conversion input is
+consumed. The native app and bundled Python worker ship atomically and both
+require version 10.
+
+Observability events, lifecycle rules, ownership, heartbeats, request size
+limits, audio-language selection, and terminal behavior are unchanged from
+[Native Worker Protocol v9](native-worker-protocol-v9.md).
+
+## Video Object
+
+Every conversion and preview request contains one strict `encoding.video`
+object. `mode` is `mv_hevc` or `av1_sbs`. `route_intent` determines the exact
+remaining keys.
+
+An automatic MV-HEVC request carries only its direct final-bitrate policy:
+
+```json
+{
+  "mode": "mv_hevc",
+  "route_intent": "automatic",
+  "direct_bitrate": {
+    "mode": "automatic"
+  }
+}
+```
+
+Custom bitrate mode adds one integer `mbps` value from 1 through 500. Automatic
+mode omits `mbps`; it does not send a numeric sentinel. The initial
+worker-owned automatic direct target is 40 Mbps, matching the aggregate budget
+of the generated route's two default 20 Mbps eye encodes. A 1080p24 synthetic
+check put direct output within 0.00045 minimum same-eye SSIM of the generated
+path at that target, but did not satisfy the qualification harness's positive
+quality-margin gate. Issue #354 therefore retains the representative-corpus
+prerelease gate before release/default promotion. Native or streamed 4K
+upscaling remains a separate route and is not inferred from this policy.
+
+A generated MV-HEVC request carries only generated-route controls:
+
+```json
+{
+  "mode": "mv_hevc",
+  "route_intent": "generated",
+  "generated_eye_bitrate": {
+    "mode": "custom",
+    "mbps": 24
+  },
+  "generated_merge_quality": 75
+}
+```
+
+The eye bitrate uses the same `automatic` or `custom` object contract. Its
+automatic value remains 20 Mbps per eye. Merge quality is an integer from 0
+through 100. A generated request never contains `direct_bitrate`.
+
+AV1 carries only its active CRF:
+
+```json
+{
+  "mode": "av1_sbs",
+  "route_intent": "encode",
+  "crf": 32
+}
+```
+
+A resume that starts after video encoding carries no encode controls:
+
+```json
+{
+  "mode": "mv_hevc",
+  "route_intent": "existing_artifact"
+}
+```
+
+The worker rejects unknown keys, invalid mode/intent combinations, automatic
+bitrate objects containing `mbps`, and custom bitrate objects omitting `mbps`.
+Protocol v9 fields such as `video_mode`, `av1_crf`, `left_right_bitrate`,
+`link_quality`, and `mv_hevc_quality` are not part of the v10 encoding object.
+
+## Upscale Object
+
+`encoding.upscale` also omits inactive numeric values:
+
+```json
+{ "enabled": false }
+```
+
+An enabled request adds `quality` from 0 through 100. AV1 rejects enabled
+upscaling. MV-HEVC upscaling selects the generated/file-backed route.
+
+## Route Resolution
+
+The worker resolves exactly one of `direct_mv_hevc`, `generated_mv_hevc`,
+`av1`, or `existing_artifact` before source inspection or conversion input.
+The resolved value is immutable for the job and is passed to stage planning,
+preflight, and execution.
+
+| Request or constraint | Resolved route |
+| --- | --- |
+| AV1 encode through stage 5 | `av1` |
+| Restart at stage 6 or later | `existing_artifact` |
+| Explicit generated MV-HEVC | `generated_mv_hevc` |
+| MV-HEVC stage 4 or 5 restart | `generated_mv_hevc` |
+| Reusable intermediates | `generated_mv_hevc` |
+| Software HEVC | `generated_mv_hevc` |
+| FX upscale | `generated_mv_hevc` |
+| FOV outside the direct helper's 1° through 180° range | `generated_mv_hevc` |
+| Eligible automatic MV-HEVC with supported helper | `direct_mv_hevc` |
+| Eligible automatic MV-HEVC with missing or valid unavailable helper | `generated_mv_hevc` |
+
+Capability-unavailable fallback uses automatic generated settings: 20 Mbps per
+eye and merge quality 75. It never applies inactive generated custom values
+from the profile. A malformed, contradictory, crashed, or timed-out capability
+probe fails preflight rather than disguising a broken helper as unsupported.
+
+Once the direct pipeline starts, encoder, normalizer, splitter, cancellation,
+or input failures remain direct-route failures. The worker never silently
+replays the job through another lossy route. The existing single-threaded
+splitter retry may replay the same direct route once.
+
+## Route Reporting
+
+Every job emits a `video_route_selected` log or a visible
+`video_route_fallback` warning. The same `video_route` object is included in
+the conversion result and preview artifact:
+
+```json
+{
+  "intent": "automatic",
+  "selected": "generated_mv_hevc",
+  "reason": "direct_capability_unavailable",
+  "eye_bitrate_mbps": 20,
+  "merge_quality": 75,
+  "fallback_reason": "stereo_mv_hevc_encode_unavailable",
+  "fallback_timing": "pre_input"
+}
+```
+
+Direct reports `bitrate_mbps`; generated reports `eye_bitrate_mbps` and
+`merge_quality`; AV1 reports `crf`; existing-artifact reports have no encode
+controls. Preview child jobs resolve capability before their duration
+inspection and use the same resolver and fallback report as full conversions.
+
+## Direct Stage Contract
+
+Direct MV-HEVC executes during existing stage 4,
+`create_left_right_files`, with this pipeline:
+
+```text
+optional source FFmpeg -> edge264_test -> FFmpeg geometry normalizer -> mv-hevc-encoder
+```
+
+It writes the existing `<name>_MV-HEVC.mov` artifact and omits stage 5,
+`combine_to_mv_hevc`. Generated MV-HEVC retains both existing eye filenames and
+stage 5. Stage numbers, restart boundaries, later audio/subtitle muxing, and
+final filenames remain unchanged.
+
+## Compatibility
+
+Protocol v9 requests and events are rejected with `protocol_mismatch` by v10
+peers. Historical v9 fixtures remain in the repository; v10 fixtures are the
+current shared Swift/Python contract. Persisted profile version 4 remains
+rollback-compatible and continues to retain inactive custom values locally;
+only the active route projection crosses the worker boundary.

--- a/docs/native-worker-protocol-v2.md
+++ b/docs/native-worker-protocol-v2.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v2
 
 > Historical contract. The native app and bundled worker now use
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 The native macOS app communicates with its bundled Python engine over a bounded
 JSON Lines (JSONL) protocol. Version 2 makes the source kind explicit and adds

--- a/docs/native-worker-protocol-v3.md
+++ b/docs/native-worker-protocol-v3.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v3
 
 > Historical protocol. Current title-aware behavior is documented in
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v3 adds immutable conversion-preview child jobs while preserving the
 single-request, single-process JSON Lines transport from v2. The native app and

--- a/docs/native-worker-protocol-v4.md
+++ b/docs/native-worker-protocol-v4.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v4
 
 > Historical protocol. Current audio-mode behavior is documented in
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v4 adds explicit 3D Blu-ray title discovery and selection while
 preserving the single-request, single-process transport from v3. The native app

--- a/docs/native-worker-protocol-v5.md
+++ b/docs/native-worker-protocol-v5.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v5
 
 > Historical protocol. Current audio-mode behavior is documented in
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v5 replaces the three legacy subtitle fields with one explicit,
 backend-neutral subtitle policy. The native app and bundled Python worker ship

--- a/docs/native-worker-protocol-v6.md
+++ b/docs/native-worker-protocol-v6.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v6
 
 > Historical protocol. The current contract is
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v6 replaces the flat audio fields with an exact nested audio policy.
 The native app and bundled Python worker ship atomically and both require

--- a/docs/native-worker-protocol-v7.md
+++ b/docs/native-worker-protocol-v7.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v7
 
 > Historical protocol. The current contract is
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v7 adds an explicit video output mode and software AV1 quality to the
 exact `encoding` schema. The native app and bundled Python worker ship

--- a/docs/native-worker-protocol-v8.md
+++ b/docs/native-worker-protocol-v8.md
@@ -1,7 +1,7 @@
 # Native Worker Protocol v8
 
 > Historical contract. Current clients must use
-> [Native Worker Protocol v9](native-worker-protocol-v9.md).
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
 
 Protocol v8 carries canonical structured observability through the worker JSONL
 stream. The native app and bundled Python worker ship atomically and both

--- a/docs/native-worker-protocol-v9.md
+++ b/docs/native-worker-protocol-v9.md
@@ -1,5 +1,8 @@
 # Native Worker Protocol v9
 
+> This historical protocol is superseded by
+> [Native Worker Protocol v10](native-worker-protocol-v10.md).
+
 Protocol v9 adds an explicit audio-language selection field. The native app
 defaults built-in and new profile options to preferred-only English, while an
 explicit all-languages selection and legacy profile migrations preserve the v8

--- a/macos/BluRayToVisionPro/Models/WorkerEvent.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerEvent.swift
@@ -1,20 +1,52 @@
 import Foundation
 
+struct VideoRouteReport: Decodable, Equatable {
+    let intent: String
+    let selected: String
+    let reason: String
+    let bitrateMbps: Int?
+    let eyeBitrateMbps: Int?
+    let mergeQuality: Int?
+    let crf: Int?
+    let fallbackReason: String?
+    let fallbackTiming: String?
+
+    enum CodingKeys: String, CodingKey {
+        case intent
+        case selected
+        case reason
+        case bitrateMbps = "bitrate_mbps"
+        case eyeBitrateMbps = "eye_bitrate_mbps"
+        case mergeQuality = "merge_quality"
+        case crf
+        case fallbackReason = "fallback_reason"
+        case fallbackTiming = "fallback_timing"
+    }
+}
+
 struct ConversionResult: Decodable, Equatable {
     let outputPath: String
     let durationSeconds: Double?
     let sizeBytes: Int64?
     let titleID: String?
+    let videoRoute: VideoRouteReport?
 
     var outputURL: URL {
         URL(fileURLWithPath: outputPath)
     }
 
-    init(outputPath: String, durationSeconds: Double? = nil, sizeBytes: Int64? = nil, titleID: String? = nil) {
+    init(
+        outputPath: String,
+        durationSeconds: Double? = nil,
+        sizeBytes: Int64? = nil,
+        titleID: String? = nil,
+        videoRoute: VideoRouteReport? = nil
+    ) {
         self.outputPath = outputPath
         self.durationSeconds = durationSeconds
         self.sizeBytes = sizeBytes
         self.titleID = titleID
+        self.videoRoute = videoRoute
     }
 
     enum CodingKeys: String, CodingKey {
@@ -22,6 +54,7 @@ struct ConversionResult: Decodable, Equatable {
         case durationSeconds = "duration_seconds"
         case sizeBytes = "size_bytes"
         case titleID = "title_id"
+        case videoRoute = "video_route"
     }
 }
 
@@ -36,6 +69,7 @@ struct PreviewArtifact: Decodable, Equatable {
     let durationSeconds: Double
     let sourceDurationSeconds: Double
     let titleID: String?
+    let videoRoute: VideoRouteReport?
 
     init(
         sourcePath: String,
@@ -47,7 +81,8 @@ struct PreviewArtifact: Decodable, Equatable {
         startSeconds: Double,
         durationSeconds: Double,
         sourceDurationSeconds: Double,
-        titleID: String? = nil
+        titleID: String? = nil,
+        videoRoute: VideoRouteReport? = nil
     ) {
         self.sourcePath = sourcePath
         self.destinationPath = destinationPath
@@ -59,6 +94,7 @@ struct PreviewArtifact: Decodable, Equatable {
         self.durationSeconds = durationSeconds
         self.sourceDurationSeconds = sourceDurationSeconds
         self.titleID = titleID
+        self.videoRoute = videoRoute
     }
 
     var outputURL: URL {
@@ -76,6 +112,7 @@ struct PreviewArtifact: Decodable, Equatable {
         case durationSeconds = "duration_seconds"
         case sourceDurationSeconds = "source_duration_seconds"
         case titleID = "title_id"
+        case videoRoute = "video_route"
     }
 }
 
@@ -323,6 +360,7 @@ struct WorkerEventPayload: Decodable, Equatable {
     let error: WorkerFailure?
     let decision: WorkerDecision?
     let observabilityEvent: ObservabilityEvent?
+    let videoRoute: VideoRouteReport?
 
     init(
         workerVersion: String? = nil,
@@ -340,7 +378,8 @@ struct WorkerEventPayload: Decodable, Equatable {
         previewResult: PreviewArtifact? = nil,
         error: WorkerFailure? = nil,
         decision: WorkerDecision? = nil,
-        observabilityEvent: ObservabilityEvent? = nil
+        observabilityEvent: ObservabilityEvent? = nil,
+        videoRoute: VideoRouteReport? = nil
     ) {
         self.workerVersion = workerVersion
         self.processGroupID = processGroupID
@@ -358,6 +397,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         self.error = error
         self.decision = decision
         self.observabilityEvent = observabilityEvent
+        self.videoRoute = videoRoute
     }
 
     init(from decoder: Decoder) throws {
@@ -383,6 +423,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         error = try container.decodeIfPresent(WorkerFailure.self, forKey: .error)
         decision = try container.decodeIfPresent(WorkerDecision.self, forKey: .decision)
         observabilityEvent = try container.decodeIfPresent(ObservabilityEvent.self, forKey: .observabilityEvent)
+        videoRoute = try container.decodeIfPresent(VideoRouteReport.self, forKey: .videoRoute)
     }
 
     var warningCode: String? { warning?.code }
@@ -411,6 +452,7 @@ struct WorkerEventPayload: Decodable, Equatable {
         case error
         case decision
         case observabilityEvent = "event"
+        case videoRoute = "video_route"
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WorkerJobSpec: Encodable, Equatable {
-    static let protocolVersion = 9
+    static let protocolVersion = 10
 
     struct Source: Encodable, Equatable {
         enum Kind: String, Encodable {
@@ -103,35 +103,114 @@ struct WorkerJobSpec: Encodable, Equatable {
             }
         }
 
+        struct Bitrate: Encodable, Equatable {
+            let mode: BitrateMode
+            let mbps: Int?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(mode, forKey: .mode)
+                if mode == .custom {
+                    guard let mbps else {
+                        throw EncodingError.invalidValue(
+                            self,
+                            EncodingError.Context(
+                                codingPath: encoder.codingPath,
+                                debugDescription: "Custom bitrate mode requires an Mbps value."
+                            )
+                        )
+                    }
+                    try container.encode(mbps, forKey: .mbps)
+                }
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case mode
+                case mbps
+            }
+        }
+
+        struct Video: Encodable, Equatable {
+            enum RouteIntent: String, Encodable, Equatable {
+                case automatic
+                case generated
+                case encode
+                case existingArtifact = "existing_artifact"
+            }
+
+            let mode: VideoOutputMode
+            let routeIntent: RouteIntent
+            let directBitrate: Bitrate?
+            let generatedEyeBitrate: Bitrate?
+            let generatedMergeQuality: Int?
+            let av1CRF: Int?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(mode, forKey: .mode)
+                try container.encode(routeIntent, forKey: .routeIntent)
+                try container.encodeIfPresent(directBitrate, forKey: .directBitrate)
+                try container.encodeIfPresent(generatedEyeBitrate, forKey: .generatedEyeBitrate)
+                try container.encodeIfPresent(generatedMergeQuality, forKey: .generatedMergeQuality)
+                try container.encodeIfPresent(av1CRF, forKey: .av1CRF)
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case mode
+                case routeIntent = "route_intent"
+                case directBitrate = "direct_bitrate"
+                case generatedEyeBitrate = "generated_eye_bitrate"
+                case generatedMergeQuality = "generated_merge_quality"
+                case av1CRF = "crf"
+            }
+        }
+
+        struct Upscale: Encodable, Equatable {
+            let enabled: Bool
+            let quality: Int?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(enabled, forKey: .enabled)
+                if enabled {
+                    guard let quality else {
+                        throw EncodingError.invalidValue(
+                            self,
+                            EncodingError.Context(
+                                codingPath: encoder.codingPath,
+                                debugDescription: "Enabled upscale mode requires a quality value."
+                            )
+                        )
+                    }
+                    try container.encode(quality, forKey: .quality)
+                }
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case enabled
+                case quality
+            }
+        }
+
         let audio: Audio
-        let videoMode: VideoOutputMode
-        let av1CRF: Int
-        let leftRightBitrate: Int
-        let linkQuality: Bool
-        let mvHEVCQuality: Int
-        let upscaleQuality: Int
+        let video: Video
+        let upscale: Upscale
         let fieldOfView: Int
         let frameRate: String
         let resolution: String
         let cropBlackBars: Bool
         let swapEyes: Bool
-        let fxUpscale: Bool
         let subtitles: Subtitles
 
         enum CodingKeys: String, CodingKey {
             case audio
-            case videoMode = "video_mode"
-            case av1CRF = "av1_crf"
-            case leftRightBitrate = "left_right_bitrate"
-            case linkQuality = "link_quality"
-            case mvHEVCQuality = "mv_hevc_quality"
-            case upscaleQuality = "upscale_quality"
+            case video
+            case upscale
             case fieldOfView = "fov"
             case frameRate = "frame_rate"
             case resolution
             case cropBlackBars = "crop_black_bars"
             case swapEyes = "swap_eyes"
-            case fxUpscale = "fx_upscale"
             case subtitles
         }
     }
@@ -212,8 +291,9 @@ struct WorkerJobSpec: Encodable, Equatable {
         source = Source(source: draft.source, titleID: Self.titleID(for: draft))
         destination = Destination(path: draft.destinationURL.path)
 
-        encoding = Self.encoding(from: draft.options.encoding)
-        job = Self.conversionJob(from: draft)
+        let job = Self.conversionJob(from: draft)
+        encoding = Self.encoding(from: draft.options.encoding, job: job)
+        self.job = job
         preview = nil
     }
 
@@ -229,10 +309,8 @@ struct WorkerJobSpec: Encodable, Equatable {
         operation = "preview_source"
         source = Source(source: conversion.source, titleID: Self.titleID(for: conversion))
         destination = Destination(path: destinationURL.path)
-        encoding = Self.encoding(from: conversion.options.encoding)
-
         let jobOptions = conversion.options.job
-        job = Job(
+        let job = Job(
             startStage: 1,
             keepFiles: false,
             overwrite: true,
@@ -242,6 +320,14 @@ struct WorkerJobSpec: Encodable, Equatable {
             outputCommands: jobOptions.outputCommands,
             keepAwake: jobOptions.keepAwake
         )
+        encoding = Self.encoding(
+            from: conversion.options.encoding,
+            job: job,
+            routeStartStage: jobOptions.startStage.rawValue,
+            routeKeepFiles: jobOptions.intermediatePolicy.createsReusableArtifacts,
+            allowsExistingArtifact: false
+        )
+        self.job = job
         preview = Preview(
             parentJobID: previewDraft.parentJobID,
             position: previewDraft.samplePosition.rawValue,
@@ -262,7 +348,13 @@ struct WorkerJobSpec: Encodable, Equatable {
         try container.encodeIfPresent(preview, forKey: .preview)
     }
 
-    private static func encoding(from options: EncodingOptions) -> Encoding {
+    private static func encoding(
+        from options: EncodingOptions,
+        job: Job,
+        routeStartStage: Int? = nil,
+        routeKeepFiles: Bool? = nil,
+        allowsExistingArtifact: Bool = true
+    ) -> Encoding {
         let isAV1Stereo = options.videoOutputMode == .av1Stereo
         return Encoding(
             audio: Encoding.Audio(
@@ -270,20 +362,100 @@ struct WorkerJobSpec: Encodable, Equatable {
                 bitrate: options.audioBitrate,
                 preferredLanguage: audioPreferredLanguage(from: options.audioLanguages)
             ),
-            videoMode: options.videoOutputMode,
-            av1CRF: options.av1CRF,
-            leftRightBitrate: options.generatedEyeCustomBitrateMbps,
-            linkQuality: options.mvHEVC.linkGeneratedAndUpscaleQuality,
-            mvHEVCQuality: options.mvHEVC.generatedMergeQuality,
-            upscaleQuality: options.upscaleQuality,
+            video: videoOptions(
+                from: options,
+                job: job,
+                routeStartStage: routeStartStage,
+                routeKeepFiles: routeKeepFiles,
+                allowsExistingArtifact: allowsExistingArtifact
+            ),
+            upscale: Encoding.Upscale(
+                enabled: isAV1Stereo ? false : options.upscaleEnabled,
+                quality: isAV1Stereo || !options.upscaleEnabled ? nil : options.upscaleQuality
+            ),
             fieldOfView: options.fieldOfView,
             frameRate: options.frameRateOverride,
             resolution: isAV1Stereo ? "" : options.resolutionOverride,
             cropBlackBars: options.cropBlackBars,
             swapEyes: options.swapEyes,
-            fxUpscale: isAV1Stereo ? false : options.upscaleEnabled,
             subtitles: subtitleOptions(from: options)
         )
+    }
+
+    private static func videoOptions(
+        from options: EncodingOptions,
+        job: Job,
+        routeStartStage: Int?,
+        routeKeepFiles: Bool?,
+        allowsExistingArtifact: Bool
+    ) -> Encoding.Video {
+        let requestedStartStage = routeStartStage ?? job.startStage
+        let keepsReusableArtifacts = routeKeepFiles ?? job.keepFiles
+        if options.videoOutputMode == .av1Stereo {
+            if allowsExistingArtifact, requestedStartStage > ConversionStage.combineToMVHEVC.rawValue {
+                return Encoding.Video(
+                    mode: .av1Stereo,
+                    routeIntent: .existingArtifact,
+                    directBitrate: nil,
+                    generatedEyeBitrate: nil,
+                    generatedMergeQuality: nil,
+                    av1CRF: nil
+                )
+            }
+            return Encoding.Video(
+                mode: .av1Stereo,
+                routeIntent: .encode,
+                directBitrate: nil,
+                generatedEyeBitrate: nil,
+                generatedMergeQuality: nil,
+                av1CRF: options.av1CRF
+            )
+        }
+
+        if allowsExistingArtifact, requestedStartStage > ConversionStage.combineToMVHEVC.rawValue {
+            return Encoding.Video(
+                mode: .mvHEVC,
+                routeIntent: .existingArtifact,
+                directBitrate: nil,
+                generatedEyeBitrate: nil,
+                generatedMergeQuality: nil,
+                av1CRF: nil
+            )
+        }
+
+        let requiresGeneratedRoute = requestedStartStage >= ConversionStage.createLeftRightFiles.rawValue
+            || keepsReusableArtifacts
+            || job.softwareEncoder
+            || options.upscaleEnabled
+            || !(1 ... 180).contains(options.fieldOfView)
+        if requiresGeneratedRoute {
+            return Encoding.Video(
+                mode: .mvHEVC,
+                routeIntent: .generated,
+                directBitrate: nil,
+                generatedEyeBitrate: bitrate(from: options.mvHEVC.generatedEyeBitrate),
+                generatedMergeQuality: options.mvHEVC.generatedMergeQuality,
+                av1CRF: nil
+            )
+        }
+
+        return Encoding.Video(
+            mode: .mvHEVC,
+            routeIntent: .automatic,
+            directBitrate: bitrate(from: options.mvHEVC.directFinalBitrate),
+            generatedEyeBitrate: nil,
+            generatedMergeQuality: nil,
+            av1CRF: nil
+        )
+    }
+
+    private static func bitrate(from preference: BitratePreference) -> Encoding.Bitrate {
+        switch preference.mode {
+        case .automatic:
+            Encoding.Bitrate(mode: .automatic, mbps: nil)
+        case .custom:
+            Encoding.Bitrate(mode: .custom, mbps: preference.customMbps)
+        }
     }
 
     private static func audioMode(from handling: AudioHandling) -> Encoding.Audio.Mode {

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -498,7 +498,7 @@ final class ConversionWorkflowTests: XCTestCase {
 
         XCTAssertEqual(spec.source.path, "/Sources/Feature.mkv")
         XCTAssertEqual(spec.destination?.path, "/Movies")
-        XCTAssertEqual(spec.encoding?.mvHEVCQuality, 92)
+        XCTAssertEqual(spec.encoding?.video.generatedMergeQuality, 92)
         XCTAssertEqual(spec.encoding?.audio.bitrate, 512)
         XCTAssertTrue(spec.job?.keepFiles == true)
         XCTAssertTrue(spec.job?.overwrite == true)
@@ -565,8 +565,8 @@ final class ConversionWorkflowTests: XCTestCase {
             options: ConversionOptions(encoding: encoding)
         )
         let spec = WorkerJobSpec(draft: draft)
-        XCTAssertEqual(spec.encoding?.mvHEVCQuality, 80)
-        XCTAssertTrue(spec.encoding?.fxUpscale == true)
+        XCTAssertEqual(spec.encoding?.video.generatedMergeQuality, 80)
+        XCTAssertTrue(spec.encoding?.upscale.enabled == true)
         XCTAssertEqual(spec.encoding?.fieldOfView, 120)
         XCTAssertEqual(
             spec.encoding?.audio,
@@ -590,10 +590,10 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let workerEncoding = WorkerJobSpec(draft: draft).encoding
 
-        XCTAssertEqual(workerEncoding?.videoMode, .av1Stereo)
-        XCTAssertEqual(workerEncoding?.av1CRF, 28)
+        XCTAssertEqual(workerEncoding?.video.mode, .av1Stereo)
+        XCTAssertEqual(workerEncoding?.video.av1CRF, 28)
         XCTAssertEqual(workerEncoding?.resolution, "")
-        XCTAssertFalse(workerEncoding?.fxUpscale == true)
+        XCTAssertFalse(workerEncoding?.upscale.enabled == true)
         XCTAssertTrue(encoding.upscaleEnabled)
         XCTAssertEqual(encoding.resolutionOverride, "3840x2160")
     }
@@ -670,7 +670,7 @@ final class ConversionWorkflowTests: XCTestCase {
         }
     }
 
-    func testAutomaticGeneratedEyeIntentKeepsProtocolV9PayloadUnchanged() {
+    func testAutomaticRouteOmitsInactiveGeneratedEyeBitrate() {
         var encoding = EncodingOptions()
         encoding.mvHEVC.generatedEyeBitrate = BitratePreference(mode: .automatic, customMbps: 37)
         let draft = ConversionDraft(
@@ -681,7 +681,10 @@ final class ConversionWorkflowTests: XCTestCase {
             options: ConversionOptions(encoding: encoding)
         )
 
-        XCTAssertEqual(WorkerJobSpec(draft: draft).encoding?.leftRightBitrate, 37)
+        let video = WorkerJobSpec(draft: draft).encoding?.video
+        XCTAssertEqual(video?.routeIntent, .automatic)
+        XCTAssertNil(video?.generatedEyeBitrate)
+        XCTAssertEqual(video?.directBitrate?.mode, .automatic)
     }
 
     func testMakeMKVRecoveryBuildsFreshStageTwoDraft() throws {
@@ -778,9 +781,18 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(json["protocol_version"] as? Int, WorkerJobSpec.protocolVersion)
         XCTAssertEqual(source["kind"] as? String, "direct_file")
         XCTAssertEqual((json["destination"] as? [String: Any])?["path"] as? String, "/Movies")
-        XCTAssertEqual(encoding["mv_hevc_quality"] as? Int, 75)
-        XCTAssertEqual(encoding["video_mode"] as? String, "mv_hevc")
-        XCTAssertEqual(encoding["av1_crf"] as? Int, 32)
+        let video = try XCTUnwrap(encoding["video"] as? [String: Any])
+        XCTAssertEqual(video["mode"] as? String, "mv_hevc")
+        XCTAssertEqual(video["route_intent"] as? String, "automatic")
+        let directBitrate = try XCTUnwrap(video["direct_bitrate"] as? [String: Any])
+        XCTAssertEqual(directBitrate["mode"] as? String, "automatic")
+        XCTAssertNil(directBitrate["mbps"])
+        XCTAssertNil(video["generated_eye_bitrate"])
+        XCTAssertNil(video["generated_merge_quality"])
+        XCTAssertNil(video["crf"])
+        let upscale = try XCTUnwrap(encoding["upscale"] as? [String: Any])
+        XCTAssertEqual(upscale["enabled"] as? Bool, false)
+        XCTAssertNil(upscale["quality"])
         let audio = try XCTUnwrap(encoding["audio"] as? [String: Any])
         XCTAssertEqual(audio["mode"] as? String, "automatic")
         XCTAssertEqual(audio["bitrate"] as? Int, 384)
@@ -794,6 +806,148 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(job["start_stage"] as? Int, 1)
         XCTAssertNil(job["output_length"])
         XCTAssertNil(json["conversion_settings"])
+    }
+
+    func testCustomDirectBitrateIsTheOnlyMVHEVCBitrateOnAutomaticRoute() throws {
+        var options = ConversionOptions()
+        options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 37)
+        options.encoding.mvHEVC.generatedEyeBitrate = BitratePreference(mode: .custom, customMbps: 42)
+        options.encoding.mvHEVC.generatedMergeQuality = 88
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(WorkerJobSpec(draft: draft)))
+                as? [String: Any]
+        )
+        let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        let video = try XCTUnwrap(encoding["video"] as? [String: Any])
+        let bitrate = try XCTUnwrap(video["direct_bitrate"] as? [String: Any])
+
+        XCTAssertEqual(video["route_intent"] as? String, "automatic")
+        XCTAssertEqual(bitrate["mode"] as? String, "custom")
+        XCTAssertEqual(bitrate["mbps"] as? Int, 37)
+        XCTAssertNil(video["generated_eye_bitrate"])
+        XCTAssertNil(video["generated_merge_quality"])
+    }
+
+    func testOutOfRangeDirectFOVProjectsGeneratedRoute() throws {
+        for fieldOfView in [0, 181] {
+            var options = ConversionOptions()
+            options.encoding.fieldOfView = fieldOfView
+            let draft = ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+                sourceDetails: nil,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+                options: options
+            )
+
+            let video = try XCTUnwrap(WorkerJobSpec(draft: draft).encoding?.video)
+
+            XCTAssertEqual(video.routeIntent, .generated)
+            XCTAssertNil(video.directBitrate)
+            XCTAssertNotNil(video.generatedEyeBitrate)
+        }
+    }
+
+    func testCustomBitrateWithoutValueFailsWireEncoding() {
+        let bitrate = WorkerJobSpec.Encoding.Bitrate(mode: .custom, mbps: nil)
+
+        XCTAssertThrowsError(try JSONEncoder().encode(bitrate))
+    }
+
+    func testReusableIntermediatesSendOnlyGeneratedMVHEVCSettings() throws {
+        var options = ConversionOptions()
+        options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 37)
+        options.encoding.mvHEVC.generatedEyeBitrate = BitratePreference(mode: .custom, customMbps: 42)
+        options.encoding.mvHEVC.generatedMergeQuality = 88
+        options.job.intermediatePolicy = .reusable
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(WorkerJobSpec(draft: draft)))
+                as? [String: Any]
+        )
+        let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        let video = try XCTUnwrap(encoding["video"] as? [String: Any])
+        let bitrate = try XCTUnwrap(video["generated_eye_bitrate"] as? [String: Any])
+
+        XCTAssertEqual(video["route_intent"] as? String, "generated")
+        XCTAssertEqual(bitrate["mode"] as? String, "custom")
+        XCTAssertEqual(bitrate["mbps"] as? Int, 42)
+        XCTAssertEqual(video["generated_merge_quality"] as? Int, 88)
+        XCTAssertNil(video["direct_bitrate"])
+    }
+
+    func testPreviewPreservesGeneratedRouteIntentWithoutKeepingArtifacts() throws {
+        var options = ConversionOptions()
+        options.job.intermediatePolicy = .reusable
+        let conversion = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+        let preview = try XCTUnwrap(
+            PreviewDraft(
+                parentJobID: UUID(),
+                conversion: conversion,
+                outputLength: .oneMinute,
+                samplePosition: .middle
+            )
+        )
+
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(
+                    WorkerJobSpec(previewDraft: preview, destinationURL: URL(fileURLWithPath: "/tmp/preview"))
+                )
+            ) as? [String: Any]
+        )
+        let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        let video = try XCTUnwrap(encoding["video"] as? [String: Any])
+        let bitrate = try XCTUnwrap(video["generated_eye_bitrate"] as? [String: Any])
+        let job = try XCTUnwrap(json["job"] as? [String: Any])
+
+        XCTAssertEqual(video["route_intent"] as? String, "generated")
+        XCTAssertEqual(bitrate["mode"] as? String, "automatic")
+        XCTAssertNil(bitrate["mbps"])
+        XCTAssertEqual(job["keep_files"] as? Bool, false)
+    }
+
+    func testLaterRestartSendsExistingArtifactWithoutEncodeControls() throws {
+        var options = ConversionOptions()
+        options.job.startStage = .upscaleVideo
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(WorkerJobSpec(draft: draft)))
+                as? [String: Any]
+        )
+        let encoding = try XCTUnwrap(json["encoding"] as? [String: Any])
+        let video = try XCTUnwrap(encoding["video"] as? [String: Any])
+
+        XCTAssertEqual(Set(video.keys), ["mode", "route_intent"])
+        XCTAssertEqual(video["route_intent"] as? String, "existing_artifact")
     }
 
     func testConversionJobSpecUsesCanonicalDutchAndNullsLanguageWhenOff() throws {
@@ -922,7 +1076,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(changedEncoding.audio, originalEncoding.audio)
     }
 
-    func testConversionJobSpecMatchesSharedV9WorkerFixture() throws {
+    func testConversionJobSpecMatchesSharedV10WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let draft = ConversionDraft(
@@ -938,7 +1092,53 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_convert_v9.json")
+            with: sharedFixtureData(named: "native_worker_convert_v10.json")
+        ) as? NSDictionary
+
+        XCTAssertEqual(encoded, fixture)
+    }
+
+    func testGeneratedRouteJobSpecMatchesSharedV10WorkerFixture() throws {
+        var options = ConversionOptions()
+        options.encoding.audioHandling = .automatic
+        options.job.intermediatePolicy = .reusable
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+        let spec = WorkerJobSpec(
+            draft: draft,
+            jobID: try XCTUnwrap(UUID(uuidString: "33333333-3333-4333-8333-333333333333"))
+        )
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
+        let fixture = try JSONSerialization.jsonObject(
+            with: sharedFixtureData(named: "native_worker_convert_generated_v10.json")
+        ) as? NSDictionary
+
+        XCTAssertEqual(encoded, fixture)
+    }
+
+    func testExistingArtifactJobSpecMatchesSharedV10WorkerFixture() throws {
+        var options = ConversionOptions()
+        options.encoding.audioHandling = .automatic
+        options.job.startStage = .upscaleVideo
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+        let spec = WorkerJobSpec(
+            draft: draft,
+            jobID: try XCTUnwrap(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        )
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
+        let fixture = try JSONSerialization.jsonObject(
+            with: sharedFixtureData(named: "native_worker_convert_existing_artifact_v10.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
@@ -969,7 +1169,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(source["title_id"] as? String, "provider:playlist-01005")
     }
 
-    func testPreviewJobSpecMatchesSharedV9WorkerFixture() throws {
+    func testPreviewJobSpecMatchesSharedV10WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let conversion = ConversionDraft(
@@ -997,13 +1197,13 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_preview_v9.json")
+            with: sharedFixtureData(named: "native_worker_preview_v10.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)
     }
 
-    func testPhysicalDiscJobSpecMatchesSharedV9WorkerFixture() throws {
+    func testPhysicalDiscJobSpecMatchesSharedV10WorkerFixture() throws {
         var options = ConversionOptions()
         options.encoding.audioHandling = .automatic
         let draft = ConversionDraft(
@@ -1032,7 +1232,7 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(spec)) as? NSDictionary
         let fixture = try JSONSerialization.jsonObject(
-            with: sharedFixtureData(named: "native_worker_convert_physical_disc_v9.json")
+            with: sharedFixtureData(named: "native_worker_convert_physical_disc_v10.json")
         ) as? NSDictionary
 
         XCTAssertEqual(encoded, fixture)

--- a/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
@@ -131,6 +131,7 @@ final class PreviewViewModelTests: XCTestCase {
         let sourceURL = URL(fileURLWithPath: "/tmp/movie.mkv")
         var options = ConversionOptions()
         options.encoding.mvHEVC.generatedMergeQuality = 82
+        options.job.intermediatePolicy = .reusable
         let conversion = ConversionDraft(
             source: ConversionSource(kind: .matroska, url: sourceURL),
             sourceDetails: nil,
@@ -152,7 +153,7 @@ final class PreviewViewModelTests: XCTestCase {
             destinationURL: URL(fileURLWithPath: "/tmp/preview", isDirectory: true)
         )
 
-        XCTAssertEqual(spec.encoding?.mvHEVCQuality, 82)
+        XCTAssertEqual(spec.encoding?.video.generatedMergeQuality, 82)
         XCTAssertEqual(spec.preview?.position, "end")
         XCTAssertEqual(spec.preview?.durationSeconds, 60)
         XCTAssertEqual(options.encoding.mvHEVC.generatedMergeQuality, 20)

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -102,10 +102,10 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertNil(state.progress)
     }
 
-    func testSharedV9ProgressFixtureDecodes() throws {
+    func testSharedV10ProgressFixtureDecodes() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_stage_started_progress_v9.json")
+            from: sharedFixtureData(named: "native_worker_stage_started_progress_v10.json")
         )
 
         XCTAssertEqual(event.payload.progress, WorkerProgress(currentStage: 1, totalStages: 2, stageFraction: nil))
@@ -130,7 +130,7 @@ final class WorkerLifecycleTests: XCTestCase {
     func testStructuredAudioFallbackWarningExposesCodecsAndActualAction() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_audio_fallback_warning_v9.json")
+            from: sharedFixtureData(named: "native_worker_audio_fallback_warning_v10.json")
         )
 
         XCTAssertEqual(event.payload.warningCode, "audio_automatic_fallback_to_aac")
@@ -151,7 +151,7 @@ final class WorkerLifecycleTests: XCTestCase {
     func testStructuredAudioLanguageFallbackWarningRemainsVisibleAndActionable() throws {
         let event = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_audio_language_fallback_warning_v9.json")
+            from: sharedFixtureData(named: "native_worker_audio_language_fallback_warning_v10.json")
         )
 
         XCTAssertEqual(event.payload.warningCode, "audio_language_fallback")
@@ -365,10 +365,10 @@ final class WorkerLifecycleTests: XCTestCase {
         }
     }
 
-    func testDecodesAndAppliesSharedV9ConversionCompletionFixture() throws {
+    func testDecodesAndAppliesSharedV10ConversionCompletionFixture() throws {
         let completed = try JSONDecoder().decode(
             WorkerEvent.self,
-            from: sharedFixtureData(named: "native_worker_conversion_completed_v9.json")
+            from: sharedFixtureData(named: "native_worker_conversion_completed_v10.json")
         )
         let fixtureJobID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
         var state = WorkerLifecycleState()
@@ -382,6 +382,8 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(state.phase, .completed)
         XCTAssertEqual(state.conversionResult?.outputPath, "/tmp/output/movie_AVP.mov")
         XCTAssertEqual(state.conversionResult?.sizeBytes, 1024)
+        XCTAssertEqual(state.conversionResult?.videoRoute?.selected, "direct_mv_hevc")
+        XCTAssertEqual(state.conversionResult?.videoRoute?.bitrateMbps, 40)
     }
 
     func testRejectsSequenceGap() throws {

--- a/macos/README.md
+++ b/macos/README.md
@@ -53,7 +53,7 @@ for dyld library validation; Developer ID packages retain Hardened Runtime. The
 package gate launches the signed Swift host with `--startup-smoke`, smokes the
 embedded conversion worker, and then performs strict deep signature validation.
 
-The app and engine use worker protocol v9. Audio and subtitle language controls
+The app and engine use worker protocol v10. Audio and subtitle language controls
 are independent: built-in and new profile options default to preferred-only
 English audio, while existing version-4 custom choices remain unchanged and
 version-1 through version-3 profiles migrate to all-languages behavior.
@@ -61,13 +61,19 @@ Profile document version 4 also stores explicit MV-HEVC bitrate intent while
 continuing to write the legacy quality, eye-bitrate, and linkage keys for one
 stable rollback window. Legacy eye bitrate 20 migrates to Automatic with 20
 preserved as the inactive custom value; other legacy values migrate to Custom.
+Protocol v10 projects only the active route controls. Eligible automatic
+MV-HEVC jobs use the packaged direct encoder during stage 4, while reusable
+intermediates, software encoding, upscaling, and restart workflows retain the
+generated/file-backed route. A valid unavailable capability result visibly
+falls back before media inspection, and preview child jobs report the same
+resolved route contract.
 Preferred-only audio keeps every metadata-language match and visibly falls
 back to the source-default or first audio stream when no match exists. MKV,
 MTS, M2TS, and ISO
 sources can create an isolated beginning, middle, or end preview child job with
 the current resolved profile. The finalized result is leased from the preview
 cache while the embedded AVPlayer is open and removed when the preview closes.
-See `docs/native-worker-protocol-v9.md` for the request, event, and ownership
+See `docs/native-worker-protocol-v10.md` for the request, event, and ownership
 contract.
 
 The application targets Apple Silicon macOS 26 or later and uses the pinned

--- a/scripts/qualify_mv_hevc_quality_match.py
+++ b/scripts/qualify_mv_hevc_quality_match.py
@@ -186,9 +186,10 @@ def search_quality_matched_bitrate(
     *,
     iterations: int,
     quality_margin: float,
+    maximum_bitrate_mbps: float | None = None,
 ) -> tuple[float, list[RunRecord]]:
     lower_bitrate = max(0.05, options.bitrate_mbps / 80)
-    upper_bitrate = options.bitrate_mbps
+    upper_bitrate = maximum_bitrate_mbps or options.bitrate_mbps
     required_ssim = target_ssim + quality_margin
     candidates: list[RunRecord] = []
 
@@ -204,7 +205,11 @@ def search_quality_matched_bitrate(
     )
     candidates.append(upper_record)
     if float(upper_record["min_same_eye_ssim"]) < required_ssim:
-        raise QualificationFailure("Configured direct bitrate cannot match the current path's decoded quality.")
+        raise QualificationFailure(
+            "Configured direct bitrate cannot match the current path's decoded quality: "
+            f"{float(upper_record['min_same_eye_ssim']):.6f} < required {required_ssim:.6f} "
+            f"at {upper_bitrate:.6f} Mbps."
+        )
 
     best_record = upper_record
     for candidate_index in range(1, iterations + 1):
@@ -237,6 +242,7 @@ def qualify_quality_match(
     runs: int,
     search_iterations: int,
     quality_margin: float,
+    direct_max_bitrate_mbps: float | None = None,
 ) -> dict[str, object]:
     if platform.system() != "Darwin" or platform.machine() != "arm64":
         raise QualificationFailure("Quality-matched MV-HEVC qualification requires macOS arm64.")
@@ -290,6 +296,7 @@ def qualify_quality_match(
             current_target_ssim,
             iterations=search_iterations,
             quality_margin=quality_margin,
+            maximum_bitrate_mbps=direct_max_bitrate_mbps,
         )
 
         direct_runs: list[RunRecord] = []
@@ -353,6 +360,7 @@ def qualify_quality_match(
                 "run_count": runs,
                 "search_candidates": search_candidates,
                 "search_iterations": search_iterations,
+                "search_maximum_bitrate_mbps": direct_max_bitrate_mbps or options.bitrate_mbps,
                 "quality_metric": "minimum decoded same-eye SSIM",
             },
             "schema_version": 2,
@@ -379,6 +387,7 @@ def main() -> int:
     parser.add_argument("--duration", type=int, default=2)
     parser.add_argument("--disparity-pixels", type=int, default=16)
     parser.add_argument("--bitrate-mbps", type=float, default=4.0)
+    parser.add_argument("--direct-max-bitrate-mbps", type=float)
     parser.add_argument("--runs", type=int, default=DEFAULT_RUNS)
     parser.add_argument("--search-iterations", type=int, default=DEFAULT_SEARCH_ITERATIONS)
     parser.add_argument("--quality-margin", type=float, default=DEFAULT_QUALITY_MARGIN)
@@ -393,6 +402,8 @@ def main() -> int:
         parser.error("disparity pixels must be a non-negative even integer")
     if args.bitrate_mbps <= 0:
         parser.error("bitrate must be positive")
+    if args.direct_max_bitrate_mbps is not None and args.direct_max_bitrate_mbps <= 0:
+        parser.error("direct maximum bitrate must be positive")
     if args.runs <= 0 or args.runs > 10:
         parser.error("runs must be between 1 and 10")
     if args.search_iterations <= 0 or args.search_iterations > 12:
@@ -416,6 +427,7 @@ def main() -> int:
             runs=args.runs,
             search_iterations=args.search_iterations,
             quality_margin=args.quality_margin,
+            direct_max_bitrate_mbps=args.direct_max_bitrate_mbps,
         )
     except QualificationFailure as error:
         parser.exit(1, f"error: {error}\n")

--- a/tests/fixtures/native_worker_audio_fallback_warning_v10.json
+++ b/tests/fixtures/native_worker_audio_fallback_warning_v10.json
@@ -1,0 +1,28 @@
+{
+  "protocol_version": 10,
+  "type": "warning",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "transcode_audio",
+    "message": "Automatic audio selected AAC conversion because one or more selected tracks are not qualified AAC.",
+    "code": "audio_automatic_fallback_to_aac",
+    "audio_mode": "automatic",
+    "action": "convert_aac",
+    "source_codecs": [
+      "aac",
+      "ac3"
+    ],
+    "unqualified_streams": [
+      {
+        "index": 1,
+        "codec": "ac3",
+        "profile": null,
+        "sample_rate": 48000,
+        "channels": 6,
+        "channel_layout": "5.1(side)",
+        "reason": "codec_not_allowed"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/native_worker_audio_language_fallback_warning_v10.json
+++ b/tests/fixtures/native_worker_audio_language_fallback_warning_v10.json
@@ -1,0 +1,17 @@
+{
+  "protocol_version": 10,
+  "type": "warning",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "transcode_audio",
+    "message": "No audio tracks matched the preferred language Japanese (jpn). Keeping the source-default audio track (English (eng)) instead.",
+    "code": "audio_language_fallback",
+    "preferred_language": "jpn",
+    "selected_language": "eng",
+    "selected_stream_index": 3,
+    "selected_audio_position": 1,
+    "fallback_reason": "source_default",
+    "action": "keep_source_default_audio"
+  }
+}

--- a/tests/fixtures/native_worker_conversion_completed_v10.json
+++ b/tests/fixtures/native_worker_conversion_completed_v10.json
@@ -1,0 +1,20 @@
+{
+  "protocol_version": 10,
+  "type": "job.completed",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 2,
+  "payload": {
+    "conversion_result": {
+      "source_path": "/tmp/movie.mkv",
+      "destination_path": "/tmp/output",
+      "output_path": "/tmp/output/movie_AVP.mov",
+      "size_bytes": 1024,
+      "video_route": {
+        "intent": "automatic",
+        "selected": "direct_mv_hevc",
+        "reason": "direct_eligible",
+        "bitrate_mbps": 40
+      }
+    }
+  }
+}

--- a/tests/fixtures/native_worker_convert_existing_artifact_v10.json
+++ b/tests/fixtures/native_worker_convert_existing_artifact_v10.json
@@ -1,0 +1,46 @@
+{
+  "protocol_version": 10,
+  "type": "job.start",
+  "job_id": "44444444-4444-4444-8444-444444444444",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384,
+      "preferred_language": "eng"
+    },
+    "video": {
+      "mode": "mv_hevc",
+      "route_intent": "existing_artifact"
+    },
+    "upscale": {
+      "enabled": false
+    },
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 6,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_convert_generated_v10.json
+++ b/tests/fixtures/native_worker_convert_generated_v10.json
@@ -1,0 +1,50 @@
+{
+  "protocol_version": 10,
+  "type": "job.start",
+  "job_id": "33333333-3333-4333-8333-333333333333",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384,
+      "preferred_language": "eng"
+    },
+    "video": {
+      "mode": "mv_hevc",
+      "route_intent": "generated",
+      "generated_eye_bitrate": {
+        "mode": "automatic"
+      },
+      "generated_merge_quality": 75
+    },
+    "upscale": {
+      "enabled": false
+    },
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": true,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_convert_physical_disc_v10.json
+++ b/tests/fixtures/native_worker_convert_physical_disc_v10.json
@@ -1,0 +1,50 @@
+{
+  "protocol_version": 10,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "physical_disc",
+    "path": "/dev/disk9",
+    "title_id": "makemkv:0"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384,
+      "preferred_language": "eng"
+    },
+    "video": {
+      "mode": "mv_hevc",
+      "route_intent": "automatic",
+      "direct_bitrate": {
+        "mode": "automatic"
+      }
+    },
+    "upscale": {
+      "enabled": false
+    },
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_convert_v10.json
+++ b/tests/fixtures/native_worker_convert_v10.json
@@ -1,0 +1,49 @@
+{
+  "protocol_version": 10,
+  "type": "job.start",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "operation": "convert_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/output"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384,
+      "preferred_language": "eng"
+    },
+    "video": {
+      "mode": "mv_hevc",
+      "route_intent": "automatic",
+      "direct_bitrate": {
+        "mode": "automatic"
+      }
+    },
+    "upscale": {
+      "enabled": false
+    },
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": false,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  }
+}

--- a/tests/fixtures/native_worker_preview_v10.json
+++ b/tests/fixtures/native_worker_preview_v10.json
@@ -1,0 +1,54 @@
+{
+  "protocol_version": 10,
+  "type": "job.start",
+  "job_id": "22222222-2222-4222-8222-222222222222",
+  "operation": "preview_source",
+  "source": {
+    "kind": "direct_file",
+    "path": "/tmp/movie.mkv"
+  },
+  "destination": {
+    "path": "/tmp/previews/22222222-2222-4222-8222-222222222222"
+  },
+  "encoding": {
+    "audio": {
+      "mode": "automatic",
+      "bitrate": 384,
+      "preferred_language": "eng"
+    },
+    "video": {
+      "mode": "mv_hevc",
+      "route_intent": "automatic",
+      "direct_bitrate": {
+        "mode": "automatic"
+      }
+    },
+    "upscale": {
+      "enabled": false
+    },
+    "fov": 90,
+    "frame_rate": "",
+    "resolution": "",
+    "crop_black_bars": false,
+    "swap_eyes": false,
+    "subtitles": {
+      "mode": "preferred_plus_others",
+      "preferred_language": "eng"
+    }
+  },
+  "job": {
+    "start_stage": 1,
+    "keep_files": false,
+    "overwrite": true,
+    "remove_original": false,
+    "continue_on_error": false,
+    "software_encoder": false,
+    "output_commands": false,
+    "keep_awake": true
+  },
+  "preview": {
+    "parent_job_id": "11111111-1111-4111-8111-111111111111",
+    "position": "middle",
+    "duration_seconds": 60
+  }
+}

--- a/tests/fixtures/native_worker_stage_started_progress_v10.json
+++ b/tests/fixtures/native_worker_stage_started_progress_v10.json
@@ -1,0 +1,14 @@
+{
+  "protocol_version": 10,
+  "type": "stage.started",
+  "job_id": "11111111-1111-4111-8111-111111111111",
+  "sequence": 0,
+  "payload": {
+    "stage": "configure",
+    "message": "Preparing conversion settings",
+    "progress": {
+      "current_stage": 1,
+      "total_stages": 2
+    }
+  }
+}

--- a/tests/test_direct_mv_hevc_route_integration.py
+++ b/tests/test_direct_mv_hevc_route_integration.py
@@ -1,0 +1,112 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from bd_to_avp.modules import video
+from bd_to_avp.modules.disc import DiscInfo
+from bd_to_avp.modules.video_route import probe_direct_mv_hevc_capability
+from scripts.qualify_direct_mv_hevc import DIRECT_REQUIRED_BOX_TYPES, box_types
+from scripts.verify_apple_media import verify_apple_media_compatible
+
+
+class DirectMVHEVCRouteIntegrationTests(unittest.TestCase):
+    def test_real_normalizer_and_encoder_pipeline_produces_mv_hevc(self) -> None:
+        capability = probe_direct_mv_hevc_capability()
+        if not capability.supported:
+            self.skipTest(f"Direct MV-HEVC helper is unavailable: {capability.reason}")
+
+        with tempfile.TemporaryDirectory(prefix="direct-route-integration-") as temporary_directory:
+            root = Path(temporary_directory)
+            y4m_path = root / "stereo.y4m"
+            source_path = root / "source.264"
+            splitter_path = root / "fake-edge264"
+            output_path = root / "Sample_MV-HEVC.mov"
+            source_path.write_bytes(b"mvc")
+            subprocess.run(
+                [
+                    video.config.FFMPEG_PATH,
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "testsrc2=size=320x180:rate=24",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "testsrc2=size=320x180:rate=24,negate",
+                    "-filter_complex",
+                    "[0:v][1:v]hstack=inputs=2,format=yuv420p",
+                    "-t",
+                    "2",
+                    "-f",
+                    "yuv4mpegpipe",
+                    "-y",
+                    y4m_path,
+                ],
+                check=True,
+            )
+            splitter_path.write_text(
+                f"#!{sys.executable}\n"
+                "import sys\n"
+                "from pathlib import Path\n"
+                f"sys.stdout.buffer.write(Path({str(y4m_path)!r}).read_bytes())\n",
+                encoding="utf-8",
+            )
+            splitter_path.chmod(0o755)
+            disc_info = DiscInfo(
+                name="Sample",
+                resolution="320x180",
+                frame_rate="24/1",
+                color_depth=8,
+            )
+
+            with (
+                patch.object(video.config, "EDGE264_TEST_PATH", splitter_path),
+                patch.object(video.config, "keep_files", True),
+                patch.object(video.config, "output_commands", False),
+                patch.object(video.config, "frame_rate", ""),
+                patch.object(video.config, "resolution", ""),
+                patch.object(video.config, "swap_eyes", False),
+                patch.object(video.config, "fov", 90),
+            ):
+                video.run_direct_mv_hevc_encoding(
+                    source_path,
+                    output_path,
+                    video.generate_direct_mv_hevc_normalizer_command(disc_info, ""),
+                    video.generate_direct_mv_hevc_encoder_command(output_path, 1),
+                )
+
+            completed = subprocess.run(
+                [
+                    video.config.FFPROBE_PATH,
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "stream=codec_name,width,height:format=duration,size",
+                    "-of",
+                    "json",
+                    output_path,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            probe = json.loads(completed.stdout)
+
+            self.assertEqual(probe["streams"][0]["codec_name"], "hevc")
+            self.assertEqual(probe["streams"][0]["width"], 320)
+            self.assertEqual(probe["streams"][0]["height"], 180)
+            self.assertGreater(int(probe["format"]["size"]), 0)
+            self.assertTrue(DIRECT_REQUIRED_BOX_TYPES.issubset(box_types(output_path)))
+            verify_apple_media_compatible(output_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mv_hevc_quality_match.py
+++ b/tests/test_mv_hevc_quality_match.py
@@ -1,9 +1,38 @@
 import unittest
 
+from pathlib import Path
+from unittest.mock import patch
+
 from scripts import qualify_mv_hevc_quality_match
+from scripts.qualify_direct_mv_hevc import FixtureOptions
 
 
 class MVHEVCQualityMatchTests(unittest.TestCase):
+    def test_search_can_use_direct_ceiling_independent_from_current_path_bitrate(self) -> None:
+        observed_bitrates: list[float] = []
+
+        def candidate(*_args: object) -> dict[str, float]:
+            bitrate = float(_args[-2])
+            observed_bitrates.append(bitrate)
+            return {"min_same_eye_ssim": 1.0, "target_bitrate_mbps": bitrate}
+
+        options = FixtureOptions(320, 180, 24, 2, 16, 4.0)
+        with patch.object(qualify_mv_hevc_quality_match, "evaluate_direct_candidate", side_effect=candidate):
+            qualify_mv_hevc_quality_match.search_quality_matched_bitrate(
+                "ffmpeg",
+                Path("encoder"),
+                Path("work"),
+                Path("left"),
+                Path("right"),
+                options,
+                0.9,
+                iterations=1,
+                quality_margin=0.0,
+                maximum_bitrate_mbps=8.0,
+            )
+
+        self.assertEqual(observed_bitrates[0], 8.0)
+
     def test_effective_bitrate_mbps_uses_file_size_and_duration(self) -> None:
         self.assertEqual(
             qualify_mv_hevc_quality_match.effective_bitrate_mbps(250_000, 2),

--- a/tests/test_native_mvc_split.py
+++ b/tests/test_native_mvc_split.py
@@ -467,6 +467,212 @@ class NativeMvcSelectionTests(unittest.TestCase):
         self.assertIs(video.select_native_pipeline_error(error, producer_present=False), splitter_error)
 
 
+class DirectMVHEVCPipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disc_info = DiscInfo(name="Sample", frame_rate="24000/1001", resolution="1920x1080", color_depth=8)
+
+    def test_normalizer_outputs_packed_progressive_y4m(self) -> None:
+        with (
+            patch.object(video.config, "swap_eyes", False),
+            patch.object(video.config, "frame_rate", ""),
+            patch.object(video.config, "resolution", ""),
+        ):
+            command = video.generate_direct_mv_hevc_normalizer_command(self.disc_info, "")
+
+        filter_graph = command[command.index("-filter_complex") + 1]
+        self.assertIn("split=2", filter_graph)
+        self.assertIn("hstack=inputs=2", filter_graph)
+        self.assertIn("-pix_fmt", command)
+        self.assertIn("yuv420p", command)
+        self.assertIn("pipe:1", command)
+        self.assertNotIn("hevc_videotoolbox", command)
+
+    def test_encoder_command_uses_packaged_helper_and_explicit_settings(self) -> None:
+        with (
+            patch.object(video.config, "MV_HEVC_ENCODER_PATH", Path("/app/bin/mv-hevc-encoder")),
+            patch.object(video.config, "fov", 105),
+        ):
+            command = video.generate_direct_mv_hevc_encoder_command(Path("Sample_MV-HEVC.mov"), 20)
+
+        self.assertEqual(command[0], Path("/app/bin/mv-hevc-encoder"))
+        self.assertEqual(command[command.index("--bitrate-mbps") + 1], "20")
+        self.assertEqual(command[command.index("--fov") + 1], "105")
+        self.assertNotIn("--swap-eyes", command)
+
+    def test_direct_attempt_runs_splitter_normalizer_and_encoder_in_order(self) -> None:
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video.ProcessPipelineRunner, "run", return_value=direct_pipeline_success(False)) as run,
+        ):
+            video.run_direct_mv_hevc_attempt(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                [Path("mv-hevc-encoder"), "--output", Path("Sample_MV-HEVC.mov")],
+                producer_command=None,
+                single_threaded=False,
+            )
+
+        stages = run.call_args.args[0]
+        self.assertEqual([stage.spec.tool_id for stage in stages], ["edge264", "ffmpeg", "mv_hevc_encoder"])
+        self.assertEqual(stages[0].spec.argv[-1], "-Omk")
+        self.assertIsNotNone(stages[-1].spec.artifacts[0].resolver)
+
+    def test_splitter_crash_retries_same_direct_route_once(self) -> None:
+        splitter_error = process_error(-signal.SIGABRT, ["edge264_test"])
+        crash = direct_pipeline_failure(splitter_error=splitter_error)
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(
+                video.ProcessPipelineRunner, "run", side_effect=[crash, direct_pipeline_success(False)]
+            ) as run,
+            patch.object(video, "remove_direct_mv_hevc_attempt_artifacts"),
+            redirect_stdout(StringIO()),
+        ):
+            video.run_direct_mv_hevc_encoding(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                ["mv-hevc-encoder", "--output", "Sample_MV-HEVC.mov"],
+            )
+
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[0].args[0][0].spec.argv[-1], "-Omk")
+        self.assertEqual(run.call_args_list[1].args[0][0].spec.argv[-1], "-Osk")
+
+    def test_direct_no_growth_retries_same_route_once(self) -> None:
+        stall = ProcessArtifactNoProgressError("direct output stopped growing")
+        failure = direct_pipeline_failure(encoder_error=stall)
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(
+                video.ProcessPipelineRunner, "run", side_effect=[failure, direct_pipeline_success(False)]
+            ) as run,
+            patch.object(video, "remove_direct_mv_hevc_attempt_artifacts"),
+            redirect_stdout(StringIO()) as output,
+        ):
+            video.run_direct_mv_hevc_encoding(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                ["mv-hevc-encoder", "--output", "Sample_MV-HEVC.mov"],
+            )
+
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("Direct MV-HEVC output stopped making progress", output.getvalue())
+
+    def test_direct_no_growth_after_retry_reports_pipeline_stall(self) -> None:
+        stall = ProcessArtifactNoProgressError("direct output stopped growing")
+        failure = direct_pipeline_failure(encoder_error=stall)
+        with (
+            patch.object(video.config, "EDGE264_TEST_PATH", Path("edge264_test")),
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=[failure, failure]) as run,
+            patch.object(video, "remove_direct_mv_hevc_attempt_artifacts"),
+            redirect_stdout(StringIO()),
+            self.assertRaisesRegex(video.NativeMvcSplitError, "splitter, geometry normalizer, or direct encoder"),
+        ):
+            video.run_direct_mv_hevc_encoding(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                ["mv-hevc-encoder", "--output", "Sample_MV-HEVC.mov"],
+            )
+
+        self.assertEqual(run.call_count, 2)
+
+    def test_encoder_failure_is_not_retried_or_fallback(self) -> None:
+        encoder_error = process_error(1, ["mv-hevc-encoder"])
+        failure = direct_pipeline_failure(encoder_error=encoder_error)
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=failure) as run,
+            self.assertRaises(ProcessExecutionError),
+        ):
+            video.run_direct_mv_hevc_encoding(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                ["mv-hevc-encoder", "--output", "Sample_MV-HEVC.mov"],
+            )
+
+        run.assert_called_once()
+
+    def test_direct_pipeline_cancellation_is_not_retried(self) -> None:
+        cancellation = ProcessCancelled("cancelled")
+        with (
+            patch.object(video, "should_stream_mvc_from_container", return_value=False),
+            patch.object(video.ProcessPipelineRunner, "run", side_effect=cancellation) as run,
+            self.assertRaises(ProcessCancelled),
+        ):
+            video.run_direct_mv_hevc_encoding(
+                Path("movie.264"),
+                Path("Sample_MV-HEVC.mov"),
+                ["ffmpeg", "normalize"],
+                ["mv-hevc-encoder", "--output", "Sample_MV-HEVC.mov"],
+            )
+
+        run.assert_called_once()
+
+    def test_encoder_error_wins_over_upstream_sigpipe(self) -> None:
+        normalizer_error = process_error(-signal.SIGPIPE, ["ffmpeg"])
+        encoder_error = process_error(1, ["mv-hevc-encoder"])
+        failure = direct_pipeline_failure(normalizer_error=normalizer_error, encoder_error=encoder_error)
+
+        selected = video.select_direct_mv_hevc_pipeline_error(failure, producer_present=False)
+
+        self.assertIs(selected, encoder_error)
+
+    def test_partial_artifact_is_observed_before_final_rename(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "Sample_MV-HEVC.mov"
+            partial_path = output_path.parent / f".{output_path.name}.partial-test"
+            partial_path.write_bytes(b"partial")
+
+            self.assertEqual(video.resolve_direct_mv_hevc_artifact(output_path), partial_path)
+            output_path.write_bytes(b"final")
+            self.assertEqual(video.resolve_direct_mv_hevc_artifact(output_path), partial_path)
+            partial_path.unlink()
+            self.assertEqual(video.resolve_direct_mv_hevc_artifact(output_path), output_path)
+
+    def test_retry_cleanup_preserves_previous_completed_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "Sample_MV-HEVC.mov"
+            partial_path = output_path.parent / f".{output_path.name}.partial-test"
+            output_path.write_bytes(b"previous")
+            partial_path.write_bytes(b"partial")
+
+            video.remove_direct_mv_hevc_attempt_artifacts(output_path)
+
+            self.assertEqual(output_path.read_bytes(), b"previous")
+            self.assertFalse(partial_path.exists())
+
+    def test_direct_stage_removes_consumed_owned_mvc_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_folder = Path(temporary_directory)
+            mvc_path = output_folder / "Sample_mvc.h264"
+            mvc_path.write_bytes(b"mvc")
+            with (
+                patch.object(video.config, "start_stage", video.Stage.CREATE_LEFT_RIGHT_FILES),
+                patch.object(video.config, "keep_files", False),
+                patch.object(video, "can_use_native_mvc_splitter", return_value=True),
+                patch.object(video, "should_stream_mvc_from_container", return_value=False),
+                patch.object(video, "run_direct_mv_hevc_encoding"),
+            ):
+                output_path = video.create_direct_mv_hevc_file(
+                    self.disc_info,
+                    output_folder,
+                    mvc_path,
+                    "",
+                    20,
+                )
+
+            self.assertEqual(output_path, output_folder / "Sample_MV-HEVC.mov")
+            self.assertFalse(mvc_path.exists())
+
+
 def process_result(tool_id: str) -> ProcessResult:
     empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
     return ProcessResult(tool_run_id=f"{tool_id}-run", returncode=0, elapsed_ms=1, stdout=empty, stderr=empty)
@@ -517,6 +723,67 @@ def pipeline_failure(
                 None if ffmpeg_error else process_result("encoder"),
                 ffmpeg_error,
                 completed_before_final=ffmpeg_error is not None,
+            ),
+        )
+    )
+    return ProcessPipelineError(ProcessPipelineResult(tuple(stages)))
+
+
+def direct_pipeline_success(producer_present: bool) -> ProcessPipelineResult:
+    tool_ids = (
+        ["ffmpeg", "edge264", "ffmpeg", "mv_hevc_encoder"]
+        if producer_present
+        else [
+            "edge264",
+            "ffmpeg",
+            "mv_hevc_encoder",
+        ]
+    )
+    return ProcessPipelineResult(
+        stages=tuple(
+            ProcessPipelineStageResult(tool_id, process_result(tool_id), completed_before_final=True)
+            for tool_id in tool_ids
+        )
+    )
+
+
+def direct_pipeline_failure(
+    *,
+    producer_present: bool = False,
+    producer_error: BaseException | None = None,
+    splitter_error: BaseException | None = None,
+    normalizer_error: BaseException | None = None,
+    encoder_error: BaseException | None = None,
+) -> ProcessPipelineError:
+    stages: list[ProcessPipelineStageResult] = []
+    if producer_present:
+        stages.append(
+            ProcessPipelineStageResult(
+                "ffmpeg",
+                None if producer_error else process_result("producer"),
+                producer_error,
+                completed_before_final=producer_error is not None,
+            )
+        )
+    stages.extend(
+        (
+            ProcessPipelineStageResult(
+                "edge264",
+                None if splitter_error else process_result("splitter"),
+                splitter_error,
+                completed_before_final=splitter_error is not None,
+            ),
+            ProcessPipelineStageResult(
+                "ffmpeg",
+                None if normalizer_error else process_result("normalizer"),
+                normalizer_error,
+                completed_before_final=normalizer_error is not None,
+            ),
+            ProcessPipelineStageResult(
+                "mv_hevc_encoder",
+                None if encoder_error else process_result("encoder"),
+                encoder_error,
+                completed_before_final=encoder_error is not None,
             ),
         )
     )

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -21,6 +21,7 @@ from bd_to_avp.modules.disc import DiscInfo, DiscTitleInfo, MKVCreationError
 from bd_to_avp.modules.process import process_each
 from bd_to_avp.modules.sub import SRTCreationError
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import DirectMVHEVCCapability
 from bd_to_avp.observability import ObservabilityEmitter
 from bd_to_avp.process_runner import ChildProcessRunner, ProcessCancelled, ProcessSpec
 from bd_to_avp.runtime import ObservabilityStream
@@ -92,18 +93,17 @@ def conversion_request_line(
         "destination": {"path": str(destination_path)},
         "encoding": {
             "audio": {"mode": "convert_aac", "bitrate": 384, "preferred_language": None},
-            "video_mode": "mv_hevc",
-            "av1_crf": 32,
-            "left_right_bitrate": 20,
-            "link_quality": True,
-            "mv_hevc_quality": 75,
-            "upscale_quality": 75,
+            "video": {
+                "mode": "mv_hevc",
+                "route_intent": "automatic",
+                "direct_bitrate": {"mode": "automatic"},
+            },
+            "upscale": {"enabled": False},
             "fov": 90,
             "frame_rate": "",
             "resolution": "",
             "crop_black_bars": False,
             "swap_eyes": False,
-            "fx_upscale": False,
             "subtitles": {
                 "mode": "preferred_plus_others",
                 "preferred_language": "eng",
@@ -238,7 +238,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(context.exception.code, "invalid_source")
 
     def test_parses_shared_swift_conversion_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v10.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -246,10 +246,18 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.source.kind, WorkerSourceKind.DIRECT_FILE)
         self.assertEqual(job.source.path, Path("/tmp/movie.mkv"))
         self.assertEqual(job.destination.path if job.destination else None, Path("/tmp/output"))
-        self.assertEqual(job.encoding.mv_hevc_quality if job.encoding else None, 75)
         self.assertEqual(job.encoding.video_mode if job.encoding else None, VideoMode.MV_HEVC)
-        self.assertEqual(job.encoding.av1_crf if job.encoding else None, 32)
+        self.assertEqual(job.encoding.video.route_intent.value if job.encoding else None, "automatic")
+        self.assertEqual(job.encoding.video.direct_bitrate.mode.value if job.encoding else None, "automatic")
         self.assertEqual(job.encoding.audio.preferred_language if job.encoding else None, "eng")
+
+    def test_retains_protocol_v9_fixture_as_rejected_historical_evidence(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v9.json"
+
+        with self.assertRaises(WorkerProtocolError) as context:
+            JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(context.exception.code, "protocol_mismatch")
 
     def test_retains_protocol_v8_fixture_as_rejected_historical_evidence(self) -> None:
         fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_v8.json"
@@ -261,22 +269,93 @@ class JobSpecTests(unittest.TestCase):
 
     def test_rejects_av1_export_with_fx_upscale(self) -> None:
         request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
-        request["encoding"]["video_mode"] = "av1_sbs"
-        request["encoding"]["fx_upscale"] = True
+        request["encoding"]["video"] = {
+            "mode": "av1_sbs",
+            "route_intent": "encode",
+            "crf": 32,
+        }
+        request["encoding"]["upscale"] = {"enabled": True, "quality": 75}
 
         with self.assertRaisesRegex(WorkerProtocolError, "does not support AI FX upscale"):
             JobSpec.from_json_line(json.dumps(request))
 
     def test_rejects_av1_export_with_resolution_override(self) -> None:
         request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
-        request["encoding"]["video_mode"] = "av1_sbs"
+        request["encoding"]["video"] = {
+            "mode": "av1_sbs",
+            "route_intent": "encode",
+            "crf": 32,
+        }
         request["encoding"]["resolution"] = "3840x2160"
 
         with self.assertRaisesRegex(WorkerProtocolError, "full source resolution"):
             JobSpec.from_json_line(json.dumps(request))
 
+    def test_rejects_automatic_bitrate_with_inactive_numeric_value(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video"]["direct_bitrate"]["mbps"] = 20
+
+        with self.assertRaisesRegex(WorkerProtocolError, "unsupported field.*mbps"):
+            JobSpec.from_json_line(json.dumps(request))
+
+    def test_rejects_custom_bitrate_without_numeric_value(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video"]["direct_bitrate"] = {"mode": "custom"}
+
+        with self.assertRaisesRegex(WorkerProtocolError, "missing required field.*mbps"):
+            JobSpec.from_json_line(json.dumps(request))
+
+    def test_rejects_generated_controls_on_automatic_route(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video"]["generated_eye_bitrate"] = {"mode": "custom", "mbps": 42}
+
+        with self.assertRaisesRegex(WorkerProtocolError, "unsupported field.*generated_eye_bitrate"):
+            JobSpec.from_json_line(json.dumps(request))
+
+    def test_parses_generated_route_with_only_generated_controls(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video"] = {
+            "mode": "mv_hevc",
+            "route_intent": "generated",
+            "generated_eye_bitrate": {"mode": "custom", "mbps": 42},
+            "generated_merge_quality": 88,
+        }
+
+        job = JobSpec.from_json_line(json.dumps(request))
+
+        self.assertEqual(job.encoding.video.generated_eye_bitrate.mbps if job.encoding else None, 42)
+        self.assertEqual(job.encoding.video.generated_merge_quality if job.encoding else None, 88)
+        self.assertIsNone(job.encoding.video.direct_bitrate if job.encoding else None)
+
+    def test_parses_existing_artifact_route_without_encode_controls(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["encoding"]["video"] = {
+            "mode": "mv_hevc",
+            "route_intent": "existing_artifact",
+        }
+        request["job"]["start_stage"] = 6
+
+        job = JobSpec.from_json_line(json.dumps(request))
+
+        self.assertEqual(job.encoding.video.route_intent.value if job.encoding else None, "existing_artifact")
+        self.assertIsNone(job.encoding.video.direct_bitrate if job.encoding else None)
+
+    def test_rejects_automatic_route_when_job_requires_generated_artifacts(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["job"]["keep_files"] = True
+
+        with self.assertRaisesRegex(WorkerProtocolError, "Reusable intermediates require the generated"):
+            JobSpec.from_json_line(json.dumps(request))
+
+    def test_rejects_encode_controls_after_video_stage(self) -> None:
+        request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
+        request["job"]["start_stage"] = 6
+
+        with self.assertRaisesRegex(WorkerProtocolError, "must request the existing video artifact"):
+            JobSpec.from_json_line(json.dumps(request))
+
     def test_parses_shared_swift_physical_disc_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_physical_disc_v10.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -287,7 +366,7 @@ class JobSpecTests(unittest.TestCase):
         self.assertFalse(job.job.remove_original if job.job else True)
 
     def test_parses_shared_swift_preview_fixture(self) -> None:
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_preview_v10.json"
 
         job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
 
@@ -295,6 +374,24 @@ class JobSpecTests(unittest.TestCase):
         self.assertEqual(job.encoding.audio.preferred_language if job.encoding else None, "eng")
         self.assertEqual(job.preview.position if job.preview else None, PreviewPosition.MIDDLE)
         self.assertEqual(job.preview.duration_seconds if job.preview else None, 60)
+
+    def test_parses_shared_swift_generated_route_fixture(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_generated_v10.json"
+
+        job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(job.encoding.video.route_intent.value if job.encoding else None, "generated")
+        self.assertEqual(job.encoding.video.generated_eye_bitrate.mode.value if job.encoding else None, "automatic")
+        self.assertEqual(job.encoding.video.generated_merge_quality if job.encoding else None, 75)
+        self.assertTrue(job.job.keep_files if job.job else False)
+
+    def test_parses_shared_swift_existing_artifact_fixture(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_convert_existing_artifact_v10.json"
+
+        job = JobSpec.from_json_line(fixture_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(job.encoding.video.route_intent.value if job.encoding else None, "existing_artifact")
+        self.assertEqual(job.job.start_stage if job.job else None, 6)
 
     def test_rejects_remove_original_for_physical_disc(self) -> None:
         request = json.loads(
@@ -353,6 +450,12 @@ class JobSpecTests(unittest.TestCase):
     def test_accepts_zero_field_of_view_used_by_existing_ui(self) -> None:
         request = json.loads(conversion_request_line(Path("/tmp/movie.mkv"), Path("/tmp/output")))
         request["encoding"]["fov"] = 0
+        request["encoding"]["video"] = {
+            "mode": "mv_hevc",
+            "route_intent": "generated",
+            "generated_eye_bitrate": {"mode": "automatic"},
+            "generated_merge_quality": 75,
+        }
 
         job = JobSpec.from_json_line(json.dumps(request) + "\n")
 
@@ -635,7 +738,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
             ],
         )
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_fallback_warning_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_fallback_warning_v10.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -657,7 +760,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
             action="keep_source_default_audio",
         )
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_language_fallback_warning_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_audio_language_fallback_warning_v10.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -669,7 +772,7 @@ class WorkerActivityReporterTests(unittest.TestCase):
 
         activity.stage_started("configure", "Preparing conversion settings")
 
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_stage_started_progress_v10.json"
         expected = json.loads(fixture_path.read_text())
         self.assertEqual(decoded_events(output), [expected])
 
@@ -980,10 +1083,16 @@ class WorkerRuntimeTests(unittest.TestCase):
                     "destination_path": "/tmp/output",
                     "output_path": "/tmp/output/movie_AVP.mov",
                     "size_bytes": 1024,
+                    "video_route": {
+                        "intent": "automatic",
+                        "selected": "direct_mv_hevc",
+                        "reason": "direct_eligible",
+                        "bitrate_mbps": 40,
+                    },
                 }
             },
         )
-        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v9.json"
+        fixture_path = Path(__file__).parent / "fixtures" / "native_worker_conversion_completed_v10.json"
         fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
         self.assertEqual(decoded_events(output)[-1], fixture)
@@ -1469,6 +1578,10 @@ class SourceConversionTests(unittest.TestCase):
                     return_value={"duration_seconds": 7200.0},
                 ),
                 patch.object(config, "configure_tool_environment"),
+                patch(
+                    "bd_to_avp.modules.video_route.probe_direct_mv_hevc_capability",
+                    return_value=DirectMVHEVCCapability(True, "direct_capability_supported"),
+                ),
                 patch("bd_to_avp.modules.process.process_each", side_effect=process_each),
             ):
                 result = preview_source(job, WorkerProcessOwner(), activity)
@@ -1480,9 +1593,68 @@ class SourceConversionTests(unittest.TestCase):
             self.assertEqual(result["output_path"], final_path.as_posix())
             self.assertEqual(result["parent_job_id"], job.preview.parent_job_id if job.preview else None)
             events = decoded_events(output)
-            self.assertEqual(events[0]["type"], "stage.started")
-            self.assertEqual(events[0]["payload"]["stage"], "inspect_source")
+            self.assertEqual(events[0]["type"], "log")
+            self.assertEqual(events[0]["payload"]["video_route"]["selected"], "direct_mv_hevc")
+            inspect_event = next(event for event in events if event["type"] == "stage.started")
+            self.assertEqual(inspect_event["payload"]["stage"], "inspect_source")
             self.assertEqual(events[-1]["type"], "artifact.ready")
+            self.assertEqual(
+                events[-1]["payload"]["artifact"]["video_route"],
+                result["video_route"],
+            )
+
+    def test_full_and_preview_share_capability_fallback_report_before_preview_inspection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            source_path = temporary_path / "movie.mkv"
+            source_path.write_bytes(b"source")
+            full_destination = temporary_path / "full"
+            preview_destination = temporary_path / "preview"
+            full_output = full_destination / "movie_AVP.mov"
+            preview_output = preview_destination / "movie_AVP.mov"
+            full_output.parent.mkdir()
+            preview_output.parent.mkdir()
+            full_output.write_bytes(b"full")
+            preview_output.write_bytes(b"preview")
+            full_job = JobSpec.from_json_line(conversion_request_line(source_path, full_destination))
+            preview_job = JobSpec.from_json_line(preview_request_line(source_path, preview_destination))
+            full_events = io.StringIO()
+            preview_events = io.StringIO()
+            order: list[str] = []
+
+            def capability_probe(*_args: object, **_kwargs: object) -> DirectMVHEVCCapability:
+                order.append("probe")
+                return DirectMVHEVCCapability(False, "stereo_mv_hevc_encode_unavailable")
+
+            def inspect(*_args: object, **_kwargs: object) -> dict[str, object]:
+                order.append("inspect")
+                return {"duration_seconds": 7200.0}
+
+            with (
+                patch.object(config, "configure_tool_environment"),
+                patch("bd_to_avp.modules.video_route.probe_direct_mv_hevc_capability", side_effect=capability_probe),
+                patch("bd_to_avp.worker.operations.inspect_source", side_effect=inspect),
+                patch("bd_to_avp.modules.process.process_each", side_effect=[full_output, preview_output]),
+            ):
+                full_result = convert_source(
+                    full_job,
+                    WorkerProcessOwner(),
+                    WorkerActivityReporter(WorkerEventEmitter(full_events, full_job.job_id)),
+                )
+                preview_result = preview_source(
+                    preview_job,
+                    WorkerProcessOwner(),
+                    WorkerActivityReporter(WorkerEventEmitter(preview_events, preview_job.job_id)),
+                )
+
+            self.assertEqual(full_result["video_route"], preview_result["video_route"])
+            self.assertEqual(full_result["video_route"]["selected"], "generated_mv_hevc")
+            self.assertEqual(full_result["video_route"]["fallback_timing"], "pre_input")
+            self.assertEqual(order, ["probe", "probe", "inspect"])
+            for events in (decoded_events(full_events), decoded_events(preview_events)):
+                fallback = next(event for event in events if event["payload"].get("code") == "video_route_fallback")
+                self.assertEqual(fallback["type"], "warning")
+                self.assertEqual(fallback["payload"]["video_route"], full_result["video_route"])
 
     def test_iso_preview_preserves_selected_title_id_through_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1766,17 +1938,18 @@ class SourceConversionTests(unittest.TestCase):
             request["encoding"].update(
                 {
                     "audio": {"mode": "pcm", "bitrate": 512, "preferred_language": "jpn"},
-                    "video_mode": "mv_hevc",
-                    "av1_crf": 27,
-                    "left_right_bitrate": 42,
-                    "mv_hevc_quality": 88,
-                    "upscale_quality": 66,
+                    "video": {
+                        "mode": "mv_hevc",
+                        "route_intent": "generated",
+                        "generated_eye_bitrate": {"mode": "custom", "mbps": 42},
+                        "generated_merge_quality": 88,
+                    },
+                    "upscale": {"enabled": True, "quality": 66},
                     "fov": 110,
                     "frame_rate": "24000/1001",
                     "resolution": "1920x1080",
                     "crop_black_bars": True,
                     "swap_eyes": True,
-                    "fx_upscale": True,
                     "subtitles": {
                         "mode": "preferred_only",
                         "preferred_language": "jpn",
@@ -1785,7 +1958,7 @@ class SourceConversionTests(unittest.TestCase):
             )
             request["job"].update(
                 {
-                    "start_stage": 7,
+                    "start_stage": 4,
                     "keep_files": True,
                     "overwrite": True,
                     "remove_original": True,
@@ -1851,7 +2024,6 @@ class SourceConversionTests(unittest.TestCase):
             self.assertEqual(observed["audio_bitrate"], 512)
             self.assertEqual(observed["audio_preferred_language"], "jpn")
             self.assertEqual(observed["video_mode"], VideoMode.MV_HEVC)
-            self.assertEqual(observed["av1_crf"], 27)
             self.assertEqual(observed["left_right_bitrate"], 42)
             self.assertEqual(observed["mv_hevc_quality"], 88)
             self.assertEqual(observed["upscale_quality"], 66)
@@ -1864,7 +2036,7 @@ class SourceConversionTests(unittest.TestCase):
             self.assertTrue(observed["fx_upscale"])
             self.assertEqual(observed["language_code"], "jpn")
             self.assertTrue(observed["remove_extra_languages"])
-            self.assertEqual(observed["start_stage"], 7)
+            self.assertEqual(observed["start_stage"], 4)
             self.assertTrue(observed["keep_files"])
             self.assertTrue(observed["overwrite"])
             self.assertTrue(observed["remove_original"])

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -7,11 +7,42 @@ from unittest.mock import Mock, patch
 from bd_to_avp import preflight
 from bd_to_avp.modules.config import Stage
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import ResolvedVideoRoute, VideoRouteKind
 from bd_to_avp.process_runner import ProcessCancelled
 from bd_to_avp.vendor.pgsrip.ocr import OcrError
+from bd_to_avp.worker.protocol import VideoRouteIntent
 
 
 class DependencyPreflightTests(unittest.TestCase):
+    def test_direct_route_requires_encoder_but_not_spatial_media_tool(self) -> None:
+        route = ResolvedVideoRoute(
+            intent=VideoRouteIntent.AUTOMATIC,
+            selected=VideoRouteKind.DIRECT_MV_HEVC,
+            reason="direct_eligible",
+            output_mode=VideoMode.MV_HEVC,
+            direct_bitrate_mbps=20,
+        )
+        with patch.object(preflight.config, "start_stage", Stage.CREATE_MKV):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job(route)
+
+        self.assertIn(preflight.config.MV_HEVC_ENCODER_PATH, required_paths)
+        self.assertNotIn(preflight.config.SPATIAL_MEDIA_PATH, required_paths)
+
+    def test_generated_route_requires_spatial_media_but_not_direct_encoder(self) -> None:
+        route = ResolvedVideoRoute(
+            intent=VideoRouteIntent.GENERATED,
+            selected=VideoRouteKind.GENERATED_MV_HEVC,
+            reason="generated_route_requested",
+            output_mode=VideoMode.MV_HEVC,
+            generated_eye_bitrate_mbps=20,
+            generated_merge_quality=75,
+        )
+        with patch.object(preflight.config, "start_stage", Stage.CREATE_MKV):
+            required_paths = preflight.get_required_dependency_binaries_for_current_job(route)
+
+        self.assertIn(preflight.config.SPATIAL_MEDIA_PATH, required_paths)
+        self.assertNotIn(preflight.config.MV_HEVC_ENCODER_PATH, required_paths)
+
     def test_missing_required_dependency_binaries_raise_clear_error(self) -> None:
         with (
             patch.object(preflight.config, "FFMPEG_PATH", Path(__file__)),

--- a/tests/test_process_audio.py
+++ b/tests/test_process_audio.py
@@ -10,8 +10,10 @@ from bd_to_avp.modules.config import Stage
 from bd_to_avp.modules.disc import DiscInfo
 from bd_to_avp.modules.preview_range import PreviewRange
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import ResolvedVideoRoute, VideoRouteKind
 from bd_to_avp.observability import ObservabilityEmitter
 from bd_to_avp.runtime import ObservabilityStream, RunContext
+from bd_to_avp.worker.protocol import VideoRouteIntent
 
 
 class ProcessAudioWiringTests(unittest.TestCase):
@@ -426,6 +428,70 @@ class ProcessAudioWiringTests(unittest.TestCase):
             create_mv_hevc.assert_not_called()
             self.assertEqual(mux.call_args.args, (audio_path, stereo_path, output_folder, "Movie"))
             self.assertEqual(mux.call_args.kwargs["observability_context"].stage.id, "create_final_file")
+
+    def test_direct_mv_hevc_route_writes_stage_four_boundary_and_skips_generated_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            mvc_path = output_folder / "Movie_mvc.h264"
+            direct_path = output_folder / "Movie_MV-HEVC.mov"
+            audio_path = output_folder / "Movie_audio_PCM.mov"
+            final_path = output_folder / "Movie_AVP.mov"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            route = ResolvedVideoRoute(
+                intent=VideoRouteIntent.AUTOMATIC,
+                selected=VideoRouteKind.DIRECT_MV_HEVC,
+                reason="direct_eligible",
+                output_mode=VideoMode.MV_HEVC,
+                direct_bitrate_mbps=20,
+            )
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(process.config, "source_path", source_path))
+                stack.enter_context(patch.object(process.config, "output_root_path", temp_path))
+                stack.enter_context(patch.object(process.config, "overwrite", True))
+                stack.enter_context(patch.object(process.config, "keep_files", False))
+                stack.enter_context(patch.object(process.config, "audio_mode", AudioMode.PCM))
+                stack.enter_context(patch.object(process.config, "video_mode", VideoMode.MV_HEVC))
+                stack.enter_context(patch.object(process.config, "fx_upscale", False))
+                stack.enter_context(patch.object(process.config, "skip_subtitles", True))
+                stack.enter_context(patch.object(process.config, "start_stage", Stage.CREATE_MKV))
+                stack.enter_context(patch.object(process.config, "remove_original", False))
+                preflight = stack.enter_context(patch.object(process.preflight, "verify_runtime_ready"))
+                stack.enter_context(
+                    patch.object(process, "get_disc_and_mvc_video_info", return_value=DiscInfo(name="Movie"))
+                )
+                stack.enter_context(
+                    patch.object(process, "prepare_output_folder_for_source", return_value=output_folder)
+                )
+                stack.enter_context(patch.object(process, "file_exists_normalized", return_value=False))
+                stack.enter_context(patch.object(process, "create_mkv_file", return_value=source_path))
+                stack.enter_context(patch.object(process, "get_video_color_depth", return_value=8))
+                stack.enter_context(patch.object(process, "detect_crop_parameters", return_value=""))
+                stack.enter_context(patch.object(process, "create_mvc_and_audio", return_value=(audio_path, mvc_path)))
+                direct = stack.enter_context(
+                    patch.object(process, "create_direct_mv_hevc_file", return_value=direct_path)
+                )
+                create_left_right = stack.enter_context(patch.object(process, "create_left_right_files"))
+                create_mv_hevc = stack.enter_context(patch.object(process, "create_mv_hevc_file"))
+                stack.enter_context(patch.object(process, "create_upscaled_file", return_value=direct_path))
+                stack.enter_context(patch.object(process, "create_transcoded_audio_file", return_value=audio_path))
+                mux = stack.enter_context(patch.object(process, "create_muxed_file", return_value=final_path))
+                stack.enter_context(patch.object(process, "move_file_to_output_root_folder", return_value=final_path))
+                stack.enter_context(patch.dict(process.os.environ, {}, clear=False))
+
+                process.process_each(video_route=route)
+
+            self.assertIs(preflight.call_args.kwargs["video_route"], route)
+            self.assertEqual(
+                direct.call_args.args, (DiscInfo(name="Movie", color_depth=8), output_folder, mvc_path, "", 20)
+            )
+            self.assertEqual(direct.call_args.kwargs["observability_context"].stage.id, "create_left_right_files")
+            create_left_right.assert_not_called()
+            create_mv_hevc.assert_not_called()
+            self.assertEqual(mux.call_args.args, (audio_path, direct_path, output_folder, "Movie"))
 
 
 if __name__ == "__main__":

--- a/tests/test_process_preflight.py
+++ b/tests/test_process_preflight.py
@@ -10,6 +10,7 @@ from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.config import is_direct_pipeline_source_reused, Stage
 from bd_to_avp.modules.disc import MKVCreationError
 from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import ResolvedVideoRoute, VideoRouteKind
 from bd_to_avp.modules.file import (
     move_file_to_output_root_folder,
     prepare_output_folder_for_source,
@@ -17,9 +18,31 @@ from bd_to_avp.modules.file import (
 )
 from bd_to_avp.observability import ObservabilityEmitter
 from bd_to_avp.runtime import CancellationToken, ObservabilityStream, RunContext
+from bd_to_avp.worker.protocol import VideoRouteIntent
 
 
 class ProcessPreflightTests(unittest.TestCase):
+    def test_direct_route_uses_stage_four_and_omits_stage_five(self) -> None:
+        route = ResolvedVideoRoute(
+            intent=VideoRouteIntent.AUTOMATIC,
+            selected=VideoRouteKind.DIRECT_MV_HEVC,
+            reason="direct_eligible",
+            output_mode=VideoMode.MV_HEVC,
+            direct_bitrate_mbps=20,
+        )
+        with (
+            patch.object(process.config, "preview_range", None),
+            patch.object(process.config, "skip_subtitles", True),
+            patch.object(process.config, "fx_upscale", False),
+            patch.object(process.config, "audio_mode", AudioMode.PCM),
+            patch.object(process.config, "video_mode", VideoMode.MV_HEVC),
+            patch.object(process.config, "start_stage", Stage.CREATE_MKV),
+        ):
+            plan = process.conversion_stage_plan(route)
+
+        self.assertIn("create_left_right_files", plan)
+        self.assertNotIn("combine_to_mv_hevc", plan)
+
     def test_conversion_stage_plan_tracks_optional_work(self) -> None:
         with (
             patch.object(process.config, "preview_range", None),

--- a/tests/test_video_route.py
+++ b/tests/test_video_route.py
@@ -1,0 +1,306 @@
+import json
+import unittest
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from bd_to_avp.modules.audio_mode import AudioMode
+from bd_to_avp.modules.video_mode import VideoMode
+from bd_to_avp.modules.video_route import (
+    AUTOMATIC_DIRECT_BITRATE_MBPS,
+    AUTOMATIC_GENERATED_EYE_BITRATE_MBPS,
+    AUTOMATIC_GENERATED_MERGE_QUALITY,
+    DirectMVHEVCCapability,
+    VideoRouteKind,
+    VideoRoutePreflightError,
+    probe_direct_mv_hevc_capability,
+    resolve_video_route,
+)
+from bd_to_avp.process_runner import ProcessExecutionError, ProcessOutputSnapshot
+from bd_to_avp.worker.protocol import (
+    AudioOptions,
+    BitrateMode,
+    BitrateOptions,
+    EncodingOptions,
+    JobOptions,
+    SubtitleMode,
+    SubtitleOptions,
+    UpscaleOptions,
+    VideoOptions,
+    VideoRouteIntent,
+)
+
+
+def mv_hevc_encoding(
+    *,
+    intent: VideoRouteIntent = VideoRouteIntent.AUTOMATIC,
+    direct_bitrate: BitrateOptions | None = None,
+    generated_eye_bitrate: BitrateOptions | None = None,
+    generated_merge_quality: int | None = None,
+    upscale: bool = False,
+    fov: int = 90,
+) -> EncodingOptions:
+    if intent is VideoRouteIntent.AUTOMATIC and direct_bitrate is None:
+        direct_bitrate = BitrateOptions(BitrateMode.AUTOMATIC)
+    if intent is VideoRouteIntent.GENERATED:
+        generated_eye_bitrate = generated_eye_bitrate or BitrateOptions(BitrateMode.AUTOMATIC)
+        generated_merge_quality = generated_merge_quality if generated_merge_quality is not None else 75
+    return EncodingOptions(
+        audio=AudioOptions(AudioMode.AUTOMATIC, 384, "eng"),
+        video=VideoOptions(
+            mode=VideoMode.MV_HEVC,
+            route_intent=intent,
+            direct_bitrate=direct_bitrate,
+            generated_eye_bitrate=generated_eye_bitrate,
+            generated_merge_quality=generated_merge_quality,
+        ),
+        upscale=UpscaleOptions(enabled=upscale, quality=75 if upscale else None),
+        fov=fov,
+        frame_rate="",
+        resolution="",
+        crop_black_bars=False,
+        swap_eyes=False,
+        subtitles=SubtitleOptions(SubtitleMode.PREFERRED_PLUS_OTHERS, "eng"),
+    )
+
+
+def av1_encoding(*, existing: bool = False) -> EncodingOptions:
+    return EncodingOptions(
+        audio=AudioOptions(AudioMode.AUTOMATIC, 384, "eng"),
+        video=VideoOptions(
+            mode=VideoMode.AV1_SBS,
+            route_intent=VideoRouteIntent.EXISTING_ARTIFACT if existing else VideoRouteIntent.ENCODE,
+            av1_crf=None if existing else 31,
+        ),
+        upscale=UpscaleOptions(enabled=False),
+        fov=90,
+        frame_rate="",
+        resolution="",
+        crop_black_bars=False,
+        swap_eyes=False,
+        subtitles=SubtitleOptions(SubtitleMode.PREFERRED_PLUS_OTHERS, "eng"),
+    )
+
+
+def job_options(
+    *,
+    start_stage: int = 1,
+    keep_files: bool = False,
+    software_encoder: bool = False,
+) -> JobOptions:
+    return JobOptions(
+        start_stage=start_stage,
+        keep_files=keep_files,
+        overwrite=False,
+        remove_original=False,
+        continue_on_error=False,
+        software_encoder=software_encoder,
+        output_commands=False,
+        keep_awake=False,
+    )
+
+
+class VideoRouteResolverTests(unittest.TestCase):
+    def test_selects_direct_with_calibrated_automatic_bitrate(self) -> None:
+        route = resolve_video_route(
+            mv_hevc_encoding(),
+            job_options(),
+            capability_probe=lambda: DirectMVHEVCCapability(True, "direct_capability_supported"),
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.DIRECT_MV_HEVC)
+        self.assertEqual(route.direct_bitrate_mbps, AUTOMATIC_DIRECT_BITRATE_MBPS)
+        self.assertEqual(route.report()["reason"], "direct_eligible")
+
+    def test_selects_direct_custom_bitrate(self) -> None:
+        route = resolve_video_route(
+            mv_hevc_encoding(direct_bitrate=BitrateOptions(BitrateMode.CUSTOM, 37)),
+            job_options(),
+            capability_probe=lambda: DirectMVHEVCCapability(True, "direct_capability_supported"),
+        )
+
+        self.assertEqual(route.direct_bitrate_mbps, 37)
+
+    def test_valid_unavailable_capability_falls_back_before_input(self) -> None:
+        route = resolve_video_route(
+            mv_hevc_encoding(direct_bitrate=BitrateOptions(BitrateMode.CUSTOM, 37)),
+            job_options(),
+            capability_probe=lambda: DirectMVHEVCCapability(False, "stereo_mv_hevc_encode_unavailable"),
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+        self.assertEqual(route.generated_eye_bitrate_mbps, AUTOMATIC_GENERATED_EYE_BITRATE_MBPS)
+        self.assertEqual(route.generated_merge_quality, AUTOMATIC_GENERATED_MERGE_QUALITY)
+        self.assertEqual(route.report()["fallback_timing"], "pre_input")
+        self.assertNotIn("bitrate_mbps", route.report())
+
+    def test_generated_request_uses_only_generated_settings(self) -> None:
+        probe = Mock()
+        route = resolve_video_route(
+            mv_hevc_encoding(
+                intent=VideoRouteIntent.GENERATED,
+                generated_eye_bitrate=BitrateOptions(BitrateMode.CUSTOM, 42),
+                generated_merge_quality=88,
+            ),
+            job_options(),
+            capability_probe=probe,
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+        self.assertEqual(route.generated_eye_bitrate_mbps, 42)
+        self.assertEqual(route.generated_merge_quality, 88)
+        probe.assert_not_called()
+
+    def test_reusable_intermediates_force_generated_without_probe(self) -> None:
+        probe = Mock()
+        route = resolve_video_route(
+            mv_hevc_encoding(),
+            job_options(keep_files=True),
+            capability_probe=probe,
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+        self.assertEqual(route.reason, "reusable_intermediates_requested")
+        probe.assert_not_called()
+
+    def test_software_encoder_forces_generated_without_probe(self) -> None:
+        probe = Mock()
+        route = resolve_video_route(
+            mv_hevc_encoding(),
+            job_options(software_encoder=True),
+            capability_probe=probe,
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+        self.assertEqual(route.reason, "software_encoder_requested")
+        probe.assert_not_called()
+
+    def test_upscale_forces_generated_without_probe(self) -> None:
+        probe = Mock()
+        route = resolve_video_route(
+            mv_hevc_encoding(upscale=True),
+            job_options(),
+            capability_probe=probe,
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+        self.assertEqual(route.reason, "upscale_requires_generated_artifacts")
+        probe.assert_not_called()
+
+    def test_out_of_range_direct_fov_forces_generated_without_probe(self) -> None:
+        for fov in (0, 181):
+            with self.subTest(fov=fov):
+                probe = Mock()
+                route = resolve_video_route(
+                    mv_hevc_encoding(fov=fov),
+                    job_options(),
+                    capability_probe=probe,
+                )
+
+                self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+                self.assertEqual(route.reason, "field_of_view_requires_generated_route")
+                probe.assert_not_called()
+
+    def test_stage_four_and_five_force_generated(self) -> None:
+        for start_stage in (4, 5):
+            with self.subTest(start_stage=start_stage):
+                probe = Mock()
+                route = resolve_video_route(
+                    mv_hevc_encoding(),
+                    job_options(start_stage=start_stage),
+                    capability_probe=probe,
+                )
+                self.assertEqual(route.selected, VideoRouteKind.GENERATED_MV_HEVC)
+                probe.assert_not_called()
+
+    def test_later_restart_uses_existing_artifact(self) -> None:
+        probe = Mock()
+        route = resolve_video_route(
+            mv_hevc_encoding(intent=VideoRouteIntent.EXISTING_ARTIFACT),
+            job_options(start_stage=6),
+            capability_probe=probe,
+        )
+
+        self.assertEqual(route.selected, VideoRouteKind.EXISTING_ARTIFACT)
+        probe.assert_not_called()
+
+    def test_existing_artifact_intent_before_stage_six_is_rejected(self) -> None:
+        with self.assertRaisesRegex(VideoRoutePreflightError, "requires a start stage after stage 5"):
+            resolve_video_route(
+                mv_hevc_encoding(intent=VideoRouteIntent.EXISTING_ARTIFACT),
+                job_options(start_stage=5),
+            )
+
+    def test_av1_encode_and_restart_routes(self) -> None:
+        encode_route = resolve_video_route(av1_encoding(), job_options())
+        restart_route = resolve_video_route(av1_encoding(existing=True), job_options(start_stage=6))
+
+        self.assertEqual(encode_route.selected, VideoRouteKind.AV1)
+        self.assertEqual(encode_route.av1_crf, 31)
+        self.assertEqual(restart_route.selected, VideoRouteKind.EXISTING_ARTIFACT)
+
+    def test_resolved_route_is_immutable(self) -> None:
+        route = resolve_video_route(
+            mv_hevc_encoding(),
+            job_options(),
+            capability_probe=lambda: DirectMVHEVCCapability(True, "direct_capability_supported"),
+        )
+
+        with self.assertRaises(FrozenInstanceError):
+            route.reason = "changed"  # type: ignore[misc]
+
+
+class CapabilityProbeTests(unittest.TestCase):
+    def test_missing_helper_is_valid_unavailable_capability(self) -> None:
+        with patch("bd_to_avp.modules.video_route.config.MV_HEVC_ENCODER_PATH", Path("/missing/helper")):
+            capability = probe_direct_mv_hevc_capability()
+
+        self.assertFalse(capability.supported)
+        self.assertEqual(capability.reason, "helper_missing")
+
+    def test_valid_unsupported_exit_is_accepted(self) -> None:
+        payload = json.dumps({"schema_version": 1, "stereo_mv_hevc_encode_supported": False})
+        snapshot = ProcessOutputSnapshot(payload.encode(), payload.encode(), len(payload), len(payload), 0, 0)
+        empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+        error = ProcessExecutionError(2, ["mv-hevc-encoder", "--capability-probe"], snapshot, empty)
+        with (
+            patch("bd_to_avp.modules.video_route.config.MV_HEVC_ENCODER_PATH", Path("/tools/mv-hevc-encoder")),
+            patch.object(Path, "is_file", return_value=True),
+            patch("bd_to_avp.modules.video_route.os.access", return_value=True),
+            patch("bd_to_avp.modules.video_route.run_process_capture", side_effect=error),
+        ):
+            capability = probe_direct_mv_hevc_capability()
+
+        self.assertFalse(capability.supported)
+        self.assertEqual(capability.reason, "stereo_mv_hevc_encode_unavailable")
+
+    def test_malformed_probe_contract_is_not_a_fallback(self) -> None:
+        payload = json.dumps({"schema_version": 1, "stereo_mv_hevc_encode_supported": "yes"})
+        snapshot = ProcessOutputSnapshot(payload.encode(), payload.encode(), len(payload), len(payload), 0, 0)
+        empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+        error = ProcessExecutionError(2, ["mv-hevc-encoder", "--capability-probe"], snapshot, empty)
+        with (
+            patch("bd_to_avp.modules.video_route.config.MV_HEVC_ENCODER_PATH", Path("/tools/mv-hevc-encoder")),
+            patch.object(Path, "is_file", return_value=True),
+            patch("bd_to_avp.modules.video_route.os.access", return_value=True),
+            patch("bd_to_avp.modules.video_route.run_process_capture", side_effect=error),
+            self.assertRaises(VideoRoutePreflightError),
+        ):
+            probe_direct_mv_hevc_capability()
+
+    def test_probe_crash_is_not_a_fallback(self) -> None:
+        empty = ProcessOutputSnapshot(b"", b"", 0, 0, 0, 0)
+        error = ProcessExecutionError(1, ["mv-hevc-encoder", "--capability-probe"], empty, empty)
+        with (
+            patch("bd_to_avp.modules.video_route.config.MV_HEVC_ENCODER_PATH", Path("/tools/mv-hevc-encoder")),
+            patch.object(Path, "is_file", return_value=True),
+            patch("bd_to_avp.modules.video_route.os.access", return_value=True),
+            patch("bd_to_avp.modules.video_route.run_process_capture", side_effect=error),
+            self.assertRaises(VideoRoutePreflightError),
+        ):
+            probe_direct_mv_hevc_capability()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add strict protocol-v10 route discriminants and shared Swift/Python fixtures
- resolve one immutable direct/generated/AV1/existing route before media input, with visible preflight-only capability fallback
- execute direct MV-HEVC as the existing stage-4 artifact, skip stage 5, and preserve cancellation, retry, and failure attribution contracts
- project and report the resolved route identically for full conversions and preview jobs
- document the initial 40 Mbps automatic direct target and retain the representative prerelease/default-promotion gate in #354

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` — 893 passed, 2 skipped
- `uv run python -m scripts.native_app test` — 287 passed
- real synthetic direct-route integration through edge264, FFmpeg normalization, and the packaged native helper; verified with FFprobe, MP4Box, and AVFoundation
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://support.example uv run python -m scripts.native_app package` — Release package and nested signature verification passed
- independent multi-agent implementation review; all concrete findings resolved

Closes #353