### PR TITLE
Implement Apple-compatible AAC layout policy

### DIFF
--- a/bd_to_avp/modules/aac_layout_policy.py
+++ b/bd_to_avp/modules/aac_layout_policy.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Mapping
+
+
+class AacLayoutAction(StrEnum):
+    PRESERVE = "preserve"
+    REMAP = "remap"
+    DOWNMIX = "downmix"
+    FAIL = "fail"
+
+
+@dataclass(frozen=True, slots=True)
+class AacLayoutPolicy:
+    id: str
+    source_layout: str
+    action: AacLayoutAction
+    target_layout: str
+    pan_filter: str | None
+    expected_identity_map: Mapping[str, tuple[str, ...]]
+    rationale: str
+
+    @property
+    def source_channels(self) -> tuple[str, ...]:
+        return LAYOUT_CHANNELS[self.source_layout]
+
+    @property
+    def target_channels(self) -> tuple[str, ...]:
+        return LAYOUT_CHANNELS[self.target_layout]
+
+
+@dataclass(frozen=True, slots=True)
+class AacLayoutDecision:
+    action: AacLayoutAction
+    source_layout: str | None
+    source_channel_count: int | None
+    target_layout: str | None
+    target_channel_count: int | None
+    pan_filter: str | None
+    reason: str | None
+    policy: AacLayoutPolicy | None
+
+
+class AacLayoutPolicyError(ValueError):
+    pass
+
+
+LAYOUT_CHANNELS: dict[str, tuple[str, ...]] = {
+    "mono": ("FC",),
+    "stereo": ("FL", "FR"),
+    "2.1": ("FL", "FR", "LFE"),
+    "3.0": ("FL", "FR", "FC"),
+    "3.0(back)": ("FL", "FR", "BC"),
+    "4.0": ("FL", "FR", "FC", "BC"),
+    "quad": ("FL", "FR", "BL", "BR"),
+    "quad(side)": ("FL", "FR", "SL", "SR"),
+    "3.1": ("FL", "FR", "FC", "LFE"),
+    "5.0": ("FL", "FR", "FC", "BL", "BR"),
+    "5.0(side)": ("FL", "FR", "FC", "SL", "SR"),
+    "4.1": ("FL", "FR", "FC", "LFE", "BC"),
+    "5.1": ("FL", "FR", "FC", "LFE", "BL", "BR"),
+    "5.1(side)": ("FL", "FR", "FC", "LFE", "SL", "SR"),
+    "6.0": ("FL", "FR", "FC", "BC", "SL", "SR"),
+    "6.0(front)": ("FL", "FR", "FLC", "FRC", "SL", "SR"),
+    "hexagonal": ("FL", "FR", "FC", "BL", "BR", "BC"),
+    "6.1": ("FL", "FR", "FC", "LFE", "BC", "SL", "SR"),
+    "6.1(back)": ("FL", "FR", "FC", "LFE", "BL", "BR", "BC"),
+    "6.1(front)": ("FL", "FR", "LFE", "FLC", "FRC", "SL", "SR"),
+    "7.0": ("FL", "FR", "FC", "BL", "BR", "SL", "SR"),
+    "7.0(front)": ("FL", "FR", "FC", "FLC", "FRC", "SL", "SR"),
+    "7.1": ("FL", "FR", "FC", "LFE", "BL", "BR", "SL", "SR"),
+    "7.1(wide)": ("FL", "FR", "FC", "LFE", "BL", "BR", "FLC", "FRC"),
+    "7.1(wide-side)": ("FL", "FR", "FC", "LFE", "FLC", "FRC", "SL", "SR"),
+    "octagonal": ("FL", "FR", "FC", "BL", "BR", "BC", "SL", "SR"),
+}
+
+
+def identity_map(**channels: str | tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    return {source: (outputs,) if isinstance(outputs, str) else outputs for source, outputs in channels.items()}
+
+
+AAC_LAYOUT_POLICIES = (
+    AacLayoutPolicy(
+        "ch01-mono",
+        "mono",
+        AacLayoutAction.PRESERVE,
+        "mono",
+        None,
+        identity_map(FC="FC"),
+        "AAC config 1.",
+    ),
+    AacLayoutPolicy(
+        "ch02-stereo",
+        "stereo",
+        AacLayoutAction.PRESERVE,
+        "stereo",
+        None,
+        identity_map(FL="FL", FR="FR"),
+        "AAC config 2.",
+    ),
+    AacLayoutPolicy(
+        "ch03-2_1",
+        "2.1",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.5*LFE|FR<FR+0.5*LFE",
+        identity_map(FL="FL", FR="FR", LFE=("FL", "FR")),
+        "FFmpeg emits PCE AAC that Apple drops; retain LFE contribution in stereo.",
+    ),
+    AacLayoutPolicy(
+        "ch03-3_0",
+        "3.0",
+        AacLayoutAction.PRESERVE,
+        "3.0",
+        None,
+        identity_map(FL="FL", FR="FR", FC="FC"),
+        "AAC config 3.",
+    ),
+    AacLayoutPolicy(
+        "ch03-3_0_back",
+        "3.0(back)",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.707*BC|FR<FR+0.707*BC",
+        identity_map(FL="FL", FR="FR", BC=("FL", "FR")),
+        "Back-center has no safe same-count canonical AAC mapping.",
+    ),
+    AacLayoutPolicy(
+        "ch04-4_0",
+        "4.0",
+        AacLayoutAction.PRESERVE,
+        "4.0",
+        None,
+        identity_map(FL="FL", FR="FR", FC="FC", BC="BC"),
+        "AAC config 4.",
+    ),
+    AacLayoutPolicy(
+        "ch04-quad",
+        "quad",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.707*BL|FR<FR+0.707*BR",
+        identity_map(FL="FL", FR="FR", BL="FL", BR="FR"),
+        "Apple retains this PCE layout, but physical placement is not qualified.",
+    ),
+    AacLayoutPolicy(
+        "ch04-quad_side",
+        "quad(side)",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.707*SL|FR<FR+0.707*SR",
+        identity_map(FL="FL", FR="FR", SL="FL", SR="FR"),
+        "PCE AAC is dropped by Apple.",
+    ),
+    AacLayoutPolicy(
+        "ch04-3_1",
+        "3.1",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.707*FC+0.5*LFE|FR<FR+0.707*FC+0.5*LFE",
+        identity_map(FL="FL", FR="FR", FC=("FL", "FR"), LFE=("FL", "FR")),
+        "PCE AAC is dropped by Apple; retain center and LFE contribution.",
+    ),
+    AacLayoutPolicy(
+        "ch05-5_0",
+        "5.0",
+        AacLayoutAction.PRESERVE,
+        "5.0",
+        None,
+        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR"),
+        "AAC config 5; FFmpeg BL/BR samples become Apple SL/SR surround positions.",
+    ),
+    AacLayoutPolicy(
+        "ch05-5_0_side",
+        "5.0(side)",
+        AacLayoutAction.REMAP,
+        "5.0",
+        "pan=5.0|FL=FL|FR=FR|FC=FC|BL=SL|BR=SR",
+        identity_map(FL="FL", FR="FR", FC="FC", SL="SL", SR="SR"),
+        "Lossless one-to-one remap to AAC config 5.",
+    ),
+    AacLayoutPolicy(
+        "ch05-4_1",
+        "4.1",
+        AacLayoutAction.DOWNMIX,
+        "stereo",
+        "pan=stereo|FL<FL+0.707*FC+0.5*LFE+0.707*BC|FR<FR+0.707*FC+0.5*LFE+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC=("FL", "FR"), LFE=("FL", "FR"), BC=("FL", "FR")),
+        "PCE AAC is dropped by Apple; no safe same-count mapping exists.",
+    ),
+    AacLayoutPolicy(
+        "ch06-5_1",
+        "5.1",
+        AacLayoutAction.PRESERVE,
+        "5.1",
+        None,
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR"),
+        "AAC config 6; FFmpeg BL/BR samples become Apple SL/SR surround positions.",
+    ),
+    AacLayoutPolicy(
+        "ch06-5_1_side",
+        "5.1(side)",
+        AacLayoutAction.REMAP,
+        "5.1",
+        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL=SL|BR=SR",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", SL="SL", SR="SR"),
+        "Lossless one-to-one remap already proven by the real-source gate in #364.",
+    ),
+    AacLayoutPolicy(
+        "ch06-6_0",
+        "6.0",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<SL+0.707*BC|BR<SR+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC="FC", BC=("SL", "SR"), SL="SL", SR="SR"),
+        "Collapse three surround positions into canonical AAC 5.0.",
+    ),
+    AacLayoutPolicy(
+        "ch06-6_0_front",
+        "6.0(front)",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC<0.5*FLC+0.5*FRC|BL=SL|BR=SR",
+        identity_map(FL="FL", FR="FR", FLC=("FL", "FC"), FRC=("FR", "FC"), SL="SL", SR="SR"),
+        "Fold front-wide channels into the canonical front stage.",
+    ),
+    AacLayoutPolicy(
+        "ch06-hexagonal",
+        "hexagonal",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+0.707*BC|BR<BR+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", BC=("SL", "SR")),
+        "Fold back-center into the canonical surround pair.",
+    ),
+    AacLayoutPolicy(
+        "ch07-6_1",
+        "6.1",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<SL+0.707*BC|BR<SR+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BC=("SL", "SR"), SL="SL", SR="SR"),
+        "Fold back-center into canonical AAC 5.1 surrounds.",
+    ),
+    AacLayoutPolicy(
+        "ch07-6_1_back",
+        "6.1(back)",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<BL+0.707*BC|BR<BR+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", BC=("SL", "SR")),
+        "Fold back-center into canonical AAC 5.1 surrounds.",
+    ),
+    AacLayoutPolicy(
+        "ch07-6_1_front",
+        "6.1(front)",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC<0.5*FLC+0.5*FRC|LFE=LFE|BL=SL|BR=SR",
+        identity_map(
+            FL="FL",
+            FR="FR",
+            LFE="LFE",
+            FLC=("FL", "FC"),
+            FRC=("FR", "FC"),
+            SL="SL",
+            SR="SR",
+        ),
+        "Fold front-wide channels into canonical AAC 5.1.",
+    ),
+    AacLayoutPolicy(
+        "ch07-7_0",
+        "7.0",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+SL|BR<BR+SR",
+        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", SL="SL", SR="SR"),
+        "Collapse side and back pairs into canonical AAC 5.0 surrounds.",
+    ),
+    AacLayoutPolicy(
+        "ch07-7_0_front",
+        "7.0(front)",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|BL=SL|BR=SR",
+        identity_map(FL="FL", FR="FR", FC="FC", FLC="FL", FRC="FR", SL="SL", SR="SR"),
+        "Fold front-wide channels into canonical AAC 5.0.",
+    ),
+    AacLayoutPolicy(
+        "ch08-7_1",
+        "7.1",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<BL+SL|BR<BR+SR",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", SL="SL", SR="SR"),
+        "FFmpeg config 7 is decoded by Apple in AAC wide order, so track presence does not prove placement.",
+    ),
+    AacLayoutPolicy(
+        "ch08-7_1_wide",
+        "7.1(wide)",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|LFE=LFE|BL=BL|BR=BR",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", FLC="FL", FRC="FR"),
+        "Fold front-wide channels into canonical AAC 5.1.",
+    ),
+    AacLayoutPolicy(
+        "ch08-7_1_wide_side",
+        "7.1(wide-side)",
+        AacLayoutAction.DOWNMIX,
+        "5.1",
+        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|LFE=LFE|BL=SL|BR=SR",
+        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", FLC="FL", FRC="FR", SL="SL", SR="SR"),
+        "Fold front-wide channels while retaining the surround pair.",
+    ),
+    AacLayoutPolicy(
+        "ch08-octagonal",
+        "octagonal",
+        AacLayoutAction.DOWNMIX,
+        "5.0",
+        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+SL+0.707*BC|BR<BR+SR+0.707*BC",
+        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", BC=("SL", "SR"), SL="SL", SR="SR"),
+        "Collapse side, back, and back-center positions into canonical AAC 5.0.",
+    ),
+)
+
+AAC_LAYOUT_POLICY_BY_SOURCE = {policy.source_layout: policy for policy in AAC_LAYOUT_POLICIES}
+AAC_COPY_LAYOUT_CHANNELS = {
+    policy.source_layout: len(policy.source_channels)
+    for policy in AAC_LAYOUT_POLICIES
+    if policy.action is AacLayoutAction.PRESERVE
+}
+UNLISTED_LAYOUT_POLICY = {
+    "action": AacLayoutAction.FAIL.value,
+    "reason": "Missing, unknown, custom, discrete, or unlisted layouts require new identity and Apple evidence.",
+}
+
+
+def resolve_aac_layout_policy(channel_layout: object, channels: object) -> AacLayoutDecision:
+    normalized_layout = _normalize_layout(channel_layout)
+    channel_count = _parse_channel_count(channels)
+    if normalized_layout is None:
+        return _failed_decision(None, channel_count, "channel_layout_missing")
+    if channel_count is None:
+        return _failed_decision(normalized_layout, None, "channel_count_missing")
+    policy = AAC_LAYOUT_POLICY_BY_SOURCE.get(normalized_layout)
+    if policy is None:
+        return _failed_decision(normalized_layout, channel_count, "channel_layout_not_qualified")
+    expected_channels = len(policy.source_channels)
+    if channel_count != expected_channels:
+        return _failed_decision(normalized_layout, channel_count, "channel_layout_mismatch")
+    return AacLayoutDecision(
+        action=policy.action,
+        source_layout=normalized_layout,
+        source_channel_count=channel_count,
+        target_layout=policy.target_layout,
+        target_channel_count=len(policy.target_channels),
+        pan_filter=policy.pan_filter,
+        reason=None,
+        policy=policy,
+    )
+
+
+def _failed_decision(source_layout: str | None, channel_count: int | None, reason: str) -> AacLayoutDecision:
+    return AacLayoutDecision(
+        action=AacLayoutAction.FAIL,
+        source_layout=source_layout,
+        source_channel_count=channel_count,
+        target_layout=None,
+        target_channel_count=None,
+        pan_filter=None,
+        reason=reason,
+        policy=None,
+    )
+
+
+def _normalize_layout(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _parse_channel_count(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol
 import ffmpeg
 
 from bd_to_avp.modules.aac_layout_policy import (
-    AAC_COPY_LAYOUT_CHANNELS as AAC_COPY_LAYOUT_CHANNELS,
+    AAC_COPY_LAYOUT_CHANNELS as _AAC_COPY_LAYOUT_CHANNELS,
     AacLayoutAction,
     AacLayoutDecision,
     AacLayoutPolicyError,
@@ -58,6 +58,7 @@ AAC_COPY_CODECS = frozenset({"aac"})
 EXPLICITLY_UNQUALIFIED_CODECS = frozenset({"ac3", "eac3", "ac-3", "e-ac-3"})
 AAC_COPY_PROFILES = frozenset({"lc", "he-aac", "he-aacv2", "mpeg-4 aac lc", "aac lc"})
 AAC_COPY_SAMPLE_RATES = frozenset({44_100, 48_000})
+AAC_COPY_LAYOUT_CHANNELS = _AAC_COPY_LAYOUT_CHANNELS
 
 
 def transcode_audio(

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -8,6 +8,13 @@ from typing import Any, Protocol
 
 import ffmpeg
 
+from bd_to_avp.modules.aac_layout_policy import (
+    AAC_COPY_LAYOUT_CHANNELS as AAC_COPY_LAYOUT_CHANNELS,
+    AacLayoutAction,
+    AacLayoutDecision,
+    AacLayoutPolicyError,
+    resolve_aac_layout_policy,
+)
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.audio_selection import (
     AudioSelection,
@@ -40,17 +47,17 @@ class AudioStreamQualification:
     channel_layout: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class PlannedAudioLayout:
+    stream_index: int
+    codec_name: str
+    decision: AacLayoutDecision
+
+
 AAC_COPY_CODECS = frozenset({"aac"})
 EXPLICITLY_UNQUALIFIED_CODECS = frozenset({"ac3", "eac3", "ac-3", "e-ac-3"})
 AAC_COPY_PROFILES = frozenset({"lc", "he-aac", "he-aacv2", "mpeg-4 aac lc", "aac lc"})
 AAC_COPY_SAMPLE_RATES = frozenset({44_100, 48_000})
-AAC_COPY_LAYOUT_CHANNELS = {
-    "mono": 1,
-    "stereo": 2,
-    "5.1": 6,
-    "7.1": 8,
-}
-AAC_TRANSCODE_LAYOUT_NORMALIZATION = {"5.1(side)": "5.1"}
 
 
 def transcode_audio(
@@ -60,6 +67,7 @@ def transcode_audio(
     audio_selector: str = "a",
     *,
     selection: AudioSelection | None = None,
+    activity: AudioActivityReporter | None = None,
     run_context: RunContext | None = None,
     cancellation_event: threading.Event | None = None,
     observability_context: ObservabilityContext | None = None,
@@ -76,6 +84,8 @@ def transcode_audio(
             observability_context=observability_context,
         )
     )
+    layout_plan = plan_aac_layouts(selected_streams)
+    enforce_aac_layout_policy(layout_plan, activity)
     selected_inputs = (
         [audio_input[selected_stream.selector] for selected_stream in selection.streams]
         if selection is not None
@@ -89,13 +99,19 @@ def transcode_audio(
         cancellation_event=cancellation_event,
         observability_context=observability_context,
     )
+    source_audio_positions = audio_positions_for_output(
+        selection,
+        audio_selector=audio_selector,
+        output_count=len(selected_streams),
+    )
     audio_transcoded = ffmpeg.output(
         *selected_inputs,
         str(f"file:{transcoded_audio_path}"),
         acodec="aac",
         audio_bitrate=f"{bitrate}k",
         map_metadata=0,
-        **aac_layout_options(selected_streams),
+        **aac_layout_options(layout_plan),
+        **audio_stream_metadata_map_options(source_audio_positions),
         **metadata_options,
     )
     run_ffmpeg_print_errors(
@@ -131,14 +147,124 @@ def audio_streams_for_selector(
     return streams[selected_index : selected_index + 1]
 
 
-def aac_layout_options(streams: list[dict[str, Any]]) -> dict[str, str]:
-    options: dict[str, str] = {}
+def plan_aac_layouts(streams: list[dict[str, Any]]) -> list[PlannedAudioLayout]:
+    plans: list[PlannedAudioLayout] = []
     for output_index, stream in enumerate(streams):
-        channel_layout = str(stream.get("channel_layout") or "").strip().lower()
-        normalized_layout = AAC_TRANSCODE_LAYOUT_NORMALIZATION.get(channel_layout)
-        if normalized_layout is not None:
-            options[f"channel_layout:a:{output_index}"] = normalized_layout
+        stream_index = parse_optional_int(stream.get("index"))
+        codec_name = str(stream.get("codec_name") or "unknown").strip().lower() or "unknown"
+        plans.append(
+            PlannedAudioLayout(
+                stream_index=stream_index if stream_index is not None else output_index,
+                codec_name=codec_name,
+                decision=resolve_aac_layout_policy(stream.get("channel_layout"), stream.get("channels")),
+            )
+        )
+    return plans
+
+
+def aac_layout_options(layout_plan: list[PlannedAudioLayout]) -> dict[str, str]:
+    options: dict[str, str] = {}
+    for output_index, planned_layout in enumerate(layout_plan):
+        decision = planned_layout.decision
+        if decision.target_layout is not None:
+            options[f"channel_layout:a:{output_index}"] = decision.target_layout
+        if decision.pan_filter is not None:
+            options[f"filter:a:{output_index}"] = decision.pan_filter
     return options
+
+
+def audio_positions_for_output(
+    selection: AudioSelection | None,
+    *,
+    audio_selector: str,
+    output_count: int,
+) -> list[int]:
+    if selection is not None:
+        return [selected_stream.audio_position for selected_stream in selection.streams]
+    if audio_selector == "a":
+        return list(range(output_count))
+    stream_type, separator, stream_index = audio_selector.partition(":")
+    if stream_type == "a" and separator and stream_index.isdigit() and output_count == 1:
+        return [int(stream_index)]
+    return []
+
+
+def audio_stream_metadata_map_options(source_audio_positions: list[int]) -> dict[str, str]:
+    return {
+        f"map_metadata:s:a:{output_index}": f"0:s:a:{source_audio_position}"
+        for output_index, source_audio_position in enumerate(source_audio_positions)
+    }
+
+
+def enforce_aac_layout_policy(
+    layout_plan: list[PlannedAudioLayout],
+    activity: AudioActivityReporter | None,
+) -> None:
+    if not layout_plan:
+        message = "Apple-compatible AAC cannot be created because the source does not contain an audio stream."
+        emit_aac_layout_policy_warning(message, [], activity, rejected=True)
+        raise AacLayoutPolicyError(message)
+
+    rejected = [plan for plan in layout_plan if plan.decision.action is AacLayoutAction.FAIL]
+    if rejected:
+        first_rejection = rejected[0]
+        decision = first_rejection.decision
+        source_layout = decision.source_layout or "missing"
+        channel_count = decision.source_channel_count if decision.source_channel_count is not None else "missing"
+        message = (
+            "Apple-compatible AAC cannot be created for audio stream "
+            f"{first_rejection.stream_index}: layout {source_layout} with {channel_count} channels "
+            f"is not qualified ({decision.reason})."
+        )
+        emit_aac_layout_policy_warning(message, layout_plan, activity, rejected=True)
+        raise AacLayoutPolicyError(message)
+
+    changed = [plan for plan in layout_plan if plan.decision.action in {AacLayoutAction.REMAP, AacLayoutAction.DOWNMIX}]
+    if not changed:
+        return
+
+    transformations = ", ".join(
+        f"stream {plan.stream_index} {plan.decision.source_layout} to {plan.decision.target_layout} "
+        f"({plan.decision.action.value})"
+        for plan in changed
+    )
+    message = f"Applying the qualified Apple-compatible AAC layout policy: {transformations}."
+    emit_aac_layout_policy_warning(message, layout_plan, activity, rejected=False)
+
+
+def emit_aac_layout_policy_warning(
+    message: str,
+    layout_plan: list[PlannedAudioLayout],
+    activity: AudioActivityReporter | None,
+    *,
+    rejected: bool,
+) -> None:
+    if activity is None:
+        cli_message(message)
+        return
+    activity.warning(
+        message,
+        stage="transcode_audio",
+        code="audio_layout_policy_rejected" if rejected else "audio_layout_policy_applied",
+        audio_mode=config.audio_mode.value,
+        action="stop_conversion" if rejected else "normalize_aac_layouts",
+        layout_decisions=[audio_layout_decision_fields(plan) for plan in layout_plan],
+    )
+
+
+def audio_layout_decision_fields(plan: PlannedAudioLayout) -> dict[str, object]:
+    decision = plan.decision
+    return {
+        "stream_index": plan.stream_index,
+        "codec": plan.codec_name,
+        "action": decision.action.value,
+        "source_layout": decision.source_layout,
+        "source_channels": decision.source_channel_count,
+        "target_layout": decision.target_layout,
+        "target_channels": decision.target_channel_count,
+        "policy_id": decision.policy.id if decision.policy is not None else None,
+        "reason": decision.reason,
+    }
 
 
 def copy_audio(
@@ -151,6 +277,9 @@ def copy_audio(
     observability_context: ObservabilityContext | None = None,
 ) -> None:
     audio_input = ffmpeg.input(str(input_path))
+    source_audio_positions = (
+        [selected_stream.audio_position for selected_stream in selection.streams] if selection is not None else []
+    )
     selected_inputs = (
         [audio_input[selected_stream.selector] for selected_stream in selection.streams]
         if selection is not None
@@ -177,6 +306,7 @@ def copy_audio(
         str(f"file:{copied_audio_path}"),
         acodec="copy",
         map_metadata=0,
+        **audio_stream_metadata_map_options(source_audio_positions),
         **metadata_options,
     )
     run_ffmpeg_print_errors(
@@ -241,6 +371,7 @@ def create_prepared_audio_file(
                         temporary_audio_path,
                         config.audio_bitrate,
                         selection=selection,
+                        activity=activity,
                         run_context=run_context,
                         cancellation_event=cancellation_event,
                         observability_context=observability_context,
@@ -251,6 +382,7 @@ def create_prepared_audio_file(
                     temporary_audio_path,
                     config.audio_bitrate,
                     selection=selection,
+                    activity=activity,
                     run_context=run_context,
                     cancellation_event=cancellation_event,
                     observability_context=observability_context,
@@ -263,6 +395,13 @@ def create_prepared_audio_file(
         return prepared_audio_path
 
     if prepared_audio_path.exists():
+        validate_resumed_prepared_audio(
+            prepared_audio_path,
+            activity,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+        )
         return prepared_audio_path
     if legacy_transcoded_audio_path.exists():
         raise FileNotFoundError(
@@ -310,6 +449,54 @@ def qualify_selected_audio_streams(
             observability_context=observability_context,
         )
     ]
+
+
+def validate_resumed_prepared_audio(
+    prepared_audio_path: Path,
+    activity: AudioActivityReporter | None,
+    *,
+    run_context: RunContext | None = None,
+    cancellation_event: threading.Event | None = None,
+    observability_context: ObservabilityContext | None = None,
+) -> None:
+    qualifications = qualify_selected_audio_streams(
+        prepared_audio_path,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        observability_context=observability_context,
+    )
+    if qualifications and all(qualification.qualified for qualification in qualifications):
+        return
+
+    message = (
+        "The prepared AAC artifact is not qualified for Apple playback. "
+        "Restart from Prepare Audio to regenerate it with the current layout policy."
+    )
+    if activity is None:
+        cli_message(message)
+    else:
+        activity.warning(
+            message,
+            stage="transcode_audio",
+            code="audio_layout_policy_rejected",
+            audio_mode=config.audio_mode.value,
+            action="restart_prepare_audio",
+            prepared_audio_path=str(prepared_audio_path),
+            unqualified_streams=[
+                {
+                    "index": qualification.index,
+                    "codec": qualification.codec_name,
+                    "profile": qualification.profile,
+                    "sample_rate": qualification.sample_rate,
+                    "channels": qualification.channels,
+                    "channel_layout": qualification.channel_layout,
+                    "reason": qualification.reason,
+                }
+                for qualification in qualifications
+                if not qualification.qualified
+            ],
+        )
+    raise AacLayoutPolicyError(message)
 
 
 def preferred_audio_selection(
@@ -414,30 +601,8 @@ def qualify_audio_stream(stream: dict[str, Any]) -> AudioStreamQualification:
             False,
             "sample_rate_not_qualified",
         )
-    if channels is None:
-        return audio_qualification_result(
-            stream_index,
-            codec_name,
-            normalized_profile,
-            sample_rate,
-            None,
-            channel_layout,
-            False,
-            "channel_count_missing",
-        )
-    if channel_layout is None or not channel_layout:
-        return audio_qualification_result(
-            stream_index,
-            codec_name,
-            normalized_profile,
-            sample_rate,
-            channels,
-            None,
-            False,
-            "channel_layout_missing",
-        )
-    expected_channels = AAC_COPY_LAYOUT_CHANNELS.get(channel_layout)
-    if expected_channels is None:
+    layout_decision = resolve_aac_layout_policy(channel_layout, channels)
+    if layout_decision.action is AacLayoutAction.FAIL:
         return audio_qualification_result(
             stream_index,
             codec_name,
@@ -446,9 +611,9 @@ def qualify_audio_stream(stream: dict[str, Any]) -> AudioStreamQualification:
             channels,
             channel_layout,
             False,
-            "channel_layout_not_qualified",
+            layout_decision.reason,
         )
-    if channels != expected_channels:
+    if layout_decision.action is not AacLayoutAction.PRESERVE:
         return audio_qualification_result(
             stream_index,
             codec_name,
@@ -457,7 +622,7 @@ def qualify_audio_stream(stream: dict[str, Any]) -> AudioStreamQualification:
             channels,
             channel_layout,
             False,
-            "channel_layout_mismatch",
+            f"channel_layout_requires_{layout_decision.action.value}",
         )
     return audio_qualification_result(
         stream_index,

--- a/docs/apple-aac-layout-policy.md
+++ b/docs/apple-aac-layout-policy.md
@@ -4,7 +4,7 @@
 
 Use an explicit **preserve / remap / downmix / fail** policy. FFmpeg decode success and audio-track count are not sufficient evidence of Apple compatibility. Every supported output must use a canonical AAC channel configuration, survive both Apple passthrough and Apple LPCM decode, and preserve the expected per-channel identity map.
 
-This qualification slice does **not** change Automatic runtime behavior. Production implementation belongs to #381, and signed-package/physical validation belongs to #382.
+The production runtime imports this same policy for Automatic and Convert-to-AAC processing. Signed-package and physical Vision Pro validation remains in #382.
 
 ## Evidence Method
 
@@ -82,7 +82,7 @@ Any missing, unknown, custom, discrete, or unlisted layout **fails** until a new
 
 ## Runtime Boundary
 
-The first PR deliberately leaves `AAC_COPY_LAYOUT_CHANNELS` and `AAC_TRANSCODE_LAYOUT_NORMALIZATION` unchanged. #381 must apply this table at the shared audio-planning boundary, emit a structured warning for every remap/downmix/fail decision, reject unqualified AAC copy, and add metadata/final-MOV coverage. #382 must then validate the exact signed package on Vision Pro before Automatic support broadens.
+`bd_to_avp/modules/aac_layout_policy.py` is the shared source of truth for this table. Automatic copies only the six qualified preserve layouts; any selected remap or downmix causes the whole selected set to be encoded with per-output policy filters. Missing, unknown, custom, discrete, or unlisted layouts stop before FFmpeg with a structured failure, and resumed prepared AAC is requalified before final muxing. #382 must validate the exact signed package on Vision Pro before this policy is considered physically validated.
 
 ## Regenerate
 

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -12,12 +12,19 @@ import subprocess
 import tempfile
 
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from bd_to_avp.modules import audio
+from bd_to_avp.modules.aac_layout_policy import (
+    AAC_LAYOUT_POLICIES,
+    LAYOUT_CHANNELS,
+    UNLISTED_LAYOUT_POLICY,
+    AacLayoutPolicy,
+    identity_map as identity_map,
+)
 from bd_to_avp.modules.config import config
 from scripts.create_spatial_audio_validation_fixtures import create_channel_identity_audio
 from scripts.verify_apple_media import (
@@ -39,35 +46,6 @@ IDENTITY_ANALYSIS_INSET_SECONDS = 0.02
 IDENTITY_RELATIVE_THRESHOLD = 0.08
 IDENTITY_ABSOLUTE_THRESHOLD = 0.01
 
-
-LAYOUT_CHANNELS: dict[str, tuple[str, ...]] = {
-    "mono": ("FC",),
-    "stereo": ("FL", "FR"),
-    "2.1": ("FL", "FR", "LFE"),
-    "3.0": ("FL", "FR", "FC"),
-    "3.0(back)": ("FL", "FR", "BC"),
-    "4.0": ("FL", "FR", "FC", "BC"),
-    "quad": ("FL", "FR", "BL", "BR"),
-    "quad(side)": ("FL", "FR", "SL", "SR"),
-    "3.1": ("FL", "FR", "FC", "LFE"),
-    "5.0": ("FL", "FR", "FC", "BL", "BR"),
-    "5.0(side)": ("FL", "FR", "FC", "SL", "SR"),
-    "4.1": ("FL", "FR", "FC", "LFE", "BC"),
-    "5.1": ("FL", "FR", "FC", "LFE", "BL", "BR"),
-    "5.1(side)": ("FL", "FR", "FC", "LFE", "SL", "SR"),
-    "6.0": ("FL", "FR", "FC", "BC", "SL", "SR"),
-    "6.0(front)": ("FL", "FR", "FLC", "FRC", "SL", "SR"),
-    "hexagonal": ("FL", "FR", "FC", "BL", "BR", "BC"),
-    "6.1": ("FL", "FR", "FC", "LFE", "BC", "SL", "SR"),
-    "6.1(back)": ("FL", "FR", "FC", "LFE", "BL", "BR", "BC"),
-    "6.1(front)": ("FL", "FR", "LFE", "FLC", "FRC", "SL", "SR"),
-    "7.0": ("FL", "FR", "FC", "BL", "BR", "SL", "SR"),
-    "7.0(front)": ("FL", "FR", "FC", "FLC", "FRC", "SL", "SR"),
-    "7.1": ("FL", "FR", "FC", "LFE", "BL", "BR", "SL", "SR"),
-    "7.1(wide)": ("FL", "FR", "FC", "LFE", "BL", "BR", "FLC", "FRC"),
-    "7.1(wide-side)": ("FL", "FR", "FC", "LFE", "FLC", "FRC", "SL", "SR"),
-    "octagonal": ("FL", "FR", "FC", "BL", "BR", "BC", "SL", "SR"),
-}
 
 CHANNEL_FREQUENCIES = {
     "FL": 330,
@@ -103,279 +81,8 @@ CANONICAL_AAC_CONFIGURATION = {
     "7.1": 7,
 }
 
-RUNTIME_AAC_COPY_LAYOUT_BASELINE = {
-    "mono": 1,
-    "stereo": 2,
-    "5.1": 6,
-    "7.1": 8,
-}
-RUNTIME_AAC_NORMALIZATION_BASELINE = {"5.1(side)": "5.1"}
-
-
-@dataclass(frozen=True)
-class AudioLayoutCase:
-    id: str
-    source_layout: str
-    action: str
-    target_layout: str
-    pan_filter: str | None
-    expected_identity_map: Mapping[str, tuple[str, ...]]
-    rationale: str
-
-    @property
-    def source_channels(self) -> tuple[str, ...]:
-        return LAYOUT_CHANNELS[self.source_layout]
-
-    @property
-    def target_channels(self) -> tuple[str, ...]:
-        return LAYOUT_CHANNELS[self.target_layout]
-
-
-def identity_map(**channels: str | tuple[str, ...]) -> dict[str, tuple[str, ...]]:
-    return {source: (outputs,) if isinstance(outputs, str) else outputs for source, outputs in channels.items()}
-
-
-LAYOUT_CASES = (
-    AudioLayoutCase("ch01-mono", "mono", "preserve", "mono", None, identity_map(FC="FC"), "AAC config 1."),
-    AudioLayoutCase(
-        "ch02-stereo",
-        "stereo",
-        "preserve",
-        "stereo",
-        None,
-        identity_map(FL="FL", FR="FR"),
-        "AAC config 2.",
-    ),
-    AudioLayoutCase(
-        "ch03-2_1",
-        "2.1",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.5*LFE|FR<FR+0.5*LFE",
-        identity_map(FL="FL", FR="FR", LFE=("FL", "FR")),
-        "FFmpeg emits PCE AAC that Apple drops; retain LFE contribution in stereo.",
-    ),
-    AudioLayoutCase(
-        "ch03-3_0",
-        "3.0",
-        "preserve",
-        "3.0",
-        None,
-        identity_map(FL="FL", FR="FR", FC="FC"),
-        "AAC config 3.",
-    ),
-    AudioLayoutCase(
-        "ch03-3_0_back",
-        "3.0(back)",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.707*BC|FR<FR+0.707*BC",
-        identity_map(FL="FL", FR="FR", BC=("FL", "FR")),
-        "Back-center has no safe same-count canonical AAC mapping.",
-    ),
-    AudioLayoutCase(
-        "ch04-4_0",
-        "4.0",
-        "preserve",
-        "4.0",
-        None,
-        identity_map(FL="FL", FR="FR", FC="FC", BC="BC"),
-        "AAC config 4.",
-    ),
-    AudioLayoutCase(
-        "ch04-quad",
-        "quad",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.707*BL|FR<FR+0.707*BR",
-        identity_map(FL="FL", FR="FR", BL="FL", BR="FR"),
-        "Apple retains this PCE layout, but physical placement is not qualified.",
-    ),
-    AudioLayoutCase(
-        "ch04-quad_side",
-        "quad(side)",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.707*SL|FR<FR+0.707*SR",
-        identity_map(FL="FL", FR="FR", SL="FL", SR="FR"),
-        "PCE AAC is dropped by Apple.",
-    ),
-    AudioLayoutCase(
-        "ch04-3_1",
-        "3.1",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.707*FC+0.5*LFE|FR<FR+0.707*FC+0.5*LFE",
-        identity_map(FL="FL", FR="FR", FC=("FL", "FR"), LFE=("FL", "FR")),
-        "PCE AAC is dropped by Apple; retain center and LFE contribution.",
-    ),
-    AudioLayoutCase(
-        "ch05-5_0",
-        "5.0",
-        "preserve",
-        "5.0",
-        None,
-        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR"),
-        "AAC config 5; FFmpeg BL/BR samples become Apple SL/SR surround positions.",
-    ),
-    AudioLayoutCase(
-        "ch05-5_0_side",
-        "5.0(side)",
-        "remap",
-        "5.0",
-        "pan=5.0|FL=FL|FR=FR|FC=FC|BL=SL|BR=SR",
-        identity_map(FL="FL", FR="FR", FC="FC", SL="SL", SR="SR"),
-        "Lossless one-to-one remap to AAC config 5.",
-    ),
-    AudioLayoutCase(
-        "ch05-4_1",
-        "4.1",
-        "downmix",
-        "stereo",
-        "pan=stereo|FL<FL+0.707*FC+0.5*LFE+0.707*BC|FR<FR+0.707*FC+0.5*LFE+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC=("FL", "FR"), LFE=("FL", "FR"), BC=("FL", "FR")),
-        "PCE AAC is dropped by Apple; no safe same-count mapping exists.",
-    ),
-    AudioLayoutCase(
-        "ch06-5_1",
-        "5.1",
-        "preserve",
-        "5.1",
-        None,
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR"),
-        "AAC config 6; FFmpeg BL/BR samples become Apple SL/SR surround positions.",
-    ),
-    AudioLayoutCase(
-        "ch06-5_1_side",
-        "5.1(side)",
-        "remap",
-        "5.1",
-        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL=SL|BR=SR",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", SL="SL", SR="SR"),
-        "Lossless one-to-one remap already proven by the real-source gate in #364.",
-    ),
-    AudioLayoutCase(
-        "ch06-6_0",
-        "6.0",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<SL+0.707*BC|BR<SR+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC="FC", BC=("SL", "SR"), SL="SL", SR="SR"),
-        "Collapse three surround positions into canonical AAC 5.0.",
-    ),
-    AudioLayoutCase(
-        "ch06-6_0_front",
-        "6.0(front)",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC<0.5*FLC+0.5*FRC|BL=SL|BR=SR",
-        identity_map(FL="FL", FR="FR", FLC=("FL", "FC"), FRC=("FR", "FC"), SL="SL", SR="SR"),
-        "Fold front-wide channels into the canonical front stage.",
-    ),
-    AudioLayoutCase(
-        "ch06-hexagonal",
-        "hexagonal",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+0.707*BC|BR<BR+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", BC=("SL", "SR")),
-        "Fold back-center into the canonical surround pair.",
-    ),
-    AudioLayoutCase(
-        "ch07-6_1",
-        "6.1",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<SL+0.707*BC|BR<SR+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BC=("SL", "SR"), SL="SL", SR="SR"),
-        "Fold back-center into canonical AAC 5.1 surrounds.",
-    ),
-    AudioLayoutCase(
-        "ch07-6_1_back",
-        "6.1(back)",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<BL+0.707*BC|BR<BR+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", BC=("SL", "SR")),
-        "Fold back-center into canonical AAC 5.1 surrounds.",
-    ),
-    AudioLayoutCase(
-        "ch07-6_1_front",
-        "6.1(front)",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC<0.5*FLC+0.5*FRC|LFE=LFE|BL=SL|BR=SR",
-        identity_map(
-            FL="FL",
-            FR="FR",
-            LFE="LFE",
-            FLC=("FL", "FC"),
-            FRC=("FR", "FC"),
-            SL="SL",
-            SR="SR",
-        ),
-        "Fold front-wide channels into canonical AAC 5.1.",
-    ),
-    AudioLayoutCase(
-        "ch07-7_0",
-        "7.0",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+SL|BR<BR+SR",
-        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", SL="SL", SR="SR"),
-        "Collapse side and back pairs into canonical AAC 5.0 surrounds.",
-    ),
-    AudioLayoutCase(
-        "ch07-7_0_front",
-        "7.0(front)",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|BL=SL|BR=SR",
-        identity_map(FL="FL", FR="FR", FC="FC", FLC="FL", FRC="FR", SL="SL", SR="SR"),
-        "Fold front-wide channels into canonical AAC 5.0.",
-    ),
-    AudioLayoutCase(
-        "ch08-7_1",
-        "7.1",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL<BL+SL|BR<BR+SR",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", SL="SL", SR="SR"),
-        "FFmpeg config 7 is decoded by Apple in AAC wide order, so track presence does not prove placement.",
-    ),
-    AudioLayoutCase(
-        "ch08-7_1_wide",
-        "7.1(wide)",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|LFE=LFE|BL=BL|BR=BR",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", BL="SL", BR="SR", FLC="FL", FRC="FR"),
-        "Fold front-wide channels into canonical AAC 5.1.",
-    ),
-    AudioLayoutCase(
-        "ch08-7_1_wide_side",
-        "7.1(wide-side)",
-        "downmix",
-        "5.1",
-        "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|LFE=LFE|BL=SL|BR=SR",
-        identity_map(FL="FL", FR="FR", FC="FC", LFE="LFE", FLC="FL", FRC="FR", SL="SL", SR="SR"),
-        "Fold front-wide channels while retaining the surround pair.",
-    ),
-    AudioLayoutCase(
-        "ch08-octagonal",
-        "octagonal",
-        "downmix",
-        "5.0",
-        "pan=5.0|FL=FL|FR=FR|FC=FC|BL<BL+SL+0.707*BC|BR<BR+SR+0.707*BC",
-        identity_map(FL="FL", FR="FR", FC="FC", BL="SL", BR="SR", BC=("SL", "SR"), SL="SL", SR="SR"),
-        "Collapse side, back, and back-center positions into canonical AAC 5.0.",
-    ),
-)
-
-UNLISTED_LAYOUT_POLICY = {
-    "action": "fail",
-    "reason": "Missing, unknown, custom, discrete, or unlisted layouts require new identity and Apple evidence.",
-}
+AudioLayoutCase = AacLayoutPolicy
+LAYOUT_CASES = AAC_LAYOUT_POLICIES
 
 
 def run(command: Sequence[str | Path], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
@@ -833,10 +540,10 @@ def policy_digest() -> str:
 
 
 def runtime_behavior_changed() -> bool:
-    return (
-        audio.AAC_COPY_LAYOUT_CHANNELS != RUNTIME_AAC_COPY_LAYOUT_BASELINE
-        or audio.AAC_TRANSCODE_LAYOUT_NORMALIZATION != RUNTIME_AAC_NORMALIZATION_BASELINE
-    )
+    expected_copy_layouts = {
+        case.source_layout: len(case.source_channels) for case in LAYOUT_CASES if case.action == "preserve"
+    }
+    return audio.AAC_COPY_LAYOUT_CHANNELS != expected_copy_layouts
 
 
 def build_report(root: Path) -> dict[str, Any]:
@@ -872,7 +579,7 @@ def build_report(root: Path) -> dict[str, Any]:
             "automatic_behavior_changed": automatic_behavior_changed,
             "current_runtime_snapshot": {
                 "aac_copy_layout_channels": audio.AAC_COPY_LAYOUT_CHANNELS,
-                "aac_transcode_layout_normalization": audio.AAC_TRANSCODE_LAYOUT_NORMALIZATION,
+                "aac_layout_policy_sha256": policy_digest(),
             },
             "unlisted_layout": UNLISTED_LAYOUT_POLICY,
             "action_counts": action_counts,
@@ -1018,11 +725,9 @@ def render_policy_markdown(report: Mapping[str, object]) -> str:
                 "## Runtime Boundary",
                 "",
                 (
-                    "The first PR deliberately leaves `AAC_COPY_LAYOUT_CHANNELS` and "
-                    "`AAC_TRANSCODE_LAYOUT_NORMALIZATION` unchanged. #381 must apply this table at the "
-                    "shared audio-planning boundary, emit a structured warning for every remap/downmix/fail "
-                    "decision, reject unqualified AAC copy, and add metadata/final-MOV coverage. #382 must "
-                    "then validate the exact signed package on Vision Pro before Automatic support broadens."
+                    "Production imports this exact table at the shared audio-planning boundary, emits structured "
+                    "remap/downmix/fail decisions, and rejects unqualified AAC copy. #382 must validate the exact "
+                    "signed package on Vision Pro before the qualified policy is considered physically validated."
                 ),
                 "",
                 "## Regenerate",

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -23,7 +23,6 @@ from bd_to_avp.modules.aac_layout_policy import (
     LAYOUT_CHANNELS,
     UNLISTED_LAYOUT_POLICY,
     AacLayoutPolicy,
-    identity_map as identity_map,
 )
 from bd_to_avp.modules.config import config
 from scripts.create_spatial_audio_validation_fixtures import create_channel_identity_audio

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,3 +1,5 @@
+import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -6,10 +8,14 @@ from unittest.mock import Mock, patch
 import ffmpeg
 
 from bd_to_avp.modules import audio
+from bd_to_avp.modules.aac_layout_policy import (
+    AAC_LAYOUT_POLICIES,
+    AacLayoutAction,
+    AacLayoutPolicyError,
+)
 from bd_to_avp.modules.audio_mode import AudioMode
 from bd_to_avp.modules.audio_selection import load_audio_selection_manifest, select_audio_streams
-from bd_to_avp.modules.config import Stage
-from scripts.qualify_apple_aac_layouts import LAYOUT_CASES
+from bd_to_avp.modules.config import Stage, config
 
 
 class AudioPreparationTests(unittest.TestCase):
@@ -136,6 +142,7 @@ class AudioPreparationTests(unittest.TestCase):
                 output_folder / "Movie_audio_AAC.part.m4a",
                 512,
                 selection=None,
+                activity=activity,
                 run_context=None,
                 cancellation_event=None,
                 observability_context=None,
@@ -177,6 +184,7 @@ class AudioPreparationTests(unittest.TestCase):
                 output_folder / "Movie_audio_AAC.part.m4a",
                 384,
                 selection=None,
+                activity=None,
                 run_context=None,
                 cancellation_event=None,
                 observability_context=None,
@@ -291,14 +299,62 @@ class AudioPreparationTests(unittest.TestCase):
             with (
                 patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(
+                    audio,
+                    "qualify_selected_audio_streams",
+                    return_value=[audio_qualification()],
+                ) as qualify,
                 patch.object(audio, "transcode_audio") as transcode,
                 patch.object(audio, "copy_audio") as copy,
             ):
                 result = audio.create_prepared_audio_file(source_path, output_folder)
 
             self.assertEqual(result, aac_path)
+            qualify.assert_called_once_with(
+                aac_path,
+                run_context=None,
+                cancellation_event=None,
+                observability_context=None,
+            )
             transcode.assert_not_called()
             copy.assert_not_called()
+
+    def test_final_mux_resume_rejects_stale_unqualified_aac(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            aac_path = output_folder / "Movie_audio_AAC.m4a"
+            aac_path.write_bytes(b"stale-aac")
+            activity = Mock()
+
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
+                patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(
+                    audio,
+                    "qualify_selected_audio_streams",
+                    return_value=[
+                        audio_qualification(
+                            channels=8,
+                            channel_layout="7.1",
+                            qualified=False,
+                            reason="channel_layout_requires_downmix",
+                        )
+                    ],
+                ),
+                self.assertRaisesRegex(AacLayoutPolicyError, "Restart from Prepare Audio"),
+            ):
+                audio.create_prepared_audio_file(source_path, output_folder, activity)
+
+            activity.warning.assert_called_once()
+            _, fields = activity.warning.call_args
+            self.assertEqual(fields["code"], "audio_layout_policy_rejected")
+            self.assertEqual(fields["action"], "restart_prepare_audio")
+            self.assertEqual(fields["unqualified_streams"][0]["channel_layout"], "7.1")
+            self.assertEqual(fields["unqualified_streams"][0]["reason"], "channel_layout_requires_downmix")
 
     def test_final_mux_resume_requires_owned_prepared_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -343,9 +399,11 @@ class AudioPreparationTests(unittest.TestCase):
             qualified_stream(index=4, profile="Main"),
             qualified_stream(index=5, sample_rate="96000"),
             qualified_stream(index=6, channels=6, channel_layout="stereo"),
-            qualified_stream(index=7, channel_layout="4.0"),
+            qualified_stream(index=7, channels=4, channel_layout="4.0"),
             {"index": 8, "codec_name": "aac", "profile": "LC"},
-            qualified_stream(index=9, channel_layout="5.1(side)"),
+            qualified_stream(index=9, channels=6, channel_layout="5.1(side)"),
+            qualified_stream(index=10, channels=8, channel_layout="7.1"),
+            qualified_stream(index=11, channels=4, channel_layout="unknown"),
         ]
 
         results = [audio.qualify_audio_stream(stream) for stream in streams]
@@ -357,37 +415,67 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertEqual(results[4].reason, "aac_profile_not_qualified")
         self.assertEqual(results[5].reason, "sample_rate_not_qualified")
         self.assertEqual(results[6].reason, "channel_layout_mismatch")
-        self.assertEqual(results[7].reason, "channel_layout_not_qualified")
+        self.assertTrue(results[7].qualified)
         self.assertEqual(results[8].reason, "sample_rate_missing")
-        self.assertEqual(results[9].reason, "channel_layout_not_qualified")
+        self.assertEqual(results[9].reason, "channel_layout_requires_remap")
+        self.assertEqual(results[10].reason, "channel_layout_requires_downmix")
+        self.assertEqual(results[11].reason, "channel_layout_not_qualified")
 
-    def test_layout_matrix_does_not_broaden_current_automatic_copy_or_normalization(self) -> None:
-        current_copy_layouts = {
-            "mono": 1,
-            "stereo": 2,
-            "5.1": 6,
-            "7.1": 8,
+    def test_layout_matrix_drives_automatic_copy_qualification(self) -> None:
+        qualified_copy_layouts = {
+            policy.source_layout: len(policy.source_channels)
+            for policy in AAC_LAYOUT_POLICIES
+            if policy.action is AacLayoutAction.PRESERVE
         }
 
-        self.assertEqual(audio.AAC_COPY_LAYOUT_CHANNELS, current_copy_layouts)
-        self.assertEqual(audio.AAC_TRANSCODE_LAYOUT_NORMALIZATION, {"5.1(side)": "5.1"})
-        for index, case in enumerate(LAYOUT_CASES):
-            with self.subTest(layout=case.source_layout):
+        self.assertEqual(audio.AAC_COPY_LAYOUT_CHANNELS, qualified_copy_layouts)
+        self.assertEqual(
+            qualified_copy_layouts,
+            {"mono": 1, "stereo": 2, "3.0": 3, "4.0": 4, "5.0": 5, "5.1": 6},
+        )
+        for index, policy in enumerate(AAC_LAYOUT_POLICIES):
+            with self.subTest(layout=policy.source_layout):
                 result = audio.qualify_audio_stream(
                     qualified_stream(
                         index=index,
-                        channels=len(case.source_channels),
-                        channel_layout=case.source_layout,
+                        channels=len(policy.source_channels),
+                        channel_layout=policy.source_layout,
                     )
                 )
-                self.assertEqual(result.qualified, case.source_layout in current_copy_layouts)
+                self.assertEqual(result.qualified, policy.action is AacLayoutAction.PRESERVE)
+                if policy.action is not AacLayoutAction.PRESERVE:
+                    self.assertEqual(result.reason, f"channel_layout_requires_{policy.action.value}")
 
-    def test_7_1_copy_is_an_explicit_policy_mismatch_deferred_to_production_followup(self) -> None:
-        policy = next(case for case in LAYOUT_CASES if case.source_layout == "7.1")
+    def test_transcode_options_match_every_qualified_policy_row(self) -> None:
+        for index, policy in enumerate(AAC_LAYOUT_POLICIES):
+            with self.subTest(layout=policy.source_layout):
+                layout_plan = audio.plan_aac_layouts(
+                    [
+                        qualified_stream(
+                            index=index,
+                            channels=len(policy.source_channels),
+                            channel_layout=policy.source_layout,
+                        )
+                    ]
+                )
+                options = audio.aac_layout_options(layout_plan)
 
-        self.assertIn("7.1", audio.AAC_COPY_LAYOUT_CHANNELS)
-        self.assertEqual(policy.action, "downmix")
+                self.assertEqual(layout_plan[0].decision.policy, policy)
+                self.assertEqual(options["channel_layout:a:0"], policy.target_layout)
+                if policy.pan_filter is None:
+                    self.assertNotIn("filter:a:0", options)
+                else:
+                    self.assertEqual(options["filter:a:0"], policy.pan_filter)
+
+    def test_7_1_copy_is_rejected_and_downmixed_to_5_1(self) -> None:
+        policy = next(policy for policy in AAC_LAYOUT_POLICIES if policy.source_layout == "7.1")
+        qualification = audio.qualify_audio_stream(qualified_stream(index=0, channels=8, channel_layout="7.1"))
+
+        self.assertNotIn("7.1", audio.AAC_COPY_LAYOUT_CHANNELS)
+        self.assertEqual(policy.action, AacLayoutAction.DOWNMIX)
         self.assertEqual(policy.target_layout, "5.1")
+        self.assertFalse(qualification.qualified)
+        self.assertEqual(qualification.reason, "channel_layout_requires_downmix")
 
     def test_transcode_audio_maps_requested_stream_selector(self) -> None:
         streams = [qualified_stream(index=0)]
@@ -433,6 +521,8 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertIn("0:a:0", command)
         self.assertIn("0:a:2", command)
         self.assertNotIn("0:a:1", command)
+        self.assertEqual(command[command.index("-map_metadata:s:a:0") + 1], "0:s:a:0")
+        self.assertEqual(command[command.index("-map_metadata:s:a:1") + 1], "0:s:a:2")
         metadata_options.assert_called_once_with(
             Path("source.mkv"),
             selected_streams=[streams[0], streams[2]],
@@ -443,16 +533,13 @@ class AudioPreparationTests(unittest.TestCase):
 
     def test_aac_transcode_explicitly_maps_the_same_preferred_track_set(self) -> None:
         streams = [
-            qualified_stream(index=1, language="eng"),
+            qualified_stream(index=1, language="eng", title="English Main", is_default=True),
             qualified_stream(index=4, language="jpn"),
-            qualified_stream(index=8, language="eng"),
+            qualified_stream(index=8, language="en-US", title="English Commentary"),
         ]
         selection = select_audio_streams(streams, "eng")
 
-        with (
-            patch.object(audio, "audio_handler_metadata_options", return_value={}),
-            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
-        ):
+        with patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg:
             audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384, selection=selection)
 
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
@@ -460,6 +547,12 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertIn("0:a:2", command)
         self.assertNotIn("0:a:1", command)
         self.assertIn("aac", command)
+        self.assertEqual(command[command.index("-map_metadata:s:a:0") + 1], "0:s:a:0")
+        self.assertEqual(command[command.index("-map_metadata:s:a:1") + 1], "0:s:a:2")
+        self.assertEqual(command[command.index("-metadata:s:a:0") + 1], "handler_name=English Main")
+        self.assertEqual(command[command.index("-metadata:s:a:1") + 1], "handler_name=English Commentary")
+        self.assertEqual(command[command.index("-disposition:a:0") + 1], "default")
+        self.assertEqual(command[command.index("-disposition:a:1") + 1], "0")
 
     def test_aac_transcode_normalizes_side_surround_for_apple_playback(self) -> None:
         streams = [
@@ -467,17 +560,174 @@ class AudioPreparationTests(unittest.TestCase):
             qualified_stream(index=4, language="eng", channel_layout="stereo", channels=2),
         ]
         selection = select_audio_streams(streams, "eng")
+        activity = Mock()
 
         with (
             patch.object(audio, "audio_handler_metadata_options", return_value={}),
             patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
-            audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384, selection=selection)
+            audio.transcode_audio(
+                Path("source.mkv"),
+                Path("audio.m4a"),
+                384,
+                selection=selection,
+                activity=activity,
+            )
 
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
-        self.assertIn("-channel_layout:a:0", command)
-        self.assertIn("5.1", command)
-        self.assertNotIn("-channel_layout:a:1", command)
+        self.assertEqual(command[command.index("-channel_layout:a:0") + 1], "5.1")
+        self.assertEqual(command[command.index("-channel_layout:a:1") + 1], "stereo")
+        self.assertEqual(
+            command[command.index("-filter:a:0") + 1],
+            "pan=5.1|FL=FL|FR=FR|FC=FC|LFE=LFE|BL=SL|BR=SR",
+        )
+        self.assertNotIn("-filter:a:1", command)
+        activity.warning.assert_called_once()
+        _, fields = activity.warning.call_args
+        self.assertEqual(fields["code"], "audio_layout_policy_applied")
+        self.assertEqual(
+            [decision["action"] for decision in fields["layout_decisions"]],
+            ["remap", "preserve"],
+        )
+
+    def test_aac_transcode_applies_exact_filters_to_mixed_layouts(self) -> None:
+        streams = [
+            qualified_stream(index=1, channels=5, channel_layout="5.0(side)"),
+            qualified_stream(index=4, channels=8, channel_layout="7.1(wide-side)"),
+            qualified_stream(index=8, channels=2, channel_layout="stereo"),
+        ]
+        selection = select_audio_streams(streams, None)
+        activity = Mock()
+
+        with (
+            patch.object(audio, "audio_handler_metadata_options", return_value={}),
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio.transcode_audio(
+                Path("source.mkv"),
+                Path("audio.m4a"),
+                512,
+                selection=selection,
+                activity=activity,
+            )
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(
+            command[command.index("-filter:a:0") + 1],
+            "pan=5.0|FL=FL|FR=FR|FC=FC|BL=SL|BR=SR",
+        )
+        self.assertEqual(
+            command[command.index("-filter:a:1") + 1],
+            "pan=5.1|FL<FL+0.707*FLC|FR<FR+0.707*FRC|FC=FC|LFE=LFE|BL=SL|BR=SR",
+        )
+        self.assertNotIn("-filter:a:2", command)
+        self.assertEqual(command[command.index("-channel_layout:a:0") + 1], "5.0")
+        self.assertEqual(command[command.index("-channel_layout:a:1") + 1], "5.1")
+        self.assertEqual(command[command.index("-channel_layout:a:2") + 1], "stereo")
+        _, fields = activity.warning.call_args
+        self.assertEqual(
+            [decision["action"] for decision in fields["layout_decisions"]],
+            ["remap", "downmix", "preserve"],
+        )
+
+    def test_aac_transcode_rejects_unknown_layout_before_ffmpeg(self) -> None:
+        streams = [qualified_stream(index=3, channels=8, channel_layout="unknown")]
+        activity = Mock()
+
+        with (
+            patch.object(audio, "audio_streams_for_selector", return_value=streams),
+            patch.object(audio, "audio_handler_metadata_options") as metadata_options,
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+            self.assertRaisesRegex(AacLayoutPolicyError, "channel_layout_not_qualified"),
+        ):
+            audio.transcode_audio(
+                Path("source.mkv"),
+                Path("audio.m4a"),
+                384,
+                activity=activity,
+            )
+
+        metadata_options.assert_not_called()
+        run_ffmpeg.assert_not_called()
+        activity.warning.assert_called_once()
+        _, fields = activity.warning.call_args
+        self.assertEqual(fields["code"], "audio_layout_policy_rejected")
+        self.assertEqual(fields["action"], "stop_conversion")
+        self.assertEqual(fields["layout_decisions"][0]["action"], "fail")
+        self.assertEqual(fields["layout_decisions"][0]["reason"], "channel_layout_not_qualified")
+
+    @unittest.skipUnless(
+        config.FFMPEG_PATH.is_file() and config.FFPROBE_PATH.is_file(),
+        "FFmpeg integration tools are unavailable",
+    )
+    def test_real_ffmpeg_remap_produces_canonical_aac_and_preserves_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mov"
+            output_path = temp_path / "output.m4a"
+            subprocess.run(
+                [
+                    config.FFMPEG_PATH,
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "anullsrc=channel_layout=5.1(side):sample_rate=48000",
+                    "-t",
+                    "0.1",
+                    "-c:a",
+                    "pcm_s16le",
+                    "-metadata:s:a:0",
+                    "language=eng",
+                    "-metadata:s:a:0",
+                    "handler_name=English Side",
+                    "-disposition:a:0",
+                    "default",
+                    "-y",
+                    source_path,
+                ],
+                check=True,
+            )
+            activity = Mock()
+
+            with patch.object(audio.config, "audio_mode", AudioMode.CONVERT_AAC):
+                audio.transcode_audio(source_path, output_path, 384, activity=activity)
+
+            probe = subprocess.run(
+                [
+                    config.FFPROBE_PATH,
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    (
+                        "stream=codec_name,profile,sample_rate,channels,channel_layout:"
+                        "stream_tags=language,handler_name:stream_disposition=default"
+                    ),
+                    "-select_streams",
+                    "a",
+                    "-of",
+                    "json",
+                    output_path,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            stream = json.loads(probe.stdout)["streams"][0]
+
+            self.assertEqual(stream["codec_name"], "aac")
+            self.assertEqual(stream["profile"], "LC")
+            self.assertEqual(stream["sample_rate"], "48000")
+            self.assertEqual(stream["channels"], 6)
+            self.assertEqual(stream["channel_layout"], "5.1")
+            self.assertEqual(stream["tags"]["language"], "eng")
+            self.assertEqual(stream["tags"]["handler_name"], "English Side")
+            self.assertEqual(stream["disposition"]["default"], 1)
+            _, fields = activity.warning.call_args
+            self.assertEqual(fields["code"], "audio_layout_policy_applied")
+            self.assertEqual(fields["layout_decisions"][0]["action"], "remap")
 
     def test_audio_preparation_preserves_stream_titles_as_handler_names(self) -> None:
         streams = [
@@ -544,6 +794,7 @@ def qualified_stream(
     channel_layout: str = "stereo",
     language: str = "eng",
     title: str | None = None,
+    is_default: bool = False,
 ) -> dict[str, object]:
     tags: dict[str, object] = {"language": language}
     if title is not None:
@@ -556,7 +807,7 @@ def qualified_stream(
         "channels": channels,
         "channel_layout": channel_layout,
         "tags": tags,
-        "disposition": {"default": 0},
+        "disposition": {"default": int(is_default)},
     }
 
 

--- a/tests/test_qualify_apple_aac_layouts.py
+++ b/tests/test_qualify_apple_aac_layouts.py
@@ -1,5 +1,6 @@
 import unittest
 
+from bd_to_avp.modules.aac_layout_policy import identity_map
 from scripts import qualify_apple_aac_layouts as qualification
 
 
@@ -84,7 +85,7 @@ class AppleAacLayoutQualificationTests(unittest.TestCase):
             samples,
             output_channels,
             source_channels,
-            qualification.identity_map(SL="SL", SR="SR"),
+            identity_map(SL="SL", SR="SR"),
         )
 
         self.assertEqual(result["status"], "passed")
@@ -108,7 +109,7 @@ class AppleAacLayoutQualificationTests(unittest.TestCase):
             samples,
             output_channels,
             source_channels,
-            qualification.identity_map(FC=("FL", "FR")),
+            identity_map(FC=("FL", "FR")),
         )
 
         self.assertEqual(result["status"], "failed")


### PR DESCRIPTION
## Summary
- centralize the qualified preserve / remap / downmix / fail table in production code
- apply exact per-stream pan filters for Automatic and Convert-to-AAC, including safe 5.0(side)/5.1(side) remaps and 7.1 downmixing
- fail closed for missing, unknown, custom, discrete, and unlisted layouts, including stale resumed AAC artifacts
- preserve selected-stream language, handler title, and disposition metadata
- keep the qualification generator and checked-in policy on the same source of truth

## Validation
- `uv run python -m unittest discover -s tests -t .` — 1028 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 297 passed
- `uv run ruff check` and `ruff format --check` on changed Python files
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- `uv build`
- JetBrains changed-files inspection — GREEN, 0 findings
- real FFmpeg integration: 5.1(side) PCM -> canonical AAC 5.1 with language, handler title, and default disposition retained

Closes #381
Refs #367

When merged, this unblocks #382 for signed-package and physical Vision Pro validation.