### PR TITLE
Add route-aware native conversion UX

### DIFF
--- a/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
+++ b/macos/BluRayToVisionPro/Diagnostics/DiagnosticCapture.swift
@@ -353,16 +353,21 @@ struct DiagnosticJobSettings: Encodable, Equatable {
     let profileKind: String
     let builtInProfileID: String?
     let videoOutputMode: String
-    let av1CRF: Int
-    let hevcQuality: Int
-    let leftRightBitrate: Int
-    let upscaleEnabled: Bool
-    let upscaleQuality: Int
-    let fieldOfView: Int
-    let frameRateOverrideSet: Bool
-    let resolutionOverrideSet: Bool
-    let cropBlackBars: Bool
-    let swapEyes: Bool
+    let requestedVideoRoute: String
+    let routeRequirement: String?
+    let directBitrateMode: String?
+    let directFinalBitrate: Int?
+    let av1CRF: Int?
+    let generatedEyeBitrateMode: String?
+    let hevcQuality: Int?
+    let leftRightBitrate: Int?
+    let upscaleEnabled: Bool?
+    let upscaleQuality: Int?
+    let fieldOfView: Int?
+    let frameRateOverrideSet: Bool?
+    let resolutionOverrideSet: Bool?
+    let cropBlackBars: Bool?
+    let swapEyes: Bool?
     let audioHandling: String
     let audioBitrate: Int
     let subtitleMode: String
@@ -378,19 +383,43 @@ struct DiagnosticJobSettings: Encodable, Equatable {
     init(draft: ConversionDraft) {
         let encoding = draft.options.encoding
         let job = draft.options.job
+        let route = VideoRoutePlan(options: draft.options)
         profileKind = draft.profile.kind.rawValue
         builtInProfileID = draft.profile.isBuiltIn ? draft.profile.id : nil
         videoOutputMode = encoding.videoOutputMode.rawValue
-        av1CRF = encoding.av1CRF
-        hevcQuality = encoding.mvHEVC.generatedMergeQuality
-        leftRightBitrate = encoding.generatedEyeCustomBitrateMbps
-        upscaleEnabled = encoding.upscaleEnabled
-        upscaleQuality = encoding.upscaleQuality
-        fieldOfView = encoding.fieldOfView
-        frameRateOverrideSet = !encoding.frameRateOverride.isEmpty
-        resolutionOverrideSet = !encoding.resolutionOverride.isEmpty
-        cropBlackBars = encoding.cropBlackBars
-        swapEyes = encoding.swapEyes
+        requestedVideoRoute = route.kind.rawValue
+        routeRequirement = route.generatedRequirement?.identifier
+        directBitrateMode = route.kind == .directMVHEVC
+            ? encoding.mvHEVC.directFinalBitrate.mode.rawValue
+            : nil
+        directFinalBitrate = route.kind == .directMVHEVC ? route.directBitrateMbps : nil
+        av1CRF = route.kind == .av1Stereo ? route.av1CRF : nil
+        generatedEyeBitrateMode = route.kind == .generatedMVHEVC
+            ? encoding.mvHEVC.generatedEyeBitrate.mode.rawValue
+            : nil
+        hevcQuality = route.generatedMergeQuality
+        leftRightBitrate = route.generatedEyeBitrateMbps
+        if route.kind == .existingArtifact {
+            let resumesAtUpscale = job.startStage == .upscaleVideo
+                && encoding.videoOutputMode == .mvHEVC
+            upscaleEnabled = resumesAtUpscale ? encoding.upscaleEnabled : nil
+            upscaleQuality = resumesAtUpscale && encoding.upscaleEnabled ? encoding.upscaleQuality : nil
+            fieldOfView = nil
+            frameRateOverrideSet = nil
+            resolutionOverrideSet = nil
+            cropBlackBars = nil
+            swapEyes = nil
+        } else {
+            let routeAllowsUpscale = route.kind != .av1Stereo
+            let activeUpscale = routeAllowsUpscale && encoding.upscaleEnabled
+            upscaleEnabled = routeAllowsUpscale ? encoding.upscaleEnabled : false
+            upscaleQuality = activeUpscale ? encoding.upscaleQuality : nil
+            fieldOfView = encoding.fieldOfView
+            frameRateOverrideSet = !encoding.frameRateOverride.isEmpty
+            resolutionOverrideSet = route.kind == .av1Stereo ? false : !encoding.resolutionOverride.isEmpty
+            cropBlackBars = encoding.cropBlackBars
+            swapEyes = encoding.swapEyes
+        }
         audioHandling = encoding.audioHandling.rawValue
         audioBitrate = encoding.audioBitrate
         subtitleMode = encoding.subtitles.mode.rawValue

--- a/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/PreviewViewModel.swift
@@ -29,6 +29,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var reviewedDraft: PreviewDraft?
     @Published private(set) var elapsedSeconds = 0
     @Published private(set) var progress: WorkerProgress?
+    @Published private(set) var videoRoute: VideoRouteReport?
 
     private let clientFactory: ClientFactory
     private let cache: PreviewCache
@@ -92,6 +93,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         pendingTerminalEvent = nil
         elapsedSeconds = 0
         progress = nil
+        videoRoute = nil
 
         let jobID = UUID()
         do {
@@ -152,6 +154,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         }
         releaseArtifact()
         reviewedDraft = nil
+        videoRoute = nil
         phase = .expired
         stageMessage = "Preview Expired"
         activityMessage = "The cached preview was removed."
@@ -164,6 +167,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
         guard cache.fileManager.fileExists(atPath: artifactLease.artifact.outputURL.path) else {
             self.artifactLease = nil
             reviewedDraft = nil
+            videoRoute = nil
             phase = .expired
             stageMessage = "Preview Expired"
             activityMessage = "The cached preview is no longer available."
@@ -182,6 +186,9 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
     private func receive(_ event: WorkerEvent) throws {
         if let observabilityEvent = event.payload.observabilityEvent {
             observabilityEventStore.append(observabilityEvent)
+        }
+        if let reportedVideoRoute = event.payload.videoRoute {
+            videoRoute = reportedVideoRoute
         }
         if event.type.isTerminal {
             pendingTerminalEvent = event
@@ -241,6 +248,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
             directoryURL: activeDirectoryURL,
             cache: cache
         )
+        videoRoute = artifact.videoRoute ?? videoRoute
         reviewedDraft = activeDraft
         phase = .ready
         stageMessage = "Ready to Play"
@@ -261,6 +269,7 @@ final class PreviewViewModel: ObservableObject, UpdateInstallPostponing {
                 failTransport(PreviewViewModelError.missingArtifact.localizedDescription)
                 return
             }
+            videoRoute = completedArtifact.videoRoute ?? videoRoute
             phase = .ready
             stageMessage = "Ready to Play"
             clearActiveWorker(preserveDirectory: true)

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -409,12 +409,18 @@ struct EncodingOptions: Codable, Equatable {
     }
 
     var videoSummary: String {
+        videoSummary(for: VideoRoutePlan(encoding: self))
+    }
+
+    func videoSummary(for route: VideoRoutePlan) -> String {
         let resolution = upscaleEnabled ? "2× upscale" : "source resolution"
-        return switch videoOutputMode {
-        case .mvHEVC:
-            "MV-HEVC \(mvHEVC.generatedMergeQuality) · \(generatedEyeCustomBitrateMbps) Mbps eyes · \(resolution)"
+        return switch route.kind {
+        case .directMVHEVC, .generatedMVHEVC:
+            "\(route.compactSummary) · \(resolution)"
         case .av1Stereo:
-            "AV1 stereo CRF \(av1CRF) · full side-by-side · source resolution"
+            "\(route.compactSummary) · full side-by-side · source resolution"
+        case .existingArtifact:
+            route.compactSummary
         }
     }
 
@@ -533,8 +539,16 @@ struct ConversionOptions: Codable, Equatable {
     var encoding = EncodingOptions()
     var job = JobOptions()
 
+    var videoRoutePlan: VideoRoutePlan {
+        VideoRoutePlan(options: self)
+    }
+
+    var videoSummary: String {
+        encoding.videoSummary(for: videoRoutePlan)
+    }
+
     var compactSummary: String {
-        encoding.compactSummary
+        "\(videoSummary) · Audio: \(encoding.audioSummary) · Subtitles: \(encoding.subtitleSummary)"
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -39,7 +39,7 @@ enum ConversionSourceKind: String, CaseIterable, Identifiable {
         case .matroska:
             "film.stack"
         case .sourceFolder:
-            "folder.stack"
+            "folder"
         case .transportStream:
             "doc.richtext"
         }
@@ -152,11 +152,13 @@ enum DiscSourceDetector {
     }
 
     static func insertedDiscs(fileManager: FileManager = .default) -> [ConversionSource] {
-        let volumeKeys: [URLResourceKey] = [.volumeNameKey, .isVolumeKey]
+        let volumeKeys: [URLResourceKey] = [.volumeNameKey, .isVolumeKey, .volumeIsLocalKey]
         let volumes = fileManager.mountedVolumeURLs(
             includingResourceValuesForKeys: volumeKeys,
             options: [.skipHiddenVolumes]
-        ) ?? []
+        )?.filter { volumeURL in
+            (try? volumeURL.resourceValues(forKeys: [.volumeIsLocalKey]).volumeIsLocal) != false
+        } ?? []
         return insertedDiscs(in: volumes, fileManager: fileManager)
     }
 
@@ -166,8 +168,8 @@ enum DiscSourceDetector {
         devicePathResolver: (URL) -> String? = physicalDevicePath(for:)
     ) -> [ConversionSource] {
         volumes.compactMap { volumeURL in
-            guard isBluRayFolder(volumeURL, fileManager: fileManager),
-                  let devicePath = devicePathResolver(volumeURL)
+            guard let devicePath = devicePathResolver(volumeURL),
+                  isBluRayFolder(volumeURL, fileManager: fileManager)
             else {
                 return nil
             }

--- a/macos/BluRayToVisionPro/Models/VideoRouting.swift
+++ b/macos/BluRayToVisionPro/Models/VideoRouting.swift
@@ -1,0 +1,565 @@
+import Foundation
+
+enum VideoRouteKind: String, Equatable {
+    case directMVHEVC = "direct_mv_hevc"
+    case generatedMVHEVC = "generated_mv_hevc"
+    case av1Stereo = "av1"
+    case existingArtifact = "existing_artifact"
+}
+
+enum GeneratedVideoRouteRequirement: Equatable {
+    case restartStage
+    case reusableIntermediates
+    case softwareEncoder
+    case upscale
+    case fieldOfView
+
+    var identifier: String {
+        switch self {
+        case .restartStage:
+            "restart_stage_requires_generated_artifacts"
+        case .reusableIntermediates:
+            "reusable_intermediates_requested"
+        case .softwareEncoder:
+            "software_encoder_requested"
+        case .upscale:
+            "upscale_requires_generated_artifacts"
+        case .fieldOfView:
+            "field_of_view_requires_generated_route"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .restartStage:
+            "The selected restart stage requires file-backed stereo artifacts."
+        case .reusableIntermediates:
+            "Creating reusable intermediate files for inspection or external processing requires generated left- and right-eye movies."
+        case .softwareEncoder:
+            "Software HEVC encoding requires generated left- and right-eye movies."
+        case .upscale:
+            "FX Upscale currently uses completed video files, so this job requires the generated route."
+        case .fieldOfView:
+            "This field of view is outside the direct encoder's 1°–180° range, so the generated route is required."
+        }
+    }
+}
+
+struct VideoRoutePlan: Equatable {
+    static let automaticDirectBitrateMbps = 40
+    static let automaticGeneratedEyeBitrateMbps = MVHEVCOptions.defaultGeneratedEyeBitrate
+    static let automaticGeneratedMergeQuality = 75
+
+    let kind: VideoRouteKind
+    let generatedRequirement: GeneratedVideoRouteRequirement?
+    let startStage: Int
+    let includesUpscale: Bool
+    let directBitrateMode: BitrateMode?
+    let directBitrateMbps: Int?
+    let generatedEyeBitrateMode: BitrateMode?
+    let generatedEyeBitrateMbps: Int?
+    let generatedMergeQuality: Int?
+    let av1CRF: Int?
+
+    init(
+        options: ConversionOptions,
+        allowsExistingArtifact: Bool = true
+    ) {
+        self.init(
+            encoding: options.encoding,
+            startStage: options.job.startStage.rawValue,
+            keepsReusableArtifacts: options.job.intermediatePolicy.createsReusableArtifacts,
+            softwareEncoder: options.job.softwareEncoder,
+            allowsExistingArtifact: allowsExistingArtifact
+        )
+    }
+
+    init(
+        encoding: EncodingOptions,
+        job: JobOptions = JobOptions(),
+        allowsExistingArtifact: Bool = true
+    ) {
+        self.init(
+            encoding: encoding,
+            startStage: job.startStage.rawValue,
+            keepsReusableArtifacts: job.intermediatePolicy.createsReusableArtifacts,
+            softwareEncoder: job.softwareEncoder,
+            allowsExistingArtifact: allowsExistingArtifact
+        )
+    }
+
+    init(
+        encoding: EncodingOptions,
+        startStage: Int,
+        keepsReusableArtifacts: Bool,
+        softwareEncoder: Bool,
+        allowsExistingArtifact: Bool
+    ) {
+        self.startStage = startStage
+        includesUpscale = encoding.videoOutputMode == .mvHEVC && encoding.upscaleEnabled
+
+        if allowsExistingArtifact, startStage > ConversionStage.combineToMVHEVC.rawValue {
+            kind = .existingArtifact
+            generatedRequirement = nil
+            directBitrateMode = nil
+            directBitrateMbps = nil
+            generatedEyeBitrateMode = nil
+            generatedEyeBitrateMbps = nil
+            generatedMergeQuality = nil
+            av1CRF = nil
+            return
+        }
+
+        if encoding.videoOutputMode == .av1Stereo {
+            kind = .av1Stereo
+            generatedRequirement = nil
+            directBitrateMode = nil
+            directBitrateMbps = nil
+            generatedEyeBitrateMode = nil
+            generatedEyeBitrateMbps = nil
+            generatedMergeQuality = nil
+            av1CRF = encoding.av1CRF
+            return
+        }
+
+        let requirement: GeneratedVideoRouteRequirement?
+        if startStage >= ConversionStage.createLeftRightFiles.rawValue {
+            requirement = .restartStage
+        } else if keepsReusableArtifacts {
+            requirement = .reusableIntermediates
+        } else if softwareEncoder {
+            requirement = .softwareEncoder
+        } else if encoding.upscaleEnabled {
+            requirement = .upscale
+        } else if !(1 ... 180).contains(encoding.fieldOfView) {
+            requirement = .fieldOfView
+        } else {
+            requirement = nil
+        }
+
+        if let requirement {
+            kind = .generatedMVHEVC
+            generatedRequirement = requirement
+            directBitrateMode = nil
+            directBitrateMbps = nil
+            generatedEyeBitrateMode = encoding.mvHEVC.generatedEyeBitrate.mode
+            generatedEyeBitrateMbps = Self.resolvedBitrate(
+                encoding.mvHEVC.generatedEyeBitrate,
+                automatic: Self.automaticGeneratedEyeBitrateMbps
+            )
+            generatedMergeQuality = encoding.mvHEVC.generatedMergeQuality
+            av1CRF = nil
+            return
+        }
+
+        kind = .directMVHEVC
+        generatedRequirement = nil
+        directBitrateMode = encoding.mvHEVC.directFinalBitrate.mode
+        directBitrateMbps = Self.resolvedBitrate(
+            encoding.mvHEVC.directFinalBitrate,
+            automatic: Self.automaticDirectBitrateMbps
+        )
+        generatedEyeBitrateMode = nil
+        generatedEyeBitrateMbps = nil
+        generatedMergeQuality = nil
+        av1CRF = nil
+    }
+
+    var usesGeneratedSettings: Bool {
+        kind == .generatedMVHEVC
+    }
+
+    var allowsFinalizedPreview: Bool {
+        kind != .existingArtifact
+    }
+
+    var title: String {
+        switch kind {
+        case .directMVHEVC:
+            "Direct MV-HEVC when available"
+        case .generatedMVHEVC:
+            "Generated MV-HEVC"
+        case .av1Stereo:
+            "AV1 stereo"
+        case .existingArtifact:
+            "Existing encoded video artifact"
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .directMVHEVC:
+            "bolt.horizontal.circle"
+        case .generatedMVHEVC:
+            "rectangle.split.2x1"
+        case .av1Stereo:
+            "rectangle.split.2x1.fill"
+        case .existingArtifact:
+            "arrow.clockwise.circle"
+        }
+    }
+
+    var settingsSummary: String {
+        switch kind {
+        case .directMVHEVC:
+            "\(bitratePolicyTitle(directBitrateMode)) · \(directBitrateMbps ?? Self.automaticDirectBitrateMbps) Mbps final"
+        case .generatedMVHEVC:
+            "\(bitratePolicyTitle(generatedEyeBitrateMode)) · \(generatedEyeBitrateMbps ?? Self.automaticGeneratedEyeBitrateMbps) Mbps per eye · merge \(generatedMergeQuality ?? Self.automaticGeneratedMergeQuality)"
+        case .av1Stereo:
+            "CRF \(av1CRF ?? 32)"
+        case .existingArtifact:
+            "No video re-encode"
+        }
+    }
+
+    var compactSummary: String {
+        "\(title) · \(settingsSummary)"
+    }
+
+    var detail: String {
+        switch kind {
+        case .directMVHEVC:
+            "The engine confirms stereo MV-HEVC support before reading conversion input. If unavailable, it visibly uses Automatic generated settings instead."
+        case .generatedMVHEVC:
+            generatedRequirement?.detail ?? "This job creates left- and right-eye movies before assembling MV-HEVC."
+        case .av1Stereo:
+            "The bundled software encoder creates a full side-by-side AV1 movie."
+        case .existingArtifact:
+            "The selected restart stage resumes from an existing encoded video artifact, so encoder controls are not applied."
+        }
+    }
+
+    var pipelineSteps: [String] {
+        switch kind {
+        case .directMVHEVC:
+            ["1 Prepare", "2–3 Extract 3D", "4 Direct MV-HEVC", "7–9 Finish"]
+        case .generatedMVHEVC:
+            if includesUpscale {
+                ["1 Prepare", "2–4 Eye files", "5 Merge MV-HEVC", "6 FX Upscale", "7–9 Finish"]
+            } else {
+                ["1 Prepare", "2–4 Eye files", "5 Merge MV-HEVC", "7–9 Finish"]
+            }
+        case .av1Stereo:
+            ["1 Prepare", "2–3 Extract 3D", "4–5 AV1 stereo", "7–9 Finish"]
+        case .existingArtifact:
+            ["Resume stage \(startStage)", "Use encoded artifact", "Finish remaining stages"]
+        }
+    }
+
+    var pipelineDetail: String {
+        switch kind {
+        case .directMVHEVC:
+            "Direct MV-HEVC writes the stage-4 spatial movie and skips stage 5."
+        case .generatedMVHEVC:
+            if includesUpscale {
+                "Generated MV-HEVC creates eye movies at stage 4, assembles them at stage 5, and upscales at stage 6."
+            } else {
+                "Generated MV-HEVC creates eye movies at stage 4 and assembles them at stage 5."
+            }
+        case .av1Stereo:
+            "AV1 uses stages 1–5 and 7–9; FX Upscale is unavailable."
+        case .existingArtifact:
+            "Earlier video stages are preserved and not repeated."
+        }
+    }
+
+    private static func resolvedBitrate(_ preference: BitratePreference, automatic: Int) -> Int {
+        if preference.mode == .custom, let customMbps = preference.customMbps {
+            return customMbps
+        }
+        return automatic
+    }
+
+    private func bitratePolicyTitle(_ mode: BitrateMode?) -> String {
+        mode == .custom ? "Custom" : "Automatic"
+    }
+}
+
+extension VideoRouteReport {
+    var kind: VideoRouteKind? {
+        VideoRouteKind(rawValue: selected)
+    }
+
+    var isFallback: Bool {
+        fallbackReason != nil
+    }
+
+    var displayTitle: String {
+        switch kind {
+        case .directMVHEVC:
+            "Direct MV-HEVC"
+        case .generatedMVHEVC:
+            isFallback ? "Generated MV-HEVC fallback" : "Generated MV-HEVC"
+        case .av1Stereo:
+            "AV1 stereo"
+        case .existingArtifact:
+            "Existing encoded video artifact"
+        case .none:
+            "Video route"
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .directMVHEVC:
+            "bolt.horizontal.circle.fill"
+        case .generatedMVHEVC:
+            isFallback ? "arrow.triangle.branch" : "rectangle.split.2x1.fill"
+        case .av1Stereo:
+            "rectangle.split.2x1.fill"
+        case .existingArtifact:
+            "arrow.clockwise.circle.fill"
+        case .none:
+            "questionmark.circle"
+        }
+    }
+
+    var settingsSummary: String {
+        switch kind {
+        case .directMVHEVC:
+            return bitrateMbps.map { "\($0) Mbps final" } ?? "Automatic final bitrate"
+        case .generatedMVHEVC:
+            if let eyeBitrateMbps, let mergeQuality {
+                return "\(eyeBitrateMbps) Mbps per eye · merge \(mergeQuality)"
+            }
+            return "Generated stereo video"
+        case .av1Stereo:
+            return crf.map { "CRF \($0)" } ?? "Software AV1"
+        case .existingArtifact:
+            return "No video re-encode"
+        case .none:
+            return selected.replacingOccurrences(of: "_", with: " ")
+        }
+    }
+
+    var compactSummary: String {
+        "\(displayTitle) · \(settingsSummary)"
+    }
+
+    var displayDetail: String {
+        if let fallbackReason {
+            let fallback = Self.fallbackDescription(fallbackReason)
+            if fallbackTiming == "pre_input" {
+                return "\(fallback) The route changed before conversion input was read."
+            }
+            return fallback
+        }
+        return Self.reasonDescription(reason)
+    }
+
+    private static func reasonDescription(_ reason: String) -> String {
+        switch reason {
+        case "direct_eligible":
+            "This Mac confirmed direct stereo MV-HEVC support before conversion input."
+        case "generated_route_requested":
+            "The requested settings require generated eye movies."
+        case "restart_stage_requires_generated_artifacts":
+            "The selected restart stage requires generated stereo artifacts."
+        case "reusable_intermediates_requested":
+            "Reusable intermediate files were requested."
+        case "software_encoder_requested":
+            "Software HEVC encoding requires generated eye movies."
+        case "upscale_requires_generated_artifacts":
+            "FX Upscale requires the file-backed generated route."
+        case "field_of_view_requires_generated_route":
+            "The selected field of view requires the generated route."
+        case "av1_output_requested":
+            "AV1 stereo output was requested."
+        case "resume_uses_existing_video_artifact":
+            "The selected restart stage uses an existing encoded video artifact."
+        case "direct_capability_unavailable":
+            "Direct stereo MV-HEVC was unavailable, so preflight selected generated MV-HEVC."
+        default:
+            "The conversion engine selected this route during preflight."
+        }
+    }
+
+    private static func fallbackDescription(_ reason: String) -> String {
+        switch reason {
+        case "helper_missing":
+            "The packaged direct MV-HEVC encoder was unavailable, so the job uses generated eye movies."
+        case "helper_not_executable":
+            "The packaged direct MV-HEVC encoder could not be launched, so the job uses generated eye movies."
+        case "stereo_mv_hevc_encode_unavailable":
+            "This Mac could not initialize stereo MV-HEVC encoding, so the job uses generated eye movies."
+        default:
+            "Direct MV-HEVC was unavailable, so the job uses generated eye movies."
+        }
+    }
+}
+
+struct VideoStorageEstimate: Equatable {
+    let finalOutputBytes: Int64?
+    let peakWorkingBytes: Int64?
+    let retainedIntermediateBytes: Int64?
+    let conservativeFallbackReserve: Bool
+    let unavailableReason: String?
+
+    init(drafts: [ConversionDraft]) {
+        guard !drafts.isEmpty else {
+            finalOutputBytes = nil
+            peakWorkingBytes = nil
+            retainedIntermediateBytes = nil
+            conservativeFallbackReserve = false
+            unavailableReason = "Available after source analysis."
+            return
+        }
+
+        var committedBytes: Int64 = 0
+        var totalFinalBytes: Int64 = 0
+        var totalRetainedBytes: Int64 = 0
+        var maximumPeakBytes: Int64 = 0
+        var usesFallbackReserve = false
+
+        for draft in drafts {
+            guard let estimate = Self.estimate(draft: draft) else {
+                finalOutputBytes = nil
+                peakWorkingBytes = nil
+                retainedIntermediateBytes = nil
+                conservativeFallbackReserve = false
+                unavailableReason = Self.unavailableReason(for: draft)
+                return
+            }
+            maximumPeakBytes = max(maximumPeakBytes, committedBytes + estimate.peakBytes)
+            committedBytes += estimate.finalBytes + estimate.retainedBytes
+            totalFinalBytes += estimate.finalBytes
+            totalRetainedBytes += estimate.retainedBytes
+            usesFallbackReserve = usesFallbackReserve || estimate.conservativeFallbackReserve
+        }
+
+        finalOutputBytes = totalFinalBytes
+        peakWorkingBytes = maximumPeakBytes
+        retainedIntermediateBytes = totalRetainedBytes
+        conservativeFallbackReserve = usesFallbackReserve
+        unavailableReason = nil
+    }
+
+    var finalOutputDescription: String {
+        guard let description = formatted(finalOutputBytes) else {
+            return unavailableReason ?? "Not available"
+        }
+        return conservativeFallbackReserve ? "Up to \(description)" : "About \(description)"
+    }
+
+    var peakWorkingDescription: String {
+        guard let description = formatted(peakWorkingBytes) else {
+            return unavailableReason ?? "Not available"
+        }
+        return conservativeFallbackReserve ? "Up to \(description)" : "About \(description)"
+    }
+
+    var retainedIntermediateDescription: String {
+        guard let retainedIntermediateBytes else {
+            return unavailableReason ?? "Not available"
+        }
+        if retainedIntermediateBytes == 0 {
+            return "None after success"
+        }
+        return "About \(formatted(retainedIntermediateBytes) ?? "0 bytes")"
+    }
+
+    var detail: String {
+        if let unavailableReason {
+            return unavailableReason
+        }
+        if conservativeFallbackReserve {
+            return "Video-only estimate with overhead. Peak reserve includes the larger generated-fallback route; audio, subtitles, and source preparation can add space."
+        }
+        return "Video-only estimate with overhead. Audio, subtitles, and source preparation can add space."
+    }
+
+    private struct DraftEstimate {
+        let finalBytes: Int64
+        let peakBytes: Int64
+        let retainedBytes: Int64
+        let conservativeFallbackReserve: Bool
+    }
+
+    private static func estimate(draft: ConversionDraft) -> DraftEstimate? {
+        guard let durationSeconds = draft.estimatedDurationSeconds,
+              durationSeconds.isFinite,
+              durationSeconds > 0
+        else {
+            return nil
+        }
+
+        let route = VideoRoutePlan(options: draft.options)
+        switch route.kind {
+        case .directMVHEVC:
+            let directFinal = bytes(
+                bitrateMbps: route.directBitrateMbps ?? VideoRoutePlan.automaticDirectBitrateMbps,
+                durationSeconds: durationSeconds
+            )
+            let fallbackFinal = bytes(
+                bitrateMbps: VideoRoutePlan.automaticGeneratedEyeBitrateMbps * 2,
+                durationSeconds: durationSeconds
+            )
+            guard let directFinal, let fallbackFinal else {
+                return nil
+            }
+            return DraftEstimate(
+                finalBytes: max(directFinal, fallbackFinal),
+                peakBytes: max(directFinal, fallbackFinal * 2),
+                retainedBytes: 0,
+                conservativeFallbackReserve: true
+            )
+        case .generatedMVHEVC:
+            let aggregateBitrate = (route.generatedEyeBitrateMbps
+                ?? VideoRoutePlan.automaticGeneratedEyeBitrateMbps) * 2
+            guard let finalBytes = bytes(
+                bitrateMbps: aggregateBitrate,
+                durationSeconds: durationSeconds
+            ) else {
+                return nil
+            }
+            let eyeBytes = finalBytes
+            let retainedBytes = draft.options.job.intermediatePolicy.createsReusableArtifacts ? eyeBytes : 0
+            return DraftEstimate(
+                finalBytes: finalBytes,
+                peakBytes: finalBytes + eyeBytes,
+                retainedBytes: retainedBytes,
+                conservativeFallbackReserve: false
+            )
+        case .av1Stereo, .existingArtifact:
+            return nil
+        }
+    }
+
+    private static func unavailableReason(for draft: ConversionDraft) -> String {
+        switch VideoRoutePlan(options: draft.options).kind {
+        case .av1Stereo:
+            "AV1 size varies with source content and CRF."
+        case .existingArtifact:
+            "This restart uses an existing encoded video artifact."
+        case .directMVHEVC, .generatedMVHEVC:
+            "Available after source duration is known."
+        }
+    }
+
+    private static func bytes(bitrateMbps: Int, durationSeconds: Double) -> Int64? {
+        let estimatedBytes = Double(bitrateMbps) * 1_000_000 / 8 * durationSeconds * 1.15
+        guard estimatedBytes.isFinite, estimatedBytes >= 0, estimatedBytes <= Double(Int64.max) else {
+            return nil
+        }
+        return Int64(estimatedBytes.rounded(.up))
+    }
+
+    private func formatted(_ bytes: Int64?) -> String? {
+        guard let bytes else {
+            return nil
+        }
+        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+extension ConversionDraft {
+    var estimatedDurationSeconds: Double? {
+        if let selectedTitle, selectedTitle.durationSeconds > 0 {
+            return selectedTitle.durationSeconds
+        }
+        guard let durationSeconds = sourceDetails?.durationSeconds, durationSeconds > 0 else {
+            return nil
+        }
+        return durationSeconds
+    }
+}

--- a/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerJobSpec.swift
@@ -391,17 +391,16 @@ struct WorkerJobSpec: Encodable, Equatable {
     ) -> Encoding.Video {
         let requestedStartStage = routeStartStage ?? job.startStage
         let keepsReusableArtifacts = routeKeepFiles ?? job.keepFiles
-        if options.videoOutputMode == .av1Stereo {
-            if allowsExistingArtifact, requestedStartStage > ConversionStage.combineToMVHEVC.rawValue {
-                return Encoding.Video(
-                    mode: .av1Stereo,
-                    routeIntent: .existingArtifact,
-                    directBitrate: nil,
-                    generatedEyeBitrate: nil,
-                    generatedMergeQuality: nil,
-                    av1CRF: nil
-                )
-            }
+        let route = VideoRoutePlan(
+            encoding: options,
+            startStage: requestedStartStage,
+            keepsReusableArtifacts: keepsReusableArtifacts,
+            softwareEncoder: job.softwareEncoder,
+            allowsExistingArtifact: allowsExistingArtifact
+        )
+
+        switch route.kind {
+        case .av1Stereo:
             return Encoding.Video(
                 mode: .av1Stereo,
                 routeIntent: .encode,
@@ -410,25 +409,16 @@ struct WorkerJobSpec: Encodable, Equatable {
                 generatedMergeQuality: nil,
                 av1CRF: options.av1CRF
             )
-        }
-
-        if allowsExistingArtifact, requestedStartStage > ConversionStage.combineToMVHEVC.rawValue {
+        case .existingArtifact:
             return Encoding.Video(
-                mode: .mvHEVC,
+                mode: options.videoOutputMode,
                 routeIntent: .existingArtifact,
                 directBitrate: nil,
                 generatedEyeBitrate: nil,
                 generatedMergeQuality: nil,
                 av1CRF: nil
             )
-        }
-
-        let requiresGeneratedRoute = requestedStartStage >= ConversionStage.createLeftRightFiles.rawValue
-            || keepsReusableArtifacts
-            || job.softwareEncoder
-            || options.upscaleEnabled
-            || !(1 ... 180).contains(options.fieldOfView)
-        if requiresGeneratedRoute {
+        case .generatedMVHEVC:
             return Encoding.Video(
                 mode: .mvHEVC,
                 routeIntent: .generated,
@@ -437,16 +427,16 @@ struct WorkerJobSpec: Encodable, Equatable {
                 generatedMergeQuality: options.mvHEVC.generatedMergeQuality,
                 av1CRF: nil
             )
+        case .directMVHEVC:
+            return Encoding.Video(
+                mode: .mvHEVC,
+                routeIntent: .automatic,
+                directBitrate: bitrate(from: options.mvHEVC.directFinalBitrate),
+                generatedEyeBitrate: nil,
+                generatedMergeQuality: nil,
+                av1CRF: nil
+            )
         }
-
-        return Encoding.Video(
-            mode: .mvHEVC,
-            routeIntent: .automatic,
-            directBitrate: bitrate(from: options.mvHEVC.directFinalBitrate),
-            generatedEyeBitrate: nil,
-            generatedMergeQuality: nil,
-            av1CRF: nil
-        )
     }
 
     private static func bitrate(from preference: BitratePreference) -> Encoding.Bitrate {

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -79,6 +79,7 @@ struct WorkerLifecycleState: Equatable {
     private(set) var progress: WorkerProgress?
     private(set) var result: SourceInspection?
     private(set) var conversionResult: ConversionResult?
+    private(set) var videoRoute: VideoRouteReport?
     private(set) var failureMessage: String?
     private(set) var failureDetails: String?
     private(set) var failureCode: String?
@@ -127,6 +128,10 @@ struct WorkerLifecycleState: Equatable {
         }
         lastSequence = event.sequence
 
+        if let reportedVideoRoute = event.payload.videoRoute {
+            videoRoute = reportedVideoRoute
+        }
+
         if phase == .stopping, !event.type.isTerminal {
             return
         }
@@ -174,6 +179,7 @@ struct WorkerLifecycleState: Equatable {
                     throw WorkerLifecycleError.missingPayload(event: event.type)
                 }
                 conversionResult = convResult
+                videoRoute = convResult.videoRoute ?? videoRoute
                 stageMessage = "Conversion complete"
             }
             progress = nil
@@ -265,6 +271,7 @@ struct WorkerLifecycleState: Equatable {
         progress = nil
         result = nil
         conversionResult = nil
+        videoRoute = nil
         failureMessage = nil
         failureDetails = nil
         failureCode = nil

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var titleSelection = DiscTitleSelection.main
     @State private var isShowingTitleChooser = false
     @State private var isShowingDiagnosticReport = false
+    @State private var isRefreshingDiscs = false
 
     init(
         viewModel: ConversionViewModel,
@@ -73,6 +74,7 @@ struct ContentView: View {
                     queueItems: visibleQueueItems,
                     destinationURL: $destinationURL,
                     plannedOutputURLs: plannedOutputURLs,
+                    storageEstimate: VideoStorageEstimate(drafts: conversionDrafts),
                     refreshDiscs: refreshDiscs,
                     useDisc: selectSource,
                     openDiscImage: { chooseFile(.discImage) },
@@ -635,6 +637,11 @@ struct ContentView: View {
         if let warningMessage = viewModel.state.warningMessage {
             return "Warning: \(warningMessage)"
         }
+        if viewModel.state.operationKind == .conversion,
+           let videoRoute = viewModel.state.videoRoute
+        {
+            return videoRoute.compactSummary
+        }
         if let batchQueue = viewModel.batchQueue {
             if batchQueue.isRunning {
                 return viewModel.state.stageMessage
@@ -729,6 +736,9 @@ struct ContentView: View {
         guard selectedVideoCount == 1 else {
             return false
         }
+        guard requestedVideoRoute.allowsFinalizedPreview else {
+            return false
+        }
         switch viewModel.source?.kind {
         case .discImage, .matroska, .transportStream:
             return true
@@ -739,10 +749,13 @@ struct ContentView: View {
 
     private var previewUnavailableReason: String {
         if previewCanStart {
-            return "Create a representative preview with the current resolved settings."
+            return "Create a finalized representative preview with the current route policy and settings."
         }
         if selectedVideoCount > 1 {
             return "Choose one 3D video to create a preview."
+        }
+        if !requestedVideoRoute.allowsFinalizedPreview {
+            return "A late-stage restart uses an existing video artifact. Choose an earlier start stage to generate a representative preview."
         }
         switch viewModel.source?.kind {
         case .physicalDisc, .bluRayFolder:
@@ -750,6 +763,10 @@ struct ContentView: View {
         default:
             return conversionUnavailableReason
         }
+    }
+
+    private var requestedVideoRoute: VideoRoutePlan {
+        VideoRoutePlan(options: options)
     }
 
     private var canSelectSource: Bool {
@@ -831,16 +848,25 @@ struct ContentView: View {
     }
 
     private func refreshDiscs() {
-        let refreshedDiscs = DiscSourceDetector.insertedDiscs()
-        insertedDiscs = refreshedDiscs
-        guard !viewModel.hasActiveWork,
-              let selectedSource = viewModel.source,
-              selectedSource.kind == .physicalDisc,
-              !refreshedDiscs.contains(where: { $0.workerSourcePath == selectedSource.workerSourcePath })
-        else {
+        guard !isRefreshingDiscs else {
             return
         }
-        viewModel.clearSource()
+        isRefreshingDiscs = true
+        Task { @MainActor in
+            let refreshedDiscs = await Task.detached(priority: .utility) {
+                DiscSourceDetector.insertedDiscs()
+            }.value
+            insertedDiscs = refreshedDiscs
+            isRefreshingDiscs = false
+            guard !viewModel.hasActiveWork,
+                  let selectedSource = viewModel.source,
+                  selectedSource.kind == .physicalDisc,
+                  !refreshedDiscs.contains(where: { $0.workerSourcePath == selectedSource.workerSourcePath })
+            else {
+                return
+            }
+            viewModel.clearSource()
+        }
     }
 
     private func handleVolumeUnmount(_ notification: Notification) {

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -88,7 +88,11 @@ struct ConversionSetupView: View {
             Group {
                 switch selectedTab {
                 case .video:
-                    EncodingOptionsEditor(options: $options.encoding, section: .video)
+                    EncodingOptionsEditor(
+                        options: $options.encoding,
+                        section: .video,
+                        jobOptions: options.job
+                    )
                 case .audioAndSubtitles:
                     EncodingOptionsEditor(options: $options.encoding, section: .audioAndSubtitles)
                 case .filesAndRecovery:
@@ -107,21 +111,31 @@ struct ConversionSetupView: View {
     private var filesAndRecoveryForm: some View {
         Form {
             Section("Pipeline and Recovery") {
+                VideoRouteSummaryView(plan: routePlan)
+
                 Picker("Start stage", selection: $options.job.startStage) {
                     ForEach(ConversionStage.allCases) { stage in
                         Text(stage.title).tag(stage)
                     }
                 }
 
-                Toggle("Keep durable stage files", isOn: reusableIntermediatesBinding)
+                Toggle("Create reusable intermediate files", isOn: reusableIntermediatesBinding)
+                Text(intermediatePolicyDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Toggle("Continue processing after recoverable errors", isOn: $options.job.continueOnError)
                 Toggle("Use software HEVC encoder", isOn: $options.job.softwareEncoder)
-                    .disabled(options.encoding.videoOutputMode == .av1Stereo)
-                    .help(
-                        options.encoding.videoOutputMode == .av1Stereo
-                            ? "AV1 output always uses the bundled software encoder."
-                            : "Use libx265 instead of the default VideoToolbox HEVC encoder."
-                    )
+                    .disabled(!softwareEncoderIsApplicable)
+                    .help(softwareEncoderHelp)
+
+                if options.job.softwareEncoder, softwareEncoderIsApplicable {
+                    Text("Software HEVC requires generated left- and right-eye movies.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             Section("Output Files") {
@@ -157,6 +171,50 @@ struct ConversionSetupView: View {
                 options.job.intermediatePolicy = enabled ? .reusable : .automatic
             }
         )
+    }
+
+    private var routePlan: VideoRoutePlan {
+        VideoRoutePlan(options: options)
+    }
+
+    private var intermediatePolicyDetail: String {
+        if options.job.intermediatePolicy.createsReusableArtifacts {
+            return switch routePlan.kind {
+            case .directMVHEVC:
+                "Creates and retains reusable stage artifacts."
+            case .generatedMVHEVC:
+                "Creates and retains generated eye files for inspection or external processing."
+            case .av1Stereo:
+                "Creates and retains reusable AV1 stage artifacts."
+            case .existingArtifact:
+                "Retains new stage artifacts created after the selected restart point; the existing video artifact is reused unchanged."
+            }
+        }
+        return switch routePlan.kind {
+        case .directMVHEVC:
+            "Direct jobs avoid eye movies. A generated fallback may create temporary eye files, which are removed after success."
+        case .generatedMVHEVC:
+            "Generated eye files are temporary and removed after a successful conversion."
+        case .av1Stereo:
+            "Temporary AV1 stage files are removed after a successful conversion."
+        case .existingArtifact:
+            "Temporary files created after the selected restart point are removed after success; the existing video artifact is preserved."
+        }
+    }
+
+    private var softwareEncoderIsApplicable: Bool {
+        options.encoding.videoOutputMode == .mvHEVC
+            && options.job.startStage.rawValue <= ConversionStage.createLeftRightFiles.rawValue
+    }
+
+    private var softwareEncoderHelp: String {
+        if options.encoding.videoOutputMode == .av1Stereo {
+            return "AV1 output always uses the bundled software encoder."
+        }
+        if !softwareEncoderIsApplicable {
+            return "The selected restart stage does not encode HEVC video."
+        }
+        return "Use libx265 instead of the default VideoToolbox HEVC encoder."
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -19,6 +19,26 @@ enum EncodingOptionsSection: String, CaseIterable, Identifiable {
 struct EncodingOptionsEditor: View {
     @Binding var options: EncodingOptions
     let section: EncodingOptionsSection
+    let jobOptions: JobOptions?
+
+    @State private var showsAdvancedDirectBitrate: Bool
+    @State private var showsAdvancedGeneratedBitrate: Bool
+
+    init(
+        options: Binding<EncodingOptions>,
+        section: EncodingOptionsSection,
+        jobOptions: JobOptions? = nil
+    ) {
+        _options = options
+        self.section = section
+        self.jobOptions = jobOptions
+        _showsAdvancedDirectBitrate = State(
+            initialValue: options.wrappedValue.mvHEVC.directFinalBitrate.mode == .custom
+        )
+        _showsAdvancedGeneratedBitrate = State(
+            initialValue: options.wrappedValue.mvHEVC.generatedEyeBitrate.mode == .custom
+        )
+    }
 
     var body: some View {
         switch section {
@@ -44,15 +64,100 @@ struct EncodingOptionsEditor: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    if options.videoOutputMode == .mvHEVC {
-                        EncodingQualitySliderRow(title: "HEVC quality", value: hevcQualityBinding)
-                        LabeledContent("Left / right bitrate") {
-                            Stepper(value: generatedEyeBitrateBinding, in: 1 ... 100) {
-                                Text("\(options.generatedEyeCustomBitrateMbps) Mbps")
-                                    .monospacedDigit()
-                                    .frame(width: 76, alignment: .trailing)
+                    Divider()
+                    VideoRouteSummaryView(plan: routePlan)
+
+                    if routePlan.kind == .existingArtifact {
+                        if options.videoOutputMode == .mvHEVC,
+                           routePlan.startStage == ConversionStage.upscaleVideo.rawValue
+                        {
+                            Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
+                            if options.upscaleEnabled {
+                                EncodingQualitySliderRow(title: "Upscale quality", value: upscaleQualityBinding)
                             }
                         }
+                    } else if options.videoOutputMode == .mvHEVC {
+                        if routePlan.usesGeneratedSettings {
+                            EncodingQualitySliderRow(
+                                title: "MV-HEVC merge quality",
+                                value: hevcQualityBinding
+                            )
+
+                            LabeledContent("Eye intermediate bitrate") {
+                                Text(generatedEyeBitrateSummary)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.trailing)
+                            }
+
+                            DisclosureGroup(
+                                "Advanced eye intermediate bitrate",
+                                isExpanded: $showsAdvancedGeneratedBitrate
+                            ) {
+                                Picker("Bitrate policy", selection: generatedEyeBitrateModeBinding) {
+                                    Text("Automatic (Recommended)").tag(BitrateMode.automatic)
+                                    Text("Custom").tag(BitrateMode.custom)
+                                }
+                                .pickerStyle(.segmented)
+
+                                if options.mvHEVC.generatedEyeBitrate.mode == .custom {
+                                    LabeledContent("Custom target") {
+                                        Stepper(value: generatedEyeBitrateBinding, in: 1 ... 500) {
+                                            Text("\(options.generatedEyeCustomBitrateMbps) Mbps per eye")
+                                                .monospacedDigit()
+                                                .multilineTextAlignment(.trailing)
+                                        }
+                                    }
+                                } else {
+                                    Text(
+                                        "Automatic currently resolves to \(VideoRoutePlan.automaticGeneratedEyeBitrateMbps) Mbps per eye."
+                                    )
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Text("This target applies only to generated left- and right-eye movies.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else {
+                            LabeledContent("Final bitrate") {
+                                Text(directFinalBitrateSummary)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.trailing)
+                            }
+
+                            DisclosureGroup(
+                                "Advanced final bitrate",
+                                isExpanded: $showsAdvancedDirectBitrate
+                            ) {
+                                Picker("Bitrate policy", selection: directFinalBitrateModeBinding) {
+                                    Text("Automatic (Recommended)").tag(BitrateMode.automatic)
+                                    Text("Custom").tag(BitrateMode.custom)
+                                }
+                                .pickerStyle(.segmented)
+
+                                if options.mvHEVC.directFinalBitrate.mode == .custom {
+                                    LabeledContent("Custom target") {
+                                        Stepper(value: directFinalBitrateBinding, in: 1 ... 500) {
+                                            Text("\(directFinalCustomBitrateMbps) Mbps final")
+                                                .monospacedDigit()
+                                                .multilineTextAlignment(.trailing)
+                                        }
+                                    }
+                                } else {
+                                    Text(
+                                        "Automatic currently resolves to \(VideoRoutePlan.automaticDirectBitrateMbps) Mbps final."
+                                    )
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Text("This target applies only when direct MV-HEVC is selected during preflight.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
                         Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
 
                         if options.upscaleEnabled {
@@ -83,42 +188,50 @@ struct EncodingOptionsEditor: View {
                     }
                 }
 
-                Section("Picture") {
-                    if options.videoOutputMode == .mvHEVC {
-                        LabeledContent("Field of view") {
-                            Stepper(value: $options.fieldOfView, in: 0 ... 360) {
-                                Text("\(options.fieldOfView)°")
-                                    .monospacedDigit()
-                                    .frame(width: 48, alignment: .trailing)
+                if routePlan.kind != .existingArtifact {
+                    Section("Picture") {
+                        if options.videoOutputMode == .mvHEVC {
+                            LabeledContent("Field of view") {
+                                Stepper(value: $options.fieldOfView, in: 0 ... 360) {
+                                    Text("\(options.fieldOfView)°")
+                                        .monospacedDigit()
+                                        .frame(width: 48, alignment: .trailing)
+                                }
+                            }
+
+                            LabeledContent("Resolution override") {
+                                TextField("", text: $options.resolutionOverride, prompt: Text("Use source"))
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 170)
+                            }
+                        } else {
+                            LabeledContent("Resolution") {
+                                Text("Full source resolution per eye")
+                                    .foregroundStyle(.secondary)
                             }
                         }
 
-                        LabeledContent("Resolution override") {
-                            TextField("", text: $options.resolutionOverride, prompt: Text("Use source"))
+                        LabeledContent("Frame-rate override") {
+                            TextField("", text: $options.frameRateOverride, prompt: Text("Use source"))
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 170)
                         }
-                    } else {
-                        LabeledContent("Resolution") {
-                            Text("Full source resolution per eye")
-                                .foregroundStyle(.secondary)
-                        }
                     }
 
-                    LabeledContent("Frame-rate override") {
-                        TextField("", text: $options.frameRateOverride, prompt: Text("Use source"))
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 170)
+                    Section("Stereo Corrections") {
+                        Toggle("Crop black bars", isOn: $options.cropBlackBars)
+                        Toggle("Swap left and right eyes", isOn: $options.swapEyes)
                     }
-                }
-
-                Section("Stereo Corrections") {
-                    Toggle("Crop black bars", isOn: $options.cropBlackBars)
-                    Toggle("Swap left and right eyes", isOn: $options.swapEyes)
                 }
             }
         }
         .formStyle(.grouped)
+        .onChange(of: options.mvHEVC.directFinalBitrate.mode) { _, mode in
+            showsAdvancedDirectBitrate = mode == .custom
+        }
+        .onChange(of: options.mvHEVC.generatedEyeBitrate.mode) { _, mode in
+            showsAdvancedGeneratedBitrate = mode == .custom
+        }
     }
 
     private var audioAndSubtitlesForm: some View {
@@ -203,6 +316,69 @@ struct EncodingOptionsEditor: View {
         )
     }
 
+    private var routePlan: VideoRoutePlan {
+        VideoRoutePlan(
+            encoding: options,
+            job: jobOptions ?? JobOptions()
+        )
+    }
+
+    private var generatedEyeBitrateSummary: String {
+        switch options.mvHEVC.generatedEyeBitrate.mode {
+        case .automatic:
+            "Automatic (Recommended) · \(VideoRoutePlan.automaticGeneratedEyeBitrateMbps) Mbps per eye"
+        case .custom:
+            "Custom · \(options.generatedEyeCustomBitrateMbps) Mbps per eye"
+        }
+    }
+
+    private var directFinalBitrateSummary: String {
+        switch options.mvHEVC.directFinalBitrate.mode {
+        case .automatic:
+            "Automatic (Recommended) · \(VideoRoutePlan.automaticDirectBitrateMbps) Mbps final"
+        case .custom:
+            "Custom · \(directFinalCustomBitrateMbps) Mbps final"
+        }
+    }
+
+    private var directFinalCustomBitrateMbps: Int {
+        options.mvHEVC.directFinalBitrate.customMbps ?? VideoRoutePlan.automaticDirectBitrateMbps
+    }
+
+    private var directFinalBitrateModeBinding: Binding<BitrateMode> {
+        Binding(
+            get: { options.mvHEVC.directFinalBitrate.mode },
+            set: { mode in
+                options.mvHEVC.directFinalBitrate.mode = mode
+                if mode == .custom, options.mvHEVC.directFinalBitrate.customMbps == nil {
+                    options.mvHEVC.directFinalBitrate.customMbps = VideoRoutePlan.automaticDirectBitrateMbps
+                }
+            }
+        )
+    }
+
+    private var directFinalBitrateBinding: Binding<Int> {
+        Binding(
+            get: { directFinalCustomBitrateMbps },
+            set: { newValue in
+                options.mvHEVC.directFinalBitrate.mode = .custom
+                options.mvHEVC.directFinalBitrate.customMbps = newValue
+            }
+        )
+    }
+
+    private var generatedEyeBitrateModeBinding: Binding<BitrateMode> {
+        Binding(
+            get: { options.mvHEVC.generatedEyeBitrate.mode },
+            set: { mode in
+                options.mvHEVC.generatedEyeBitrate.mode = mode
+                if mode == .custom, options.mvHEVC.generatedEyeBitrate.customMbps == nil {
+                    options.mvHEVC.generatedEyeBitrate.customMbps = MVHEVCOptions.defaultGeneratedEyeBitrate
+                }
+            }
+        )
+    }
+
     private var generatedEyeBitrateBinding: Binding<Int> {
         Binding(
             get: { options.generatedEyeCustomBitrateMbps },
@@ -241,7 +417,7 @@ private struct EncodingQualitySliderRow: View {
                     in: 0 ... 100,
                     step: 1
                 )
-                .frame(minWidth: 180)
+                .frame(minWidth: 120, idealWidth: 180)
 
                 Text("\(value)")
                     .monospacedDigit()

--- a/macos/BluRayToVisionPro/Views/PreviewSheet.swift
+++ b/macos/BluRayToVisionPro/Views/PreviewSheet.swift
@@ -44,7 +44,7 @@ struct PreviewSheet: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Representative Conversion Preview")
                     .font(.title2.weight(.semibold))
-                Text("Uses a separate child job and the exact resolved profile settings below.")
+                Text("Uses a separate finalized child job with the route policy and settings below.")
                     .foregroundStyle(.secondary)
             }
             Spacer()
@@ -104,6 +104,17 @@ struct PreviewSheet: View {
                     }
                 }
 
+                Divider()
+                    .gridCellColumns(2)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Requested Route")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    VideoRouteSummaryView(plan: requestedRoute)
+                }
+                .gridCellColumns(2)
+
                 if conversionDraft.source.kind == .discImage {
                     Divider()
                         .gridCellColumns(2)
@@ -140,6 +151,7 @@ struct PreviewSheet: View {
         if viewModel.phase == .ready, let lease = viewModel.artifactLease {
             PreviewPlayerView(
                 lease: lease,
+                videoRoute: viewModel.videoRoute,
                 generateAgain: generatePreview,
                 removePreview: viewModel.discardPreview,
                 startFullConversion: startReviewedConversion
@@ -175,6 +187,16 @@ struct PreviewSheet: View {
                     }
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(statusAccessibilityLabel)
+
+                    if let resolvedRoute = viewModel.videoRoute {
+                        Divider()
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text(previewRouteStatusTitle)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            VideoRouteSummaryView(report: resolvedRoute)
+                        }
+                    }
 
                 }
                 .padding(4)
@@ -273,7 +295,24 @@ struct PreviewSheet: View {
         if let progress = viewModel.progress, viewModel.hasActiveWorker {
             components.append(progress.accessibilityValue)
         }
+        if let videoRoute = viewModel.videoRoute {
+            components.append(videoRoute.compactSummary)
+            components.append(videoRoute.displayDetail)
+        }
         return components.joined(separator: ". ")
+    }
+
+    private var requestedRoute: VideoRoutePlan {
+        VideoRoutePlan(options: conversionDraft.options, allowsExistingArtifact: false)
+    }
+
+    private var previewRouteStatusTitle: String {
+        switch viewModel.phase {
+        case .failed, .idle:
+            "Last Attempted Route"
+        case .preparing, .encoding, .ready, .stopping, .expired:
+            "Resolved Route"
+        }
     }
 
     private func generatePreview() {
@@ -297,6 +336,7 @@ struct PreviewSheet: View {
 
 private struct PreviewPlayerView: View {
     let lease: PreviewArtifactLease
+    let videoRoute: VideoRouteReport?
     let generateAgain: () -> Void
     let removePreview: () -> Void
     let startFullConversion: () -> Void
@@ -305,11 +345,13 @@ private struct PreviewPlayerView: View {
 
     init(
         lease: PreviewArtifactLease,
+        videoRoute: VideoRouteReport?,
         generateAgain: @escaping () -> Void,
         removePreview: @escaping () -> Void,
         startFullConversion: @escaping () -> Void
     ) {
         self.lease = lease
+        self.videoRoute = videoRoute
         self.generateAgain = generateAgain
         self.removePreview = removePreview
         self.startFullConversion = startFullConversion
@@ -325,6 +367,10 @@ private struct PreviewPlayerView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .accessibilityLabel("Conversion preview video")
                     .accessibilityHint("Use the playback controls to play, pause, seek, and choose available audio or subtitles.")
+
+                if let resolvedRoute = videoRoute ?? lease.artifact.videoRoute {
+                    VideoRouteSummaryView(report: resolvedRoute)
+                }
 
                 HStack(spacing: 12) {
                     Label(rangeDescription, systemImage: "timeline.selection")

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -465,30 +465,55 @@ private struct ProfileEncodingSummaryView: View {
     }
 
     private var videoItems: [ProfileSummaryItem] {
-        var items = [ProfileSummaryItem(title: "Format", value: options.videoOutputMode.title)]
-        switch options.videoOutputMode {
-        case .mvHEVC:
+        let route = VideoRoutePlan(encoding: options)
+        var items = [
+            ProfileSummaryItem(title: "Format", value: options.videoOutputMode.title),
+            ProfileSummaryItem(title: "Route", value: route.title),
+        ]
+        switch route.kind {
+        case .directMVHEVC:
+            items.append(ProfileSummaryItem(title: "Final bitrate", value: route.settingsSummary))
+            items.append(ProfileSummaryItem(title: "AI FX upscale to 2× resolution", value: "Disabled"))
+        case .generatedMVHEVC:
             items.append(contentsOf: [
-                ProfileSummaryItem(title: "HEVC quality", value: "\(options.mvHEVC.generatedMergeQuality)"),
                 ProfileSummaryItem(
-                    title: "Left / right bitrate",
-                    value: "\(options.generatedEyeCustomBitrateMbps) Mbps"
+                    title: "Eye intermediate bitrate",
+                    value: generatedEyeBitrateSummary
+                ),
+                ProfileSummaryItem(
+                    title: "MV-HEVC merge quality",
+                    value: "\(options.mvHEVC.generatedMergeQuality)"
                 ),
                 ProfileSummaryItem(title: "AI FX upscale to 2× resolution", value: enabledText(options.upscaleEnabled)),
-                ProfileSummaryItem(title: "Upscale quality", value: "\(options.upscaleQuality)"),
-                ProfileSummaryItem(
-                    title: "Link HEVC and upscale quality",
-                    value: enabledText(options.mvHEVC.linkGeneratedAndUpscaleQuality)
-                ),
             ])
+            if options.upscaleEnabled {
+                items.append(contentsOf: [
+                    ProfileSummaryItem(title: "Upscale quality", value: "\(options.upscaleQuality)"),
+                    ProfileSummaryItem(
+                        title: "Link MV-HEVC and upscale quality",
+                        value: enabledText(options.mvHEVC.linkGeneratedAndUpscaleQuality)
+                    ),
+                ])
+            }
         case .av1Stereo:
             items.append(contentsOf: [
                 ProfileSummaryItem(title: "AV1 quality", value: "CRF \(options.av1CRF)"),
                 ProfileSummaryItem(title: "Packing", value: "Full side-by-side"),
                 ProfileSummaryItem(title: "Encoder", value: "Software SVT-AV1"),
             ])
+        case .existingArtifact:
+            items.append(ProfileSummaryItem(title: "Encoding", value: "Uses an existing stage artifact"))
         }
         return items
+    }
+
+    private var generatedEyeBitrateSummary: String {
+        switch options.mvHEVC.generatedEyeBitrate.mode {
+        case .automatic:
+            "Automatic (Recommended) · \(VideoRoutePlan.automaticGeneratedEyeBitrateMbps) Mbps per eye"
+        case .custom:
+            "Custom · \(options.generatedEyeCustomBitrateMbps) Mbps per eye"
+        }
     }
 
     private var pictureItems: [ProfileSummaryItem] {
@@ -731,7 +756,7 @@ private struct AdvancedSettingsPane: View {
 
             Section("Defaults for New Jobs") {
                 Toggle("Default to the software encoder", isOn: $settings.useSoftwareEncoder)
-                Toggle("Keep durable stage files by default", isOn: reusableIntermediatesBinding)
+                Toggle("Create reusable intermediate files by default", isOn: reusableIntermediatesBinding)
             }
 
             Section("Diagnostics") {

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -16,6 +16,7 @@ struct SourceWorkspaceView: View {
     let queueItems: [ConversionQueueItem]
     @Binding var destinationURL: URL
     let plannedOutputURLs: [URL]
+    let storageEstimate: VideoStorageEstimate
     let refreshDiscs: () -> Void
     let useDisc: (ConversionSource) -> Void
     let openDiscImage: () -> Void
@@ -136,7 +137,7 @@ struct SourceWorkspaceView: View {
                     }
                     HStack(spacing: 8) {
                         sourceButton("Open 3D MKV…", systemImage: "film.stack", action: openMKV)
-                        sourceButton("Open Source Folder…", systemImage: "folder.stack", action: openSourceFolder)
+                        sourceButton("Open Source Folder…", systemImage: "folder", action: openSourceFolder)
                     }
                 }
 
@@ -345,7 +346,7 @@ struct SourceWorkspaceView: View {
                 }
             }
         } else {
-            Label("Choose a source folder to build a conversion queue.", systemImage: "folder.stack")
+            Label("Choose a source folder to build a conversion queue.", systemImage: "folder")
                 .font(.callout)
                 .foregroundStyle(.secondary)
         }
@@ -459,13 +460,17 @@ struct SourceWorkspaceView: View {
         GroupBox {
             VStack(alignment: .leading, spacing: 10) {
                 LabeledContent("Destination") {
-                    HStack(spacing: 8) {
-                        Text(destinationURL.path)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Button("Choose…", action: chooseDestination)
-                            .disabled(outputControlsLocked)
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 8) {
+                            destinationPathText
+                            Button("Choose…", action: chooseDestination)
+                                .disabled(outputControlsLocked)
+                        }
+                        VStack(alignment: .trailing, spacing: 6) {
+                            destinationPathText
+                            Button("Choose…", action: chooseDestination)
+                                .disabled(outputControlsLocked)
+                        }
                     }
                 }
 
@@ -496,6 +501,31 @@ struct SourceWorkspaceView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
+
+                Divider()
+                if storageEstimate.peakWorkingBytes != nil {
+                    LabeledContent("Estimated final video") {
+                        Text(storageEstimate.finalOutputDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    LabeledContent("Peak video workspace") {
+                        Text(storageEstimate.peakWorkingDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                    LabeledContent("Retained intermediates") {
+                        Text(storageEstimate.retainedIntermediateDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    LabeledContent("Video workspace") {
+                        Text("Not available yet")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(storageEstimate.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(4)
         } label: {
@@ -518,7 +548,7 @@ struct SourceWorkspaceView: View {
                     }
                 }
                 LabeledContent("Video") {
-                    Text(options.encoding.videoSummary)
+                    Text(options.videoSummary)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.trailing)
                 }
@@ -541,6 +571,24 @@ struct SourceWorkspaceView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Divider()
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Requested Route")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    VideoRouteSummaryView(plan: routePlan)
+                }
+
+                if let resolvedRoute = state.videoRoute {
+                    Divider()
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(state.phase.isRunning ? "Resolved Route" : "Last Resolved Route")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        VideoRouteSummaryView(report: resolvedRoute)
+                    }
+                }
             }
             .padding(4)
         } label: {
@@ -552,28 +600,26 @@ struct SourceWorkspaceView: View {
     private var pipelineSection: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 5) {
-                    PipelineStep(systemImage: "opticaldisc", title: "1 Create MKV")
-                    pipelineChevron
-                    PipelineStep(
-                        systemImage: "rectangle.split.2x1",
-                        title: options.encoding.videoOutputMode == .av1Stereo ? "2–3 Extract 3D" : "2–4 Extract 3D"
-                    )
-                    pipelineChevron
-                    PipelineStep(
-                        systemImage: options.encoding.videoOutputMode == .av1Stereo ? "rectangle.split.2x1" : "visionpro",
-                        title: options.encoding.videoOutputMode == .av1Stereo ? "4–5 AV1 Stereo" : "5–6 Spatial"
-                    )
-                    pipelineChevron
-                    PipelineStep(systemImage: "checkmark.circle", title: "7–9 Finish")
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 5) {
+                        ForEach(Array(routePlan.pipelineSteps.enumerated()), id: \.offset) { index, title in
+                            PipelineStep(systemImage: pipelineSystemImage(at: index), title: title)
+                            if index < routePlan.pipelineSteps.count - 1 {
+                                pipelineChevron
+                            }
+                        }
+                    }
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(Array(routePlan.pipelineSteps.enumerated()), id: \.offset) { index, title in
+                            Label(title, systemImage: pipelineSystemImage(at: index))
+                                .font(.caption.weight(.medium))
+                        }
+                    }
                 }
-                Text(
-                    options.encoding.videoOutputMode == .av1Stereo
-                        ? "AV1 uses stages 1–5 and 7–9; stage 6 FX Upscale is unavailable."
-                        : "Nine restartable stages are available under Files & Recovery."
-                )
+                Text(routePlan.pipelineDetail)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(4)
         } label: {
@@ -601,6 +647,37 @@ struct SourceWorkspaceView: View {
 
     private var outputControlsLocked: Bool {
         isBatchRunning || state.phase.isRunning || state.phase == .decisionRequired
+    }
+
+    private var routePlan: VideoRoutePlan {
+        VideoRoutePlan(options: options)
+    }
+
+    private var destinationPathText: some View {
+        Text(destinationURL.path)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .textSelection(.enabled)
+    }
+
+    private func pipelineSystemImage(at index: Int) -> String {
+        if index == 0 {
+            return "opticaldisc"
+        }
+        if index == routePlan.pipelineSteps.count - 1 {
+            return "checkmark.circle"
+        }
+        switch routePlan.kind {
+        case .directMVHEVC:
+            return index == 2 ? "visionpro" : "rectangle.split.2x1"
+        case .generatedMVHEVC:
+            return index == 1 ? "rectangle.split.2x1" : "visionpro"
+        case .av1Stereo:
+            return "rectangle.split.2x1"
+        case .existingArtifact:
+            return "arrow.clockwise.circle"
+        }
     }
 
     private var outputSummary: String {

--- a/macos/BluRayToVisionPro/Views/VideoRouteSummaryView.swift
+++ b/macos/BluRayToVisionPro/Views/VideoRouteSummaryView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct VideoRouteSummaryView: View {
+    let title: String
+    let settings: String
+    let detail: String
+    let systemImage: String
+    let isFallback: Bool
+
+    init(plan: VideoRoutePlan) {
+        title = plan.title
+        settings = plan.settingsSummary
+        detail = plan.detail
+        systemImage = plan.systemImage
+        isFallback = false
+    }
+
+    init(report: VideoRouteReport) {
+        title = report.displayTitle
+        settings = report.settingsSummary
+        detail = report.displayDetail
+        systemImage = report.systemImage
+        isFallback = report.isFallback
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 30, height: 30)
+                .background(tint.opacity(0.12), in: Circle())
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 6) {
+                        Text(title)
+                            .fontWeight(.medium)
+                        Text(settings)
+                            .foregroundStyle(.secondary)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .fontWeight(.medium)
+                        Text(settings)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(isFallback ? tint : .secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title). \(settings). \(detail)")
+    }
+
+    private var tint: Color {
+        isFallback ? .orange : .accentColor
+    }
+}

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -188,13 +188,245 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertTrue(EncodingOptions().compactSummary.contains("Subtitles: English + others"))
         XCTAssertEqual(
             EncodingOptions(audioHandling: .automatic, audioBitrate: 448).compactSummary,
-            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: automatic audio (AAC fallback 448 kbps), English only · Subtitles: English + others"
+            "Direct MV-HEVC when available · Automatic · 40 Mbps final · source resolution · Audio: automatic audio (AAC fallback 448 kbps), English only · Subtitles: English + others"
         )
         XCTAssertEqual(
             EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
-            "MV-HEVC 75 · 20 Mbps eyes · source resolution · Audio: AAC 448 kbps, English only · Subtitles: English + others"
+            "Direct MV-HEVC when available · Automatic · 40 Mbps final · source resolution · Audio: AAC 448 kbps, English only · Subtitles: English + others"
         )
         XCTAssertTrue(BuiltInProfile.balanced.summary.contains("English audio only"))
+    }
+
+    func testVideoRoutePlanCoversDirectGeneratedAV1AndExistingRoutes() {
+        var options = ConversionOptions()
+
+        var route = VideoRoutePlan(options: options)
+        XCTAssertEqual(route.kind, .directMVHEVC)
+        XCTAssertEqual(route.directBitrateMode, .automatic)
+        XCTAssertEqual(route.directBitrateMbps, 40)
+        XCTAssertNil(route.generatedEyeBitrateMbps)
+        XCTAssertTrue(route.allowsFinalizedPreview)
+
+        options.job.intermediatePolicy = .reusable
+        route = VideoRoutePlan(options: options)
+        XCTAssertEqual(route.kind, .generatedMVHEVC)
+        XCTAssertEqual(route.generatedRequirement, .reusableIntermediates)
+        XCTAssertEqual(route.generatedEyeBitrateMode, .automatic)
+        XCTAssertEqual(route.generatedEyeBitrateMbps, 20)
+        XCTAssertEqual(route.generatedMergeQuality, 75)
+
+        options.job.intermediatePolicy = .automatic
+        options.encoding.upscaleEnabled = true
+        route = VideoRoutePlan(options: options)
+        XCTAssertEqual(route.kind, .generatedMVHEVC)
+        XCTAssertEqual(route.generatedRequirement, .upscale)
+
+        options.encoding.videoOutputMode = .av1Stereo
+        route = VideoRoutePlan(options: options)
+        XCTAssertEqual(route.kind, .av1Stereo)
+        XCTAssertEqual(route.av1CRF, 32)
+
+        options.job.startStage = .transcodeAudio
+        route = VideoRoutePlan(options: options)
+        XCTAssertEqual(route.kind, .existingArtifact)
+        XCTAssertFalse(route.allowsFinalizedPreview)
+
+        route = VideoRoutePlan(
+            encoding: options.encoding,
+            startStage: options.job.startStage.rawValue,
+            keepsReusableArtifacts: false,
+            softwareEncoder: false,
+            allowsExistingArtifact: false
+        )
+        XCTAssertEqual(route.kind, .av1Stereo)
+    }
+
+    func testRouteAwareSummariesDoNotExposeInactiveGeneratedSettings() {
+        let direct = EncodingOptions()
+        XCTAssertEqual(
+            direct.videoSummary,
+            "Direct MV-HEVC when available · Automatic · 40 Mbps final · source resolution"
+        )
+        XCTAssertFalse(direct.videoSummary.contains("Mbps per eye"))
+        XCTAssertFalse(direct.videoSummary.contains("merge 75"))
+
+        var generated = ConversionOptions()
+        generated.job.intermediatePolicy = .reusable
+        generated.encoding.mvHEVC.generatedEyeBitrate = BitratePreference(mode: .custom, customMbps: 35)
+        generated.encoding.mvHEVC.generatedMergeQuality = 82
+
+        XCTAssertEqual(
+            generated.videoSummary,
+            "Generated MV-HEVC · Custom · 35 Mbps per eye · merge 82 · source resolution"
+        )
+        XCTAssertTrue(generated.compactSummary.contains("Generated MV-HEVC"))
+
+        var customDirect = EncodingOptions()
+        customDirect.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 48)
+        XCTAssertEqual(
+            customDirect.videoSummary,
+            "Direct MV-HEVC when available · Custom · 48 Mbps final · source resolution"
+        )
+    }
+
+    func testVideoRouteReportPresentationCoversEveryRouteAndFallback() {
+        let direct = VideoRouteReport(
+            intent: "automatic",
+            selected: "direct_mv_hevc",
+            reason: "direct_eligible",
+            bitrateMbps: 40,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil
+        )
+        XCTAssertEqual(direct.displayTitle, "Direct MV-HEVC")
+        XCTAssertEqual(direct.settingsSummary, "40 Mbps final")
+        XCTAssertTrue(direct.displayDetail.contains("confirmed direct stereo MV-HEVC support"))
+
+        let generated = VideoRouteReport(
+            intent: "generated",
+            selected: "generated_mv_hevc",
+            reason: "reusable_intermediates_requested",
+            bitrateMbps: nil,
+            eyeBitrateMbps: 20,
+            mergeQuality: 75,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil
+        )
+        XCTAssertEqual(generated.displayTitle, "Generated MV-HEVC")
+        XCTAssertEqual(generated.settingsSummary, "20 Mbps per eye · merge 75")
+        XCTAssertEqual(generated.displayDetail, "Reusable intermediate files were requested.")
+
+        let fallback = VideoRouteReport(
+            intent: "automatic",
+            selected: "generated_mv_hevc",
+            reason: "direct_capability_unavailable",
+            bitrateMbps: nil,
+            eyeBitrateMbps: 20,
+            mergeQuality: 75,
+            crf: nil,
+            fallbackReason: "helper_missing",
+            fallbackTiming: "pre_input"
+        )
+        XCTAssertEqual(fallback.displayTitle, "Generated MV-HEVC fallback")
+        XCTAssertTrue(fallback.isFallback)
+        XCTAssertTrue(fallback.displayDetail.contains("packaged direct MV-HEVC encoder was unavailable"))
+        XCTAssertTrue(fallback.displayDetail.contains("before conversion input was read"))
+
+        let av1 = VideoRouteReport(
+            intent: "encode",
+            selected: "av1",
+            reason: "av1_output_requested",
+            bitrateMbps: nil,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: 32,
+            fallbackReason: nil,
+            fallbackTiming: nil
+        )
+        XCTAssertEqual(av1.displayTitle, "AV1 stereo")
+        XCTAssertEqual(av1.settingsSummary, "CRF 32")
+        XCTAssertEqual(av1.displayDetail, "AV1 stereo output was requested.")
+
+        let existing = VideoRouteReport(
+            intent: "existing_artifact",
+            selected: "existing_artifact",
+            reason: "resume_uses_existing_video_artifact",
+            bitrateMbps: nil,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil
+        )
+        XCTAssertEqual(existing.displayTitle, "Existing encoded video artifact")
+        XCTAssertEqual(existing.settingsSummary, "No video re-encode")
+        XCTAssertEqual(existing.displayDetail, "The selected restart stage uses an existing encoded video artifact.")
+
+        let unknown = VideoRouteReport(
+            intent: "future",
+            selected: "future_route",
+            reason: "future_reason",
+            bitrateMbps: nil,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil
+        )
+        XCTAssertEqual(unknown.displayTitle, "Video route")
+        XCTAssertEqual(unknown.settingsSummary, "future route")
+        XCTAssertEqual(unknown.displayDetail, "The conversion engine selected this route during preflight.")
+    }
+
+    func testVideoStorageEstimateReservesFallbackAndRetainedEyeFiles() throws {
+        let inspection = SourceInspection(
+            name: "movie.mkv",
+            resolution: "1920x1080",
+            frameRate: "23.976",
+            interlaced: false,
+            sizeBytes: 30_000_000_000,
+            durationSeconds: 7_200
+        )
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv"))
+
+        let directDraft = ConversionDraft(
+            source: source,
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: ConversionOptions()
+        )
+        let directEstimate = VideoStorageEstimate(drafts: [directDraft])
+        let directFinalBytes = try XCTUnwrap(directEstimate.finalOutputBytes)
+        let directPeakBytes = try XCTUnwrap(directEstimate.peakWorkingBytes)
+
+        XCTAssertTrue(directEstimate.conservativeFallbackReserve)
+        XCTAssertGreaterThan(directPeakBytes, directFinalBytes)
+        XCTAssertEqual(directEstimate.retainedIntermediateBytes, 0)
+        XCTAssertTrue(directEstimate.finalOutputDescription.hasPrefix("Up to "))
+
+        var generatedOptions = ConversionOptions()
+        generatedOptions.job.intermediatePolicy = .reusable
+        let generatedDraft = ConversionDraft(
+            source: source,
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: generatedOptions
+        )
+        let generatedEstimate = VideoStorageEstimate(drafts: [generatedDraft])
+        let generatedFinalBytes = try XCTUnwrap(generatedEstimate.finalOutputBytes)
+
+        XCTAssertFalse(generatedEstimate.conservativeFallbackReserve)
+        XCTAssertEqual(generatedEstimate.retainedIntermediateBytes, generatedFinalBytes)
+        XCTAssertEqual(generatedEstimate.peakWorkingBytes, generatedFinalBytes * 2)
+    }
+
+    func testVideoStorageEstimateAvoidsFalsePrecisionForAV1() {
+        var options = ConversionOptions()
+        options.encoding.videoOutputMode = .av1Stereo
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv")),
+            sourceDetails: SourceInspection(
+                name: "movie.mkv",
+                resolution: "1920x1080",
+                frameRate: "23.976",
+                interlaced: false,
+                durationSeconds: 7_200
+            ),
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+            options: options
+        )
+
+        let estimate = VideoStorageEstimate(drafts: [draft])
+
+        XCTAssertNil(estimate.finalOutputBytes)
+        XCTAssertEqual(estimate.unavailableReason, "AV1 size varies with source content and CRF.")
     }
 
     func testSourceInferencePreservesProductHierarchy() throws {
@@ -383,6 +615,19 @@ final class ConversionWorkflowTests: XCTestCase {
 
             XCTAssertTrue(discs.isEmpty)
         }
+    }
+
+    func testInsertedDiscDetectionSkipsDirectoryProbeWhenVolumeHasNoDevice() {
+        let fileManager = DirectoryProbeRecordingFileManager()
+
+        let discs = DiscSourceDetector.insertedDiscs(
+            in: [URL(fileURLWithPath: "/Volumes/Unavailable", isDirectory: true)],
+            fileManager: fileManager,
+            devicePathResolver: { _ in nil }
+        )
+
+        XCTAssertTrue(discs.isEmpty)
+        XCTAssertFalse(fileManager.didProbeDirectory)
     }
 
     func testCurrentCapabilitiesStayHonest() {
@@ -1282,4 +1527,13 @@ private struct StableJobOptions: Decodable {
     let outputCommands: Bool
     let keepAwake: Bool
     let playSound: Bool
+}
+
+private final class DirectoryProbeRecordingFileManager: FileManager, @unchecked Sendable {
+    private(set) var didProbeDirectory = false
+
+    override func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        didProbeDirectory = true
+        return false
+    }
 }

--- a/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
+++ b/macos/BluRayToVisionProTests/DiagnosticBundleTests.swift
@@ -6,6 +6,72 @@ final class DiagnosticBundleTests: XCTestCase {
     private let fixedDate = Date(timeIntervalSince1970: 1_784_323_200)
     private let fixedBundleID = UUID(uuidString: "01234567-89AB-4CDE-8F01-23456789ABCD")!
 
+    func testDiagnosticJobSettingsIncludeOnlyActiveRouteFields() throws {
+        func encodedSettings(options: ConversionOptions) throws -> [String: Any] {
+            let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/movie.mkv"))
+            let draft = ConversionDraft(
+                source: source,
+                sourceDetails: nil,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/tmp/output", isDirectory: true),
+                options: options
+            )
+            let encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            let data = try encoder.encode(DiagnosticJobSettings(draft: draft))
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        let direct = try encodedSettings(options: ConversionOptions())
+        XCTAssertEqual(direct["requested_video_route"] as? String, "direct_mv_hevc")
+        XCTAssertEqual(direct["direct_bitrate_mode"] as? String, "automatic")
+        XCTAssertEqual(direct["direct_final_bitrate"] as? Int, 40)
+        XCTAssertNil(direct["left_right_bitrate"])
+        XCTAssertNil(direct["hevc_quality"])
+        XCTAssertEqual(direct["upscale_enabled"] as? Bool, false)
+        XCTAssertNil(direct["upscale_quality"])
+        XCTAssertNil(direct["av1_crf"])
+
+        var generatedOptions = ConversionOptions()
+        generatedOptions.job.intermediatePolicy = .reusable
+        let generated = try encodedSettings(options: generatedOptions)
+        XCTAssertEqual(generated["requested_video_route"] as? String, "generated_mv_hevc")
+        XCTAssertEqual(generated["route_requirement"] as? String, "reusable_intermediates_requested")
+        XCTAssertEqual(generated["generated_eye_bitrate_mode"] as? String, "automatic")
+        XCTAssertEqual(generated["left_right_bitrate"] as? Int, 20)
+        XCTAssertEqual(generated["hevc_quality"] as? Int, 75)
+        XCTAssertNil(generated["direct_final_bitrate"])
+        XCTAssertNil(generated["av1_crf"])
+
+        var av1Options = ConversionOptions()
+        av1Options.encoding.videoOutputMode = .av1Stereo
+        av1Options.encoding.upscaleEnabled = true
+        av1Options.encoding.resolutionOverride = "3840x2160"
+        let av1 = try encodedSettings(options: av1Options)
+        XCTAssertEqual(av1["requested_video_route"] as? String, "av1")
+        XCTAssertEqual(av1["upscale_enabled"] as? Bool, false)
+        XCTAssertNil(av1["upscale_quality"])
+        XCTAssertEqual(av1["resolution_override_set"] as? Bool, false)
+
+        var existingOptions = ConversionOptions()
+        existingOptions.job.startStage = .transcodeAudio
+        existingOptions.encoding.upscaleEnabled = true
+        existingOptions.encoding.frameRateOverride = "24"
+        existingOptions.encoding.cropBlackBars = true
+        let existing = try encodedSettings(options: existingOptions)
+        XCTAssertEqual(existing["requested_video_route"] as? String, "existing_artifact")
+        XCTAssertNil(existing["upscale_enabled"])
+        XCTAssertNil(existing["upscale_quality"])
+        XCTAssertNil(existing["field_of_view"])
+        XCTAssertNil(existing["frame_rate_override_set"])
+        XCTAssertNil(existing["crop_black_bars"])
+
+        existingOptions.job.startStage = .upscaleVideo
+        let upscaleResume = try encodedSettings(options: existingOptions)
+        XCTAssertEqual(upscaleResume["upscale_enabled"] as? Bool, true)
+        XCTAssertEqual(upscaleResume["upscale_quality"] as? Int, 75)
+    }
+
     func testDiagnosticZipArchiveMatchesSharedNativeFixture() throws {
         let fixtureURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewViewModelTests.swift
@@ -52,6 +52,8 @@ final class PreviewViewModelTests: XCTestCase {
                 WorkerJobSpec(previewDraft: previewDraft, destinationURL: playerLease!.directoryURL).encoding
             )
             XCTAssertTrue(FileManager.default.fileExists(atPath: playerLease!.artifact.outputURL.path))
+            XCTAssertEqual(viewModel.videoRoute?.selected, "direct_mv_hevc")
+            XCTAssertEqual(viewModel.videoRoute, playerLease!.artifact.videoRoute)
 
             let directoryURL = playerLease!.directoryURL
             viewModel.discardPreview()
@@ -60,6 +62,38 @@ final class PreviewViewModelTests: XCTestCase {
             XCTAssertTrue(FileManager.default.fileExists(atPath: directoryURL.path))
             playerLease = nil
             XCTAssertFalse(FileManager.default.fileExists(atPath: directoryURL.path))
+        }
+    }
+
+    @MainActor
+    func testPreviewRetainsVisibleGeneratedFallbackRoute() async throws {
+        try await withTemporaryPreviewEnvironment { sourceURL, cache in
+            let completed = expectation(description: "preview completed")
+            let fallbackRoute = VideoRouteReport(
+                intent: "automatic",
+                selected: "generated_mv_hevc",
+                reason: "direct_capability_unavailable",
+                bitrateMbps: nil,
+                eyeBitrateMbps: 20,
+                mergeQuality: 75,
+                crf: nil,
+                fallbackReason: "stereo_mv_hevc_encode_unavailable",
+                fallbackTiming: "pre_input"
+            )
+            let worker = PreviewWorkerClient(
+                videoRouteOverride: fallbackRoute,
+                onCompleted: { completed.fulfill() }
+            )
+            let viewModel = PreviewViewModel(clientFactory: { worker }, cache: cache)
+            let previewDraft = try XCTUnwrap(makePreviewDraft(sourceURL: sourceURL))
+
+            viewModel.startPreview(previewDraft)
+            await fulfillment(of: [completed], timeout: 2)
+            while viewModel.hasActiveWorker { await Task.yield() }
+
+            XCTAssertEqual(viewModel.videoRoute, fallbackRoute)
+            XCTAssertEqual(viewModel.artifactLease?.artifact.videoRoute, fallbackRoute)
+            XCTAssertEqual(viewModel.videoRoute?.displayTitle, "Generated MV-HEVC fallback")
         }
     }
 
@@ -241,6 +275,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
     private let initialStage: String
     private let initialStageMessage: String
     private let observabilityEvent: ObservabilityEvent?
+    private let videoRouteOverride: VideoRouteReport?
     private let waitsForCancellation: Bool
     private let onStarted: (() -> Void)?
     private let onCancellationEventsDelivered: (() -> Void)?
@@ -256,6 +291,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
         initialStage: String = "create_left_right_files",
         initialStageMessage: String = "Encoding Preview",
         observabilityEvent: ObservabilityEvent? = nil,
+        videoRouteOverride: VideoRouteReport? = nil,
         waitsForCancellation: Bool = false,
         onStarted: (() -> Void)? = nil,
         onCancellationEventsDelivered: (() -> Void)? = nil,
@@ -264,6 +300,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
         self.initialStage = initialStage
         self.initialStageMessage = initialStageMessage
         self.observabilityEvent = observabilityEvent
+        self.videoRouteOverride = videoRouteOverride
         self.waitsForCancellation = waitsForCancellation
         self.onStarted = onStarted
         self.onCancellationEventsDelivered = onCancellationEventsDelivered
@@ -275,6 +312,7 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
         onEvent: @escaping (WorkerEvent) async throws -> Void
     ) async throws -> WorkerRunResult {
         receivedJob = job
+        let videoRoute = videoRouteOverride ?? Self.videoRoute(for: job)
         let ready = WorkerEvent(
             protocolVersion: WorkerJobSpec.protocolVersion,
             type: .workerReady,
@@ -292,7 +330,8 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             payload: WorkerEventPayload(
                 stage: initialStage,
                 message: initialStageMessage,
-                progress: WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: nil)
+                progress: WorkerProgress(currentStage: 9, totalStages: 13, stageFraction: nil),
+                videoRoute: videoRoute
             )
         )
         try await onEvent(stage)
@@ -383,7 +422,8 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
             position: job.preview!.position,
             startSeconds: 3570,
             durationSeconds: 60,
-            sourceDurationSeconds: 7200
+            sourceDurationSeconds: 7200,
+            videoRoute: videoRoute
         )
         let artifactReady = WorkerEvent(
             protocolVersion: WorkerJobSpec.protocolVersion,
@@ -404,6 +444,72 @@ private final class PreviewWorkerClient: WorkerProcessRunning, @unchecked Sendab
         try await onEvent(completed)
         onCompleted?()
         return WorkerRunResult(terminalEvent: completed, exitStatus: 0, diagnostics: "")
+    }
+
+    private static func videoRoute(for job: WorkerJobSpec) -> VideoRouteReport {
+        guard let video = job.encoding?.video else {
+            return VideoRouteReport(
+                intent: "automatic",
+                selected: "direct_mv_hevc",
+                reason: "direct_eligible",
+                bitrateMbps: 40,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil
+            )
+        }
+        switch video.routeIntent {
+        case .automatic:
+            return VideoRouteReport(
+                intent: "automatic",
+                selected: "direct_mv_hevc",
+                reason: "direct_eligible",
+                bitrateMbps: video.directBitrate?.mbps ?? 40,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil
+            )
+        case .generated:
+            return VideoRouteReport(
+                intent: "generated",
+                selected: "generated_mv_hevc",
+                reason: "generated_route_requested",
+                bitrateMbps: nil,
+                eyeBitrateMbps: video.generatedEyeBitrate?.mbps ?? 20,
+                mergeQuality: video.generatedMergeQuality,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil
+            )
+        case .encode:
+            return VideoRouteReport(
+                intent: "encode",
+                selected: "av1",
+                reason: "av1_output_requested",
+                bitrateMbps: nil,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: video.av1CRF,
+                fallbackReason: nil,
+                fallbackTiming: nil
+            )
+        case .existingArtifact:
+            return VideoRouteReport(
+                intent: "existing_artifact",
+                selected: "existing_artifact",
+                reason: "resume_uses_existing_video_artifact",
+                bitrateMbps: nil,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil
+            )
+        }
     }
 
     func cancel() {

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -384,6 +384,39 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(state.conversionResult?.sizeBytes, 1024)
         XCTAssertEqual(state.conversionResult?.videoRoute?.selected, "direct_mv_hevc")
         XCTAssertEqual(state.conversionResult?.videoRoute?.bitrateMbps, 40)
+        XCTAssertEqual(state.videoRoute, state.conversionResult?.videoRoute)
+    }
+
+    func testRetainsResolvedVideoRouteFromPreflightEvent() throws {
+        let route = VideoRouteReport(
+            intent: "automatic",
+            selected: "generated_mv_hevc",
+            reason: "direct_capability_unavailable",
+            bitrateMbps: nil,
+            eyeBitrateMbps: 20,
+            mergeQuality: 75,
+            crf: nil,
+            fallbackReason: "stereo_mv_hevc_encode_unavailable",
+            fallbackTiming: "pre_input"
+        )
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        try state.receive(
+            event(
+                .warning,
+                sequence: 0,
+                payload: WorkerEventPayload(
+                    message: "Direct MV-HEVC is unavailable on this Mac.",
+                    videoRoute: route
+                )
+            )
+        )
+
+        XCTAssertEqual(state.videoRoute, route)
+        XCTAssertEqual(state.videoRoute?.displayTitle, "Generated MV-HEVC fallback")
+        XCTAssertTrue(state.videoRoute?.displayDetail.contains("before conversion input was read") == true)
     }
 
     func testRejectsSequenceGap() throws {

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -222,8 +222,11 @@ class NativeAppPackagingTests(unittest.TestCase):
             source_view.index("Import MTS or M2TS transport stream"),
         )
         for label in (
-            "HEVC quality",
-            "Left / right bitrate",
+            "Final bitrate",
+            "Advanced final bitrate",
+            "MV-HEVC merge quality",
+            "Eye intermediate bitrate",
+            "Advanced eye intermediate bitrate",
             "Video Output",
             "AV1 quality",
             "AI FX upscale to 2\u00d7 resolution",
@@ -237,7 +240,7 @@ class NativeAppPackagingTests(unittest.TestCase):
             "Subtitle handling",
             "Subtitle language",
             "Start stage",
-            "Keep durable stage files",
+            "Create reusable intermediate files",
             "Continue processing after recoverable errors",
             "Use software HEVC encoder",
             "Overwrite an existing output file",
@@ -251,7 +254,7 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn('LabeledContent("Video")', source_view)
         self.assertIn('LabeledContent("Audio")', source_view)
         self.assertIn('LabeledContent("Subtitles")', source_view)
-        self.assertIn("Text(options.encoding.videoSummary)", source_view)
+        self.assertIn("Text(options.videoSummary)", source_view)
         self.assertIn("Text(options.encoding.audioSummary)", source_view)
         self.assertIn("Opens a searchable list of audio languages", language_picker)
         self.assertIn("Opens a searchable list of subtitle languages", language_picker)


### PR DESCRIPTION
## Summary

- add a shared Swift video-route projection used by protocol-v10 job encoding and native presentation
- show route-conditional bitrate, merge, recovery, pipeline, storage, fallback, and finalized-preview UI
- retain resolved routes in conversion and preview lifecycle state and emit only active route settings in diagnostics
- keep packaged startup responsive by skipping non-local disc probes and moving mounted-disc discovery off the main actor

## Validation

- `uv run python -m scripts.native_app test` — 296 Swift tests passed
- `uv run python -m unittest discover -s tests -t .` — 893 Python tests passed, 3 skipped
- `uv run ruff format --check tests/test_native_app.py`
- `uv run ruff check tests/test_native_app.py`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://support.example uv run python -m scripts.native_app package`
- packaged app opened at the 1080-point minimum width with mounted network volumes; bundled direct-helper capability probe returned supported
- manual direct, generated, AV1, and existing-artifact route-state review at minimum width

Implements #363. Prerelease corpus, packaged source-preview parity, rollback, and physical Vision Pro validation remain in #364.
