### PR TITLE
Qualify direct 4K on representative MVC content

### DIFF
--- a/docs/direct-4k-mv-hevc-release-gate.md
+++ b/docs/direct-4k-mv-hevc-release-gate.md
@@ -1,12 +1,12 @@
 # Direct 4K MetalFX MV-HEVC release gate
 
-Issue #359 qualifies the in-process 2× MetalFX route integrated by #358. The July 24–25, 2026 local gate selects a
+Issue #359 qualifies the in-process 2× MetalFX route integrated by #358. The July 24–26, 2026 local gate selects a
 separate Automatic compression quality of `0.6` for direct 4K output; the source-resolution direct route remains at
 `0.7`, and Custom remains an exact user-owned average-bitrate target.
 
-The local deterministic, resource, Developer ID package, packaged-helper, Apple media, seek, device-transfer, and
-physical Vision Pro playback gates pass. Final promotion remains blocked on the private representative-MVC corpus,
-the complete packaged worker direct/fallback matrix using that source, and notarization evidence.
+The local deterministic, resource, Developer ID package, packaged-helper, Apple media, seek, device-transfer,
+physical Vision Pro playback, representative real-MVC package-route, and feature-length gates pass. Final promotion
+is now blocked only on the notarization and release-publication work tracked by #377.
 
 ## Policy decision
 
@@ -47,7 +47,7 @@ The motion fixture uses three 120-frame runs. Every additional control uses one 
 All six controls pass. The crop fixture is a scaler-content control whose input is normalized back to exact 1080p;
 product jobs requesting automatic crop still use the generated route.
 
-Every quality JSON records the exact Developer ID helper SHA-256
+Every synthetic quality JSON records the exact issue-#359 Developer ID helper SHA-256
 `f5326193a580aa10a2645a7126a0555cfd34e2382f301c9737a9f962f1374879`:
 
 | Evidence | SHA-256 |
@@ -59,10 +59,33 @@ Every quality JSON records the exact Developer ID helper SHA-256
 | Crop control | `9c4cc5ce26034131928705813f5852a6f48f072feffa7bf479ba77db1a5e139e` |
 | Disparity | `b338d09e6f96aad96e58100a411799fe6fd62c43a7961c232dc867a4e3f3337b` |
 
+## Representative real-MVC quality gate
+
+`scripts/qualify_real_mvc_4k_quality.py` repeats both production 4K routes three times against the deterministic
+65.649-second MVC segment. The direct route runs through the signed package at Automatic quality `0.6`; the
+file-based comparison uses the same package with a controlled pre-input MetalFX-unavailable capability response and
+then the production FX Upscale stage. Subtitles are disabled only for this visual comparison; the eight-route package
+matrix independently verifies audio and subtitle preservation.
+
+The gate creates lossless FFV1 left/right references with the packaged FFmpeg and edge264 tools, splits each MV-HEVC
+output with the packaged Spatial Media Toolkit, verifies exactly 1,573 frames at 3840×2160 per eye, downsamples each
+eye to source resolution, and measures both same-eye and cross-eye SSIM. Every run must remain within `0.002` of the
+file-based median, stay within 105% of its median size, and preserve at least a `0.001` eye-order margin.
+
+- Direct median worst-eye SSIM is `0.952509`, `0.001647` above the file-based median of `0.950862`.
+- Every direct output is `101,009,167` bytes. The largest direct/file-median ratio is `0.374800`, well below `1.05`.
+- The minimum eye-order margin is `0.037974` for direct output and `0.034867` for file-based output.
+- Hardware-encoder container hashes vary across repeats, while decoded measurements and direct output sizes remain
+  stable; the gate intentionally evaluates every run rather than requiring byte-identical hardware output.
+
+The representative real-MVC quality evidence SHA-256 is
+`ac0dd829b06d6d6dd214a5ffd1a8389eb93f79ab75197bc9730789ee7463565a`. It binds the package app-tree, helper,
+worker, controlled fallback helper, and packaged tool hashes without recording source paths or titles.
+
 ## Resource gate
 
 `scripts/benchmark_mv_hevc_metalfx.py --quality 0.6` compares 24-frame and 2,400-frame runs. The 100-second MetalFX
-run passes the bounded allocation model:
+run establishes a useful synthetic allocation diagnostic:
 
 - Metal device peak delta is `419,086,336` bytes for the short run and `452,280,320` bytes for the long run.
 - The `33,193,984`-byte difference is exactly one aligned 3840×2160 BGRA texture. The same helper also produced
@@ -70,7 +93,7 @@ run passes the bounded allocation model:
   than monotonic duration growth.
 - Declared Metal-compatible pools and private textures are `364,953,600` bytes. The gate permits up to three aligned
   4K texture-equivalents (`99,581,952` bytes) for MetalFX-owned internal allocation but no more than one texture of
-  short-to-long variance. The observed peak remains below the `464,535,552`-byte ceiling.
+  short-to-long variance. The observed synthetic peak remains below the modeled `464,535,552`-byte ceiling.
 - Baseline-normalized excess process-RSS growth is zero.
 - Decoded frame count, 3840×2160 per-eye geometry, and limited-range BT.709 signaling pass.
 
@@ -84,18 +107,56 @@ are informational rather than exact helper attribution. The raw trace SHA-256 is
 `3dd47c2ad85bbb64bc33d7ec40d1a50e79e783d086321d8f39f8e4d9694a1557`; its bound workload evidence SHA-256 is
 `10b2753fe6ee0419f423f9e2cc5459cabcf2b9c28295a25c6fbe8bd19580961e`.
 
-The private representative source is still required for feature-length thermal and real-MVC backpressure evidence.
+The synthetic modeled ceiling is not used as an absolute production limit. Real workloads include the MVC splitter,
+two FFmpeg processes, the direct encoder, framework warm-up, and MetalFX allocation classes that are absent from the
+standalone benchmark. `scripts/qualify_real_mvc_feature.py` therefore applies the production gate to a deterministic
+65.649-second segment and its verified 5,737.760-second parent source:
+
+- the complete source contributes exactly `137,568` packets at `24000/1001`, and the direct 4K encoder reports exactly
+  `137,568` output frames;
+- the resulting 3840×2160-per-eye artifact is `5,737.731667` seconds and `6,546,871,801` bytes, passes Apple media
+  compatibility and beginning/middle/end seeks, and has SHA-256
+  `d2f46d8a929a7e0b060f6dec2fd57f901dafd6101ddb4580310eebd51f568867`;
+- aggregate process RSS peaks at `1,516,781,568` bytes, below the prerelease safety ceiling of `2,147,483,648` bytes;
+  its diagnostic quartile peaks are `1,386,217,472`, `1,441,972,224`, `1,446,772,736`, and `1,516,781,568` bytes;
+- plateau acceptance is evaluated per process because aggregate quartile peaks combine non-coincident maxima. The
+  largest Q3-to-Q4 process increase is `50,937,856` bytes, below the 64 MiB allowance. A separate fixed 128 MiB
+  process-tree cap prevents the allowance from scaling with process count; the aggregate increase is `70,008,832`
+  bytes and passes that cap;
+- the normalizer FFmpeg process peaks at `793,739,264` bytes and the direct encoder at `474,562,560` bytes. Their
+  per-process timelines distinguish finite warm-up from monotonic duration growth;
+- Metal device peak delta is `485,474,304` bytes and final allocated size is `485,556,224` bytes, below the
+  prerelease safety ceiling of `1,073,741,824` bytes. Its `33,193,984`-byte short-to-feature increase is exactly one
+  aligned 4K texture and passes the duration-growth allowance;
+- all `9,017` in-process thermal samples and all `1,046` `powermetrics` thermal sections remain nominal;
+- `2,580` of `2,581` recorded artifact samples increase, with a maximum growth gap of `7.190` seconds and no
+  reported failure codes; and
+- production-style cancellation after direct output begins emits `job.cancelled` with exit 130, preserves an existing
+  destination sentinel, leaves no partial files or surviving descendants, removes its private work directory, and
+  remains at nominal thermal pressure.
+
+The complete feature evidence SHA-256 is
+`84f18a732b303a2032e6a4db5ba98e14dc7a1042f11903b31b131cfa45919d02`. It transparently reassesses retained raw
+telemetry with SHA-256 `0d34d59cf819aaf66b81339c2b34e361f13ec4651702f7c392bf89426e028dfd` under the reviewed
+`per-process-and-aggregate-q3-q4-plateau-v3` policy. The public-safe aggregate is committed at
+`docs/qualification/direct-4k-real-mvc-v1.json`; private source paths, source titles, media, and raw traces remain
+outside the repository.
+
+The public aggregate also pins SHA-256 values for the nine qualification scripts and shared policy helpers used by
+these gates. `tests/test_real_mvc_public_evidence.py` recomputes those hashes so later harness edits cannot silently
+reuse this evidence without an explicit reviewed update.
 
 ## Package and rollback gate
 
 An arm64 Release app with the approved diagnostics endpoint builds, assembles, signs with `Developer ID Application:
 Shiny Computers Leasing LLC (MM5YXC7T6E)`, deep-verifies, passes Gatekeeper assessment, and passes the packaged
 native-app/helper/worker smokes. The app and helper both declare the required macOS 26.0 deployment target. The exact
-packaged helper SHA-256 is `f5326193a580aa10a2645a7126a0555cfd34e2382f301c9737a9f962f1374879`, and its
+packaged helper SHA-256 is `4245452e4c5dbc05479c48c5a37caa077d5c95f18a93b78272e6ac583fbd5394`, and its
 capability probe reports ordinary direct MV-HEVC, MetalFX 2×, MetalFX spatial scaling, and pixel-transfer 2× support.
 The app does not yet have a stapled ticket; notarization remains a release-workflow gate.
 
-`scripts/verify_packaged_mv_hevc_routes.py` now verifies both route families:
+`scripts/verify_packaged_mv_hevc_routes.py` verifies both route families against the deterministic representative
+segment (SHA-256 `da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec`):
 
 - ordinary direct plus the existing stereo-capability-unavailable fallback;
 - direct 4K MetalFX plus a controlled helper that supports ordinary stereo MV-HEVC but reports MetalFX unavailable;
@@ -103,8 +164,16 @@ The app does not yet have a stapled ticket; notarization remains a release-workf
   audio/subtitle preservation, Apple passthrough, and beginning/middle/end seeks.
 
 The controlled MetalFX-unavailable app is cloned, helper-replaced, ad-hoc re-signed, and deep-verified. Its helper may
-only answer the capability probe, so any accidental attempt to encode through it fails immediately. Executing the full
-matrix remains blocked on the private 65-second representative MVC source.
+only answer the capability probe, so any accidental attempt to encode through it fails immediately. All eight signed-
+package combinations pass: ordinary direct and generated fallback plus direct 4K MetalFX and MetalFX-unavailable
+generated fallback, each for full and finalized-preview output. The matrix records exact route decisions, stage
+contracts, artifact hashes, dimensions, spatial boxes, audio/subtitle preservation, Apple passthrough, and seeks.
+
+The package under test is version `0.3.0b6`, with app-tree SHA-256
+`7294f205d9d95d53f72d7fa30d977b2551c6d6ab8c0bdeddc444c354060fc801`, helper SHA-256
+`4245452e4c5dbc05479c48c5a37caa077d5c95f18a93b78272e6ac583fbd5394`, and worker SHA-256
+`1a9f2edeabc5341f15d804d805511a35fecca05ce9e7db2ba7aa29d80b59f109`. The final matrix evidence SHA-256 is
+`e182cc91b890f3177a00ad32db0c8e1039d314c79976f0ab2c56f631f4862f6e`.
 
 ## Physical playback gate
 
@@ -150,7 +219,51 @@ BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com \
 scripts/create_direct_mv_hevc_playback_fixture.sh \
   build/issue-359/Probe-4K.mov \
   "macos/build/package/3D Blu-ray to Vision Pro.app/Contents/Resources/app/bd_to_avp/bin/mv-hevc-encoder"
+
+export BD_TO_AVP_QUALIFICATION_ROOT=/private/path/issue-376
+export BD_TO_AVP_SIGNED_APP=/private/path/3D-Blu-ray-to-Vision-Pro.app
+
+uv run python -m scripts.create_real_mvc_qualification_segment \
+  --source "$BD_TO_AVP_RELEASE_MVC_SOURCE" \
+  --output "$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv" \
+  --evidence "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/real-mvc-segment-v1.json" \
+  --start-seconds 4500 \
+  --duration-seconds 65.648 \
+  --video-track 0 \
+  --audio-track 1 \
+  --subtitle-track 41 \
+  --expected-source-sha256 a1e3adf85f64a5a667d16ef4aa5a982183acece5af1cf7142e49da620982f97c \
+  --deterministic-seed bd-to-avp-issue-376-segment-v1
+
+uv run python -m scripts.verify_packaged_mv_hevc_routes \
+  --app "$BD_TO_AVP_SIGNED_APP" \
+  --source "$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv" \
+  --output "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/packaged-real-mvc-routes.json" \
+  --fixture-output "$BD_TO_AVP_QUALIFICATION_ROOT/artifacts/real-mvc-direct-4k.mov" \
+  --expected-source-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec
+
+uv run python -m scripts.qualify_real_mvc_4k_quality \
+  --app "$BD_TO_AVP_SIGNED_APP" \
+  --source "$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv" \
+  --output "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/quality-real-mvc.json" \
+  --work-directory "$BD_TO_AVP_QUALIFICATION_ROOT/quality-real-mvc" \
+  --expected-source-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec
+
+sudo -v
+uv run python -m scripts.qualify_real_mvc_feature \
+  --app "$BD_TO_AVP_SIGNED_APP" \
+  --source "$BD_TO_AVP_RELEASE_MVC_SOURCE" \
+  --segment "$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv" \
+  --output "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc.json" \
+  --work-directory "$BD_TO_AVP_QUALIFICATION_ROOT/feature-real-mvc" \
+  --expected-source-sha256 a1e3adf85f64a5a667d16ef4aa5a982183acece5af1cf7142e49da620982f97c \
+  --expected-segment-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec
+
+uv run python -m scripts.reassess_real_mvc_feature \
+  --input "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc.json" \
+  --output "$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc-reassessed.json"
 ```
 
-The private corpus and package-route reproduction continues to use `BD_TO_AVP_RELEASE_MVC_SOURCE` and
-`BD_TO_AVP_ITU_MVC_VECTOR`; source paths are never written to evidence.
+The operator supplies `BD_TO_AVP_RELEASE_MVC_SOURCE`, `BD_TO_AVP_SIGNED_APP`, and a private qualification root.
+Source paths are never written to evidence. The replacement segment is mode `0600`; only aggregate hashes, public
+media properties, route decisions, and bounded resource summaries are committed.

--- a/docs/direct-mv-hevc-feasibility.md
+++ b/docs/direct-mv-hevc-feasibility.md
@@ -266,7 +266,8 @@ uv run python -m scripts.qualify_mv_hevc_corpus \
 uv run python -m scripts.verify_packaged_mv_hevc_routes \
   --app "/absolute/path/to/3D Blu-ray to Vision Pro.app" \
   --source /absolute/path/to/representative-65-second.mkv \
-  --output build/direct-mv-hevc-packaged/evidence.json
+  --output build/direct-mv-hevc-packaged/evidence.json \
+  --expected-source-sha256 "$REPRESENTATIVE_SEGMENT_SHA256"
 
 uv run python -m unittest \
   tests.test_audio \

--- a/docs/direct-mv-hevc-release-gate.md
+++ b/docs/direct-mv-hevc-release-gate.md
@@ -172,7 +172,8 @@ uv run python -m scripts.verify_packaged_mv_hevc_routes \
   --app /absolute/path/to/3D\ Blu-ray\ to\ Vision\ Pro.app \
   --source /absolute/path/to/representative-65-second.mkv \
   --output build/issue-366-packaged/evidence.json \
-  --fixture-output build/issue-366-packaged/Probe.mov
+  --fixture-output build/issue-366-packaged/Probe.mov \
+  --expected-source-sha256 "$REPRESENTATIVE_SEGMENT_SHA256"
 ```
 
 Evidence artifacts intentionally remain build outputs because they contain fingerprints of private source segments.

--- a/docs/qualification/direct-4k-real-mvc-v1.json
+++ b/docs/qualification/direct-4k-real-mvc-v1.json
@@ -1,0 +1,251 @@
+{
+  "acceptance": {
+    "deterministic_segment": true,
+    "feature_length_direct_4k": true,
+    "packaged_route_matrix": true,
+    "privacy_review": true,
+    "repeated_real_mvc_quality_size": true,
+    "resource_thermal_and_cancellation": true,
+    "passed": true
+  },
+  "evidence_files": {
+    "feature_length_input_sha256": "0d34d59cf819aaf66b81339c2b34e361f13ec4651702f7c392bf89426e028dfd",
+    "feature_length_sha256": "84f18a732b303a2032e6a4db5ba98e14dc7a1042f11903b31b131cfa45919d02",
+    "packaged_route_matrix_sha256": "e182cc91b890f3177a00ad32db0c8e1039d314c79976f0ab2c56f631f4862f6e",
+    "real_mvc_quality_sha256": "ac0dd829b06d6d6dd214a5ffd1a8389eb93f79ab75197bc9730789ee7463565a",
+    "segment_generation_sha256": "71283ff4101b9f369bbf7d7ae9948a37052470dbbea1c2912d965a80b12389d5"
+  },
+  "feature_length": {
+    "artifact": {
+      "duration_seconds": 5737.731667,
+      "frame_count": 137568,
+      "sha256": "d2f46d8a929a7e0b060f6dec2fd57f901dafd6101ddb4580310eebd51f568867",
+      "size_bytes": 6546871801,
+      "video_dimensions": {
+        "height": 2160,
+        "width": 3840
+      }
+    },
+    "assessment": {
+      "input_evidence_sha256": "0d34d59cf819aaf66b81339c2b34e361f13ec4651702f7c392bf89426e028dfd",
+      "policy": "per-process-and-aggregate-q3-q4-plateau-v3"
+    },
+    "backpressure": {
+      "artifact_sample_count": 2581,
+      "failure_codes": [],
+      "increasing_artifact_sample_count": 2580,
+      "max_artifact_growth_gap_seconds": 7.19,
+      "positive_growth_sample_count": 2568
+    },
+    "cancellation": {
+      "cancel_after_bytes": 33554432,
+      "elapsed_seconds": 81.448,
+      "entered_direct_encode_stage": true,
+      "heartbeat_max_gap_seconds": 0.353,
+      "job_cancelled_exit_code": 130,
+      "no_completed_event": true,
+      "no_partial_files": true,
+      "no_surviving_processes": true,
+      "observed_artifact_bytes_before_cancel": 57671680,
+      "overwrite_sentinel_preserved": true,
+      "peak_process_tree_rss_bytes": 1322123264,
+      "private_work_directory_removed": true,
+      "thermal_pressure": "nominal"
+    },
+    "elapsed_seconds": 5240.939,
+    "resources": {
+      "aggregate_late_quartile_growth_ceiling_bytes": 134217728,
+      "edge264_peak_rss_bytes": 115163136,
+      "late_quartile_growth_ceiling_bytes": 67108864,
+      "max_process_late_quartile_growth_bytes": 50937856,
+      "metal_final_allocated_size_bytes": 485556224,
+      "metal_duration_growth_allowance_bytes": 33193984,
+      "metal_duration_growth_bytes": 33193984,
+      "metal_duration_growth_passed": true,
+      "metal_peak_delta_bytes": 485474304,
+      "metal_safety_ceiling_bytes": 1073741824,
+      "normalizer_ffmpeg_peak_rss_bytes": 793739264,
+      "per_process_late_quartile_growth_bytes": {
+        "edge264": 212992,
+        "mv_hevc_encoder": 5259264,
+        "normalizer_ffmpeg": 16613376,
+        "source_ffmpeg": 50937856
+      },
+      "process_quartile_peak_rss_bytes": [
+        1386217472,
+        1441972224,
+        1446772736,
+        1516781568
+      ],
+      "process_rss_safety_ceiling_bytes": 2147483648,
+      "process_tree_peak_rss_bytes": 1516781568,
+      "short_process_tree_peak_rss_bytes": 1168850944,
+      "source_ffmpeg_peak_rss_bytes": 141164544,
+      "stereo_encoder_peak_rss_bytes": 474562560,
+      "total_late_quartile_growth_bytes": 70008832
+    },
+    "thermal": {
+      "in_process_max_state": "nominal",
+      "in_process_sample_count": 9017,
+      "powermetrics_all_nominal": true,
+      "powermetrics_sample_count": 1046,
+      "powermetrics_trace_sha256": "81464c9e194ab8e6accad728127faee22dff6fdb849d4e71d657191fa904a37c",
+      "powermetrics_trace_size_bytes": 947996
+    }
+  },
+  "generated_at_utc": "2026-07-26T02:59:15+00:00",
+  "package": {
+    "app_tree_sha256": "7294f205d9d95d53f72d7fa30d977b2551c6d6ab8c0bdeddc444c354060fc801",
+    "bundle_identifier": "com.shinycomputers.bd-to-avp",
+    "capability": {
+      "metalfx_2x_mv_hevc_supported": true,
+      "metalfx_spatial_scaling_supported": true,
+      "pixel_transfer_2x_mv_hevc_supported": true,
+      "stereo_mv_hevc_encode_supported": true
+    },
+    "helper_sha256": "4245452e4c5dbc05479c48c5a37caa077d5c95f18a93b78272e6ac583fbd5394",
+    "version": "0.3.0b6",
+    "worker_sha256": "1a9f2edeabc5341f15d804d805511a35fecca05ce9e7db2ba7aa29d80b59f109"
+  },
+  "packaged_route_matrix": {
+    "app_tree_sha256": "7294f205d9d95d53f72d7fa30d977b2551c6d6ab8c0bdeddc444c354060fc801",
+    "physical_fixture": {
+      "sha256": "d7b9dc1bd16f0f6d3baa293c8673b681113ed839574e80c59d486859c81b0348",
+      "size_bytes": 101011343
+    },
+    "route_count": 8,
+    "routes": {
+      "metalfx_4k_direct_full": true,
+      "metalfx_4k_direct_preview": true,
+      "metalfx_4k_fallback_full": true,
+      "metalfx_4k_fallback_preview": true,
+      "ordinary_direct_full": true,
+      "ordinary_direct_preview": true,
+      "ordinary_fallback_full": true,
+      "ordinary_fallback_preview": true
+    },
+    "validated_contracts": [
+      "explicit_pre_input_fallback",
+      "full_preview_route_parity",
+      "stage_boundaries",
+      "1080p_and_4k_dimensions",
+      "spatial_boxes",
+      "audio_and_subtitle_preservation",
+      "apple_media_passthrough",
+      "beginning_middle_end_seeks"
+    ]
+  },
+  "privacy": {
+    "media_committed": false,
+    "raw_traces_committed": false,
+    "source_paths_recorded": false,
+    "source_titles_recorded": false
+  },
+  "qualification_harness": {
+    "files": {
+      "scripts/benchmark_mv_hevc_metalfx.py": "98e7afaa3881db4afafb67912113f9b6e4c2431e7d3bec5ecb2a73ec71c5c52b",
+      "scripts/create_real_mvc_qualification_segment.py": "13b8fb6465af8c2e819b6007fbd9495d98f5ac132026bccaceae144c0274b778",
+      "scripts/qualify_direct_mv_hevc.py": "cd1207dcb1d89694655e8bccdf44393d8c37535c6c266b33700332d7323089d4",
+      "scripts/qualify_mv_hevc_corpus.py": "bd81d8e6db5f368cfd4251e2c80ee0dc8ffa8a32bfb9c7256136a85e71c63ecd",
+      "scripts/qualify_mv_hevc_quality_match.py": "2df839f6974fd55bce9b3ec8655c092a8ee39daecb4d9c0d1759d3af291073cd",
+      "scripts/qualify_real_mvc_4k_quality.py": "159c1425087c64e12d152d7bfbe332ff97c9aa5a7366bee65dd6b6462b83c922",
+      "scripts/qualify_real_mvc_feature.py": "aef71039177d651a752f69fbb092feb03ef41763ad343b5b4107a68fc47c1c17",
+      "scripts/reassess_real_mvc_feature.py": "8f5f3e3ceb9c89117a824245229438388cf008b54d3865192d085cde3ddcf262",
+      "scripts/verify_packaged_mv_hevc_routes.py": "d4e940c0358f0c67e806ea38b8261d136cd1ea177db5e5028e94b9a8bec511c9"
+    }
+  },
+  "real_mvc_quality": {
+    "acceptance": {
+      "direct_quality": true,
+      "direct_size": true,
+      "eye_order": true,
+      "repeated_full_routes": true,
+      "passed": true
+    },
+    "file_based": {
+      "frame_count_per_eye": 1573,
+      "median_final_bytes": 269501345,
+      "median_min_same_eye_ssim": 0.950862,
+      "minimum_eye_order_margin": 0.034867,
+      "run_count": 3
+    },
+    "direct": {
+      "frame_count_per_eye": 1573,
+      "median_final_bytes": 101009167,
+      "median_min_same_eye_ssim": 0.952509,
+      "minimum_eye_order_margin": 0.037974,
+      "run_count": 3
+    },
+    "reference": {
+      "frame_count": 1573,
+      "left_sha256": "b5ed556fcc5a1236a1a1c154f0d79891995b1c7746126397bb14c6c9cf2dc9fa",
+      "right_sha256": "d39bff88a5e44809708a2655fbd0a82273b83432bfe9808f55c3a09caf6b3229",
+      "size_bytes": 1887599140
+    },
+    "source_sha256": "da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec",
+    "summary": {
+      "max_run_size_ratio": 0.3748002333717481,
+      "quality_delta": 0.001647000000000065,
+      "required_direct_min_same_eye_ssim": 0.948862
+    },
+    "thresholds": {
+      "max_size_ratio": 1.05,
+      "minimum_eye_order_margin": 0.001,
+      "quality_tolerance": 0.002,
+      "runs_per_route": 3
+    }
+  },
+  "representative_segment": {
+    "deterministic_repeat_match": true,
+    "duration_seconds": 65.649,
+    "selection": {
+      "audio_track": 1,
+      "deterministic_seed": "bd-to-avp-issue-376-segment-v1",
+      "requested_duration_seconds": 65.648,
+      "start_seconds": 4500.0,
+      "subtitle_track": 41,
+      "video_track": 0
+    },
+    "sha256": "da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec",
+    "size_bytes": 354460821,
+    "supersedes": "Deleted 65.648-second representative MVC clip",
+    "tracks": [
+      {
+        "codec": "AVC/H.264/MPEG-4p10",
+        "pixel_dimensions": "1920x1080",
+        "stereo_mode": 13,
+        "type": "video"
+      },
+      {
+        "codec": "TrueHD Atmos",
+        "language": "eng",
+        "type": "audio"
+      },
+      {
+        "codec": "HDMV PGS",
+        "language": "eng",
+        "type": "subtitles"
+      }
+    ]
+  },
+  "repository": {
+    "base_commit_sha": "c3e34474424c638ebdf27a11a465f71cbdc86a19"
+  },
+  "reproduction": {
+    "feature_length": "uv run python -m scripts.qualify_real_mvc_feature --app \"$BD_TO_AVP_SIGNED_APP\" --source \"$BD_TO_AVP_RELEASE_MVC_SOURCE\" --segment \"$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv\" --output \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc.json\" --work-directory \"$BD_TO_AVP_QUALIFICATION_ROOT/feature-real-mvc\" --expected-source-sha256 a1e3adf85f64a5a667d16ef4aa5a982183acece5af1cf7142e49da620982f97c --expected-segment-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec",
+    "feature_length_reassessment": "uv run python -m scripts.reassess_real_mvc_feature --input \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc.json\" --output \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/feature-real-mvc-reassessed.json\"",
+    "packaged_route_matrix": "uv run python -m scripts.verify_packaged_mv_hevc_routes --app \"$BD_TO_AVP_SIGNED_APP\" --source \"$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv\" --output \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/packaged-real-mvc-routes.json\" --fixture-output \"$BD_TO_AVP_QUALIFICATION_ROOT/artifacts/real-mvc-direct-4k.mov\" --expected-source-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec",
+    "real_mvc_quality": "uv run python -m scripts.qualify_real_mvc_4k_quality --app \"$BD_TO_AVP_SIGNED_APP\" --source \"$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv\" --output \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/quality-real-mvc.json\" --work-directory \"$BD_TO_AVP_QUALIFICATION_ROOT/quality-real-mvc\" --expected-source-sha256 da31e6ae9749897ca199f4a37a781b2be9a2d82076885efea4d0c156673bbcec",
+    "segment": "uv run python -m scripts.create_real_mvc_qualification_segment --source \"$BD_TO_AVP_RELEASE_MVC_SOURCE\" --output \"$BD_TO_AVP_QUALIFICATION_ROOT/segment/real-mvc-segment-v1.mkv\" --evidence \"$BD_TO_AVP_QUALIFICATION_ROOT/evidence/real-mvc-segment-v1.json\" --start-seconds 4500 --duration-seconds 65.648 --video-track 0 --audio-track 1 --subtitle-track 41 --expected-source-sha256 a1e3adf85f64a5a667d16ef4aa5a982183acece5af1cf7142e49da620982f97c --deterministic-seed bd-to-avp-issue-376-segment-v1"
+  },
+  "schema_version": 3,
+  "source": {
+    "container_duration_seconds": 5737.76,
+    "frame_rate": "24000/1001",
+    "packet_count": 137568,
+    "sha256": "a1e3adf85f64a5a667d16ef4aa5a982183acece5af1cf7142e49da620982f97c",
+    "size_bytes": 32056079827,
+    "track_count": 55,
+    "video_duration_seconds": 5737.732
+  }
+}

--- a/docs/qualification/direct-4k-real-mvc-v1.json
+++ b/docs/qualification/direct-4k-real-mvc-v1.json
@@ -148,10 +148,10 @@
       "scripts/qualify_direct_mv_hevc.py": "cd1207dcb1d89694655e8bccdf44393d8c37535c6c266b33700332d7323089d4",
       "scripts/qualify_mv_hevc_corpus.py": "bd81d8e6db5f368cfd4251e2c80ee0dc8ffa8a32bfb9c7256136a85e71c63ecd",
       "scripts/qualify_mv_hevc_quality_match.py": "2df839f6974fd55bce9b3ec8655c092a8ee39daecb4d9c0d1759d3af291073cd",
-      "scripts/qualify_real_mvc_4k_quality.py": "159c1425087c64e12d152d7bfbe332ff97c9aa5a7366bee65dd6b6462b83c922",
-      "scripts/qualify_real_mvc_feature.py": "aef71039177d651a752f69fbb092feb03ef41763ad343b5b4107a68fc47c1c17",
+      "scripts/qualify_real_mvc_4k_quality.py": "d457d18fb2e16f65b05fec00ada15d83ccfb269d1f18394c61b09fe1b3d8c247",
+      "scripts/qualify_real_mvc_feature.py": "de7c5fdf7a68b661163de99995ae98e868f7b16417843274c7c98322f43af7bc",
       "scripts/reassess_real_mvc_feature.py": "8f5f3e3ceb9c89117a824245229438388cf008b54d3865192d085cde3ddcf262",
-      "scripts/verify_packaged_mv_hevc_routes.py": "d4e940c0358f0c67e806ea38b8261d136cd1ea177db5e5028e94b9a8bec511c9"
+      "scripts/verify_packaged_mv_hevc_routes.py": "2b65e5c858dcdf096aba175e46702222f347526912663b07e50d44ff27991e40"
     }
   },
   "real_mvc_quality": {

--- a/scripts/create_real_mvc_qualification_segment.py
+++ b/scripts/create_real_mvc_qualification_segment.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+MVC_STEREO_MODE = 13
+MAX_EVIDENCE_BYTES = 128 * 1024
+
+
+class SegmentFailure(RuntimeError):
+    pass
+
+
+def command_path(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise SegmentFailure(f"Required command is unavailable: {name}")
+    return path
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def format_seconds(value: float) -> str:
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def redact_private_paths(message: str, paths: Sequence[Path]) -> str:
+    redacted = message
+    for path in paths:
+        for candidate in {str(path), str(path.resolve())}:
+            redacted = redacted.replace(candidate, "<private-source>")
+    return redacted
+
+
+def run(
+    command: Sequence[str | Path],
+    *,
+    private_paths: Sequence[Path] = (),
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [str(item) for item in command],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        redacted = redact_private_paths(detail, private_paths)
+        raise SegmentFailure(f"Qualification command failed: {redacted or 'no diagnostic output'}") from error
+
+
+def run_json(
+    command: Sequence[str | Path],
+    *,
+    private_paths: Sequence[Path] = (),
+) -> Mapping[str, object]:
+    completed = run(command, private_paths=private_paths)
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise SegmentFailure("Qualification command did not emit valid JSON.") from error
+    if not isinstance(document, Mapping):
+        raise SegmentFailure("Qualification command did not emit a JSON object.")
+    return document
+
+
+def tool_version(command: str, *, argument: str) -> str:
+    completed = run([command, argument])
+    line = completed.stdout.splitlines()[0].strip() if completed.stdout else ""
+    if not line:
+        raise SegmentFailure(f"Could not read the version for {Path(command).name}.")
+    return line
+
+
+def build_mkvmerge_command(
+    mkvmerge: str,
+    source: Path,
+    output: Path,
+    *,
+    start_seconds: float,
+    duration_seconds: float,
+    video_track: int,
+    audio_track: int,
+    subtitle_track: int,
+    deterministic_seed: str,
+) -> list[str]:
+    end_seconds = start_seconds + duration_seconds
+    return [
+        mkvmerge,
+        "--output",
+        str(output),
+        "--deterministic",
+        deterministic_seed,
+        "--no-date",
+        "--disable-track-statistics-tags",
+        "--title",
+        "",
+        "--no-chapters",
+        "--no-attachments",
+        "--no-global-tags",
+        "--split",
+        f"parts:{format_seconds(start_seconds)}s-{format_seconds(end_seconds)}s",
+        "--video-tracks",
+        str(video_track),
+        "--audio-tracks",
+        str(audio_track),
+        "--subtitle-tracks",
+        str(subtitle_track),
+        "--track-name",
+        f"{video_track}:",
+        "--track-name",
+        f"{audio_track}:",
+        "--track-name",
+        f"{subtitle_track}:",
+        str(source),
+    ]
+
+
+def create_segment(
+    mkvmerge: str,
+    source: Path,
+    output: Path,
+    *,
+    start_seconds: float,
+    duration_seconds: float,
+    video_track: int,
+    audio_track: int,
+    subtitle_track: int,
+    deterministic_seed: str,
+) -> None:
+    command = build_mkvmerge_command(
+        mkvmerge,
+        source,
+        output,
+        start_seconds=start_seconds,
+        duration_seconds=duration_seconds,
+        video_track=video_track,
+        audio_track=audio_track,
+        subtitle_track=subtitle_track,
+        deterministic_seed=deterministic_seed,
+    )
+    run(command, private_paths=(source,))
+    if not output.is_file():
+        raise SegmentFailure("mkvmerge did not create the requested qualification segment.")
+
+
+def _tracks(document: Mapping[str, object]) -> list[Mapping[str, object]]:
+    tracks = document.get("tracks")
+    if not isinstance(tracks, list) or not all(isinstance(track, Mapping) for track in tracks):
+        raise SegmentFailure("Matroska inspection did not report a valid track list.")
+    return tracks
+
+
+def _track_properties(track: Mapping[str, object]) -> Mapping[str, object]:
+    properties = track.get("properties")
+    return properties if isinstance(properties, Mapping) else {}
+
+
+def public_track_summary(document: Mapping[str, object]) -> list[dict[str, object]]:
+    summary: list[dict[str, object]] = []
+    for track in _tracks(document):
+        properties = _track_properties(track)
+        summary.append(
+            {
+                "codec": track.get("codec"),
+                "language": properties.get("language"),
+                "pixel_dimensions": properties.get("pixel_dimensions"),
+                "stereo_mode": properties.get("stereo_mode"),
+                "type": track.get("type"),
+            }
+        )
+    return summary
+
+
+def validate_segment_document(document: Mapping[str, object]) -> None:
+    tracks = _tracks(document)
+    observed_types = [track.get("type") for track in tracks]
+    if not all(isinstance(track_type, str) for track_type in observed_types):
+        raise SegmentFailure("Qualification segment reported an invalid track type.")
+    typed_observed_types = [track_type for track_type in observed_types if isinstance(track_type, str)]
+    if sorted(typed_observed_types) != ["audio", "subtitles", "video"]:
+        raise SegmentFailure("Qualification segment must contain one video, one audio, and one subtitle track.")
+    video_track = next(track for track in tracks if track.get("type") == "video")
+    video_properties = _track_properties(video_track)
+    if video_properties.get("stereo_mode") != MVC_STEREO_MODE:
+        raise SegmentFailure("Qualification segment did not preserve the MVC both-eyes-laced track mode.")
+    if video_properties.get("pixel_dimensions") != "1920x1080":
+        raise SegmentFailure("Qualification segment did not preserve 1920x1080 MVC eye dimensions.")
+    if "AVC/H.264" not in str(video_track.get("codec")):
+        raise SegmentFailure("Qualification segment did not preserve the MVC AVC video codec.")
+    audio_track = next(track for track in tracks if track.get("type") == "audio")
+    subtitle_track = next(track for track in tracks if track.get("type") == "subtitles")
+    if not isinstance(audio_track.get("codec"), str) or not audio_track["codec"]:
+        raise SegmentFailure("Qualification segment did not preserve an audio codec.")
+    if subtitle_track.get("codec") != "HDMV PGS":
+        raise SegmentFailure("Qualification segment did not preserve an HDMV PGS subtitle track.")
+
+
+def media_duration_seconds(document: Mapping[str, object]) -> float:
+    format_data = document.get("format")
+    if not isinstance(format_data, Mapping) or format_data.get("duration") is None:
+        raise SegmentFailure("Media inspection did not report a duration.")
+    try:
+        duration_seconds = float(format_data["duration"])
+    except (TypeError, ValueError) as error:
+        raise SegmentFailure("Media inspection reported an invalid duration.") from error
+    if duration_seconds <= 0:
+        raise SegmentFailure("Media inspection reported a non-positive duration.")
+    return duration_seconds
+
+
+def build_evidence(
+    *,
+    source_sha256: str,
+    source_size_bytes: int,
+    source_duration_seconds: float,
+    source_track_count: int,
+    segment_sha256: str,
+    segment_size_bytes: int,
+    segment_duration_seconds: float,
+    segment_tracks: list[dict[str, object]],
+    repeat_sha256: str,
+    start_seconds: float,
+    requested_duration_seconds: float,
+    video_track: int,
+    audio_track: int,
+    subtitle_track: int,
+    deterministic_seed: str,
+    mkvmerge_version: str,
+    ffprobe_version: str,
+) -> dict[str, object]:
+    deterministic = segment_sha256 == repeat_sha256
+    evidence = {
+        "acceptance": {
+            "deterministic_repeat_match": deterministic,
+            "preserved_mvc_both_eyes_laced": True,
+            "preserved_required_track_types": True,
+            "passed": deterministic,
+        },
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "schema_version": 1,
+        "segment": {
+            "duration_seconds": segment_duration_seconds,
+            "sha256": segment_sha256,
+            "size_bytes": segment_size_bytes,
+            "tracks": segment_tracks,
+        },
+        "selection": {
+            "audio_track": audio_track,
+            "deterministic_seed": deterministic_seed,
+            "requested_duration_seconds": requested_duration_seconds,
+            "start_seconds": start_seconds,
+            "subtitle_track": subtitle_track,
+            "video_track": video_track,
+        },
+        "source": {
+            "duration_seconds": source_duration_seconds,
+            "sha256": source_sha256,
+            "size_bytes": source_size_bytes,
+            "track_count": source_track_count,
+        },
+        "supersedes": {
+            "description": "Deleted 65.648-second representative MVC clip",
+            "reason": "Deterministically regenerated from the verified feature-length parent source",
+        },
+        "tools": {
+            "ffprobe": ffprobe_version,
+            "mkvmerge": mkvmerge_version,
+        },
+    }
+    encoded = (json.dumps(evidence, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(encoded) > MAX_EVIDENCE_BYTES:
+        raise SegmentFailure("Qualification segment evidence exceeded its bounded size limit.")
+    return evidence
+
+
+def qualify_segment(args: argparse.Namespace) -> dict[str, object]:
+    if args.start_seconds < 0 or args.duration_seconds <= 0:
+        raise SegmentFailure("Segment start must be non-negative and duration must be positive.")
+    if min(args.video_track, args.audio_track, args.subtitle_track) < 0:
+        raise SegmentFailure("Selected Matroska track ids must be non-negative.")
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    evidence_output = args.evidence.expanduser().resolve()
+    if not source.is_file():
+        raise SegmentFailure("Private MVC source is unavailable.")
+    if output == source or evidence_output in {source, output}:
+        raise SegmentFailure("Source, segment, and evidence destinations must be distinct.")
+    if (output.exists() or evidence_output.exists()) and not args.overwrite:
+        raise SegmentFailure("Output already exists; pass --overwrite to replace qualification artifacts.")
+
+    mkvmerge = command_path("mkvmerge")
+    ffprobe = command_path("ffprobe")
+    source_sha256 = sha256_file(source)
+    if args.expected_source_sha256 is not None and source_sha256 != args.expected_source_sha256.lower():
+        raise SegmentFailure("Private MVC source SHA-256 does not match the expected parent source.")
+    source_mkv = run_json([mkvmerge, "-J", source], private_paths=(source,))
+    source_probe = run_json(
+        [ffprobe, "-v", "error", "-show_entries", "format=duration", "-of", "json", source],
+        private_paths=(source,),
+    )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    evidence_output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="real-mvc-segment-", dir=output.parent) as temporary_directory:
+        temporary_root = Path(temporary_directory)
+        first_segment = temporary_root / "segment.mkv"
+        repeat_segment = temporary_root / "segment-repeat.mkv"
+        for destination in (first_segment, repeat_segment):
+            create_segment(
+                mkvmerge,
+                source,
+                destination,
+                start_seconds=args.start_seconds,
+                duration_seconds=args.duration_seconds,
+                video_track=args.video_track,
+                audio_track=args.audio_track,
+                subtitle_track=args.subtitle_track,
+                deterministic_seed=args.deterministic_seed,
+            )
+        segment_sha256 = sha256_file(first_segment)
+        repeat_sha256 = sha256_file(repeat_segment)
+        if segment_sha256 != repeat_sha256:
+            raise SegmentFailure("Repeated deterministic segment generation produced different SHA-256 values.")
+
+        segment_mkv = run_json([mkvmerge, "-J", first_segment])
+        validate_segment_document(segment_mkv)
+        segment_probe = run_json(
+            [ffprobe, "-v", "error", "-show_entries", "format=duration", "-of", "json", first_segment]
+        )
+        segment_duration_seconds = media_duration_seconds(segment_probe)
+        if abs(segment_duration_seconds - args.duration_seconds) > 0.5:
+            raise SegmentFailure("Qualification segment duration differs from the requested range by more than 0.5s.")
+        evidence = build_evidence(
+            source_sha256=source_sha256,
+            source_size_bytes=source.stat().st_size,
+            source_duration_seconds=media_duration_seconds(source_probe),
+            source_track_count=len(_tracks(source_mkv)),
+            segment_sha256=segment_sha256,
+            segment_size_bytes=first_segment.stat().st_size,
+            segment_duration_seconds=segment_duration_seconds,
+            segment_tracks=public_track_summary(segment_mkv),
+            repeat_sha256=repeat_sha256,
+            start_seconds=args.start_seconds,
+            requested_duration_seconds=args.duration_seconds,
+            video_track=args.video_track,
+            audio_track=args.audio_track,
+            subtitle_track=args.subtitle_track,
+            deterministic_seed=args.deterministic_seed,
+            mkvmerge_version=tool_version(mkvmerge, argument="--version"),
+            ffprobe_version=tool_version(ffprobe, argument="-version"),
+        )
+        first_segment.replace(output)
+        output.chmod(0o600)
+
+    evidence_text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    temporary_evidence = evidence_output.with_suffix(evidence_output.suffix + ".tmp")
+    temporary_evidence.write_text(evidence_text, encoding="utf-8")
+    temporary_evidence.replace(evidence_output)
+    return evidence
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create and hash a deterministic, public-safe real-MVC qualification segment."
+    )
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--start-seconds", type=float, required=True)
+    parser.add_argument("--duration-seconds", type=float, required=True)
+    parser.add_argument("--video-track", type=int, required=True)
+    parser.add_argument("--audio-track", type=int, required=True)
+    parser.add_argument("--subtitle-track", type=int, required=True)
+    parser.add_argument("--expected-source-sha256")
+    parser.add_argument("--deterministic-seed", default="bd-to-avp-real-mvc-segment-v1")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        evidence = qualify_segment(args)
+    except (OSError, SegmentFailure) as error:
+        raise SystemExit(f"error: {error}") from error
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_real_mvc_4k_quality.py
+++ b/scripts/qualify_real_mvc_4k_quality.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 import uuid
 
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -131,10 +132,8 @@ def terminate_pipeline_processes(*processes: subprocess.Popen[bytes]) -> None:
         try:
             process.wait(timeout=max(0.1, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
-            try:
+            with suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
             process.wait(timeout=10)
 
 

--- a/scripts/qualify_real_mvc_4k_quality.py
+++ b/scripts/qualify_real_mvc_4k_quality.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+import uuid
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from scripts.qualify_direct_mv_hevc import (
+    CURRENT_REQUIRED_BOX_TYPES,
+    DIRECT_REQUIRED_BOX_TYPES,
+    box_types,
+    verify_seeks,
+)
+from scripts.qualify_mv_hevc_corpus import summarize_quality_size_gate
+from scripts.qualify_mv_hevc_quality_match import sha256_file
+from scripts.verify_packaged_mv_hevc_routes import (
+    MEDIA_DURATION_TOLERANCE_SECONDS,
+    PACKAGE_BIN_RELATIVE_PATH,
+    AppBundle,
+    PackagedRouteFailure,
+    _media_duration,
+    _media_probe,
+    _media_streams,
+    app_tree_sha256,
+    build_worker_request,
+    metalfx_unavailable_capability_app,
+    read_app_bundle,
+    run_worker,
+    validate_route_pair,
+    validate_stage_contract,
+)
+
+
+EXPECTED_RUNS = 3
+QUALITY_TOLERANCE = 0.002
+MAX_SIZE_RATIO = 1.05
+MINIMUM_EYE_ORDER_MARGIN = 0.001
+MAX_EVIDENCE_BYTES = 256 * 1024
+COMMAND_TIMEOUT_SECONDS = 30 * 60
+SSIM_PATTERN = re.compile(r"All:([0-9.]+)")
+
+
+class RealMVCQualityFailure(RuntimeError):
+    pass
+
+
+def require_mapping(document: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = document.get(key)
+    if not isinstance(value, Mapping):
+        raise RealMVCQualityFailure(f"Real-MVC quality evidence omitted mapping {key!r}.")
+    return value
+
+
+def require_int(document: Mapping[str, object], key: str) -> int:
+    value = document.get(key)
+    if type(value) is not int:
+        raise RealMVCQualityFailure(f"Real-MVC quality evidence omitted integer {key!r}.")
+    return value
+
+
+def require_float(document: Mapping[str, object], key: str) -> float:
+    value = document.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RealMVCQualityFailure(f"Real-MVC quality evidence omitted number {key!r}.")
+    return float(value)
+
+
+def require_bool(document: Mapping[str, object], key: str) -> bool:
+    value = document.get(key)
+    if type(value) is not bool:
+        raise RealMVCQualityFailure(f"Real-MVC quality evidence omitted boolean {key!r}.")
+    return value
+
+
+def packaged_tool(app: AppBundle, name: str) -> Path:
+    path = app.path / PACKAGE_BIN_RELATIVE_PATH / name
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise RealMVCQualityFailure(f"Packaged quality tool is unavailable: {name}")
+    return path
+
+
+def run_checked(command: Sequence[str | Path], *, timeout: float = COMMAND_TIMEOUT_SECONDS) -> str:
+    try:
+        completed = subprocess.run(
+            [str(item) for item in command],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise RealMVCQualityFailure("Real-MVC quality command failed.") from error
+    return completed.stdout
+
+
+def parse_json_object(text: str, description: str) -> Mapping[str, object]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise RealMVCQualityFailure(f"{description} emitted invalid JSON.") from error
+    if not isinstance(payload, Mapping):
+        raise RealMVCQualityFailure(f"{description} did not emit a JSON object.")
+    return payload
+
+
+def terminate_pipeline_processes(*processes: subprocess.Popen[bytes]) -> None:
+    for process in processes:
+        if process.poll() is not None:
+            continue
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+    deadline = time.monotonic() + 10
+    for process in processes:
+        if process.poll() is not None:
+            continue
+        try:
+            process.wait(timeout=max(0.1, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=10)
+
+
+def run_pipeline(
+    producer_command: Sequence[str | Path],
+    consumer_command: Sequence[str | Path],
+) -> None:
+    try:
+        producer = subprocess.Popen(
+            [str(item) for item in producer_command],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as error:
+        raise RealMVCQualityFailure("Could not start the real-MVC reference producer.") from error
+    assert producer.stdout is not None
+    try:
+        consumer = subprocess.Popen(
+            [str(item) for item in consumer_command],
+            stdin=producer.stdout,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as error:
+        terminate_pipeline_processes(producer)
+        raise RealMVCQualityFailure("Could not start the real-MVC reference consumer.") from error
+    producer.stdout.close()
+    try:
+        consumer.wait(timeout=COMMAND_TIMEOUT_SECONDS)
+        producer.wait(timeout=60)
+    except subprocess.TimeoutExpired as error:
+        terminate_pipeline_processes(consumer, producer)
+        raise RealMVCQualityFailure("Real-MVC reference preparation timed out.") from error
+    if producer.returncode != 0 or consumer.returncode != 0:
+        raise RealMVCQualityFailure("Real-MVC reference preparation failed.")
+
+
+def source_video_info(ffprobe: Path, source: Path) -> dict[str, object]:
+    payload = parse_json_object(
+        run_checked(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-count_packets",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=avg_frame_rate,nb_read_packets:format=duration",
+                "-of",
+                "json",
+                source,
+            ]
+        ),
+        "Representative segment probe",
+    )
+    streams = payload.get("streams")
+    format_data = payload.get("format")
+    if not isinstance(streams, list) or len(streams) != 1 or not isinstance(streams[0], Mapping):
+        raise RealMVCQualityFailure("Representative segment did not report one video stream.")
+    if not isinstance(format_data, Mapping):
+        raise RealMVCQualityFailure("Representative segment did not report container timing.")
+    frame_rate = streams[0].get("avg_frame_rate")
+    packet_count = streams[0].get("nb_read_packets")
+    duration = format_data.get("duration")
+    if not isinstance(frame_rate, str) or not isinstance(packet_count, str) or duration is None:
+        raise RealMVCQualityFailure("Representative segment omitted frame timing.")
+    try:
+        parsed_packets = int(packet_count)
+        parsed_duration = float(duration)
+    except ValueError as error:
+        raise RealMVCQualityFailure("Representative segment reported invalid frame timing.") from error
+    if parsed_packets <= 0 or parsed_duration <= 0:
+        raise RealMVCQualityFailure("Representative segment reported non-positive frame timing.")
+    return {
+        "duration_seconds": parsed_duration,
+        "frame_rate": frame_rate,
+        "frame_count": parsed_packets,
+    }
+
+
+def probe_eye(ffprobe: Path, path: Path, *, expected_dimensions: tuple[int, int], expected_frames: int) -> int:
+    payload = parse_json_object(
+        run_checked(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-count_frames",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,nb_read_frames",
+                "-of",
+                "json",
+                path,
+            ]
+        ),
+        "Quality eye probe",
+    )
+    streams = payload.get("streams")
+    if not isinstance(streams, list) or len(streams) != 1 or not isinstance(streams[0], Mapping):
+        raise RealMVCQualityFailure("Quality eye did not contain one video stream.")
+    stream = streams[0]
+    if (stream.get("width"), stream.get("height")) != expected_dimensions:
+        raise RealMVCQualityFailure("Quality eye reported unexpected dimensions.")
+    try:
+        frame_count = int(stream.get("nb_read_frames") or 0)
+    except (TypeError, ValueError) as error:
+        raise RealMVCQualityFailure("Quality eye reported an invalid frame count.") from error
+    if frame_count != expected_frames:
+        raise RealMVCQualityFailure("Quality eye frame count did not match the representative source.")
+    return frame_count
+
+
+def prepare_reference_eyes(
+    app: AppBundle,
+    source: Path,
+    work_directory: Path,
+    source_info: Mapping[str, object],
+) -> tuple[Path, Path]:
+    edge264 = packaged_tool(app, "edge264_test")
+    annex_b = work_directory / "reference-source.264"
+    left = work_directory / "reference-left.mkv"
+    right = work_directory / "reference-right.mkv"
+    run_checked(
+        [
+            app.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            source,
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "copy",
+            "-bsf:v",
+            "h264_mp4toannexb",
+            "-f",
+            "h264",
+            "-y",
+            annex_b,
+        ]
+    )
+    run_pipeline(
+        [edge264, annex_b, "-Omk"],
+        [
+            app.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "yuv4mpegpipe",
+            "-r",
+            str(source_info["frame_rate"]),
+            "-i",
+            "-",
+            "-filter_complex",
+            (
+                "[0:v]split=2[left_source][right_source];"
+                "[left_source]crop=1920:1080:0:0[left];"
+                "[right_source]crop=1920:1080:1920:0[right]"
+            ),
+            "-map",
+            "[left]",
+            "-c:v",
+            "ffv1",
+            "-level",
+            "3",
+            "-g",
+            "1",
+            "-y",
+            left,
+            "-map",
+            "[right]",
+            "-c:v",
+            "ffv1",
+            "-level",
+            "3",
+            "-g",
+            "1",
+            "-y",
+            right,
+        ],
+    )
+    annex_b.unlink(missing_ok=True)
+    for path in (left, right):
+        path.chmod(0o600)
+        probe_eye(
+            app.ffprobe,
+            path,
+            expected_dimensions=(1920, 1080),
+            expected_frames=require_int(source_info, "frame_count"),
+        )
+    return left, right
+
+
+def split_mv_hevc(app: AppBundle, movie: Path, output_directory: Path) -> tuple[Path, Path]:
+    spatial_media_tool = packaged_tool(app, "spatial-media-kit-tool")
+    output_directory.mkdir(parents=True, mode=0o700)
+    run_checked([spatial_media_tool, "split", "--input-file", movie, "--output-dir", output_directory])
+    left = sorted(output_directory.glob("*LEFT*.mov"))
+    right = sorted(output_directory.glob("*RIGHT*.mov"))
+    if len(left) != 1 or len(right) != 1:
+        raise RealMVCQualityFailure("Spatial Media Toolkit did not produce one left and one right quality eye.")
+    left[0].chmod(0o600)
+    right[0].chmod(0o600)
+    return left[0], right[0]
+
+
+def downscaled_ssim(ffmpeg: Path, candidate: Path, reference: Path) -> float:
+    process = subprocess.run(
+        [
+            str(ffmpeg),
+            "-hide_banner",
+            "-loglevel",
+            "info",
+            "-i",
+            str(candidate),
+            "-i",
+            str(reference),
+            "-lavfi",
+            (
+                "[0:v]scale=1920:1080:flags=lanczos,format=yuv420p,setpts=PTS-STARTPTS[candidate];"
+                "[1:v]format=yuv420p,setpts=PTS-STARTPTS[reference];"
+                "[candidate][reference]ssim"
+            ),
+            "-f",
+            "null",
+            "-",
+        ],
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if process.returncode != 0:
+        raise RealMVCQualityFailure("Real-MVC SSIM comparison failed.")
+    matches = SSIM_PATTERN.findall(process.stderr)
+    if not matches:
+        raise RealMVCQualityFailure("Real-MVC SSIM comparison did not report an aggregate score.")
+    return float(matches[-1])
+
+
+def measure_output(
+    app: AppBundle,
+    movie: Path,
+    reference_left: Path,
+    reference_right: Path,
+    split_directory: Path,
+    *,
+    expected_frames: int,
+    elapsed_seconds: float,
+) -> dict[str, object]:
+    left, right = split_mv_hevc(app, movie, split_directory)
+    left_frame_count = probe_eye(
+        app.ffprobe,
+        left,
+        expected_dimensions=(3840, 2160),
+        expected_frames=expected_frames,
+    )
+    right_frame_count = probe_eye(
+        app.ffprobe,
+        right,
+        expected_dimensions=(3840, 2160),
+        expected_frames=expected_frames,
+    )
+    left_match = downscaled_ssim(app.ffmpeg, left, reference_left)
+    left_cross = downscaled_ssim(app.ffmpeg, left, reference_right)
+    right_match = downscaled_ssim(app.ffmpeg, right, reference_right)
+    right_cross = downscaled_ssim(app.ffmpeg, right, reference_left)
+    record = {
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "final_bytes": movie.stat().st_size,
+        "left_frame_count": left_frame_count,
+        "left_cross_ssim": left_cross,
+        "left_match_ssim": left_match,
+        "min_eye_order_margin": min(left_match - left_cross, right_match - right_cross),
+        "min_same_eye_ssim": min(left_match, right_match),
+        "right_cross_ssim": right_cross,
+        "right_frame_count": right_frame_count,
+        "right_match_ssim": right_match,
+        "sha256": sha256_file(movie),
+    }
+    shutil.rmtree(split_directory, ignore_errors=True)
+    movie.unlink(missing_ok=True)
+    return record
+
+
+def probe_quality_artifact(
+    app: AppBundle,
+    path: Path,
+    required_box_types: set[str],
+    *,
+    expected_duration_seconds: float,
+) -> None:
+    missing_boxes = sorted(required_box_types - box_types(path))
+    if missing_boxes:
+        raise RealMVCQualityFailure("Quality artifact is missing required spatial metadata.")
+    probe = _media_probe(app, path)
+    duration_seconds = _media_duration(probe)
+    if abs(duration_seconds - expected_duration_seconds) > MEDIA_DURATION_TOLERANCE_SECONDS:
+        raise RealMVCQualityFailure("Quality artifact duration did not match the source segment.")
+    streams = _media_streams(probe)
+    video_streams = [stream for stream in streams if stream.get("codec_type") == "video"]
+    audio_streams = [stream for stream in streams if stream.get("codec_type") == "audio"]
+    if len(streams) != 2 or len(video_streams) != 1 or len(audio_streams) != 1:
+        raise RealMVCQualityFailure("Quality artifact did not contain exactly one video and one audio stream.")
+    video = video_streams[0]
+    audio = audio_streams[0]
+    if video.get("codec_name") != "hevc" or (video.get("width"), video.get("height")) != (3840, 2160):
+        raise RealMVCQualityFailure("Quality artifact did not preserve 3840x2160 HEVC video.")
+    if audio.get("codec_name") != "aac" or audio.get("language") != "eng":
+        raise RealMVCQualityFailure("Quality artifact did not preserve the expected English AAC audio.")
+    verify_seeks(app.ffmpeg.as_posix(), path, max(1, math.ceil(duration_seconds)))
+
+
+def run_quality_route(
+    app: AppBundle,
+    source: Path,
+    destination: Path,
+    *,
+    source_duration_seconds: float,
+    direct: bool,
+) -> tuple[Path, float]:
+    started = time.monotonic()
+    request = build_worker_request(
+        "convert_source",
+        source,
+        destination,
+        job_id=str(uuid.uuid4()),
+        upscale_enabled=True,
+    )
+    encoding = request.get("encoding")
+    if not isinstance(encoding, dict):
+        raise RealMVCQualityFailure("Quality request omitted encoding settings.")
+    encoding["subtitles"] = {"mode": "off", "preferred_language": None}
+    result = run_worker(
+        app,
+        request,
+        home_directory=destination.with_name(f"{destination.name}-home"),
+    )
+    if direct:
+        validate_route_pair(
+            result,
+            result,
+            expected_selected="direct_mv_hevc",
+            expected_fallback_reason=None,
+            expected_upscale_mode="metalfx",
+        )
+        validate_stage_contract(
+            result,
+            required={"create_left_right_files"},
+            forbidden={"combine_to_mv_hevc", "upscale_video"},
+        )
+        required_boxes = DIRECT_REQUIRED_BOX_TYPES
+    else:
+        validate_route_pair(
+            result,
+            result,
+            expected_selected="generated_mv_hevc",
+            expected_fallback_reason="metalfx_2x_mv_hevc_unavailable",
+            expected_upscale_mode=None,
+        )
+        validate_stage_contract(
+            result,
+            required={"combine_to_mv_hevc", "create_left_right_files", "upscale_video"},
+            forbidden=set(),
+        )
+        required_boxes = CURRENT_REQUIRED_BOX_TYPES
+    probe_quality_artifact(
+        app,
+        result.output_path,
+        required_boxes,
+        expected_duration_seconds=source_duration_seconds,
+    )
+    result.output_path.chmod(0o600)
+    return result.output_path, time.monotonic() - started
+
+
+def summarize_real_mvc_quality(
+    file_based_runs: Sequence[Mapping[str, object]],
+    direct_runs: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    if len(file_based_runs) != EXPECTED_RUNS or len(direct_runs) != EXPECTED_RUNS:
+        raise ValueError(f"Real-MVC quality requires exactly {EXPECTED_RUNS} runs per route.")
+    summary = summarize_quality_size_gate(
+        file_based_runs,
+        direct_runs,
+        quality_tolerance=QUALITY_TOLERANCE,
+        max_size_ratio=MAX_SIZE_RATIO,
+        minimum_eye_order_margin=MINIMUM_EYE_ORDER_MARGIN,
+    )
+    file_based_eye_order_passed = all(
+        require_float(run, "min_eye_order_margin") >= MINIMUM_EYE_ORDER_MARGIN for run in file_based_runs
+    )
+    summary.update(
+        {
+            "direct_run_count": len(direct_runs),
+            "file_based_eye_order_passed": file_based_eye_order_passed,
+            "file_based_run_count": len(file_based_runs),
+            "passed": require_bool(summary, "passed") and file_based_eye_order_passed,
+        }
+    )
+    return summary
+
+
+def build_evidence(
+    *,
+    app: AppBundle,
+    source: Path,
+    source_info: Mapping[str, object],
+    reference_left: Path,
+    reference_right: Path,
+    direct_runs: list[dict[str, object]],
+    file_based_runs: list[dict[str, object]],
+    fallback_helper_sha256: str,
+) -> dict[str, object]:
+    summary = summarize_real_mvc_quality(file_based_runs, direct_runs)
+    return {
+        "acceptance": {
+            "direct_quality": bool(summary["quality_passed"]),
+            "direct_size": bool(summary["size_passed"]),
+            "eye_order": bool(summary["eye_order_passed"]) and bool(summary["file_based_eye_order_passed"]),
+            "passed": bool(summary["passed"]),
+            "repeated_full_routes": len(direct_runs) == EXPECTED_RUNS and len(file_based_runs) == EXPECTED_RUNS,
+        },
+        "direct_runs": direct_runs,
+        "file_based_runs": file_based_runs,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "package": {
+            "app_tree_sha256": app_tree_sha256(app.path),
+            "bundle_identifier": app.bundle_identifier,
+            "fallback_helper_sha256": fallback_helper_sha256,
+            "helper_sha256": sha256_file(app.helper),
+            "version": app.version,
+            "worker_sha256": sha256_file(app.worker),
+        },
+        "reference": {
+            "frame_count": require_int(source_info, "frame_count"),
+            "left_sha256": sha256_file(reference_left),
+            "right_sha256": sha256_file(reference_right),
+            "size_bytes": reference_left.stat().st_size + reference_right.stat().st_size,
+        },
+        "schema_version": 1,
+        "source": {
+            "duration_seconds": require_float(source_info, "duration_seconds"),
+            "frame_count": require_int(source_info, "frame_count"),
+            "frame_rate": str(source_info["frame_rate"]),
+            "sha256": sha256_file(source),
+            "size_bytes": source.stat().st_size,
+        },
+        "summary": summary,
+        "thresholds": {
+            "max_size_ratio": MAX_SIZE_RATIO,
+            "minimum_eye_order_margin": MINIMUM_EYE_ORDER_MARGIN,
+            "quality_tolerance": QUALITY_TOLERANCE,
+            "runs_per_route": EXPECTED_RUNS,
+        },
+        "tools": {
+            "edge264_sha256": sha256_file(packaged_tool(app, "edge264_test")),
+            "ffmpeg_sha256": sha256_file(app.ffmpeg),
+            "ffprobe_sha256": sha256_file(app.ffprobe),
+            "fx_upscale_sha256": sha256_file(packaged_tool(app, "fx-upscale")),
+            "spatial_media_tool_sha256": sha256_file(packaged_tool(app, "spatial-media-kit-tool")),
+        },
+    }
+
+
+def validate_paths(app: AppBundle, source: Path, output: Path, work_directory: Path, requested_work: Path) -> None:
+    if requested_work.is_symlink():
+        raise RealMVCQualityFailure("Real-MVC quality work directory must not be a symlink.")
+    protected = {app.path, app.worker, app.helper, source, output}
+    if work_directory in protected or work_directory in {Path("/"), Path.home().resolve()}:
+        raise RealMVCQualityFailure("Real-MVC quality work directory is not a safe dedicated destination.")
+    if any(path.is_relative_to(work_directory) for path in protected):
+        raise RealMVCQualityFailure("Real-MVC quality work directory must not contain protected inputs.")
+    if output.is_relative_to(work_directory) or output.is_relative_to(app.path):
+        raise RealMVCQualityFailure("Real-MVC quality evidence output must remain outside transient inputs.")
+    if work_directory.exists() and any(work_directory.iterdir()):
+        raise RealMVCQualityFailure("Real-MVC quality work directory must be new or empty.")
+
+
+def remove_private_work_directory(work_directory: Path) -> None:
+    try:
+        shutil.rmtree(work_directory)
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        raise RealMVCQualityFailure("Could not remove the private real-MVC quality work directory.") from error
+    if work_directory.exists():
+        raise RealMVCQualityFailure("Private real-MVC quality work directory remained after cleanup.")
+
+
+def qualify(args: argparse.Namespace) -> dict[str, object]:
+    app = read_app_bundle(args.app)
+    source = args.source.expanduser().resolve()
+    requested_output = args.output.expanduser()
+    if requested_output.is_symlink():
+        raise RealMVCQualityFailure("Real-MVC quality evidence output must not be a symlink.")
+    output = requested_output.resolve()
+    requested_work = args.work_directory.expanduser()
+    work_directory = requested_work.resolve()
+    validate_paths(app, source, output, work_directory, requested_work)
+    if not source.is_file():
+        raise RealMVCQualityFailure("Representative MVC segment is unavailable.")
+    if sha256_file(source) != args.expected_source_sha256.lower():
+        raise RealMVCQualityFailure("Representative MVC segment SHA-256 did not match the expected fixture.")
+    work_directory.mkdir(parents=True, mode=0o700)
+    source_info = source_video_info(app.ffprobe, source)
+    source_duration_seconds = require_float(source_info, "duration_seconds")
+    source_frame_count = require_int(source_info, "frame_count")
+    direct_runs: list[dict[str, object]] = []
+    file_based_runs: list[dict[str, object]] = []
+    evidence: dict[str, object]
+    try:
+        reference_left, reference_right = prepare_reference_eyes(app, source, work_directory, source_info)
+        with metalfx_unavailable_capability_app(app, work_directory / "fallback-app") as fallback_app:
+            fallback_helper_sha256 = sha256_file(fallback_app.helper)
+            for run_index in range(EXPECTED_RUNS):
+                direct_movie, direct_elapsed = run_quality_route(
+                    app,
+                    source,
+                    work_directory / f"direct-{run_index}",
+                    source_duration_seconds=source_duration_seconds,
+                    direct=True,
+                )
+                direct_runs.append(
+                    measure_output(
+                        app,
+                        direct_movie,
+                        reference_left,
+                        reference_right,
+                        work_directory / f"direct-{run_index}-split",
+                        expected_frames=source_frame_count,
+                        elapsed_seconds=direct_elapsed,
+                    )
+                )
+                file_based_movie, file_based_elapsed = run_quality_route(
+                    fallback_app,
+                    source,
+                    work_directory / f"file-based-{run_index}",
+                    source_duration_seconds=source_duration_seconds,
+                    direct=False,
+                )
+                file_based_runs.append(
+                    measure_output(
+                        app,
+                        file_based_movie,
+                        reference_left,
+                        reference_right,
+                        work_directory / f"file-based-{run_index}-split",
+                        expected_frames=source_frame_count,
+                        elapsed_seconds=file_based_elapsed,
+                    )
+                )
+        evidence = build_evidence(
+            app=app,
+            source=source,
+            source_info=source_info,
+            reference_left=reference_left,
+            reference_right=reference_right,
+            direct_runs=direct_runs,
+            file_based_runs=file_based_runs,
+            fallback_helper_sha256=fallback_helper_sha256,
+        )
+    finally:
+        remove_private_work_directory(work_directory)
+    evidence_text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if len(evidence_text.encode("utf-8")) > MAX_EVIDENCE_BYTES:
+        raise RealMVCQualityFailure("Real-MVC quality evidence exceeded its bounded size limit.")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output.with_suffix(output.suffix + ".tmp")
+    temporary_output.write_text(evidence_text, encoding="utf-8")
+    temporary_output.replace(output)
+    return evidence
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare repeated packaged direct 4K MetalFX and file-based FX Upscale quality on real MVC."
+    )
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--work-directory", type=Path, required=True)
+    parser.add_argument("--expected-source-sha256", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    try:
+        evidence = qualify(parse_args())
+    except (OSError, PackagedRouteFailure, RealMVCQualityFailure, subprocess.SubprocessError) as error:
+        parser.exit(1, f"error: {error}\n")
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+    return 0 if require_bool(require_mapping(evidence, "acceptance"), "passed") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_real_mvc_feature.py
+++ b/scripts/qualify_real_mvc_feature.py
@@ -1,0 +1,1502 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+import os
+import platform
+import queue
+import re
+import shutil
+import signal
+import statistics
+import subprocess
+import threading
+import time
+import uuid
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from fractions import Fraction
+from pathlib import Path
+from typing import BinaryIO, Mapping, Sequence, TextIO
+
+import psutil
+
+from bd_to_avp.observability import (
+    ObservabilityContext,
+    ObservabilityEmitter,
+    ObservabilityEvent,
+    ObservabilityStage,
+)
+from bd_to_avp.process_runner import (
+    CaptureOverflowPolicy,
+    ProcessArtifactProbe,
+    ProcessCancelled,
+    ProcessPipelineRunner,
+    ProcessPipelineStage,
+    ProcessSpec,
+)
+from bd_to_avp.runtime import CancellationToken, ObservabilityStream, RunContext
+from bd_to_avp.modules.video import resolve_direct_mv_hevc_artifact
+from scripts.benchmark_mv_hevc_metalfx import (
+    aligned_4k_bgra_texture_bytes,
+    declared_metal_payload_bytes,
+)
+from scripts.qualify_direct_mv_hevc import DIRECT_REQUIRED_BOX_TYPES, box_types, verify_seeks
+from scripts.qualify_mv_hevc_quality_match import sha256_file
+from scripts.verify_apple_media import verify_apple_media_compatible
+from scripts.verify_packaged_mv_hevc_routes import (
+    AppBundle,
+    app_tree_sha256,
+    build_worker_request,
+    parse_worker_events,
+    read_app_bundle,
+)
+
+
+MAX_EVIDENCE_BYTES = 512 * 1024
+DEFAULT_FRAME_RATE = "24000/1001"
+DEFAULT_MAX_RSS_GROWTH_MIB = 64
+DEFAULT_CANCEL_AFTER_MIB = 32
+AGGREGATE_RSS_GROWTH_MULTIPLIER = 2
+METALFX_INTERNAL_TEXTURE_ALLOWANCE = 3
+METALFX_DURATION_TEXTURE_GROWTH_ALLOWANCE = 1
+MAX_FEATURE_METAL_BYTES = 1024 * 1024 * 1024
+MAX_FEATURE_PROCESS_RSS_BYTES = 2 * 1024 * 1024 * 1024
+DIRECT_ARTIFACT_NO_GROWTH_SECONDS = 120
+PACKAGE_BIN_RELATIVE_PATH = Path("Contents/Resources/app/bd_to_avp/bin")
+TERMINAL_TOOL_EVENTS = {"tool.cancelled", "tool.completed", "tool.failed"}
+THERMAL_NAMES = {0: "nominal", 1: "fair", 2: "serious", 3: "critical"}
+POWERMETRICS_THERMAL_PATTERN = re.compile(
+    r"^Current pressure level:\s*(Nominal|Fair|Serious|Critical)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class FeatureQualificationFailure(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PackagedTools:
+    ffmpeg: Path
+    ffprobe: Path
+    edge264: Path
+    encoder: Path
+
+
+def packaged_tools(app: AppBundle) -> PackagedTools:
+    binary_root = app.path / PACKAGE_BIN_RELATIVE_PATH
+    tools = PackagedTools(
+        ffmpeg=binary_root / "ffmpeg",
+        ffprobe=binary_root / "ffprobe",
+        edge264=binary_root / "edge264_test",
+        encoder=app.helper,
+    )
+    for path in (tools.ffmpeg, tools.ffprobe, tools.edge264, tools.encoder):
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise FeatureQualificationFailure(f"Packaged qualification tool is unavailable: {path.name}")
+    return tools
+
+
+def thermal_state() -> int:
+    try:
+        from Foundation import NSProcessInfo  # type: ignore[import-untyped]
+
+        state = int(NSProcessInfo.processInfo().thermalState())
+    except (ImportError, TypeError, ValueError) as error:
+        raise FeatureQualificationFailure("Could not read the macOS thermal pressure state.") from error
+    if state not in THERMAL_NAMES:
+        raise FeatureQualificationFailure(f"macOS reported an unknown thermal pressure state: {state}")
+    return state
+
+
+def powermetrics_thermal_summary(trace_text: str) -> dict[str, object]:
+    thermal_section_count = trace_text.count("**** Thermal pressure ****")
+    states_by_name = {name: state for state, name in THERMAL_NAMES.items()}
+    observed_names = [match.lower() for match in POWERMETRICS_THERMAL_PATTERN.findall(trace_text)]
+    if thermal_section_count <= 0 or len(observed_names) != thermal_section_count:
+        raise FeatureQualificationFailure("powermetrics trace did not contain complete thermal pressure values.")
+    states = [states_by_name[name] for name in observed_names]
+    max_state = max(states)
+    return {
+        "all_nominal": max_state == 0,
+        "counts": {name: observed_names.count(name) for name in THERMAL_NAMES.values()},
+        "max_state": max_state,
+        "max_state_name": THERMAL_NAMES[max_state],
+        "sample_count": len(states),
+    }
+
+
+def require_nominal_powermetrics_thermal(trace_text: str) -> dict[str, object]:
+    thermal = powermetrics_thermal_summary(trace_text)
+    if not require_bool_value(thermal, "all_nominal"):
+        raise FeatureQualificationFailure("powermetrics reported non-nominal thermal pressure.")
+    return thermal
+
+
+def percentile(values: Sequence[int], fraction: float) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(len(ordered) * fraction) - 1))
+    return ordered[index]
+
+
+def quartile_peaks(values: Sequence[int]) -> list[int]:
+    if not values:
+        return [0, 0, 0, 0]
+    peaks: list[int] = []
+    for index in range(4):
+        start = index * len(values) // 4
+        end = (index + 1) * len(values) // 4
+        peaks.append(max(values[start : max(start + 1, end)], default=0))
+    return peaks
+
+
+def process_role(tool_id: str, process_id: int, count: int) -> str:
+    try:
+        command = psutil.Process(process_id).cmdline()
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        command = []
+    if tool_id == "ffmpeg":
+        if "-bsf:v" in command:
+            return "source_ffmpeg"
+        if "yuv4mpegpipe" in command:
+            return "normalizer_ffmpeg"
+    return f"{tool_id}_{count}"
+
+
+def require_mapping_value(document: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = document.get(key)
+    if not isinstance(value, Mapping):
+        raise FeatureQualificationFailure(f"Qualification evidence omitted mapping {key!r}.")
+    return value
+
+
+def require_int_value(document: Mapping[str, object], key: str) -> int:
+    value = document.get(key)
+    if type(value) is not int:
+        raise FeatureQualificationFailure(f"Qualification evidence omitted integer {key!r}.")
+    return value
+
+
+def require_number_value(document: Mapping[str, object], key: str) -> float:
+    value = document.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise FeatureQualificationFailure(f"Qualification evidence omitted number {key!r}.")
+    return float(value)
+
+
+def require_bool_value(document: Mapping[str, object], key: str) -> bool:
+    value = document.get(key)
+    if type(value) is not bool:
+        raise FeatureQualificationFailure(f"Qualification evidence omitted boolean {key!r}.")
+    return value
+
+
+def require_int_list_value(document: Mapping[str, object], key: str, *, length: int) -> list[int]:
+    value = document.get(key)
+    if not isinstance(value, list) or len(value) != length or any(type(item) is not int for item in value):
+        raise FeatureQualificationFailure(f"Qualification evidence omitted integer list {key!r}.")
+    return [item for item in value if isinstance(item, int)]
+
+
+class QualificationEventSink:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active_pids: set[int] = set()
+        self._process_labels: dict[int, str] = {}
+        self._tool_counts: dict[str, int] = {}
+        self._artifact_samples: list[dict[str, object]] = []
+        self._failure_codes: list[str] = []
+
+    def emit(self, event: ObservabilityEvent) -> None:
+        process = event.context.process
+        with self._lock:
+            process_id = process.pid if process is not None else None
+            if isinstance(process_id, int) and event.kind == "tool.started":
+                self._active_pids.add(process_id)
+                tool_id = event.context.tool.id if event.context.tool is not None else "process"
+                count = self._tool_counts.get(tool_id, 0) + 1
+                self._tool_counts[tool_id] = count
+                self._process_labels[process_id] = process_role(tool_id, process_id, count)
+            if isinstance(process_id, int) and event.kind in TERMINAL_TOOL_EVENTS:
+                self._active_pids.discard(process_id)
+            if event.data.failure is not None:
+                self._failure_codes.append(event.data.failure.code)
+            artifact = event.data.artifact
+            if artifact is not None:
+                self._artifact_samples.append(
+                    {
+                        "elapsed_seconds": round((event.elapsed_ms or 0) / 1000, 3),
+                        "growth_bytes_per_second": artifact.growth_bytes_per_second,
+                        "role": artifact.role,
+                        "size_bytes": artifact.size_bytes,
+                        "state": artifact.state,
+                    }
+                )
+
+    def active_pids(self) -> tuple[int, ...]:
+        with self._lock:
+            return tuple(self._active_pids)
+
+    def active_processes(self) -> tuple[tuple[int, str], ...]:
+        with self._lock:
+            return tuple(
+                (process_id, self._process_labels.get(process_id, "process")) for process_id in self._active_pids
+            )
+
+    def summary(self) -> dict[str, object]:
+        with self._lock:
+            samples = list(self._artifact_samples)
+            failure_codes = list(self._failure_codes)
+        stereo_samples = [sample for sample in samples if sample["role"] == "stereo_video_output"]
+        growth_samples = [
+            sample
+            for sample in stereo_samples
+            if isinstance(sample["growth_bytes_per_second"], int) and sample["growth_bytes_per_second"] > 0
+        ]
+        increasing_samples: list[dict[str, object]] = []
+        prior_size = 0
+        for sample in stereo_samples:
+            size = sample["size_bytes"]
+            if isinstance(size, int) and size > prior_size:
+                increasing_samples.append(sample)
+                prior_size = size
+        growth_gaps = [
+            require_number_value(current, "elapsed_seconds") - require_number_value(previous, "elapsed_seconds")
+            for previous, current in itertools.pairwise(increasing_samples)
+        ]
+        return {
+            "artifact_sample_count": len(stereo_samples),
+            "failure_codes": sorted(set(failure_codes)),
+            "increasing_artifact_sample_count": len(increasing_samples),
+            "max_artifact_growth_gap_seconds": round(max(growth_gaps, default=0), 3),
+            "positive_growth_sample_count": len(growth_samples),
+        }
+
+
+class ResourceSampler:
+    def __init__(self, event_sink: QualificationEventSink, *, interval_seconds: float = 0.5) -> None:
+        self._event_sink = event_sink
+        self._interval_seconds = interval_seconds
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._rss_samples: list[int] = []
+        self._thermal_samples: list[int] = []
+        self._process_samples: list[tuple[float, dict[str, int]]] = []
+        self._error: BaseException | None = None
+        self._started_at = time.monotonic()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> dict[str, object]:
+        self._stop.set()
+        self._thread.join(timeout=max(5.0, self._interval_seconds * 4))
+        if self._thread.is_alive():
+            raise FeatureQualificationFailure("Resource sampler did not stop.")
+        if self._error is not None:
+            raise FeatureQualificationFailure("Resource sampler failed during qualification.") from self._error
+        rss_samples = [sample for sample in self._rss_samples if sample > 0]
+        thermal_samples = list(self._thermal_samples)
+        sample_count = len(rss_samples)
+        total_quartile_peaks = quartile_peaks(rss_samples)
+        duration_seconds = time.monotonic() - self._started_at
+        expected_samples = max(1, int(duration_seconds / self._interval_seconds) - 1)
+        process_labels = sorted({label for _elapsed, sample in self._process_samples for label in sample})
+        process_summaries: dict[str, object] = {}
+        for label in process_labels:
+            samples = [sample[label] for _elapsed, sample in self._process_samples if sample.get(label, 0) > 0]
+            label_quartile_peaks = quartile_peaks(samples)
+            process_summaries[label] = {
+                "final_rss_bytes": samples[-1] if samples else 0,
+                "first_quarter_peak_rss_bytes": label_quartile_peaks[0],
+                "last_quarter_peak_rss_bytes": label_quartile_peaks[-1],
+                "median_rss_bytes": int(statistics.median(samples)) if samples else 0,
+                "peak_rss_bytes": max(samples, default=0),
+                "quartile_peak_rss_bytes": label_quartile_peaks,
+                "sample_count": len(samples),
+            }
+        timeline_limit = 64
+        if len(self._process_samples) <= timeline_limit:
+            timeline_samples = self._process_samples
+        else:
+            timeline_indices = {
+                round(index * (len(self._process_samples) - 1) / (timeline_limit - 1))
+                for index in range(timeline_limit)
+            }
+            timeline_samples = [
+                sample for index, sample in enumerate(self._process_samples) if index in timeline_indices
+            ]
+        return {
+            "coverage_fraction": round(min(1.0, sample_count / expected_samples), 6),
+            "duration_seconds": round(duration_seconds, 3),
+            "final_rss_bytes": rss_samples[-1] if rss_samples else 0,
+            "first_quarter_peak_rss_bytes": total_quartile_peaks[0],
+            "last_quarter_peak_rss_bytes": total_quartile_peaks[-1],
+            "median_rss_bytes": int(statistics.median(rss_samples)) if rss_samples else 0,
+            "peak_rss_bytes": max(rss_samples, default=0),
+            "p95_rss_bytes": percentile(rss_samples, 0.95),
+            "processes": process_summaries,
+            "quartile_peak_rss_bytes": total_quartile_peaks,
+            "sample_count": sample_count,
+            "thermal": {
+                "counts": {
+                    name: sum(sample == state for sample in thermal_samples) for state, name in THERMAL_NAMES.items()
+                },
+                "max_state": max(thermal_samples, default=0),
+                "max_state_name": THERMAL_NAMES[max(thermal_samples, default=0)],
+                "sample_count": len(thermal_samples),
+            },
+            "timeline": [
+                {
+                    "elapsed_seconds": round(elapsed, 3),
+                    "process_rss_bytes": process_rss,
+                    "total_rss_bytes": sum(process_rss.values()),
+                }
+                for elapsed, process_rss in timeline_samples
+            ],
+        }
+
+    def _run(self) -> None:
+        try:
+            while not self._stop.wait(self._interval_seconds):
+                process_rss = {
+                    label: process_id_tree_rss(process_id) for process_id, label in self._event_sink.active_processes()
+                }
+                total_rss = sum(process_rss.values())
+                self._rss_samples.append(total_rss)
+                self._process_samples.append((time.monotonic() - self._started_at, process_rss))
+                self._thermal_samples.append(thermal_state())
+        except BaseException as error:
+            self._error = error
+            self._stop.set()
+
+
+class PowerTrace:
+    def __init__(self, output_path: Path) -> None:
+        self.output_path = output_path
+        self.process: subprocess.Popen[bytes] | None = None
+        self.output_file: BinaryIO | None = None
+
+    def start(self) -> None:
+        if shutil.which("powermetrics") is None or shutil.which("sudo") is None:
+            raise FeatureQualificationFailure("powermetrics and sudo are required for feature-length thermal evidence.")
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self.output_path.write_bytes(b"")
+        self.output_path.chmod(0o600)
+        self.output_file = self.output_path.open("wb")
+        self.process = subprocess.Popen(
+            [
+                "sudo",
+                "-n",
+                "powermetrics",
+                "--samplers",
+                "thermal,gpu_power",
+                "--sample-rate",
+                "5000",
+                "--show-process-gpu",
+            ],
+            stdout=self.output_file,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        time.sleep(0.5)
+        if self.process.poll() is not None:
+            self.output_file.close()
+            raise FeatureQualificationFailure("powermetrics could not start without an interactive authorization.")
+
+    def stop(self) -> dict[str, object]:
+        if self.process is None:
+            raise FeatureQualificationFailure("powermetrics trace was not started.")
+        if self.process.poll() is None:
+            os.killpg(self.process.pid, signal.SIGTERM)
+        try:
+            self.process.wait(timeout=30)
+        except subprocess.TimeoutExpired as error:
+            os.killpg(self.process.pid, signal.SIGKILL)
+            self.process.wait(timeout=10)
+            raise FeatureQualificationFailure("powermetrics did not stop cleanly.") from error
+        finally:
+            if self.output_file is not None and not self.output_file.closed:
+                self.output_file.close()
+        if self.process.returncode not in {0, -signal.SIGTERM}:
+            raise FeatureQualificationFailure(
+                f"powermetrics exited unexpectedly with status {self.process.returncode}."
+            )
+        if not self.output_path.is_file() or self.output_path.stat().st_size == 0:
+            raise FeatureQualificationFailure("powermetrics did not produce a thermal trace.")
+        self.output_path.chmod(0o600)
+        trace_text = self.output_path.read_text(encoding="utf-8", errors="replace")
+        sample_count = trace_text.count("*** Sampled system activity")
+        thermal = require_nominal_powermetrics_thermal(trace_text)
+        if sample_count <= 0:
+            raise FeatureQualificationFailure("powermetrics trace did not contain thermal samples.")
+        return {
+            "sample_count": sample_count,
+            "sha256": sha256_file(self.output_path),
+            "size_bytes": self.output_path.stat().st_size,
+            "thermal": thermal,
+        }
+
+
+def producer_command(ffmpeg: Path, source: Path) -> list[str | Path]:
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        source,
+        "-map",
+        "0:v:0",
+        "-c:v",
+        "copy",
+        "-bsf:v",
+        "h264_mp4toannexb",
+        "-f",
+        "h264",
+        "-",
+    ]
+
+
+def normalizer_command(ffmpeg: Path, *, frame_rate: str) -> list[str | Path]:
+    filter_complex = (
+        "[0:v]split=2[left_source][right_source];"
+        "[left_source]crop=1920:1080:0:0[left];"
+        "[right_source]crop=1920:1080:1920:0[right];"
+        "[left][right]hstack=inputs=2,format=yuv420p[stereo]"
+    )
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "yuv4mpegpipe",
+        "-r",
+        frame_rate,
+        "-i",
+        "-",
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[stereo]",
+        "-f",
+        "yuv4mpegpipe",
+        "-pix_fmt",
+        "yuv420p",
+        "-r",
+        frame_rate,
+        "-",
+    ]
+
+
+def encoder_command(encoder: Path, output: Path) -> list[str | Path]:
+    return [
+        encoder,
+        "--output",
+        output,
+        "--quality",
+        "0.6",
+        "--upscale-mode",
+        "metalfx",
+        "--fov",
+        "90",
+        "--disparity-adjustment",
+        "0",
+        "--overwrite",
+    ]
+
+
+def safe_encoder_summary(summary: Mapping[str, object]) -> dict[str, object]:
+    keys = (
+        "frame_count",
+        "metalfx_device_final_allocated_size_bytes",
+        "metalfx_device_initial_allocated_size_bytes",
+        "metalfx_device_peak_allocated_size_bytes",
+        "metalfx_device_peak_delta_bytes",
+        "upscale_converted_input_buffer_limit_per_eye",
+        "upscale_mode",
+        "upscale_output_buffer_limit_per_eye",
+        "upscale_source_buffer_limit",
+    )
+    return {key: summary[key] for key in keys if key in summary}
+
+
+def parse_encoder_summary(stdout: str) -> Mapping[str, object]:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise FeatureQualificationFailure("MV-HEVC encoder did not emit a summary.")
+    try:
+        summary = json.loads(lines[-1])
+    except json.JSONDecodeError as error:
+        raise FeatureQualificationFailure("MV-HEVC encoder emitted an invalid summary.") from error
+    if not isinstance(summary, Mapping):
+        raise FeatureQualificationFailure("MV-HEVC encoder summary was not a JSON object.")
+    if summary.get("upscale_mode") != "metalfx" or not isinstance(summary.get("frame_count"), int):
+        raise FeatureQualificationFailure("MV-HEVC encoder summary omitted the MetalFX frame contract.")
+    for key in (
+        "metalfx_device_peak_allocated_size_bytes",
+        "metalfx_device_peak_delta_bytes",
+    ):
+        if not isinstance(summary.get(key), int) or int(summary[key]) < 0:
+            raise FeatureQualificationFailure(f"MV-HEVC encoder summary omitted valid {key} telemetry.")
+    return summary
+
+
+def probe_direct_artifact(tools: PackagedTools, path: Path) -> dict[str, object]:
+    verify_apple_media_compatible(path)
+    observed_boxes = box_types(path)
+    missing_boxes = sorted(DIRECT_REQUIRED_BOX_TYPES - observed_boxes)
+    if missing_boxes:
+        raise FeatureQualificationFailure("Direct artifact is missing spatial boxes: " + ", ".join(missing_boxes))
+    completed = subprocess.run(
+        [
+            str(tools.ffprobe),
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration,size:stream=codec_name,codec_type,width,height",
+            "-of",
+            "json",
+            str(path),
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    probe = json.loads(completed.stdout)
+    duration_seconds = float(probe["format"]["duration"])
+    verify_seeks(str(tools.ffmpeg), path, max(1, math.ceil(duration_seconds)))
+    video_streams = [stream for stream in probe.get("streams", []) if stream.get("codec_type") == "video"]
+    if len(video_streams) != 1 or (video_streams[0].get("width"), video_streams[0].get("height")) != (3840, 2160):
+        raise FeatureQualificationFailure("Direct feature artifact did not preserve 3840x2160 per-eye output.")
+    return {
+        "duration_seconds": duration_seconds,
+        "sha256": sha256_file(path),
+        "size_bytes": path.stat().st_size,
+        "video_dimensions": {"height": 2160, "width": 3840},
+    }
+
+
+def run_direct_workload(
+    tools: PackagedTools,
+    source: Path,
+    output: Path,
+    *,
+    frame_rate: str,
+    trace_path: Path | None = None,
+    timeout_seconds: float,
+) -> dict[str, object]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.unlink(missing_ok=True)
+    for partial in output.parent.glob(f".{output.name}.partial-*"):
+        partial.unlink(missing_ok=True)
+
+    context = ObservabilityContext(stage=ObservabilityStage("feature_length_direct"))
+    sink = QualificationEventSink()
+    run_context = RunContext(ObservabilityStream(ObservabilityEmitter.WORKER, sink), CancellationToken())
+    environment = os.environ.copy()
+    stages = (
+        ProcessPipelineStage(
+            ProcessSpec(
+                argv=tuple(producer_command(tools.ffmpeg, source)),
+                tool_id="ffmpeg",
+                display_name="Extract real MVC stream",
+                env=environment,
+                event_context=context,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            )
+        ),
+        ProcessPipelineStage(
+            ProcessSpec(
+                argv=(tools.edge264, Path("-"), "-Omk"),
+                tool_id="edge264",
+                display_name="Split real MVC stream",
+                env=environment,
+                event_context=context,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            )
+        ),
+        ProcessPipelineStage(
+            ProcessSpec(
+                argv=tuple(normalizer_command(tools.ffmpeg, frame_rate=frame_rate)),
+                tool_id="ffmpeg",
+                display_name="Normalize real stereo frames",
+                env=environment,
+                event_context=context,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            )
+        ),
+        ProcessPipelineStage(
+            ProcessSpec(
+                argv=tuple(encoder_command(tools.encoder, output)),
+                tool_id="mv_hevc_encoder",
+                display_name="Encode direct 4K MetalFX MV-HEVC",
+                env=environment,
+                event_context=context,
+                artifacts=(
+                    ProcessArtifactProbe(
+                        "stereo_video_output",
+                        resolver=lambda: resolve_direct_mv_hevc_artifact(output),
+                    ),
+                ),
+                artifact_no_growth_timeout_seconds=DIRECT_ARTIFACT_NO_GROWTH_SECONDS,
+                capture_overflow=CaptureOverflowPolicy.TRUNCATE,
+            )
+        ),
+    )
+    power_trace = PowerTrace(trace_path) if trace_path is not None else None
+    sampler = ResourceSampler(sink)
+    timed_out = threading.Event()
+
+    def cancel_after_timeout() -> None:
+        timed_out.set()
+        run_context.cancellation.cancel()
+
+    started_at = time.monotonic()
+    timeout_timer: threading.Timer | None = None
+    power_trace_started = False
+    sampler_started = False
+    resources: dict[str, object] | None = None
+    trace_evidence: dict[str, object] | None = None
+    try:
+        if power_trace is not None:
+            power_trace.start()
+            power_trace_started = True
+        sampler.start()
+        sampler_started = True
+        timeout_timer = threading.Timer(timeout_seconds, cancel_after_timeout)
+        timeout_timer.daemon = True
+        timeout_timer.start()
+        try:
+            result = ProcessPipelineRunner(exit_grace_seconds=5).run(stages, run_context=run_context)
+        except ProcessCancelled as error:
+            if timed_out.is_set():
+                raise FeatureQualificationFailure("Direct feature workload exceeded its configured timeout.") from error
+            raise
+    finally:
+        if timeout_timer is not None:
+            timeout_timer.cancel()
+        try:
+            if sampler_started:
+                resources = sampler.stop()
+        finally:
+            if power_trace is not None and power_trace_started:
+                trace_evidence = power_trace.stop()
+    if resources is None:
+        raise FeatureQualificationFailure("Direct feature workload did not record resource evidence.")
+    elapsed_seconds = time.monotonic() - started_at
+    final_result = result.stages[-1].result
+    if final_result is None:
+        raise FeatureQualificationFailure("Direct pipeline did not return an encoder result.")
+    summary = parse_encoder_summary(final_result.stdout.text())
+    artifact = probe_direct_artifact(tools, output)
+    observability = sink.summary()
+    thermal = require_mapping_value(resources, "thermal")
+    artifact_progress = require_int_value(observability, "increasing_artifact_sample_count") > 0
+    no_tool_failures = not observability["failure_codes"]
+    acceptable_thermal = require_int_value(thermal, "max_state") < 2
+    resource_samples = require_int_value(resources, "sample_count") > 0
+    thermal_samples = require_int_value(thermal, "sample_count") > 0
+    resource_coverage = require_number_value(resources, "coverage_fraction") >= 0.8
+    passed = (
+        no_tool_failures
+        and artifact_progress
+        and require_number_value(observability, "max_artifact_growth_gap_seconds") <= DIRECT_ARTIFACT_NO_GROWTH_SECONDS
+        and acceptable_thermal
+        and resource_samples
+        and thermal_samples
+        and resource_coverage
+    )
+    evidence: dict[str, object] = {
+        "acceptance": {
+            "artifact_progress": artifact_progress,
+            "no_tool_failures": no_tool_failures,
+            "no_unacceptable_thermal_pressure": acceptable_thermal,
+            "passed": passed,
+            "resource_samples_recorded": resource_samples,
+            "resource_sampling_coverage": resource_coverage,
+            "thermal_samples_recorded": thermal_samples,
+        },
+        "artifact": artifact,
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "encoder": safe_encoder_summary(summary),
+        "observability": observability,
+        "resources": resources,
+    }
+    if trace_evidence is not None:
+        evidence["powermetrics_trace"] = trace_evidence
+    return evidence
+
+
+def resource_boundedness(
+    short_run: Mapping[str, object],
+    feature_run: Mapping[str, object],
+    *,
+    max_rss_growth_bytes: int,
+) -> dict[str, object]:
+    short_resources = require_mapping_value(short_run, "resources")
+    feature_resources = require_mapping_value(feature_run, "resources")
+    short_encoder = require_mapping_value(short_run, "encoder")
+    feature_encoder = require_mapping_value(feature_run, "encoder")
+    short_peak_rss = require_int_value(short_resources, "peak_rss_bytes")
+    feature_peak_rss = require_int_value(feature_resources, "peak_rss_bytes")
+    short_duration = require_number_value(short_resources, "duration_seconds")
+    feature_duration = require_number_value(feature_resources, "duration_seconds")
+    feature_quartile_peaks = require_int_list_value(feature_resources, "quartile_peak_rss_bytes", length=4)
+    feature_processes = require_mapping_value(feature_resources, "processes")
+    rss_growth = max(0, feature_peak_rss - short_peak_rss)
+    feature_plateau_applicable = feature_duration >= short_duration * 4
+    process_plateau_growth: dict[str, int] = {}
+    for process_name, process_value in feature_processes.items():
+        if not isinstance(process_name, str) or not isinstance(process_value, Mapping):
+            raise FeatureQualificationFailure("Feature process evidence reported an invalid process summary.")
+        process_quartiles = require_int_list_value(process_value, "quartile_peak_rss_bytes", length=4)
+        process_plateau_growth[process_name] = max(0, process_quartiles[3] - process_quartiles[2])
+    feature_plateau_growth = max(process_plateau_growth.values(), default=0)
+    feature_total_plateau_growth = max(0, feature_quartile_peaks[3] - feature_quartile_peaks[2])
+    feature_aggregate_plateau_allowance = max_rss_growth_bytes * AGGREGATE_RSS_GROWTH_MULTIPLIER
+    feature_process_plateau_passed = not feature_plateau_applicable or (
+        bool(process_plateau_growth)
+        and all(growth <= max_rss_growth_bytes for growth in process_plateau_growth.values())
+    )
+    feature_total_plateau_passed = (
+        not feature_plateau_applicable or feature_total_plateau_growth <= feature_aggregate_plateau_allowance
+    )
+    feature_plateau_passed = feature_process_plateau_passed and feature_total_plateau_passed
+    feature_process_peak_passed = feature_peak_rss <= MAX_FEATURE_PROCESS_RSS_BYTES
+    short_metal_peak = require_int_value(short_encoder, "metalfx_device_peak_delta_bytes")
+    feature_metal_peak = require_int_value(feature_encoder, "metalfx_device_peak_delta_bytes")
+    feature_metal_final = require_int_value(feature_encoder, "metalfx_device_final_allocated_size_bytes")
+    metal_growth = max(0, feature_metal_peak - short_metal_peak)
+    metal_growth_allowance = aligned_4k_bgra_texture_bytes(METALFX_DURATION_TEXTURE_GROWTH_ALLOWANCE)
+    metal_growth_passed = metal_growth <= metal_growth_allowance
+    legacy_modeled_metal_peak_ceiling = declared_metal_payload_bytes("metalfx") + aligned_4k_bgra_texture_bytes(
+        METALFX_INTERNAL_TEXTURE_ALLOWANCE
+    )
+    feature_metal_peak_passed = (
+        feature_metal_peak <= MAX_FEATURE_METAL_BYTES and feature_metal_final <= MAX_FEATURE_METAL_BYTES
+    )
+    passed = (
+        feature_plateau_passed and feature_process_peak_passed and feature_metal_peak_passed and metal_growth_passed
+    )
+    return {
+        "feature_metal_final_allocated_size_bytes": feature_metal_final,
+        "feature_peak_rss_bytes": feature_peak_rss,
+        "feature_plateau_applicable": feature_plateau_applicable,
+        "feature_aggregate_plateau_allowance_bytes": feature_aggregate_plateau_allowance,
+        "feature_plateau_growth_bytes": feature_plateau_growth,
+        "feature_plateau_passed": feature_plateau_passed,
+        "feature_process_plateau_passed": feature_process_plateau_passed,
+        "feature_process_plateau_growth_bytes": process_plateau_growth,
+        "feature_metal_peak_delta_bytes": feature_metal_peak,
+        "feature_metal_duration_growth_passed": metal_growth_passed,
+        "feature_metal_peak_passed": feature_metal_peak_passed,
+        "feature_process_peak_passed": feature_process_peak_passed,
+        "feature_quartile_peak_rss_bytes": feature_quartile_peaks,
+        "feature_total_plateau_growth_bytes": feature_total_plateau_growth,
+        "feature_total_plateau_passed": feature_total_plateau_passed,
+        "legacy_modeled_metal_peak_ceiling_bytes": legacy_modeled_metal_peak_ceiling,
+        "max_feature_metal_bytes": MAX_FEATURE_METAL_BYTES,
+        "max_feature_process_rss_bytes": MAX_FEATURE_PROCESS_RSS_BYTES,
+        "max_rss_growth_bytes": max_rss_growth_bytes,
+        "metal_duration_growth_allowance_bytes": metal_growth_allowance,
+        "metal_duration_growth_bytes": metal_growth,
+        "passed": passed,
+        "rss_duration_growth_bytes": rss_growth,
+        "short_peak_rss_bytes": short_peak_rss,
+        "short_metal_peak_delta_bytes": short_metal_peak,
+    }
+
+
+def process_tree_rss(process: psutil.Process) -> int:
+    total = 0
+    try:
+        total += process.memory_info().rss
+        descendants = process.children(recursive=True)
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return total
+    for descendant in descendants:
+        try:
+            total += descendant.memory_info().rss
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            continue
+    return total
+
+
+def process_id_tree_rss(process_id: int) -> int:
+    try:
+        process = psutil.Process(process_id)
+    except psutil.NoSuchProcess:
+        return 0
+    return process_tree_rss(process)
+
+
+def read_worker_lines(stream: TextIO, stream_name: str, output: queue.Queue[tuple[str, str | None]]) -> None:
+    try:
+        for line in stream:
+            output.put((stream_name, line))
+    finally:
+        output.put((stream_name, None))
+
+
+def _artifact_from_worker_event(event: Mapping[str, object]) -> Mapping[str, object] | None:
+    if event.get("type") != "observability":
+        return None
+    payload = event.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    observability = payload.get("event")
+    if not isinstance(observability, Mapping) or observability.get("kind") != "tool.artifact":
+        return None
+    data = observability.get("data")
+    if not isinstance(data, Mapping):
+        return None
+    artifact = data.get("artifact")
+    return artifact if isinstance(artifact, Mapping) else None
+
+
+def _process_id_from_worker_event(event: Mapping[str, object]) -> int | None:
+    if event.get("type") != "observability":
+        return None
+    payload = event.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    observability = payload.get("event")
+    if not isinstance(observability, Mapping):
+        return None
+    context = observability.get("context")
+    if not isinstance(context, Mapping):
+        return None
+    process = context.get("process")
+    if not isinstance(process, Mapping):
+        return None
+    process_id = process.get("pid")
+    return process_id if isinstance(process_id, int) and process_id > 0 else None
+
+
+def record_process_identity(process: psutil.Process, identities: dict[int, float]) -> None:
+    try:
+        identities.setdefault(process.pid, process.create_time())
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return
+
+
+def process_identity_is_running(process_id: int, create_time: float) -> bool:
+    try:
+        process = psutil.Process(process_id)
+        return (
+            process.create_time() == create_time and process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+        )
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return False
+
+
+def remove_private_work_directory(work_directory: Path) -> bool:
+    try:
+        shutil.rmtree(work_directory)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return not work_directory.exists()
+
+
+def process_group_is_running(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate_packaged_worker(process: subprocess.Popen[str], process_group_id: int | None) -> None:
+    if process_group_id is not None:
+        try:
+            os.killpg(process_group_id, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.terminate()
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        if process_group_id is not None:
+            try:
+                os.killpg(process_group_id, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        elif process.poll() is None:
+            process.kill()
+        process.wait(timeout=10)
+    if process_group_id is None:
+        return
+    deadline = time.monotonic() + 5
+    while process_group_is_running(process_group_id) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if process_group_is_running(process_group_id):
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        deadline = time.monotonic() + 5
+        while process_group_is_running(process_group_id) and time.monotonic() < deadline:
+            time.sleep(0.1)
+    if process_group_is_running(process_group_id):
+        raise FeatureQualificationFailure("Packaged worker process group survived forced termination.")
+
+
+def run_packaged_cancellation(
+    app: AppBundle,
+    source: Path,
+    work_directory: Path,
+    *,
+    cancel_after_bytes: int,
+    timeout_seconds: float,
+) -> dict[str, object]:
+    destination = work_directory / "destination"
+    home = work_directory / "home"
+    if work_directory.exists():
+        raise FeatureQualificationFailure("Packaged cancellation work directory must be newly created.")
+    destination.mkdir(parents=True, mode=0o700)
+    home.mkdir(parents=True, mode=0o700)
+    work_directory.chmod(0o700)
+    sentinel_path = destination / f"{source.stem}_AVP.mov"
+    sentinel_bytes = b"bd-to-avp-overwrite-preservation-v1\n"
+    sentinel_path.write_bytes(sentinel_bytes)
+    sentinel_sha256 = sha256_file(sentinel_path)
+
+    job_id = str(uuid.uuid4())
+    request = build_worker_request(
+        "convert_source",
+        source,
+        destination,
+        job_id=job_id,
+        upscale_enabled=True,
+    )
+    encoding = request.get("encoding")
+    if not isinstance(encoding, dict):
+        raise FeatureQualificationFailure("Packaged cancellation request omitted encoding settings.")
+    encoding["subtitles"] = {"mode": "off", "preferred_language": None}
+    environment = os.environ.copy()
+    environment["HOME"] = str(home)
+    process = subprocess.Popen(
+        [str(app.worker)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=environment,
+    )
+    assert process.stdin is not None and process.stdout is not None and process.stderr is not None
+    process.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+    process.stdin.close()
+
+    lines: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    readers = [
+        threading.Thread(target=read_worker_lines, args=(process.stdout, "stdout", lines), daemon=True),
+        threading.Thread(target=read_worker_lines, args=(process.stderr, "stderr", lines), daemon=True),
+    ]
+    for reader in readers:
+        reader.start()
+
+    events: list[Mapping[str, object]] = []
+    stderr_bytes = 0
+    worker_process = psutil.Process(process.pid)
+    observed_processes: dict[int, float] = {}
+    record_process_identity(worker_process, observed_processes)
+    peak_rss_bytes = 0
+    thermal_samples: list[int] = []
+    heartbeat_times: list[float] = []
+    stages: list[str] = []
+    process_group_id: int | None = None
+    cancellation_sent_at: float | None = None
+    trigger_size_bytes = 0
+    streams_closed: set[str] = set()
+    started_at = time.monotonic()
+
+    try:
+        while process.poll() is None or streams_closed != {"stdout", "stderr"}:
+            elapsed = time.monotonic() - started_at
+            if elapsed > timeout_seconds:
+                raise FeatureQualificationFailure("Packaged cancellation workload timed out.")
+            try:
+                stream_name, line = lines.get(timeout=0.25)
+            except queue.Empty:
+                stream_name, line = "", ""
+            if line is None:
+                streams_closed.add(stream_name)
+            elif stream_name == "stderr":
+                stderr_bytes += len(line.encode("utf-8", errors="replace"))
+            elif stream_name == "stdout" and line.strip():
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise FeatureQualificationFailure(
+                        "Packaged worker emitted invalid JSON during cancellation."
+                    ) from error
+                if not isinstance(event, Mapping):
+                    raise FeatureQualificationFailure("Packaged worker cancellation event was not an object.")
+                events.append(event)
+                payload = event.get("payload")
+                if event.get("type") == "worker.ready" and isinstance(payload, Mapping):
+                    ready_group = payload.get("process_group_id")
+                    if isinstance(ready_group, int) and ready_group > 0:
+                        try:
+                            launched_group = os.getpgid(process.pid)
+                        except OSError as error:
+                            raise FeatureQualificationFailure(
+                                "Worker exited before its process group could be validated."
+                            ) from error
+                        if ready_group != process.pid or ready_group != launched_group:
+                            raise FeatureQualificationFailure(
+                                "Worker-reported process group does not belong to the launched worker."
+                            )
+                        process_group_id = ready_group
+                event_process_id = _process_id_from_worker_event(event)
+                if event_process_id is not None:
+                    try:
+                        record_process_identity(psutil.Process(event_process_id), observed_processes)
+                    except psutil.NoSuchProcess:
+                        pass
+                if event.get("type") == "heartbeat":
+                    heartbeat_times.append(elapsed)
+                if event.get("type") == "stage.started" and isinstance(payload, Mapping):
+                    stage = payload.get("stage")
+                    if isinstance(stage, str):
+                        stages.append(stage)
+                artifact = _artifact_from_worker_event(event)
+                if artifact is not None:
+                    role = artifact.get("role")
+                    size = artifact.get("size_bytes")
+                    if role == "stereo_video_output" and isinstance(size, int):
+                        trigger_size_bytes = max(trigger_size_bytes, size)
+                        if size >= cancel_after_bytes and cancellation_sent_at is None:
+                            if process_group_id is None:
+                                raise FeatureQualificationFailure(
+                                    "Worker did not report its process group before cancellation."
+                                )
+                            os.killpg(process_group_id, signal.SIGTERM)
+                            cancellation_sent_at = time.monotonic()
+            try:
+                for descendant in worker_process.children(recursive=True):
+                    record_process_identity(descendant, observed_processes)
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                pass
+            peak_rss_bytes = max(peak_rss_bytes, process_tree_rss(worker_process))
+            thermal_samples.append(thermal_state())
+            if (
+                cancellation_sent_at is not None
+                and time.monotonic() - cancellation_sent_at > 30
+                and process.poll() is None
+            ):
+                raise FeatureQualificationFailure("Packaged worker did not exit within 30 seconds of cancellation.")
+    except BaseException as error:
+        termination_error: BaseException | None = None
+        try:
+            terminate_packaged_worker(process, process_group_id)
+        except BaseException as cleanup_error:
+            termination_error = cleanup_error
+        cleanup_complete = remove_private_work_directory(work_directory)
+        if termination_error is not None or not cleanup_complete:
+            raise FeatureQualificationFailure(
+                "Packaged cancellation failed to terminate descendants or remove its private work directory."
+            ) from (termination_error or error)
+        raise
+    finally:
+        for reader in readers:
+            reader.join(timeout=5)
+        for stream in (process.stdout, process.stderr):
+            if not stream.closed:
+                stream.close()
+
+    try:
+        if cancellation_sent_at is None:
+            raise FeatureQualificationFailure("Packaged cancellation workload never produced the target artifact size.")
+        parsed_events = parse_worker_events("\n".join(json.dumps(event) for event in events), job_id=job_id)
+        terminal = parsed_events[-1]
+        heartbeat_gaps = [current - previous for previous, current in itertools.pairwise(heartbeat_times)]
+        partial_files = [
+            path
+            for path in destination.rglob("*")
+            if path.is_file() and (".partial-" in path.name or path.name.endswith((".part", ".part.mov", ".part.mkv")))
+        ]
+        sentinel_preserved = sentinel_path.is_file() and sha256_file(sentinel_path) == sentinel_sha256
+        descendants_deadline = time.monotonic() + 5
+        live_processes = [
+            process_id
+            for process_id, create_time in observed_processes.items()
+            if process_identity_is_running(process_id, create_time)
+        ]
+        while live_processes and time.monotonic() < descendants_deadline:
+            time.sleep(0.1)
+            live_processes = [
+                process_id
+                for process_id, create_time in observed_processes.items()
+                if process_identity_is_running(process_id, create_time)
+            ]
+        if process_group_id is None:
+            process_group_gone = False
+        else:
+            try:
+                os.killpg(process_group_id, 0)
+            except ProcessLookupError:
+                process_group_gone = True
+            except PermissionError:
+                process_group_gone = False
+            else:
+                process_group_gone = False
+    except BaseException as error:
+        if not remove_private_work_directory(work_directory):
+            raise FeatureQualificationFailure(
+                "Packaged cancellation could not remove its private work directory after validation failed."
+            ) from error
+        raise
+    cleanup_complete = remove_private_work_directory(work_directory)
+    passed = (
+        process.returncode == 130
+        and terminal.get("type") == "job.cancelled"
+        and not any(event.get("type") == "job.completed" for event in parsed_events)
+        and "create_left_right_files" in stages
+        and sentinel_preserved
+        and not partial_files
+        and not live_processes
+        and process_group_gone
+        and cleanup_complete
+        and max(thermal_samples, default=0) < 2
+    )
+    evidence = {
+        "acceptance": {
+            "entered_direct_encode_stage": "create_left_right_files" in stages,
+            "no_completed_event": not any(event.get("type") == "job.completed" for event in parsed_events),
+            "no_partial_files": not partial_files,
+            "no_surviving_processes": not live_processes and process_group_gone,
+            "overwrite_sentinel_preserved": sentinel_preserved,
+            "passed": passed,
+            "private_work_directory_removed": cleanup_complete,
+            "terminal_cancelled": terminal.get("type") == "job.cancelled" and process.returncode == 130,
+            "thermal_pressure_acceptable": max(thermal_samples, default=0) < 2,
+        },
+        "cancel_after_bytes": cancel_after_bytes,
+        "elapsed_seconds": round(time.monotonic() - started_at, 3),
+        "event_count": len(parsed_events),
+        "heartbeat": {
+            "count": len(heartbeat_times),
+            "max_gap_seconds": round(max(heartbeat_gaps, default=0), 3),
+        },
+        "observed_artifact_bytes_before_cancel": trigger_size_bytes,
+        "peak_process_tree_rss_bytes": peak_rss_bytes,
+        "processes_observed": len(observed_processes),
+        "stages": stages,
+        "stderr_bytes_drained": stderr_bytes,
+        "thermal": {
+            "max_state": max(thermal_samples, default=0),
+            "max_state_name": THERMAL_NAMES[max(thermal_samples, default=0)],
+            "sample_count": len(thermal_samples),
+        },
+    }
+    return evidence
+
+
+def capability_evidence(tools: PackagedTools) -> dict[str, object]:
+    completed = subprocess.run(
+        [str(tools.encoder), "--capability-probe"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    capability = json.loads(completed.stdout)
+    required = (
+        "metalfx_2x_mv_hevc_supported",
+        "metalfx_spatial_scaling_supported",
+        "stereo_mv_hevc_encode_supported",
+    )
+    if any(capability.get(key) is not True for key in required):
+        raise FeatureQualificationFailure("Packaged helper does not support the required direct MetalFX route.")
+    return {key: capability[key] for key in sorted(capability) if isinstance(capability[key], (bool, int, str))}
+
+
+def source_video_info(ffprobe: Path, source: Path) -> dict[str, object]:
+    completed = subprocess.run(
+        [
+            str(ffprobe),
+            "-v",
+            "error",
+            "-count_packets",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=avg_frame_rate,nb_read_packets:format=duration",
+            "-of",
+            "json",
+            str(source),
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    probe = json.loads(completed.stdout)
+    streams = probe.get("streams")
+    format_data = probe.get("format")
+    if not isinstance(streams, list) or len(streams) != 1 or not isinstance(streams[0], Mapping):
+        raise FeatureQualificationFailure("Feature source probe did not report one video stream.")
+    if not isinstance(format_data, Mapping):
+        raise FeatureQualificationFailure("Feature source probe did not report format timing.")
+    frame_rate = streams[0].get("avg_frame_rate")
+    packet_count = streams[0].get("nb_read_packets")
+    duration = format_data.get("duration")
+    if not isinstance(frame_rate, str) or not isinstance(packet_count, str) or duration is None:
+        raise FeatureQualificationFailure("Feature source probe omitted frame count or frame rate.")
+    try:
+        parsed_frame_rate = Fraction(frame_rate)
+        parsed_packet_count = int(packet_count)
+        parsed_duration = float(duration)
+    except (ValueError, ZeroDivisionError) as error:
+        raise FeatureQualificationFailure("Feature source probe reported invalid timing values.") from error
+    if parsed_frame_rate <= 0 or parsed_packet_count <= 0 or parsed_duration <= 0:
+        raise FeatureQualificationFailure("Feature source probe reported non-positive timing values.")
+    return {
+        "container_duration_seconds": parsed_duration,
+        "frame_rate": frame_rate,
+        "packet_count": parsed_packet_count,
+        "video_duration_seconds": parsed_packet_count / float(parsed_frame_rate),
+    }
+
+
+def validate_qualification_paths(
+    app: AppBundle,
+    source: Path,
+    segment: Path,
+    output: Path,
+    work_directory: Path,
+    *,
+    requested_work_directory: Path,
+) -> None:
+    if requested_work_directory.is_symlink():
+        raise FeatureQualificationFailure("Feature work directory must not be a symlink.")
+    protected_paths = {source, segment, app.path, app.worker, app.helper}
+    if output in protected_paths:
+        raise FeatureQualificationFailure("Feature evidence output must be distinct from media and package inputs.")
+    if work_directory in protected_paths or work_directory in {Path("/"), Path.home().resolve()}:
+        raise FeatureQualificationFailure("Feature work directory is not a safe dedicated destination.")
+    if any(path.is_relative_to(work_directory) for path in protected_paths):
+        raise FeatureQualificationFailure("Feature work directory must not contain media or package inputs.")
+    if output.is_relative_to(work_directory):
+        raise FeatureQualificationFailure("Feature evidence output must remain outside the transient work directory.")
+    if output.is_relative_to(app.path):
+        raise FeatureQualificationFailure("Feature evidence output must remain outside the packaged app.")
+    if work_directory.exists() and any(work_directory.iterdir()):
+        raise FeatureQualificationFailure("Feature work directory must be new or empty.")
+
+
+def remove_direct_workload_artifacts(*output_paths: Path) -> None:
+    for output_path in output_paths:
+        output_path.unlink(missing_ok=True)
+        for partial in output_path.parent.glob(f".{output_path.name}.partial-*"):
+            partial.unlink(missing_ok=True)
+
+
+def qualify(args: argparse.Namespace) -> dict[str, object]:
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        raise FeatureQualificationFailure("Real-MVC MetalFX qualification requires macOS arm64.")
+    if args.max_rss_growth_mib < 0 or args.cancel_after_mib <= 0 or args.timeout_hours <= 0:
+        raise FeatureQualificationFailure("Resource, cancellation, and timeout settings must be positive.")
+    app = read_app_bundle(args.app)
+    tools = packaged_tools(app)
+    source = args.source.expanduser().resolve()
+    segment = args.segment.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    work_directory = args.work_directory.expanduser().resolve()
+    validate_qualification_paths(
+        app,
+        source,
+        segment,
+        output,
+        work_directory,
+        requested_work_directory=args.work_directory.expanduser(),
+    )
+    if not source.is_file() or not segment.is_file():
+        raise FeatureQualificationFailure("Feature source and deterministic segment must both be available.")
+    source_sha256 = sha256_file(source)
+    segment_sha256 = sha256_file(segment)
+    if source_sha256 != args.expected_source_sha256.lower():
+        raise FeatureQualificationFailure("Feature source SHA-256 does not match the expected parent source.")
+    if segment_sha256 != args.expected_segment_sha256.lower():
+        raise FeatureQualificationFailure("Deterministic segment SHA-256 does not match the expected replacement.")
+    source_info = source_video_info(tools.ffprobe, source)
+    try:
+        source_frame_rate = Fraction(str(source_info["frame_rate"]))
+        requested_frame_rate = Fraction(args.frame_rate)
+    except (ValueError, ZeroDivisionError) as error:
+        raise FeatureQualificationFailure("Configured or source frame rate is invalid.") from error
+    source_packet_count = require_int_value(source_info, "packet_count")
+    source_video_duration = require_number_value(source_info, "video_duration_seconds")
+    expected_frames = (
+        source_packet_count
+        if requested_frame_rate == source_frame_rate
+        else round(source_video_duration * float(requested_frame_rate))
+    )
+    expected_output_duration = expected_frames / float(requested_frame_rate)
+
+    work_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    work_directory.chmod(0o700)
+    short_output = work_directory / "short-direct-4k.mov"
+    feature_output = work_directory / "feature-direct-4k.mov"
+    trace_path = work_directory / f"powermetrics-feature-{uuid.uuid4().hex}.txt"
+    workload_timeout_seconds = args.timeout_hours * 3600
+    try:
+        short_run = run_direct_workload(
+            tools,
+            segment,
+            short_output,
+            frame_rate=args.frame_rate,
+            timeout_seconds=workload_timeout_seconds,
+        )
+        feature_run = run_direct_workload(
+            tools,
+            source,
+            feature_output,
+            frame_rate=args.frame_rate,
+            trace_path=trace_path,
+            timeout_seconds=workload_timeout_seconds,
+        )
+        boundedness = resource_boundedness(
+            short_run,
+            feature_run,
+            max_rss_growth_bytes=args.max_rss_growth_mib * 1024 * 1024,
+        )
+        cancellation = run_packaged_cancellation(
+            app,
+            source,
+            work_directory / f"cancellation-{uuid.uuid4().hex}",
+            cancel_after_bytes=args.cancel_after_mib * 1024 * 1024,
+            timeout_seconds=workload_timeout_seconds,
+        )
+    finally:
+        remove_direct_workload_artifacts(short_output, feature_output)
+
+    short_acceptance = require_mapping_value(short_run, "acceptance")
+    feature_acceptance = require_mapping_value(feature_run, "acceptance")
+    feature_encoder = require_mapping_value(feature_run, "encoder")
+    feature_artifact = require_mapping_value(feature_run, "artifact")
+    cancellation_acceptance = require_mapping_value(cancellation, "acceptance")
+    feature_frame_count = require_int_value(feature_encoder, "frame_count")
+    feature_duration = require_number_value(feature_artifact, "duration_seconds")
+    complete_feature_frames = feature_frame_count == expected_frames
+    duration_tolerance_seconds = max(0.1, 2 / float(requested_frame_rate))
+    complete_feature_duration = abs(feature_duration - expected_output_duration) <= duration_tolerance_seconds
+    short_passed = require_bool_value(short_acceptance, "passed")
+    feature_passed = require_bool_value(feature_acceptance, "passed")
+    boundedness_passed = require_bool_value(boundedness, "passed")
+    cancellation_passed = require_bool_value(cancellation_acceptance, "passed")
+    passed = (
+        short_passed
+        and feature_passed
+        and boundedness_passed
+        and cancellation_passed
+        and complete_feature_frames
+        and complete_feature_duration
+    )
+    evidence = {
+        "acceptance": {
+            "complete_feature_length_duration": complete_feature_duration,
+            "complete_feature_length_frame_count": complete_feature_frames,
+            "packaged_cancellation": cancellation_passed,
+            "passed": passed,
+            "resource_boundedness": boundedness_passed,
+            "short_direct_workload": short_passed,
+            "feature_direct_workload": feature_passed,
+        },
+        "boundedness": boundedness,
+        "cancellation": cancellation,
+        "configuration": {
+            "automatic_direct_4k_quality": 0.6,
+            "cancel_after_mib": args.cancel_after_mib,
+            "frame_rate": args.frame_rate,
+            "max_rss_growth_mib": args.max_rss_growth_mib,
+            "output_duration_tolerance_seconds": duration_tolerance_seconds,
+        },
+        "feature_run": feature_run,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "package": {
+            "app_tree_sha256": app_tree_sha256(app.path),
+            "bundle_identifier": app.bundle_identifier,
+            "capability": capability_evidence(tools),
+            "helper_sha256": sha256_file(app.helper),
+            "version": app.version,
+            "worker_sha256": sha256_file(app.worker),
+        },
+        "platform": {
+            "hardware_model": subprocess.check_output(["sysctl", "-n", "hw.model"], text=True).strip(),
+            "macos_version": platform.mac_ver()[0],
+        },
+        "schema_version": 2,
+        "short_run": short_run,
+        "sources": {
+            "feature": {
+                **source_info,
+                "sha256": source_sha256,
+                "size_bytes": source.stat().st_size,
+            },
+            "segment": {
+                "sha256": segment_sha256,
+                "size_bytes": segment.stat().st_size,
+            },
+        },
+    }
+    evidence_text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    encoded = evidence_text.encode("utf-8")
+    if len(encoded) > MAX_EVIDENCE_BYTES:
+        raise FeatureQualificationFailure("Feature-length qualification evidence exceeded its bounded size limit.")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output.with_suffix(output.suffix + ".tmp")
+    temporary_output.write_text(evidence_text, encoding="utf-8")
+    temporary_output.replace(output)
+    return evidence
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Qualify feature-length real MVC direct 4K resources, thermal behavior, progress, and cancellation."
+    )
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--segment", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--work-directory", type=Path, required=True)
+    parser.add_argument("--expected-source-sha256", required=True)
+    parser.add_argument("--expected-segment-sha256", required=True)
+    parser.add_argument("--frame-rate", default=DEFAULT_FRAME_RATE)
+    parser.add_argument("--max-rss-growth-mib", type=int, default=DEFAULT_MAX_RSS_GROWTH_MIB)
+    parser.add_argument("--cancel-after-mib", type=int, default=DEFAULT_CANCEL_AFTER_MIB)
+    parser.add_argument("--timeout-hours", type=float, default=6)
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        evidence = qualify(parse_args())
+    except (FeatureQualificationFailure, OSError, subprocess.SubprocessError) as error:
+        raise SystemExit(f"error: {error}") from error
+    acceptance = require_mapping_value(evidence, "acceptance")
+    print(json.dumps(acceptance, indent=2, sort_keys=True))
+    return 0 if require_bool_value(acceptance, "passed") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_real_mvc_feature.py
+++ b/scripts/qualify_real_mvc_feature.py
@@ -18,6 +18,7 @@ import threading
 import time
 import uuid
 
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from fractions import Fraction
@@ -374,7 +375,7 @@ class ResourceSampler:
                 self._rss_samples.append(total_rss)
                 self._process_samples.append((time.monotonic() - self._started_at, process_rss))
                 self._thermal_samples.append(thermal_state())
-        except BaseException as error:
+        except Exception as error:
             self._error = error
             self._stop.set()
 
@@ -923,20 +924,16 @@ def process_group_is_running(process_group_id: int) -> bool:
 
 def terminate_packaged_worker(process: subprocess.Popen[str], process_group_id: int | None) -> None:
     if process_group_id is not None:
-        try:
+        with suppress(ProcessLookupError):
             os.killpg(process_group_id, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
     elif process.poll() is None:
         process.terminate()
     try:
         process.wait(timeout=30)
     except subprocess.TimeoutExpired:
         if process_group_id is not None:
-            try:
+            with suppress(ProcessLookupError):
                 os.killpg(process_group_id, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
         elif process.poll() is None:
             process.kill()
         process.wait(timeout=10)
@@ -1067,10 +1064,8 @@ def run_packaged_cancellation(
                         process_group_id = ready_group
                 event_process_id = _process_id_from_worker_event(event)
                 if event_process_id is not None:
-                    try:
+                    with suppress(psutil.NoSuchProcess):
                         record_process_identity(psutil.Process(event_process_id), observed_processes)
-                    except psutil.NoSuchProcess:
-                        pass
                 if event.get("type") == "heartbeat":
                     heartbeat_times.append(elapsed)
                 if event.get("type") == "stage.started" and isinstance(payload, Mapping):
@@ -1090,11 +1085,9 @@ def run_packaged_cancellation(
                                 )
                             os.killpg(process_group_id, signal.SIGTERM)
                             cancellation_sent_at = time.monotonic()
-            try:
+            with suppress(psutil.AccessDenied, psutil.NoSuchProcess):
                 for descendant in worker_process.children(recursive=True):
                     record_process_identity(descendant, observed_processes)
-            except (psutil.AccessDenied, psutil.NoSuchProcess):
-                pass
             peak_rss_bytes = max(peak_rss_bytes, process_tree_rss(worker_process))
             thermal_samples.append(thermal_state())
             if (
@@ -1103,11 +1096,11 @@ def run_packaged_cancellation(
                 and process.poll() is None
             ):
                 raise FeatureQualificationFailure("Packaged worker did not exit within 30 seconds of cancellation.")
-    except BaseException as error:
+    except (Exception, KeyboardInterrupt) as error:
         termination_error: BaseException | None = None
         try:
             terminate_packaged_worker(process, process_group_id)
-        except BaseException as cleanup_error:
+        except (Exception, KeyboardInterrupt) as cleanup_error:
             termination_error = cleanup_error
         cleanup_complete = remove_private_work_directory(work_directory)
         if termination_error is not None or not cleanup_complete:
@@ -1158,7 +1151,7 @@ def run_packaged_cancellation(
                 process_group_gone = False
             else:
                 process_group_gone = False
-    except BaseException as error:
+    except (Exception, KeyboardInterrupt) as error:
         if not remove_private_work_directory(work_directory):
             raise FeatureQualificationFailure(
                 "Packaged cancellation could not remove its private work directory after validation failed."

--- a/scripts/reassess_real_mvc_feature.py
+++ b/scripts/reassess_real_mvc_feature.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping
+
+from scripts.qualify_mv_hevc_quality_match import sha256_file
+from scripts.qualify_real_mvc_feature import (
+    FeatureQualificationFailure,
+    require_bool_value,
+    require_int_value,
+    require_mapping_value,
+    require_number_value,
+    resource_boundedness,
+)
+
+
+MAX_EVIDENCE_BYTES = 512 * 1024
+
+
+def reassess(document: Mapping[str, object], *, input_sha256: str) -> dict[str, object]:
+    short_run = require_mapping_value(document, "short_run")
+    feature_run = require_mapping_value(document, "feature_run")
+    cancellation = require_mapping_value(document, "cancellation")
+    configuration = require_mapping_value(document, "configuration")
+    sources = require_mapping_value(document, "sources")
+    feature_source = require_mapping_value(sources, "feature")
+    feature_encoder = require_mapping_value(feature_run, "encoder")
+    feature_artifact = require_mapping_value(feature_run, "artifact")
+    short_acceptance = require_mapping_value(short_run, "acceptance")
+    feature_acceptance = require_mapping_value(feature_run, "acceptance")
+    cancellation_acceptance = require_mapping_value(cancellation, "acceptance")
+
+    max_rss_growth_mib = require_int_value(configuration, "max_rss_growth_mib")
+    boundedness = resource_boundedness(
+        short_run,
+        feature_run,
+        max_rss_growth_bytes=max_rss_growth_mib * 1024 * 1024,
+    )
+    expected_frames = require_int_value(feature_source, "packet_count")
+    observed_frames = require_int_value(feature_encoder, "frame_count")
+    expected_duration = require_number_value(feature_source, "video_duration_seconds")
+    observed_duration = require_number_value(feature_artifact, "duration_seconds")
+    duration_tolerance = require_number_value(configuration, "output_duration_tolerance_seconds")
+    complete_frames = observed_frames == expected_frames
+    complete_duration = abs(observed_duration - expected_duration) <= duration_tolerance
+    short_passed = require_bool_value(short_acceptance, "passed")
+    feature_passed = require_bool_value(feature_acceptance, "passed")
+    cancellation_passed = require_bool_value(cancellation_acceptance, "passed")
+    boundedness_passed = require_bool_value(boundedness, "passed")
+    passed = (
+        short_passed
+        and feature_passed
+        and cancellation_passed
+        and boundedness_passed
+        and complete_frames
+        and complete_duration
+    )
+
+    evidence = dict(document)
+    evidence["acceptance"] = {
+        "complete_feature_length_duration": complete_duration,
+        "complete_feature_length_frame_count": complete_frames,
+        "feature_direct_workload": feature_passed,
+        "packaged_cancellation": cancellation_passed,
+        "passed": passed,
+        "resource_boundedness": boundedness_passed,
+        "short_direct_workload": short_passed,
+    }
+    evidence["assessment"] = {
+        "input_evidence_sha256": input_sha256,
+        "policy": "per-process-and-aggregate-q3-q4-plateau-v3",
+        "reassessed_at_utc": datetime.now(UTC).isoformat(),
+    }
+    evidence["boundedness"] = boundedness
+    evidence["schema_version"] = 3
+    return evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reassess retained real-MVC feature telemetry against the reviewed per-process resource policy."
+    )
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    input_path = args.input.expanduser().resolve()
+    output_path = args.output.expanduser().resolve()
+    if not input_path.is_file() or output_path == input_path:
+        parser.exit(1, "error: reassessment input must exist and output must be distinct\n")
+    try:
+        loaded = json.loads(input_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, Mapping):
+            raise FeatureQualificationFailure("Feature reassessment input was not a JSON object.")
+        evidence = reassess(loaded, input_sha256=sha256_file(input_path))
+    except (FeatureQualificationFailure, json.JSONDecodeError, OSError) as error:
+        parser.exit(1, f"error: {error}\n")
+    evidence_text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if len(evidence_text.encode("utf-8")) > MAX_EVIDENCE_BYTES:
+        parser.exit(1, "error: reassessed feature evidence exceeded its bounded size limit\n")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output_path.with_suffix(output_path.suffix + ".tmp")
+    temporary_output.write_text(evidence_text, encoding="utf-8")
+    temporary_output.replace(output_path)
+    print(json.dumps(evidence["acceptance"], indent=2, sort_keys=True))
+    return 0 if bool(require_mapping_value(evidence, "acceptance")["passed"]) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_packaged_mv_hevc_routes.py
+++ b/scripts/verify_packaged_mv_hevc_routes.py
@@ -14,7 +14,7 @@ import subprocess
 import tempfile
 import uuid
 
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -298,10 +298,8 @@ def _process_is_running(process: psutil.Process) -> bool:
 def _terminate_worker_process(process: subprocess.Popen[str]) -> None:
     tracked = {candidate.pid: candidate for candidate in _process_tree(process.pid)}
     if process.poll() is None:
-        try:
+        with suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
     try:
         process.communicate(timeout=30)
     except subprocess.TimeoutExpired:
@@ -320,10 +318,8 @@ def _terminate_worker_process(process: subprocess.Popen[str]) -> None:
             except psutil.Error:
                 continue
         if process.poll() is None:
-            try:
+            with suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
         process.communicate(timeout=10)
     surviving_descendants = [
         candidate

--- a/scripts/verify_packaged_mv_hevc_routes.py
+++ b/scripts/verify_packaged_mv_hevc_routes.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
 import plistlib
+import signal
 import shutil
 import subprocess
 import tempfile
@@ -17,6 +19,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterator, Mapping, Sequence
+
+import psutil
 
 from bd_to_avp.modules.video_route import (
     AUTOMATIC_DIRECT_QUALITY,
@@ -31,14 +35,17 @@ from scripts.qualify_direct_mv_hevc import (
     verify_seeks,
 )
 from scripts.qualify_mv_hevc_quality_match import sha256_file
-from scripts.verify_apple_media import find_ffprobe, verify_apple_media_compatible
+from scripts.verify_apple_media import verify_apple_media_compatible
 
 
 PROTOCOL_VERSION = 10
 WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
-HELPER_RELATIVE_PATH = Path("Contents/Resources/app/bd_to_avp/bin/mv-hevc-encoder")
+PACKAGE_BIN_RELATIVE_PATH = Path("Contents/Resources/app/bd_to_avp/bin")
+HELPER_RELATIVE_PATH = PACKAGE_BIN_RELATIVE_PATH / "mv-hevc-encoder"
 MAX_EVIDENCE_BYTES = 256 * 1024
 WORKER_TIMEOUT_SECONDS = 30 * 60
+MEDIA_DURATION_TOLERANCE_SECONDS = 0.5
+PREVIEW_DURATION_SECONDS = 60
 
 
 class PackagedRouteFailure(RuntimeError):
@@ -50,6 +57,8 @@ class AppBundle:
     path: Path
     worker: Path
     helper: Path
+    ffmpeg: Path
+    ffprobe: Path
     bundle_identifier: str
     version: str
 
@@ -63,6 +72,85 @@ class WorkerResult:
     preview: Mapping[str, object] | None
 
 
+def app_tree_sha256(app_path: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(app_path.rglob("*"), key=lambda item: item.relative_to(app_path).as_posix()):
+        relative = path.relative_to(app_path).as_posix().encode("utf-8")
+        status = path.lstat()
+        mode = status.st_mode & 0o7777
+        if path.is_symlink():
+            payload = os.readlink(path).encode("utf-8")
+            kind = b"symlink"
+        elif path.is_file():
+            payload_digest = hashlib.sha256()
+            with path.open("rb") as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    payload_digest.update(chunk)
+            payload = payload_digest.digest()
+            kind = b"file"
+        elif path.is_dir():
+            payload = b""
+            kind = b"directory"
+        else:
+            continue
+        for component in (kind, relative, f"{mode:o}".encode("ascii"), payload):
+            digest.update(len(component).to_bytes(8, "big"))
+            digest.update(component)
+    return digest.hexdigest()
+
+
+def validate_qualification_paths(
+    app_path: Path,
+    source_path: Path,
+    output_path: Path,
+    fixture_output: Path | None,
+) -> tuple[Path, Path, Path, Path | None]:
+    requested_output = output_path.expanduser()
+    requested_fixture = fixture_output.expanduser() if fixture_output is not None else None
+    for requested, description in (
+        (requested_output, "evidence output"),
+        (requested_fixture, "fixture output"),
+    ):
+        if requested is not None and requested.is_symlink():
+            raise PackagedRouteFailure(f"Packaged-route {description} must not be a symlink.")
+
+    app = app_path.expanduser().resolve()
+    source = source_path.expanduser().resolve()
+    output = requested_output.resolve()
+    fixture = requested_fixture.resolve() if requested_fixture is not None else None
+    destinations = [output, *(path for path in (fixture,) if path is not None)]
+    if len(destinations) != len(set(destinations)):
+        raise PackagedRouteFailure("Packaged-route evidence and fixture outputs must be distinct.")
+    for destination in destinations:
+        if destination == source:
+            raise PackagedRouteFailure("Packaged-route output must not replace the representative source.")
+        if destination == app or destination.is_relative_to(app):
+            raise PackagedRouteFailure("Packaged-route output must remain outside the app bundle.")
+        if destination.exists() and not destination.is_file():
+            raise PackagedRouteFailure("Packaged-route output must be a file destination.")
+    return app, source, output, fixture
+
+
+def atomic_copy(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        shutil.copy2(source, temporary)
+        temporary.replace(destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def atomic_write_text(destination: Path, text: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(text, encoding="utf-8")
+        temporary.replace(destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def read_app_bundle(path: Path) -> AppBundle:
     app_path = path.resolve()
     info_path = app_path / "Contents/Info.plist"
@@ -72,7 +160,9 @@ def read_app_bundle(path: Path) -> AppBundle:
         info = plistlib.load(info_file)
     worker = app_path / "Contents/MacOS" / WORKER_EXECUTABLE_NAME
     helper = app_path / HELPER_RELATIVE_PATH
-    for executable in (worker, helper):
+    ffmpeg = app_path / PACKAGE_BIN_RELATIVE_PATH / "ffmpeg"
+    ffprobe = app_path / PACKAGE_BIN_RELATIVE_PATH / "ffprobe"
+    for executable in (worker, helper, ffmpeg, ffprobe):
         if not executable.is_file() or not os.access(executable, os.X_OK):
             raise PackagedRouteFailure(f"Packaged executable is unavailable: {executable}")
     bundle_identifier = info.get("CFBundleIdentifier")
@@ -81,7 +171,7 @@ def read_app_bundle(path: Path) -> AppBundle:
         raise PackagedRouteFailure("Packaged app bundle identifier is unavailable.")
     if not isinstance(version, str) or not version:
         raise PackagedRouteFailure("Packaged app version is unavailable.")
-    return AppBundle(app_path, worker, helper, bundle_identifier, version)
+    return AppBundle(app_path, worker, helper, ffmpeg, ffprobe, bundle_identifier, version)
 
 
 def build_worker_request(
@@ -167,11 +257,18 @@ def parse_worker_events(stdout: str, *, job_id: str) -> tuple[Mapping[str, objec
 def _terminal_result(events: Sequence[Mapping[str, object]], operation: str) -> Mapping[str, object]:
     terminal = events[-1]
     if terminal.get("type") != "job.completed":
-        message = (
-            terminal.get("payload", {}).get("error", {}).get("message")
-            if isinstance(terminal.get("payload"), Mapping)
-            else None
-        )
+        payload = terminal.get("payload")
+        message: object | None = None
+        if isinstance(payload, Mapping):
+            error = payload.get("error")
+            if isinstance(error, Mapping):
+                message = error.get("message")
+            decision = payload.get("decision")
+            if message is None and isinstance(decision, Mapping):
+                decision_id = decision.get("id")
+                prompt = decision.get("prompt")
+                if isinstance(decision_id, str) and isinstance(prompt, str):
+                    message = f"{decision_id}: {prompt}"
         raise PackagedRouteFailure(f"Packaged worker did not complete {operation}: {message or terminal.get('type')}")
     payload = terminal.get("payload")
     if not isinstance(payload, Mapping):
@@ -181,6 +278,66 @@ def _terminal_result(events: Sequence[Mapping[str, object]], operation: str) -> 
     if not isinstance(result, Mapping):
         raise PackagedRouteFailure(f"Packaged worker omitted {result_key}.")
     return result
+
+
+def _process_tree(process_id: int) -> list[psutil.Process]:
+    try:
+        root = psutil.Process(process_id)
+        return [root, *root.children(recursive=True)]
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return []
+
+
+def _process_is_running(process: psutil.Process) -> bool:
+    try:
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        return False
+
+
+def _terminate_worker_process(process: subprocess.Popen[str]) -> None:
+    tracked = {candidate.pid: candidate for candidate in _process_tree(process.pid)}
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    try:
+        process.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        for candidate in _process_tree(process.pid):
+            tracked[candidate.pid] = candidate
+        descendants = [candidate for process_id, candidate in tracked.items() if process_id != process.pid]
+        for descendant in descendants:
+            try:
+                descendant.terminate()
+            except psutil.Error:
+                continue
+        _, alive = psutil.wait_procs(descendants, timeout=5)
+        for descendant in alive:
+            try:
+                descendant.kill()
+            except psutil.Error:
+                continue
+        if process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        process.communicate(timeout=10)
+    surviving_descendants = [
+        candidate
+        for process_id, candidate in tracked.items()
+        if process_id != process.pid and _process_is_running(candidate)
+    ]
+    for descendant in surviving_descendants:
+        try:
+            descendant.kill()
+        except psutil.Error:
+            continue
+    _, alive = psutil.wait_procs(surviving_descendants, timeout=5)
+    if alive:
+        raise PackagedRouteFailure("Packaged worker timeout cleanup left surviving descendants.")
 
 
 def run_worker(
@@ -197,20 +354,29 @@ def run_worker(
     destination = request.get("destination")
     if not isinstance(destination, Mapping) or not isinstance(destination.get("path"), str):
         raise PackagedRouteFailure("Packaged worker request destination was invalid.")
-    Path(destination["path"]).mkdir(parents=True, exist_ok=True)
-    completed = subprocess.run(
+    destination_root = Path(destination["path"]).resolve()
+    destination_root.mkdir(parents=True, exist_ok=True)
+    process = subprocess.Popen(
         [app.worker.as_posix()],
-        input=json.dumps(request, separators=(",", ":")) + "\n",
-        text=True,
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        text=True,
         env=environment,
-        timeout=WORKER_TIMEOUT_SECONDS,
+        start_new_session=True,
     )
-    events = parse_worker_events(completed.stdout, job_id=job_id)
+    try:
+        stdout, _stderr = process.communicate(
+            json.dumps(request, separators=(",", ":")) + "\n",
+            timeout=WORKER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as error:
+        _terminate_worker_process(process)
+        raise PackagedRouteFailure(f"Packaged worker timed out during {operation}.") from error
+    events = parse_worker_events(stdout, job_id=job_id)
     result = _terminal_result(events, operation)
-    if completed.returncode != 0:
-        raise PackagedRouteFailure(f"Packaged worker exited {completed.returncode} after emitting a completion event.")
+    if process.returncode != 0:
+        raise PackagedRouteFailure(f"Packaged worker exited {process.returncode} after emitting a completion event.")
     route = result.get("video_route")
     output_path = result.get("output_path")
     if not isinstance(route, Mapping) or not isinstance(output_path, str):
@@ -218,6 +384,8 @@ def run_worker(
     resolved_output = Path(output_path).resolve()
     if not resolved_output.is_file():
         raise PackagedRouteFailure("Packaged worker output artifact is unavailable.")
+    if not resolved_output.is_relative_to(destination_root):
+        raise PackagedRouteFailure("Packaged worker output escaped the requested destination.")
     preview = result if operation == "preview_source" else None
     return WorkerResult(operation, route, resolved_output, events, preview)
 
@@ -263,23 +431,25 @@ def validate_route_pair(
             raise PackagedRouteFailure("Generated fallback unexpectedly reported direct rate control.")
     event_code = "video_route_selected" if expected_fallback_reason is None else "video_route_fallback"
     for worker_result in (full, preview):
-        route_events = [
-            event
-            for event in worker_result.events
-            if isinstance(event.get("payload"), Mapping) and event["payload"].get("code") == event_code
-        ]
-        if len(route_events) != 1 or route_events[0]["payload"].get("video_route") != worker_result.route:
+        route_payloads: list[Mapping[str, object]] = []
+        for event in worker_result.events:
+            payload = event.get("payload")
+            if isinstance(payload, Mapping) and payload.get("code") == event_code:
+                route_payloads.append(payload)
+        if len(route_payloads) != 1 or route_payloads[0].get("video_route") != worker_result.route:
             raise PackagedRouteFailure(f"Worker did not emit one truthful {event_code} event.")
 
 
 def stage_names(result: WorkerResult) -> tuple[str, ...]:
-    return tuple(
-        str(event["payload"]["stage"])
-        for event in result.events
-        if event.get("type") == "stage.started"
-        and isinstance(event.get("payload"), Mapping)
-        and isinstance(event["payload"].get("stage"), str)
-    )
+    stages: list[str] = []
+    for event in result.events:
+        payload = event.get("payload")
+        if event.get("type") != "stage.started" or not isinstance(payload, Mapping):
+            continue
+        stage = payload.get("stage")
+        if isinstance(stage, str):
+            stages.append(stage)
+    return tuple(stages)
 
 
 def validate_stage_contract(
@@ -297,20 +467,10 @@ def validate_stage_contract(
         raise PackagedRouteFailure("Worker ran forbidden stages: " + ", ".join(unexpected))
 
 
-def _probe_artifact(
-    path: Path,
-    required_box_types: set[str],
-    *,
-    expected_video_dimensions: tuple[int, int],
-) -> dict[str, object]:
-    verify_apple_media_compatible(path)
-    observed_boxes = box_types(path)
-    missing_boxes = sorted(required_box_types - observed_boxes)
-    if missing_boxes:
-        raise PackagedRouteFailure("Finalized artifact is missing spatial boxes: " + ", ".join(missing_boxes))
+def _media_probe(app: AppBundle, path: Path) -> Mapping[str, object]:
     completed = subprocess.run(
         [
-            find_ffprobe(),
+            app.ffprobe.as_posix(),
             "-v",
             "error",
             "-show_entries",
@@ -324,17 +484,137 @@ def _probe_artifact(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    probe = json.loads(completed.stdout)
-    duration_seconds = float(probe["format"]["duration"])
-    verify_seeks("ffmpeg", path, max(1, math.ceil(duration_seconds)))
-    streams = probe.get("streams", [])
-    stream_types = {stream.get("codec_type") for stream in streams if isinstance(stream, Mapping)}
-    if not {"video", "audio", "subtitle"}.issubset(stream_types):
-        raise PackagedRouteFailure("Finalized artifact did not preserve video, audio, and subtitles.")
-    video_dimensions = {
-        (stream.get("width"), stream.get("height"))
+    try:
+        probe = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise PackagedRouteFailure("Packaged ffprobe emitted invalid media JSON.") from error
+    if not isinstance(probe, Mapping):
+        raise PackagedRouteFailure("Packaged ffprobe did not emit a media object.")
+    return probe
+
+
+def _media_duration(probe: Mapping[str, object]) -> float:
+    format_data = probe.get("format")
+    if not isinstance(format_data, Mapping) or format_data.get("duration") is None:
+        raise PackagedRouteFailure("Media probe omitted duration.")
+    try:
+        duration_seconds = float(format_data["duration"])
+    except (TypeError, ValueError) as error:
+        raise PackagedRouteFailure("Media probe reported an invalid duration.") from error
+    if duration_seconds <= 0:
+        raise PackagedRouteFailure("Media probe reported a non-positive duration.")
+    return duration_seconds
+
+
+def _float_field(document: Mapping[str, object], key: str) -> float:
+    value = document.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise PackagedRouteFailure(f"Media evidence omitted numeric {key!r}.")
+    try:
+        return float(value)
+    except ValueError as error:
+        raise PackagedRouteFailure(f"Media evidence reported invalid numeric {key!r}.") from error
+
+
+def _media_streams(probe: Mapping[str, object]) -> list[dict[str, object]]:
+    streams = probe.get("streams")
+    if not isinstance(streams, list) or not all(isinstance(stream, Mapping) for stream in streams):
+        raise PackagedRouteFailure("Media probe omitted a valid stream list.")
+    return [
+        {
+            "codec_name": stream.get("codec_name"),
+            "codec_type": stream.get("codec_type"),
+            "height": stream.get("height"),
+            "language": stream.get("tags", {}).get("language") if isinstance(stream.get("tags"), Mapping) else None,
+            "width": stream.get("width"),
+        }
         for stream in streams
-        if isinstance(stream, Mapping) and stream.get("codec_type") == "video"
+        if isinstance(stream, Mapping)
+    ]
+
+
+def _validate_stream_contract(
+    streams: Sequence[Mapping[str, object]],
+    expected: Mapping[str, tuple[str, str | None]],
+) -> None:
+    grouped = {
+        stream_type: [stream for stream in streams if stream.get("codec_type") == stream_type]
+        for stream_type in expected
+    }
+    if len(streams) != len(expected) or any(len(matches) != 1 for matches in grouped.values()):
+        raise PackagedRouteFailure("Media did not contain exactly one video, audio, and subtitle stream.")
+    for stream_type, (codec_name, language) in expected.items():
+        stream = grouped[stream_type][0]
+        if stream.get("codec_name") != codec_name:
+            raise PackagedRouteFailure(f"Media {stream_type} stream reported an unexpected codec.")
+        if language is not None and stream.get("language") != language:
+            raise PackagedRouteFailure(f"Media {stream_type} stream did not preserve the expected language.")
+
+
+def _source_media_contract(app: AppBundle, path: Path) -> dict[str, object]:
+    probe = _media_probe(app, path)
+    streams = _media_streams(probe)
+    _validate_stream_contract(
+        streams,
+        {
+            "audio": ("truehd", "eng"),
+            "subtitle": ("hdmv_pgs_subtitle", "eng"),
+            "video": ("h264", None),
+        },
+    )
+    video_stream = next(stream for stream in streams if stream.get("codec_type") == "video")
+    if (video_stream.get("width"), video_stream.get("height")) != (1920, 1080):
+        raise PackagedRouteFailure("Representative MVC source did not preserve 1920x1080 eye dimensions.")
+    return {"duration_seconds": _media_duration(probe), "streams": streams}
+
+
+def _preview_duration(result: WorkerResult, source_duration_seconds: float) -> float:
+    preview = result.preview
+    if not isinstance(preview, Mapping) or preview.get("position") != "middle":
+        raise PackagedRouteFailure("Packaged preview omitted its middle-position timing contract.")
+    duration_seconds = _float_field(preview, "duration_seconds")
+    reported_source_duration = _float_field(preview, "source_duration_seconds")
+    start_seconds = _float_field(preview, "start_seconds")
+    expected_duration = min(PREVIEW_DURATION_SECONDS, source_duration_seconds)
+    expected_start = max(0.0, (source_duration_seconds - duration_seconds) / 2)
+    if abs(reported_source_duration - source_duration_seconds) > MEDIA_DURATION_TOLERANCE_SECONDS:
+        raise PackagedRouteFailure("Packaged preview reported the wrong source duration.")
+    if abs(duration_seconds - expected_duration) > MEDIA_DURATION_TOLERANCE_SECONDS:
+        raise PackagedRouteFailure("Packaged preview duration differed from the requested range.")
+    if abs(start_seconds - expected_start) > MEDIA_DURATION_TOLERANCE_SECONDS:
+        raise PackagedRouteFailure("Packaged preview did not use the requested middle position.")
+    return duration_seconds
+
+
+def _probe_artifact(
+    app: AppBundle,
+    path: Path,
+    required_box_types: set[str],
+    *,
+    expected_duration_seconds: float,
+    expected_video_dimensions: tuple[int, int],
+) -> dict[str, object]:
+    verify_apple_media_compatible(path)
+    observed_boxes = box_types(path)
+    missing_boxes = sorted(required_box_types - observed_boxes)
+    if missing_boxes:
+        raise PackagedRouteFailure("Finalized artifact is missing spatial boxes: " + ", ".join(missing_boxes))
+    probe = _media_probe(app, path)
+    duration_seconds = _media_duration(probe)
+    if abs(duration_seconds - expected_duration_seconds) > MEDIA_DURATION_TOLERANCE_SECONDS:
+        raise PackagedRouteFailure("Finalized artifact duration did not match the requested workload.")
+    verify_seeks(app.ffmpeg.as_posix(), path, max(1, math.ceil(duration_seconds)))
+    streams = _media_streams(probe)
+    _validate_stream_contract(
+        streams,
+        {
+            "audio": ("aac", "eng"),
+            "subtitle": ("mov_text", "eng"),
+            "video": ("hevc", None),
+        },
+    )
+    video_dimensions = {
+        (stream.get("width"), stream.get("height")) for stream in streams if stream.get("codec_type") == "video"
     }
     if video_dimensions != {expected_video_dimensions}:
         raise PackagedRouteFailure(
@@ -349,17 +629,7 @@ def _probe_artifact(
             "height": expected_video_dimensions[1],
             "width": expected_video_dimensions[0],
         },
-        "streams": [
-            {
-                "codec_name": stream.get("codec_name"),
-                "codec_type": stream.get("codec_type"),
-                "height": stream.get("height"),
-                "language": stream.get("tags", {}).get("language") if isinstance(stream.get("tags"), Mapping) else None,
-                "width": stream.get("width"),
-            }
-            for stream in streams
-            if isinstance(stream, Mapping)
-        ],
+        "streams": streams,
     }
 
 
@@ -485,6 +755,7 @@ def run_verified_route_pair(
     expected_selected: str,
     expected_fallback_reason: str | None,
     expected_upscale_mode: str | None,
+    source_duration_seconds: float,
     expected_video_dimensions: tuple[int, int],
     required_box_types: set[str],
     required_stages: set[str],
@@ -492,29 +763,35 @@ def run_verified_route_pair(
 ) -> tuple[WorkerResult, WorkerResult, dict[str, object], dict[str, object]]:
     full_id = str(uuid.uuid4())
     preview_id = str(uuid.uuid4())
-    full = run_worker(
-        app,
-        build_worker_request(
-            "convert_source",
-            source,
-            root / f"{name}-full",
-            job_id=full_id,
-            upscale_enabled=upscale_enabled,
-        ),
-        home_directory=root / f"{name}-full-home",
-    )
-    preview = run_worker(
-        app,
-        build_worker_request(
-            "preview_source",
-            source,
-            root / f"{name}-preview",
-            job_id=preview_id,
-            parent_job_id=full_id,
-            upscale_enabled=upscale_enabled,
-        ),
-        home_directory=root / f"{name}-preview-home",
-    )
+    try:
+        full = run_worker(
+            app,
+            build_worker_request(
+                "convert_source",
+                source,
+                root / f"{name}-full",
+                job_id=full_id,
+                upscale_enabled=upscale_enabled,
+            ),
+            home_directory=root / f"{name}-full-home",
+        )
+    except PackagedRouteFailure as error:
+        raise PackagedRouteFailure(f"{name} full route failed: {error}") from error
+    try:
+        preview = run_worker(
+            app,
+            build_worker_request(
+                "preview_source",
+                source,
+                root / f"{name}-preview",
+                job_id=preview_id,
+                parent_job_id=full_id,
+                upscale_enabled=upscale_enabled,
+            ),
+            home_directory=root / f"{name}-preview-home",
+        )
+    except PackagedRouteFailure as error:
+        raise PackagedRouteFailure(f"{name} preview route failed: {error}") from error
     validate_route_pair(
         full,
         preview,
@@ -524,14 +801,19 @@ def run_verified_route_pair(
     )
     for result in (full, preview):
         validate_stage_contract(result, required=required_stages, forbidden=forbidden_stages)
+    preview_duration_seconds = _preview_duration(preview, source_duration_seconds)
     full_artifact = _probe_artifact(
+        app,
         full.output_path,
         required_box_types,
+        expected_duration_seconds=source_duration_seconds,
         expected_video_dimensions=expected_video_dimensions,
     )
     preview_artifact = _probe_artifact(
+        app,
         preview.output_path,
         required_box_types,
+        expected_duration_seconds=preview_duration_seconds,
         expected_video_dimensions=expected_video_dimensions,
     )
     return full, preview, full_artifact, preview_artifact
@@ -542,11 +824,17 @@ def verify_packaged_routes(
     source_path: Path,
     *,
     fixture_output: Path | None,
+    expected_source_sha256: str,
 ) -> dict[str, object]:
     app = read_app_bundle(app_path)
     source = source_path.resolve()
     if not source.is_file():
         raise PackagedRouteFailure("Representative MVC source is unavailable.")
+    source_sha256 = sha256_file(source)
+    if source_sha256 != expected_source_sha256.lower():
+        raise PackagedRouteFailure("Representative MVC source SHA-256 did not match the expected fixture.")
+    source_media = _source_media_contract(app, source)
+    source_duration_seconds = _float_field(source_media, "duration_seconds")
     with tempfile.TemporaryDirectory(prefix="packaged-mv-hevc-routes-") as temporary_directory:
         root = Path(temporary_directory)
         direct_full, direct_preview, direct_full_artifact, direct_preview_artifact = run_verified_route_pair(
@@ -558,6 +846,7 @@ def verify_packaged_routes(
             expected_selected="direct_mv_hevc",
             expected_fallback_reason=None,
             expected_upscale_mode=None,
+            source_duration_seconds=source_duration_seconds,
             expected_video_dimensions=(1_920, 1_080),
             required_box_types=DIRECT_REQUIRED_BOX_TYPES,
             required_stages={"create_left_right_files"},
@@ -575,6 +864,7 @@ def verify_packaged_routes(
                     expected_selected="generated_mv_hevc",
                     expected_fallback_reason="stereo_mv_hevc_encode_unavailable",
                     expected_upscale_mode=None,
+                    source_duration_seconds=source_duration_seconds,
                     expected_video_dimensions=(1_920, 1_080),
                     required_box_types=CURRENT_REQUIRED_BOX_TYPES,
                     required_stages={"combine_to_mv_hevc", "create_left_right_files"},
@@ -592,14 +882,14 @@ def verify_packaged_routes(
             expected_selected="direct_mv_hevc",
             expected_fallback_reason=None,
             expected_upscale_mode="metalfx",
+            source_duration_seconds=source_duration_seconds,
             expected_video_dimensions=(3_840, 2_160),
             required_box_types=DIRECT_REQUIRED_BOX_TYPES,
             required_stages={"create_left_right_files"},
             forbidden_stages={"combine_to_mv_hevc", "upscale_video"},
         )
         if fixture_output is not None:
-            fixture_output.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(metalfx_full.output_path, fixture_output)
+            atomic_copy(metalfx_full.output_path, fixture_output)
 
         with metalfx_unavailable_capability_app(app, root / "metalfx-fallback-app") as metalfx_fallback_app:
             (
@@ -616,6 +906,7 @@ def verify_packaged_routes(
                 expected_selected="generated_mv_hevc",
                 expected_fallback_reason="metalfx_2x_mv_hevc_unavailable",
                 expected_upscale_mode=None,
+                source_duration_seconds=source_duration_seconds,
                 expected_video_dimensions=(3_840, 2_160),
                 required_box_types=CURRENT_REQUIRED_BOX_TYPES,
                 required_stages={"combine_to_mv_hevc", "create_left_right_files", "upscale_video"},
@@ -624,15 +915,20 @@ def verify_packaged_routes(
             metalfx_fallback_helper_sha256 = sha256_file(metalfx_fallback_app.helper)
 
     evidence: dict[str, object] = {
-        "schema_version": 2,
+        "schema_version": 3,
         "generated_at": datetime.now(UTC).isoformat(),
         "package": {
+            "app_tree_sha256": app_tree_sha256(app.path),
             "bundle_identifier": app.bundle_identifier,
             "helper_sha256": sha256_file(app.helper),
             "version": app.version,
             "worker_sha256": sha256_file(app.worker),
         },
-        "source": {"sha256": sha256_file(source), "size_bytes": source.stat().st_size},
+        "source": {
+            "media": source_media,
+            "sha256": source_sha256,
+            "size_bytes": source.stat().st_size,
+        },
         "ordinary": {
             "direct": {
                 "full": _route_evidence(direct_full, direct_full_artifact),
@@ -684,7 +980,7 @@ def verify_packaged_routes(
             "sha256": sha256_file(fixture_output),
             "size_bytes": fixture_output.stat().st_size,
         }
-    encoded = json.dumps(evidence, sort_keys=True).encode("utf-8")
+    encoded = (json.dumps(evidence, indent=2, sort_keys=True) + "\n").encode("utf-8")
     if len(encoded) > MAX_EVIDENCE_BYTES:
         raise PackagedRouteFailure("Packaged-route evidence exceeded its bounded size limit.")
     return evidence
@@ -698,18 +994,25 @@ def main() -> int:
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--fixture-output", type=Path)
+    parser.add_argument("--expected-source-sha256", required=True)
     args = parser.parse_args()
     try:
-        evidence = verify_packaged_routes(
+        app, source, output, fixture_output = validate_qualification_paths(
             args.app,
             args.source,
-            fixture_output=args.fixture_output,
+            args.output,
+            args.fixture_output,
+        )
+        evidence = verify_packaged_routes(
+            app,
+            source,
+            fixture_output=fixture_output,
+            expected_source_sha256=args.expected_source_sha256,
         )
     except (PackagedRouteFailure, OSError, subprocess.SubprocessError) as error:
         parser.exit(1, f"error: {error}\n")
     text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(text, encoding="utf-8")
+    atomic_write_text(output, text)
     print(text, end="")
     return 0
 

--- a/tests/test_packaged_mv_hevc_routes.py
+++ b/tests/test_packaged_mv_hevc_routes.py
@@ -1,18 +1,29 @@
 import json
+import signal
+import subprocess
+import tempfile
 import unittest
 
 from pathlib import Path
+from unittest.mock import Mock, patch
 
+from bd_to_avp.modules.video_route import AUTOMATIC_DIRECT_QUALITY
 from scripts.verify_packaged_mv_hevc_routes import (
     METALFX_UNAVAILABLE_HELPER_SOURCE,
     PROTOCOL_VERSION,
     UNAVAILABLE_HELPER_SOURCE,
     PackagedRouteFailure,
     WorkerResult,
+    _preview_duration,
+    _terminate_worker_process,
+    _terminal_result,
+    _validate_stream_contract,
     build_worker_request,
     parse_worker_events,
+    validate_qualification_paths,
     validate_stage_contract,
     validate_route_pair,
+    verify_packaged_routes,
 )
 
 
@@ -139,6 +150,135 @@ class PackagedEventTests(unittest.TestCase):
         with self.assertRaisesRegex(PackagedRouteFailure, "valid JSON"):
             parse_worker_events("not json", job_id="job")
 
+    def test_terminal_decision_reports_safe_id_and_prompt(self) -> None:
+        events = (
+            event(
+                0,
+                job_id="job",
+                event_type="job.decision_required",
+                payload={
+                    "decision": {
+                        "id": "subtitle_decision_required",
+                        "prompt": "Subtitle extraction did not produce usable subtitle files.",
+                    }
+                },
+            ),
+        )
+
+        with self.assertRaisesRegex(PackagedRouteFailure, "subtitle_decision_required"):
+            _terminal_result(events, "preview_source")
+
+
+class PackagedMediaContractTests(unittest.TestCase):
+    def test_preview_timing_matches_requested_middle_range(self) -> None:
+        result = WorkerResult(
+            operation="preview_source",
+            route={},
+            output_path=Path("preview.mov"),
+            events=(),
+            preview={
+                "duration_seconds": 60.435,
+                "position": "middle",
+                "source_duration_seconds": 65.649,
+                "start_seconds": 2.544,
+            },
+        )
+
+        self.assertAlmostEqual(_preview_duration(result, 65.649), 60.435)
+
+    def test_stream_contract_rejects_missing_subtitles(self) -> None:
+        streams = (
+            {"codec_name": "hevc", "codec_type": "video", "language": None},
+            {"codec_name": "aac", "codec_type": "audio", "language": "eng"},
+        )
+
+        with self.assertRaisesRegex(PackagedRouteFailure, "exactly one"):
+            _validate_stream_contract(
+                streams,
+                {
+                    "audio": ("aac", "eng"),
+                    "subtitle": ("mov_text", "eng"),
+                    "video": ("hevc", None),
+                },
+            )
+
+    def test_timeout_cleanup_signals_worker_group(self) -> None:
+        process = Mock(pid=123)
+        process.poll.return_value = None
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="worker", timeout=30),
+            ("", ""),
+        ]
+        root = Mock(pid=123)
+        child = Mock(pid=124)
+
+        with (
+            patch(
+                "scripts.verify_packaged_mv_hevc_routes._process_tree",
+                return_value=[root, child],
+            ),
+            patch(
+                "scripts.verify_packaged_mv_hevc_routes._process_is_running",
+                return_value=False,
+            ),
+            patch(
+                "scripts.verify_packaged_mv_hevc_routes.psutil.wait_procs",
+                return_value=([child], []),
+            ),
+            patch("scripts.verify_packaged_mv_hevc_routes.os.killpg") as killpg,
+        ):
+            _terminate_worker_process(process)
+
+        killpg.assert_any_call(123, signal.SIGTERM)
+        killpg.assert_any_call(123, signal.SIGKILL)
+        child.terminate.assert_called_once_with()
+
+    def test_qualification_paths_reject_source_and_destination_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = root / "Qualification.app"
+            app.mkdir()
+            source = root / "source.mkv"
+            source.write_bytes(b"source")
+
+            with self.assertRaisesRegex(PackagedRouteFailure, "representative source"):
+                validate_qualification_paths(app, source, source, None)
+            with self.assertRaisesRegex(PackagedRouteFailure, "must be distinct"):
+                validate_qualification_paths(app, source, root / "evidence.json", root / "evidence.json")
+            with self.assertRaisesRegex(PackagedRouteFailure, "outside the app bundle"):
+                validate_qualification_paths(app, source, app / "evidence.json", None)
+
+    def test_qualification_paths_reject_symlink_destinations(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = root / "Qualification.app"
+            app.mkdir()
+            source = root / "source.mkv"
+            source.write_bytes(b"source")
+            real_output = root / "real-evidence.json"
+            real_output.write_text("{}", encoding="utf-8")
+            linked_output = root / "evidence.json"
+            linked_output.symlink_to(real_output)
+
+            with self.assertRaisesRegex(PackagedRouteFailure, "must not be a symlink"):
+                validate_qualification_paths(app, source, linked_output, None)
+
+    def test_route_verifier_rejects_wrong_source_hash_before_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            source.write_bytes(b"source")
+
+            with (
+                patch("scripts.verify_packaged_mv_hevc_routes.read_app_bundle", return_value=Mock()),
+                self.assertRaisesRegex(PackagedRouteFailure, "SHA-256"),
+            ):
+                verify_packaged_routes(
+                    Path("Qualification.app"),
+                    source,
+                    fixture_output=None,
+                    expected_source_sha256="0" * 64,
+                )
+
 
 class PackagedRouteParityTests(unittest.TestCase):
     def test_direct_full_and_preview_require_identical_route(self) -> None:
@@ -147,7 +287,7 @@ class PackagedRouteParityTests(unittest.TestCase):
             "selected": "direct_mv_hevc",
             "reason": "direct_eligible",
             "rate_control": "quality",
-            "quality": 0.7,
+            "quality": AUTOMATIC_DIRECT_QUALITY,
         }
 
         validate_route_pair(

--- a/tests/test_real_mvc_4k_quality.py
+++ b/tests/test_real_mvc_4k_quality.py
@@ -1,0 +1,176 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import qualify_real_mvc_4k_quality as quality
+from scripts.qualify_real_mvc_4k_quality import (
+    EXPECTED_RUNS,
+    RealMVCQualityFailure,
+    build_evidence,
+    probe_eye,
+    remove_private_work_directory,
+    source_video_info,
+    summarize_real_mvc_quality,
+)
+
+
+def run_record(
+    *,
+    quality_score: float,
+    eye_order_margin: float = 0.01,
+    final_bytes: int = 100,
+    sha256: str = "a" * 64,
+) -> dict[str, object]:
+    return {
+        "final_bytes": final_bytes,
+        "min_eye_order_margin": eye_order_margin,
+        "min_same_eye_ssim": quality_score,
+        "sha256": sha256,
+    }
+
+
+class RealMVC4KQualityTests(unittest.TestCase):
+    def test_quality_summary_accepts_three_nondeterministic_runs(self) -> None:
+        file_based = [run_record(quality_score=0.95, final_bytes=110, sha256=str(index) * 64) for index in range(3)]
+        direct = [run_record(quality_score=0.949, final_bytes=100, sha256=str(index + 3) * 64) for index in range(3)]
+
+        summary = summarize_real_mvc_quality(file_based, direct)
+
+        self.assertTrue(summary["passed"])
+        self.assertEqual(summary["direct_run_count"], EXPECTED_RUNS)
+        self.assertLess(summary["size_ratio"], 1)
+
+    def test_quality_summary_rejects_direct_quality_loss(self) -> None:
+        file_based = [run_record(quality_score=0.95, final_bytes=110) for _ in range(3)]
+        direct = [run_record(quality_score=0.947, final_bytes=100) for _ in range(3)]
+
+        summary = summarize_real_mvc_quality(file_based, direct)
+
+        self.assertFalse(summary["quality_passed"])
+        self.assertFalse(summary["passed"])
+
+    def test_quality_summary_rejects_oversize_direct_run(self) -> None:
+        file_based = [run_record(quality_score=0.95, final_bytes=100) for _ in range(3)]
+        direct = [run_record(quality_score=0.95, final_bytes=size) for size in (100, 104, 106)]
+
+        summary = summarize_real_mvc_quality(file_based, direct)
+
+        self.assertFalse(summary["size_passed"])
+        self.assertFalse(summary["passed"])
+
+    def test_quality_summary_rejects_file_based_eye_swap(self) -> None:
+        file_based = [run_record(quality_score=0.95, eye_order_margin=0.0005) for _ in range(3)]
+        direct = [run_record(quality_score=0.95) for _ in range(3)]
+
+        summary = summarize_real_mvc_quality(file_based, direct)
+
+        self.assertFalse(summary["file_based_eye_order_passed"])
+        self.assertFalse(summary["passed"])
+
+    def test_quality_summary_requires_three_runs_per_route(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly 3"):
+            summarize_real_mvc_quality(
+                [run_record(quality_score=0.95) for _ in range(2)],
+                [run_record(quality_score=0.95) for _ in range(3)],
+            )
+
+    def test_source_video_info_parses_public_timing_only(self) -> None:
+        payload = json.dumps(
+            {
+                "format": {"duration": "65.649"},
+                "streams": [{"avg_frame_rate": "24000/1001", "nb_read_packets": "1573"}],
+            }
+        )
+        with patch.object(quality, "run_checked", return_value=payload):
+            info = source_video_info(Path("ffprobe"), Path("private-source.mkv"))
+
+        self.assertEqual(
+            info,
+            {"duration_seconds": 65.649, "frame_count": 1573, "frame_rate": "24000/1001"},
+        )
+
+    def test_source_video_info_rejects_missing_timing(self) -> None:
+        with patch.object(quality, "run_checked", return_value='{"streams": []}'):
+            with self.assertRaises(RealMVCQualityFailure):
+                source_video_info(Path("ffprobe"), Path("private-source.mkv"))
+
+    def test_quality_eye_requires_exact_frame_count(self) -> None:
+        payload = json.dumps(
+            {
+                "streams": [
+                    {
+                        "height": 2160,
+                        "nb_read_frames": "1572",
+                        "width": 3840,
+                    }
+                ]
+            }
+        )
+        with patch.object(quality, "run_checked", return_value=payload):
+            with self.assertRaisesRegex(RealMVCQualityFailure, "frame count"):
+                probe_eye(
+                    Path("ffprobe"),
+                    Path("candidate.mov"),
+                    expected_dimensions=(3840, 2160),
+                    expected_frames=1573,
+                )
+
+    def test_private_work_cleanup_fails_closed(self) -> None:
+        with patch.object(quality.shutil, "rmtree", side_effect=OSError("busy")):
+            with self.assertRaisesRegex(RealMVCQualityFailure, "private real-MVC quality work directory"):
+                remove_private_work_directory(Path("private-work"))
+
+    def test_public_quality_evidence_omits_private_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_path = root / "Qualification.app"
+            worker = app_path / "Contents/MacOS/worker"
+            binary_root = app_path / "Contents/Resources/app/bd_to_avp/bin"
+            helper = binary_root / "mv-hevc-encoder"
+            tools = {
+                name: binary_root / name
+                for name in ("edge264_test", "ffmpeg", "ffprobe", "fx-upscale", "spatial-media-kit-tool")
+            }
+            for path in (worker, helper, *tools.values()):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(path.name.encode())
+                path.chmod(0o755)
+            app = quality.AppBundle(
+                path=app_path,
+                worker=worker,
+                helper=helper,
+                ffmpeg=tools["ffmpeg"],
+                ffprobe=tools["ffprobe"],
+                bundle_identifier="com.example.qualification",
+                version="1.0",
+            )
+            source = root / "private-source.mkv"
+            reference_left = root / "private-left.mkv"
+            reference_right = root / "private-right.mkv"
+            for path in (source, reference_left, reference_right):
+                path.write_bytes(path.name.encode())
+            file_based = [run_record(quality_score=0.95, final_bytes=110) for _ in range(3)]
+            direct = [run_record(quality_score=0.949, final_bytes=100) for _ in range(3)]
+
+            evidence = build_evidence(
+                app=app,
+                source=source,
+                source_info={"duration_seconds": 65.649, "frame_count": 1573, "frame_rate": "24000/1001"},
+                reference_left=reference_left,
+                reference_right=reference_right,
+                direct_runs=direct,
+                file_based_runs=file_based,
+                fallback_helper_sha256="b" * 64,
+            )
+            encoded = json.dumps(evidence, sort_keys=True)
+
+            self.assertTrue(evidence["acceptance"]["passed"])
+            self.assertNotIn(temporary_directory, encoded)
+            self.assertNotIn("private-source", encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_real_mvc_feature_qualification.py
+++ b/tests/test_real_mvc_feature_qualification.py
@@ -1,0 +1,341 @@
+import json
+import subprocess
+import tempfile
+import time
+import unittest
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from scripts import qualify_real_mvc_feature as feature
+from scripts.qualify_real_mvc_feature import (
+    FeatureQualificationFailure,
+    PackagedTools,
+    QualificationEventSink,
+    ResourceSampler,
+    app_tree_sha256,
+    normalizer_command,
+    powermetrics_thermal_summary,
+    probe_direct_artifact,
+    require_nominal_powermetrics_thermal,
+    remove_private_work_directory,
+    resource_boundedness,
+    safe_encoder_summary,
+    source_video_info,
+    terminate_packaged_worker,
+    validate_qualification_paths,
+)
+from scripts.verify_packaged_mv_hevc_routes import AppBundle
+
+
+def run_evidence(
+    *,
+    rss: int,
+    metal: int,
+    duration_seconds: float,
+    first_quarter_peak_rss: int | None = None,
+    last_quarter_peak_rss: int | None = None,
+) -> dict[str, object]:
+    return {
+        "resources": {
+            "duration_seconds": duration_seconds,
+            "first_quarter_peak_rss_bytes": first_quarter_peak_rss or rss,
+            "last_quarter_peak_rss_bytes": last_quarter_peak_rss or rss,
+            "peak_rss_bytes": rss,
+            "quartile_peak_rss_bytes": [
+                first_quarter_peak_rss or rss,
+                first_quarter_peak_rss or rss,
+                first_quarter_peak_rss or rss,
+                last_quarter_peak_rss or rss,
+            ],
+            "processes": {
+                "pipeline": {
+                    "quartile_peak_rss_bytes": [
+                        first_quarter_peak_rss or rss,
+                        first_quarter_peak_rss or rss,
+                        first_quarter_peak_rss or rss,
+                        last_quarter_peak_rss or rss,
+                    ]
+                }
+            },
+        },
+        "encoder": {
+            "frame_count": 240,
+            "metalfx_device_final_allocated_size_bytes": metal,
+            "metalfx_device_peak_delta_bytes": metal,
+            "upscale_mode": "metalfx",
+        },
+    }
+
+
+class RealMVCFeatureQualificationTests(unittest.TestCase):
+    def app_bundle(self, root: Path) -> AppBundle:
+        app_path = root / "Qualification.app"
+        return AppBundle(
+            path=app_path,
+            worker=app_path / "Contents/MacOS/worker",
+            helper=app_path / "Contents/Resources/app/bd_to_avp/bin/mv-hevc-encoder",
+            ffmpeg=app_path / "Contents/Resources/app/bd_to_avp/bin/ffmpeg",
+            ffprobe=app_path / "Contents/Resources/app/bd_to_avp/bin/ffprobe",
+            bundle_identifier="com.example.qualification",
+            version="1.0",
+        )
+
+    def test_normalizer_preserves_two_1080p_eyes(self) -> None:
+        command = normalizer_command(Path("ffmpeg"), frame_rate="24000/1001")
+        filter_complex = command[command.index("-filter_complex") + 1]
+
+        self.assertIn("crop=1920:1080:0:0", filter_complex)
+        self.assertIn("crop=1920:1080:1920:0", filter_complex)
+        self.assertIn("hstack=inputs=2", filter_complex)
+
+    def test_resource_boundedness_accepts_documented_growth(self) -> None:
+        result = resource_boundedness(
+            run_evidence(rss=500_000_000, metal=419_086_336, duration_seconds=60),
+            run_evidence(rss=550_000_000, metal=452_280_320, duration_seconds=600),
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertTrue(result["passed"])
+
+    def test_resource_boundedness_rejects_unbounded_rss(self) -> None:
+        result = resource_boundedness(
+            run_evidence(rss=500_000_000, metal=419_086_336, duration_seconds=60),
+            run_evidence(rss=3 * 1024**3, metal=419_086_336, duration_seconds=600),
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertFalse(result["feature_process_peak_passed"])
+        self.assertFalse(result["passed"])
+
+    def test_resource_boundedness_rejects_late_feature_growth(self) -> None:
+        result = resource_boundedness(
+            run_evidence(rss=500_000_000, metal=419_086_336, duration_seconds=60),
+            run_evidence(
+                rss=550_000_000,
+                metal=419_086_336,
+                duration_seconds=600,
+                first_quarter_peak_rss=450_000_000,
+                last_quarter_peak_rss=550_000_000,
+            ),
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertFalse(result["feature_plateau_passed"])
+        self.assertFalse(result["passed"])
+
+    def test_resource_boundedness_allows_bounded_process_and_aggregate_growth(self) -> None:
+        short_run = run_evidence(rss=500_000_000, metal=419_086_336, duration_seconds=60)
+        feature_run = run_evidence(rss=600_000_000, metal=452_280_320, duration_seconds=600)
+        feature_run["resources"]["quartile_peak_rss_bytes"] = [
+            500_000_000,
+            520_000_000,
+            530_000_000,
+            610_000_000,
+        ]
+        feature_run["resources"]["processes"] = {
+            "decoder": {"quartile_peak_rss_bytes": [100_000_000, 110_000_000, 120_000_000, 160_000_000]},
+            "normalizer": {"quartile_peak_rss_bytes": [400_000_000, 410_000_000, 410_000_000, 450_000_000]},
+        }
+
+        result = resource_boundedness(
+            short_run,
+            feature_run,
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertGreater(result["feature_total_plateau_growth_bytes"], 64 * 1024 * 1024)
+        self.assertLessEqual(
+            result["feature_total_plateau_growth_bytes"],
+            result["feature_aggregate_plateau_allowance_bytes"],
+        )
+        self.assertTrue(result["feature_total_plateau_passed"])
+        self.assertTrue(result["feature_plateau_passed"])
+        self.assertTrue(result["passed"])
+
+    def test_resource_boundedness_rejects_distributed_aggregate_growth(self) -> None:
+        short_run = run_evidence(rss=500_000_000, metal=419_086_336, duration_seconds=60)
+        feature_run = run_evidence(rss=700_000_000, metal=452_280_320, duration_seconds=600)
+        feature_run["resources"]["quartile_peak_rss_bytes"] = [
+            500_000_000,
+            520_000_000,
+            530_000_000,
+            680_000_000,
+        ]
+        feature_run["resources"]["processes"] = {
+            "decoder": {"quartile_peak_rss_bytes": [100_000_000, 110_000_000, 120_000_000, 170_000_000]},
+            "encoder": {"quartile_peak_rss_bytes": [100_000_000, 110_000_000, 120_000_000, 170_000_000]},
+            "normalizer": {"quartile_peak_rss_bytes": [300_000_000, 300_000_000, 290_000_000, 340_000_000]},
+        }
+
+        result = resource_boundedness(
+            short_run,
+            feature_run,
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertTrue(result["feature_process_plateau_passed"])
+        self.assertFalse(result["feature_total_plateau_passed"])
+        self.assertFalse(result["feature_plateau_passed"])
+        self.assertFalse(result["passed"])
+
+    def test_resource_boundedness_rejects_excess_metal_duration_growth(self) -> None:
+        result = resource_boundedness(
+            run_evidence(rss=500_000_000, metal=100_000_000, duration_seconds=60),
+            run_evidence(rss=500_000_000, metal=900_000_000, duration_seconds=600),
+            max_rss_growth_bytes=64 * 1024 * 1024,
+        )
+
+        self.assertFalse(result["feature_metal_duration_growth_passed"])
+        self.assertFalse(result["passed"])
+
+    def test_resource_sampler_surfaces_background_failures(self) -> None:
+        sampler = ResourceSampler(QualificationEventSink(), interval_seconds=0.01)
+        with patch.object(feature, "thermal_state", side_effect=FeatureQualificationFailure("boom")):
+            sampler.start()
+            time.sleep(0.05)
+            with self.assertRaisesRegex(FeatureQualificationFailure, "Resource sampler failed"):
+                sampler.stop()
+
+    def test_powermetrics_thermal_summary_requires_complete_values(self) -> None:
+        trace = "\n".join(
+            (
+                "**** Thermal pressure ****",
+                "Current pressure level: Nominal",
+                "**** Thermal pressure ****",
+                "Current pressure level: Nominal",
+            )
+        )
+
+        summary = powermetrics_thermal_summary(trace)
+
+        self.assertTrue(summary["all_nominal"])
+        self.assertEqual(summary["sample_count"], 2)
+        self.assertEqual(summary["counts"]["nominal"], 2)
+
+    def test_powermetrics_gate_rejects_non_nominal_pressure(self) -> None:
+        trace = "\n".join(
+            (
+                "**** Thermal pressure ****",
+                "Current pressure level: Fair",
+            )
+        )
+
+        with self.assertRaisesRegex(FeatureQualificationFailure, "non-nominal"):
+            require_nominal_powermetrics_thermal(trace)
+
+    def test_safe_encoder_summary_drops_unapproved_fields(self) -> None:
+        summary = safe_encoder_summary(
+            {
+                "frame_count": 100,
+                "metalfx_device_peak_delta_bytes": 42,
+                "private_source_path": "/private/source.mkv",
+                "upscale_mode": "metalfx",
+            }
+        )
+
+        self.assertNotIn("private_source_path", summary)
+        self.assertEqual(summary["frame_count"], 100)
+
+    def test_source_video_info_requires_positive_packet_timing(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "format": {"duration": "10.01"},
+                    "streams": [{"avg_frame_rate": "24000/1001", "nb_read_packets": "240"}],
+                }
+            ),
+            stderr="",
+        )
+        with patch.object(feature.subprocess, "run", return_value=completed):
+            info = source_video_info(Path("ffprobe"), Path("source.mkv"))
+
+        self.assertEqual(info["packet_count"], 240)
+        self.assertEqual(info["frame_rate"], "24000/1001")
+        self.assertAlmostEqual(info["video_duration_seconds"], 10.01)
+
+    def test_validate_qualification_paths_rejects_private_inputs_under_work_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            work_directory = root / "work"
+
+            with self.assertRaisesRegex(FeatureQualificationFailure, "must not contain media"):
+                validate_qualification_paths(
+                    self.app_bundle(root),
+                    work_directory / "source.mkv",
+                    root / "segment.mkv",
+                    root / "evidence.json",
+                    work_directory,
+                    requested_work_directory=work_directory,
+                )
+
+    def test_validate_qualification_paths_rejects_symlinked_work_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            work_directory = root / "work"
+            work_directory.mkdir()
+            requested_work_directory = root / "work-link"
+            requested_work_directory.symlink_to(work_directory, target_is_directory=True)
+
+            with self.assertRaisesRegex(FeatureQualificationFailure, "must not be a symlink"):
+                validate_qualification_paths(
+                    self.app_bundle(root),
+                    root / "source.mkv",
+                    root / "segment.mkv",
+                    root / "evidence.json",
+                    work_directory,
+                    requested_work_directory=requested_work_directory,
+                )
+
+    def test_private_work_directory_cleanup_removes_source_derived_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            work_directory = Path(temporary_directory) / "work"
+            work_directory.mkdir()
+            (work_directory / "partial.mov").write_bytes(b"partial")
+
+            self.assertTrue(remove_private_work_directory(work_directory))
+            self.assertFalse(work_directory.exists())
+
+    def test_packaged_worker_cleanup_signals_validated_process_group(self) -> None:
+        process = Mock()
+        process.wait.return_value = 130
+
+        with (
+            patch.object(feature.os, "killpg") as killpg,
+            patch.object(feature, "process_group_is_running", return_value=False),
+        ):
+            terminate_packaged_worker(process, 123)
+
+        killpg.assert_called_once_with(123, feature.signal.SIGTERM)
+        process.terminate.assert_not_called()
+
+    def test_direct_artifact_requires_projection_box(self) -> None:
+        tools = PackagedTools(
+            ffmpeg=Path("ffmpeg"),
+            ffprobe=Path("ffprobe"),
+            edge264=Path("edge264"),
+            encoder=Path("encoder"),
+        )
+        with (
+            patch.object(feature, "verify_apple_media_compatible"),
+            patch.object(feature, "box_types", return_value={"hvcC", "lhvC", "eyes", "hero", "st3d", "sv3d"}),
+            self.assertRaisesRegex(FeatureQualificationFailure, "proj"),
+        ):
+            probe_direct_artifact(tools, Path("artifact.mov"))
+
+    def test_app_tree_hash_includes_symlink_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "payload").write_text("payload", encoding="utf-8")
+            (root / "link").symlink_to("payload")
+            first = app_tree_sha256(root)
+            (root / "link").unlink()
+            (root / "link").symlink_to("different")
+
+            self.assertNotEqual(first, app_tree_sha256(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_real_mvc_public_evidence.py
+++ b/tests/test_real_mvc_public_evidence.py
@@ -1,0 +1,136 @@
+import hashlib
+import json
+import re
+import unittest
+
+from pathlib import Path
+
+
+EVIDENCE_PATH = Path(__file__).parents[1] / "docs/qualification/direct-4k-real-mvc-v1.json"
+REPOSITORY_ROOT = EVIDENCE_PATH.parents[2]
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+PRIVATE_PATH_PATTERN = re.compile(r"(?:/(?:Users|Volumes|home|private|tmp|var)/|[A-Za-z]:\\\\|\\\\\\\\)")
+
+
+class RealMVCPublicEvidenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.evidence = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+
+    def test_all_acceptance_checks_pass(self) -> None:
+        acceptance = self.evidence["acceptance"]
+
+        self.assertTrue(acceptance["passed"])
+        self.assertTrue(all(acceptance.values()))
+
+    def test_evidence_hashes_are_final_sha256_values(self) -> None:
+        evidence_files = self.evidence["evidence_files"]
+
+        self.assertTrue(all(SHA256_PATTERN.fullmatch(value) for value in evidence_files.values()))
+
+    def test_qualification_harness_hashes_match_reviewed_files(self) -> None:
+        harness = self.evidence["qualification_harness"]
+
+        for relative_path, expected_sha256 in harness["files"].items():
+            digest = hashlib.sha256((REPOSITORY_ROOT / relative_path).read_bytes()).hexdigest()
+            self.assertEqual(digest, expected_sha256, relative_path)
+
+    def test_route_matrix_records_all_eight_routes(self) -> None:
+        route_matrix = self.evidence["packaged_route_matrix"]
+        routes = route_matrix["routes"]
+
+        self.assertEqual(route_matrix["route_count"], 8)
+        self.assertEqual(len(routes), 8)
+        self.assertTrue(all(routes.values()))
+        self.assertEqual(route_matrix["app_tree_sha256"], self.evidence["package"]["app_tree_sha256"])
+        self.assertEqual(
+            self.evidence["feature_length"]["assessment"]["input_evidence_sha256"],
+            self.evidence["evidence_files"]["feature_length_input_sha256"],
+        )
+
+    def test_feature_resource_gate_is_bounded(self) -> None:
+        resources = self.evidence["feature_length"]["resources"]
+
+        self.assertLessEqual(resources["process_tree_peak_rss_bytes"], resources["process_rss_safety_ceiling_bytes"])
+        self.assertLessEqual(resources["metal_peak_delta_bytes"], resources["metal_safety_ceiling_bytes"])
+        self.assertLessEqual(
+            resources["max_process_late_quartile_growth_bytes"],
+            resources["late_quartile_growth_ceiling_bytes"],
+        )
+        self.assertLessEqual(
+            resources["total_late_quartile_growth_bytes"],
+            resources["aggregate_late_quartile_growth_ceiling_bytes"],
+        )
+        self.assertEqual(
+            resources["max_process_late_quartile_growth_bytes"],
+            max(resources["per_process_late_quartile_growth_bytes"].values()),
+        )
+
+    def test_real_mvc_quality_gate_is_repeated_and_bounded(self) -> None:
+        quality = self.evidence["real_mvc_quality"]
+        direct = quality["direct"]
+        file_based = quality["file_based"]
+        thresholds = quality["thresholds"]
+
+        self.assertTrue(all(quality["acceptance"].values()))
+        self.assertEqual(direct["run_count"], thresholds["runs_per_route"])
+        self.assertEqual(file_based["run_count"], thresholds["runs_per_route"])
+        self.assertGreaterEqual(
+            direct["median_min_same_eye_ssim"],
+            quality["summary"]["required_direct_min_same_eye_ssim"],
+        )
+        self.assertLessEqual(quality["summary"]["max_run_size_ratio"], thresholds["max_size_ratio"])
+        self.assertGreaterEqual(direct["minimum_eye_order_margin"], thresholds["minimum_eye_order_margin"])
+        self.assertGreaterEqual(file_based["minimum_eye_order_margin"], thresholds["minimum_eye_order_margin"])
+        self.assertEqual(quality["source_sha256"], self.evidence["representative_segment"]["sha256"])
+
+    def test_public_evidence_omits_private_paths_and_titles(self) -> None:
+        encoded = json.dumps(self.evidence, sort_keys=True)
+
+        for forbidden in ("file://", "Private title"):
+            self.assertNotIn(forbidden, encoded)
+        self.assertIsNone(PRIVATE_PATH_PATTERN.search(encoded))
+        self.assertEqual(
+            set(self.evidence["source"]),
+            {
+                "container_duration_seconds",
+                "frame_rate",
+                "packet_count",
+                "sha256",
+                "size_bytes",
+                "track_count",
+                "video_duration_seconds",
+            },
+        )
+        self.assertEqual(
+            set(self.evidence["representative_segment"]),
+            {
+                "deterministic_repeat_match",
+                "duration_seconds",
+                "selection",
+                "sha256",
+                "size_bytes",
+                "supersedes",
+                "tracks",
+            },
+        )
+        forbidden_keys = {"device_name", "hardware_model", "hostname", "path", "source_title", "title", "username"}
+        observed_keys: set[str] = set()
+
+        def collect_keys(value: object) -> None:
+            if isinstance(value, dict):
+                observed_keys.update(str(key) for key in value)
+                for item in value.values():
+                    collect_keys(item)
+            elif isinstance(value, list):
+                for item in value:
+                    collect_keys(item)
+
+        collect_keys(self.evidence)
+        self.assertFalse(forbidden_keys & observed_keys)
+        self.assertFalse(self.evidence["privacy"]["source_paths_recorded"])
+        self.assertFalse(self.evidence["privacy"]["source_titles_recorded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_real_mvc_qualification_segment.py
+++ b/tests/test_real_mvc_qualification_segment.py
@@ -1,0 +1,115 @@
+import json
+import unittest
+
+from pathlib import Path
+
+from scripts.create_real_mvc_qualification_segment import (
+    SegmentFailure,
+    build_evidence,
+    build_mkvmerge_command,
+    public_track_summary,
+    validate_segment_document,
+)
+
+
+def mvc_document(*, stereo_mode: int = 13) -> dict[str, object]:
+    return {
+        "container": {"properties": {"title": "Private title", "duration": 65_649_000_000}},
+        "tracks": [
+            {
+                "id": 0,
+                "type": "video",
+                "codec": "AVC/H.264/MPEG-4p10",
+                "properties": {
+                    "language": "und",
+                    "pixel_dimensions": "1920x1080",
+                    "stereo_mode": stereo_mode,
+                    "track_name": "Private video title",
+                },
+            },
+            {
+                "id": 1,
+                "type": "audio",
+                "codec": "TrueHD Atmos",
+                "properties": {"language": "eng", "track_name": "Private audio title"},
+            },
+            {
+                "id": 2,
+                "type": "subtitles",
+                "codec": "HDMV PGS",
+                "properties": {"language": "eng", "track_name": "Private subtitle title"},
+            },
+        ],
+    }
+
+
+class RealMVCQualificationSegmentTests(unittest.TestCase):
+    def test_mkvmerge_command_has_stable_selection_and_private_metadata_stripping(self) -> None:
+        command = build_mkvmerge_command(
+            "mkvmerge",
+            Path("private-source.mkv"),
+            Path("segment.mkv"),
+            start_seconds=4500,
+            duration_seconds=65.648,
+            video_track=0,
+            audio_track=1,
+            subtitle_track=6,
+            deterministic_seed="seed-v1",
+        )
+
+        self.assertIn("parts:4500s-4565.648s", command)
+        self.assertIn("--deterministic", command)
+        self.assertIn("--no-date", command)
+        self.assertEqual(command.count("--track-name"), 3)
+        self.assertEqual(command[-1], "private-source.mkv")
+
+    def test_public_track_summary_omits_titles_and_container_metadata(self) -> None:
+        encoded = json.dumps(public_track_summary(mvc_document()))
+
+        self.assertNotIn("Private", encoded)
+        self.assertIn("TrueHD Atmos", encoded)
+        self.assertIn("HDMV PGS", encoded)
+
+    def test_segment_validation_requires_mvc_both_eyes_laced(self) -> None:
+        validate_segment_document(mvc_document())
+
+        with self.assertRaisesRegex(SegmentFailure, "both-eyes-laced"):
+            validate_segment_document(mvc_document(stereo_mode=0))
+
+    def test_segment_validation_requires_pgs_subtitles(self) -> None:
+        document = mvc_document()
+        document["tracks"][2]["codec"] = "SubRip/SRT"
+
+        with self.assertRaisesRegex(SegmentFailure, "HDMV PGS"):
+            validate_segment_document(document)
+
+    def test_evidence_is_path_free_and_records_supersession(self) -> None:
+        evidence = build_evidence(
+            source_sha256="a" * 64,
+            source_size_bytes=32_000_000_000,
+            source_duration_seconds=5737.76,
+            source_track_count=55,
+            segment_sha256="b" * 64,
+            segment_size_bytes=354_000_000,
+            segment_duration_seconds=65.649,
+            segment_tracks=public_track_summary(mvc_document()),
+            repeat_sha256="b" * 64,
+            start_seconds=4500,
+            requested_duration_seconds=65.648,
+            video_track=0,
+            audio_track=1,
+            subtitle_track=6,
+            deterministic_seed="seed-v1",
+            mkvmerge_version="mkvmerge v100.0",
+            ffprobe_version="ffprobe version 8.1.2",
+        )
+        encoded = json.dumps(evidence)
+
+        self.assertTrue(evidence["acceptance"]["passed"])
+        self.assertIn("supersedes", evidence)
+        self.assertNotIn("/Users/", encoded)
+        self.assertNotIn("Private", encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reassess_real_mvc_feature.py
+++ b/tests/test_reassess_real_mvc_feature.py
@@ -1,0 +1,87 @@
+import unittest
+
+from scripts.reassess_real_mvc_feature import reassess
+
+
+def run_evidence(*, duration_seconds: float, rss: int, metal: int) -> dict[str, object]:
+    return {
+        "acceptance": {"passed": True},
+        "artifact": {"duration_seconds": duration_seconds},
+        "encoder": {
+            "frame_count": 240,
+            "metalfx_device_final_allocated_size_bytes": metal,
+            "metalfx_device_peak_delta_bytes": metal,
+        },
+        "resources": {
+            "duration_seconds": duration_seconds,
+            "peak_rss_bytes": rss,
+            "processes": {
+                "pipeline": {
+                    "quartile_peak_rss_bytes": [rss - 20, rss - 10, rss - 5, rss],
+                }
+            },
+            "quartile_peak_rss_bytes": [rss - 20, rss - 10, rss - 5, rss],
+        },
+    }
+
+
+class RealMVCFeatureReassessmentTests(unittest.TestCase):
+    def test_reassessment_recomputes_reviewed_resource_policy(self) -> None:
+        document = {
+            "acceptance": {"passed": False},
+            "boundedness": {"passed": False},
+            "cancellation": {"acceptance": {"passed": True}},
+            "configuration": {
+                "max_rss_growth_mib": 64,
+                "output_duration_tolerance_seconds": 0.1,
+            },
+            "feature_run": run_evidence(duration_seconds=10.01, rss=600_000_000, metal=452_280_320),
+            "schema_version": 2,
+            "short_run": run_evidence(duration_seconds=1, rss=500_000_000, metal=419_086_336),
+            "sources": {
+                "feature": {
+                    "packet_count": 240,
+                    "video_duration_seconds": 10.01,
+                }
+            },
+        }
+
+        evidence = reassess(document, input_sha256="a" * 64)
+
+        self.assertTrue(evidence["acceptance"]["passed"])
+        self.assertTrue(evidence["boundedness"]["passed"])
+        self.assertEqual(evidence["assessment"]["input_evidence_sha256"], "a" * 64)
+        self.assertEqual(
+            evidence["assessment"]["policy"],
+            "per-process-and-aggregate-q3-q4-plateau-v3",
+        )
+        self.assertEqual(evidence["schema_version"], 3)
+
+    def test_reassessment_requires_exact_feature_frame_count(self) -> None:
+        document = {
+            "acceptance": {"passed": False},
+            "boundedness": {"passed": False},
+            "cancellation": {"acceptance": {"passed": True}},
+            "configuration": {
+                "max_rss_growth_mib": 64,
+                "output_duration_tolerance_seconds": 0.1,
+            },
+            "feature_run": run_evidence(duration_seconds=10.01, rss=600_000_000, metal=452_280_320),
+            "schema_version": 2,
+            "short_run": run_evidence(duration_seconds=1, rss=500_000_000, metal=419_086_336),
+            "sources": {
+                "feature": {
+                    "packet_count": 241,
+                    "video_duration_seconds": 10.01,
+                }
+            },
+        }
+
+        evidence = reassess(document, input_sha256="a" * 64)
+
+        self.assertFalse(evidence["acceptance"]["complete_feature_length_frame_count"])
+        self.assertFalse(evidence["acceptance"]["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- generate and verify a deterministic replacement real-MVC segment without publishing private source metadata
- qualify all eight packaged ordinary/direct-4K/fallback full/preview routes and harden source/output/process safety
- add repeated real-MVC direct-vs-file-based 4K quality/size evidence plus feature-length resource, thermal, progress, and cancellation gates
- publish a privacy-safe, harness-hash-bound evidence aggregate and update release-gate documentation

## Validation

- deterministic segment rerun: byte-identical
- packaged route matrix: 8/8 routes passed
- repeated real-MVC quality: 3 direct + 3 file-based runs passed; exact 1,573 frames per eye
- feature-length direct 4K: 137,568/137,568 frames, nominal thermal pressure, bounded RSS/Metal allocation, cancellation cleanup passed
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy ...`
- `uv run python -m unittest discover -s tests` (1,015 passed, 3 skipped)

Closes #376
