### PR TITLE
Make packaged AAC fixtures reproducible

### DIFF
--- a/docs/apple-aac-layout-policy.md
+++ b/docs/apple-aac-layout-policy.md
@@ -100,6 +100,8 @@ uv run python -m scripts.create_packaged_aac_layout_fixtures \
 
 The schema-v2 generator receipt requires source, FFmpeg, FFprobe, and per-fixture provenance records while recording that direct-MVC routing remains unproven. The receipt detects drift between generation and verification; it is reproducibility evidence rather than a cryptographic signature. The packaged verifier requires that receipt and exact fixture hashes before closing the routing gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker.
 
+Schema v2 supersedes the earlier schema-v1 fixture receipts and package evidence. Existing schema-v1 artifacts remain historical records only: regenerate the private fixture directory with the current generator and rerun package verification before using the result for a current release gate. The verifier intentionally rejects schema-v1 receipts rather than silently upgrading or reusing them.
+
 ```bash
 uv run python -m scripts.verify_packaged_aac_layouts \
   --app "$BD_TO_AVP_CANDIDATE_APP" \

--- a/docs/apple-aac-layout-policy.md
+++ b/docs/apple-aac-layout-policy.md
@@ -90,6 +90,16 @@ Any missing, unknown, custom, discrete, or unlisted layout **fails** until a new
 
 Each private fixture is a short MVC MKV with the #380 time-slotted channel-identity signal and the exact stream metadata declared by the manifest. Run the verifier from the checkout that built the candidate:
 
+Create the private fixture set from a short real MVC MKV. The generator writes atomically to a new directory, validates every audio stream against the checked manifest, and records source, tool, and fixture hashes without storing the private source path:
+
+```bash
+uv run python -m scripts.create_packaged_aac_layout_fixtures \
+  --mvc-source "$BD_TO_AVP_REAL_MVC_SOURCE" \
+  --output "$BD_TO_AVP_AAC_FIXTURE_ROOT"
+```
+
+The generator receipt records that direct-MVC routing remains unproven. The packaged verifier closes that gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker.
+
 ```bash
 uv run python -m scripts.verify_packaged_aac_layouts \
   --app "$BD_TO_AVP_CANDIDATE_APP" \

--- a/docs/apple-aac-layout-policy.md
+++ b/docs/apple-aac-layout-policy.md
@@ -90,7 +90,7 @@ Any missing, unknown, custom, discrete, or unlisted layout **fails** until a new
 
 Each private fixture is a short MVC MKV with the #380 time-slotted channel-identity signal and the exact stream metadata declared by the manifest. Run the verifier from the checkout that built the candidate:
 
-Create the private fixture set from a short real MVC MKV. The generator writes atomically to a new directory, validates every audio stream against the checked manifest, and records source, tool, and fixture hashes without storing the private source path:
+Create the private fixture set from a short real MVC MKV. The generator bounds source size and finite duration, hashes inputs and tools before use, rechecks them before atomic publication, removes private staging data after failures, Python interruptions, or handled termination signals, validates every audio stream against the checked manifest, and records source, tool, and fixture hashes without storing the private source path:
 
 ```bash
 uv run python -m scripts.create_packaged_aac_layout_fixtures \
@@ -98,7 +98,7 @@ uv run python -m scripts.create_packaged_aac_layout_fixtures \
   --output "$BD_TO_AVP_AAC_FIXTURE_ROOT"
 ```
 
-The generator receipt records that direct-MVC routing remains unproven. The packaged verifier closes that gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker.
+The schema-v2 generator receipt requires source, FFmpeg, FFprobe, and per-fixture provenance records while recording that direct-MVC routing remains unproven. The receipt detects drift between generation and verification; it is reproducibility evidence rather than a cryptographic signature. The packaged verifier requires that receipt and exact fixture hashes before closing the routing gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker.
 
 ```bash
 uv run python -m scripts.verify_packaged_aac_layouts \
@@ -108,7 +108,7 @@ uv run python -m scripts.verify_packaged_aac_layouts \
   --output "$BD_TO_AVP_AAC_EVIDENCE_ROOT/evidence.json"
 ```
 
-The verifier rejects package-policy drift, validates each fixture before execution, runs the packaged worker with protocol v10, checks structured layout decisions and visible rejections, verifies final AAC layout and metadata, runs Apple passthrough and LPCM identity analysis, and records bounded package/source/output hashes. An ad-hoc package run is deterministic package evidence only. It does not establish Developer ID/notarization provenance, physical Vision Pro surround placement, repeated device seeks, or perceptual lip-sync; those remain exact signed-candidate gates under #382.
+The verifier rejects package-policy drift, requires failure coverage to match the declared rejection semantics, binds every source to the generator receipt, validates each fixture before and after execution, terminates the packaged worker on interruption, rechecks the package after the matrix, runs the packaged worker with protocol v10, checks structured layout decisions and visible rejections, verifies final AAC layout and metadata, runs Apple passthrough across the complete output, isolates each selected audio track before Apple LPCM identity analysis, and records bounded package/source/output hashes. Final-output checks own handler-title and default-disposition assertions; the Apple passthrough evidence names those fields as not compared because Core Media normalizes them. An ad-hoc package run is deterministic package evidence only. It does not establish Developer ID/notarization provenance, physical Vision Pro surround placement, repeated device seeks, or perceptual lip-sync; those remain exact signed-candidate gates under #382.
 
 ## Regenerate
 

--- a/scripts/create_packaged_aac_layout_fixtures.py
+++ b/scripts/create_packaged_aac_layout_fixtures.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -30,12 +31,15 @@ from scripts.verify_packaged_aac_layouts import (
     TrackSpec,
     _audio_streams,
     _input_summary,
+    _managed_sigterm_exit,
     _validate_streams,
     load_fixture_manifest,
 )
 
 
 COMMAND_TIMEOUT_SECONDS = 30 * 60
+MAX_SOURCE_DURATION_SECONDS = 120.0
+MAX_SOURCE_SIZE_BYTES = 1024 * 1024 * 1024
 EXTRA_CHANNEL_FREQUENCIES = {"TFL": 1430, "TFR": 1540}
 FAILURE_IDENTITY_RECIPES = {
     "fail-missing-layout": ("5.1", ("FL", "FR", "FC", "LFE", "BL", "BR")),
@@ -46,6 +50,25 @@ FAILURE_IDENTITY_RECIPES = {
 
 class FixtureBuildFailure(RuntimeError):
     pass
+
+
+def _redact_command_paths(detail: str, command: Sequence[str | Path]) -> str:
+    redacted = detail
+    paths = {
+        str(item) for item in command if isinstance(item, Path) or (isinstance(item, str) and item.startswith("/"))
+    }
+    paths.add(str(Path.home()))
+    for path in sorted(paths, key=len, reverse=True):
+        if path:
+            redacted = redacted.replace(path, "<redacted-path>")
+    return redacted
+
+
+def _hash_file(path: Path, label: str) -> str:
+    try:
+        return sha256_file(path)
+    except OSError as error:
+        raise FixtureBuildFailure(f"Could not hash the {label}.") from error
 
 
 def _run(command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
@@ -62,7 +85,10 @@ def _run(command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
         raise FixtureBuildFailure(f"Fixture command timed out: {Path(str(command[0])).name}") from error
     except subprocess.CalledProcessError as error:
         detail = (error.stderr or error.stdout or "").strip()
-        raise FixtureBuildFailure(f"Fixture command failed: {detail or 'no diagnostic output'}") from error
+        safe_detail = _redact_command_paths(detail, command)
+        raise FixtureBuildFailure(f"Fixture command failed: {safe_detail or 'no diagnostic output'}") from error
+    except OSError as error:
+        raise FixtureBuildFailure(f"Fixture command could not start: {Path(str(command[0])).name}") from error
 
 
 def _probe_document(path: Path) -> Mapping[str, object]:
@@ -89,6 +115,12 @@ def _probe_document(path: Path) -> Mapping[str, object]:
 
 
 def _source_video_summary(source: Path) -> dict[str, object]:
+    try:
+        source_size = source.stat().st_size
+    except OSError as error:
+        raise FixtureBuildFailure("MVC fixture source metadata is unavailable.") from error
+    if source_size > MAX_SOURCE_SIZE_BYTES:
+        raise FixtureBuildFailure("MVC fixture source exceeds the bounded fixture-generation size limit.")
     document = _probe_document(source)
     raw_streams = document.get("streams")
     streams = raw_streams if isinstance(raw_streams, list) else []
@@ -103,9 +135,13 @@ def _source_video_summary(source: Path) -> dict[str, object]:
         duration_seconds = float(str(format_data.get("duration")))
     except (TypeError, ValueError) as error:
         raise FixtureBuildFailure("MVC fixture source duration is unavailable.") from error
+    if not math.isfinite(duration_seconds):
+        raise FixtureBuildFailure("MVC fixture source duration must be finite.")
     minimum_duration = 2 * IDENTITY_GUARD_SECONDS + 8 * IDENTITY_SLOT_SECONDS
     if duration_seconds < minimum_duration:
         raise FixtureBuildFailure("MVC fixture source is too short for the eight-channel identity signal.")
+    if duration_seconds > MAX_SOURCE_DURATION_SECONDS:
+        raise FixtureBuildFailure("MVC fixture source exceeds the bounded fixture-generation duration limit.")
     stream = video_streams[0]
     return {
         "codec_name": stream.get("codec_name"),
@@ -228,12 +264,37 @@ def create_packaged_aac_layout_fixtures(
     if output.exists():
         raise FixtureBuildFailure("Fixture output directory must not already exist.")
     output.parent.mkdir(parents=True, exist_ok=True)
-    source_video = _source_video_summary(source)
+    try:
+        source_size = source.stat().st_size
+    except OSError as error:
+        raise FixtureBuildFailure("MVC fixture source metadata is unavailable.") from error
+    if source_size > MAX_SOURCE_SIZE_BYTES:
+        raise FixtureBuildFailure("MVC fixture source exceeds the bounded fixture-generation size limit.")
+    source_sha256 = _hash_file(source, "MVC fixture source")
+    manifest_sha256 = _hash_file(manifest_path, "fixture manifest")
+    ffmpeg_sha256 = _hash_file(config.FFMPEG_PATH, "fixture FFmpeg")
+    ffprobe_sha256 = _hash_file(config.FFPROBE_PATH, "fixture FFprobe")
     manifest = load_fixture_manifest(manifest_path)
+    source_video = _source_video_summary(source)
+    ffmpeg_version = _version_line(config.FFMPEG_PATH)
+    ffprobe_version = _version_line(config.FFPROBE_PATH)
+    try:
+        validated_source_size = source.stat().st_size
+    except OSError as error:
+        raise FixtureBuildFailure("MVC fixture source metadata became unavailable.") from error
+    if validated_source_size != source_size or _hash_file(source, "MVC fixture source") != source_sha256:
+        raise FixtureBuildFailure("MVC fixture source changed during validation.")
+    if _hash_file(manifest_path, "fixture manifest") != manifest_sha256:
+        raise FixtureBuildFailure("Fixture manifest changed during validation.")
+    if _hash_file(config.FFMPEG_PATH, "fixture FFmpeg") != ffmpeg_sha256:
+        raise FixtureBuildFailure("Fixture FFmpeg changed during validation.")
+    if _hash_file(config.FFPROBE_PATH, "fixture FFprobe") != ffprobe_sha256:
+        raise FixtureBuildFailure("Fixture FFprobe changed during validation.")
     temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
     work_directory = temporary / ".work"
     work_directory.mkdir()
     fixture_evidence: list[dict[str, object]] = []
+    published = False
     try:
         for case in manifest.cases:
             encoded_audio: list[Path] = []
@@ -251,25 +312,43 @@ def create_packaged_aac_layout_fixtures(
                 {
                     "id": case.case_id,
                     "file": case.source_file,
-                    "sha256": sha256_file(fixture_path),
+                    "sha256": _hash_file(fixture_path, f"fixture {case.case_id}"),
                     "size_bytes": fixture_path.stat().st_size,
                     "audio_streams": observed_streams,
                 }
             )
         shutil.rmtree(work_directory)
+        try:
+            current_source_size = source.stat().st_size
+        except OSError as error:
+            raise FixtureBuildFailure("MVC fixture source metadata became unavailable.") from error
+        if current_source_size != source_size or _hash_file(source, "MVC fixture source") != source_sha256:
+            raise FixtureBuildFailure("MVC fixture source changed during generation.")
+        if _hash_file(manifest_path, "fixture manifest") != manifest_sha256:
+            raise FixtureBuildFailure("Fixture manifest changed during generation.")
+        if _hash_file(config.FFMPEG_PATH, "fixture FFmpeg") != ffmpeg_sha256:
+            raise FixtureBuildFailure("Fixture FFmpeg changed during generation.")
+        if _hash_file(config.FFPROBE_PATH, "fixture FFprobe") != ffprobe_sha256:
+            raise FixtureBuildFailure("Fixture FFprobe changed during generation.")
         receipt: dict[str, object] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "generated_at_utc": datetime.now(UTC).isoformat(),
             "fixture_set_id": manifest.fixture_set_id,
-            "manifest_sha256": sha256_file(manifest_path),
+            "manifest_sha256": manifest_sha256,
             "source": {
-                "sha256": sha256_file(source),
-                "size_bytes": source.stat().st_size,
+                "sha256": source_sha256,
+                "size_bytes": source_size,
                 "video": source_video,
             },
             "tools": {
-                "ffmpeg": _version_line(config.FFMPEG_PATH),
-                "ffprobe": _version_line(config.FFPROBE_PATH),
+                "ffmpeg": {
+                    "sha256": ffmpeg_sha256,
+                    "version": ffmpeg_version,
+                },
+                "ffprobe": {
+                    "sha256": ffprobe_sha256,
+                    "version": ffprobe_version,
+                },
             },
             "fixtures": fixture_evidence,
         }
@@ -280,10 +359,11 @@ def create_packaged_aac_layout_fixtures(
         if output.exists():
             raise FixtureBuildFailure("Fixture output directory appeared during generation.")
         os.replace(temporary, output)
+        published = True
         return receipt
-    except Exception:
-        shutil.rmtree(temporary, ignore_errors=True)
-        raise
+    finally:
+        if not published:
+            shutil.rmtree(temporary, ignore_errors=True)
 
 
 def main() -> int:
@@ -295,13 +375,16 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     args = parser.parse_args()
     try:
-        receipt = create_packaged_aac_layout_fixtures(
-            args.mvc_source,
-            args.output,
-            manifest_path=args.manifest,
-        )
-    except (FixtureBuildFailure, PackagedAacFailure, OSError) as error:
+        with _managed_sigterm_exit():
+            receipt = create_packaged_aac_layout_fixtures(
+                args.mvc_source,
+                args.output,
+                manifest_path=args.manifest,
+            )
+    except (FixtureBuildFailure, PackagedAacFailure) as error:
         parser.exit(1, f"error: {error}\n")
+    except OSError:
+        parser.exit(1, "error: Fixture generation encountered a filesystem error.\n")
     print(json.dumps(receipt, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/create_packaged_aac_layout_fixtures.py
+++ b/scripts/create_packaged_aac_layout_fixtures.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from bd_to_avp.modules.config import config
+from scripts.create_spatial_audio_validation_fixtures import create_channel_identity_audio
+from scripts.qualify_apple_aac_layouts import (
+    CHANNEL_FREQUENCIES,
+    IDENTITY_BURST_SECONDS,
+    IDENTITY_GUARD_SECONDS,
+    IDENTITY_SLOT_SECONDS,
+    create_source_identity,
+)
+from scripts.qualify_mv_hevc_quality_match import sha256_file
+from scripts.verify_packaged_aac_layouts import (
+    DEFAULT_MANIFEST,
+    FixtureCase,
+    PackagedAacFailure,
+    TrackSpec,
+    _audio_streams,
+    _input_summary,
+    _validate_streams,
+    load_fixture_manifest,
+)
+
+
+COMMAND_TIMEOUT_SECONDS = 30 * 60
+EXTRA_CHANNEL_FREQUENCIES = {"TFL": 1430, "TFR": 1540}
+FAILURE_IDENTITY_RECIPES = {
+    "fail-missing-layout": ("5.1", ("FL", "FR", "FC", "LFE", "BL", "BR")),
+    "fail-unknown-layout": ("3.1.2", ("FL", "FR", "FC", "LFE", "TFL", "TFR")),
+    "fail-pce-layout": ("5.1(side)", ("FL", "FR", "FC", "LFE", "SL", "SR")),
+}
+
+
+class FixtureBuildFailure(RuntimeError):
+    pass
+
+
+def _run(command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [str(item) for item in command],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise FixtureBuildFailure(f"Fixture command timed out: {Path(str(command[0])).name}") from error
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        raise FixtureBuildFailure(f"Fixture command failed: {detail or 'no diagnostic output'}") from error
+
+
+def _probe_document(path: Path) -> Mapping[str, object]:
+    completed = _run(
+        [
+            config.FFPROBE_PATH,
+            "-v",
+            "error",
+            "-show_streams",
+            "-show_format",
+            "-show_data",
+            "-of",
+            "json",
+            path,
+        ]
+    )
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise FixtureBuildFailure("FFprobe returned malformed fixture JSON.") from error
+    if not isinstance(document, Mapping):
+        raise FixtureBuildFailure("FFprobe fixture output must be an object.")
+    return document
+
+
+def _source_video_summary(source: Path) -> dict[str, object]:
+    document = _probe_document(source)
+    raw_streams = document.get("streams")
+    streams = raw_streams if isinstance(raw_streams, list) else []
+    video_streams = [
+        stream for stream in streams if isinstance(stream, Mapping) and stream.get("codec_type") == "video"
+    ]
+    if source.suffix.lower() != ".mkv" or len(video_streams) != 1 or video_streams[0].get("codec_name") != "h264":
+        raise FixtureBuildFailure("Fixture generation requires one H.264 video stream in a real MVC MKV source.")
+    raw_format = document.get("format")
+    format_data = raw_format if isinstance(raw_format, Mapping) else {}
+    try:
+        duration_seconds = float(str(format_data.get("duration")))
+    except (TypeError, ValueError) as error:
+        raise FixtureBuildFailure("MVC fixture source duration is unavailable.") from error
+    minimum_duration = 2 * IDENTITY_GUARD_SECONDS + 8 * IDENTITY_SLOT_SECONDS
+    if duration_seconds < minimum_duration:
+        raise FixtureBuildFailure("MVC fixture source is too short for the eight-channel identity signal.")
+    stream = video_streams[0]
+    return {
+        "codec_name": stream.get("codec_name"),
+        "profile": stream.get("profile"),
+        "width": stream.get("width"),
+        "height": stream.get("height"),
+        "duration_seconds": round(duration_seconds, 6),
+        "direct_mvc_route_proven": False,
+    }
+
+
+def _channel_frequency(channel: str) -> int:
+    frequency = CHANNEL_FREQUENCIES.get(channel) or EXTRA_CHANNEL_FREQUENCIES.get(channel)
+    if frequency is None:
+        raise FixtureBuildFailure(f"No channel-identity frequency is defined for {channel}.")
+    return frequency
+
+
+def _create_identity_source(case: FixtureCase, track: TrackSpec, output: Path) -> None:
+    policy = track.policy
+    if policy is not None:
+        create_source_identity(output, policy)
+        return
+    recipe = FAILURE_IDENTITY_RECIPES.get(case.case_id)
+    if recipe is None:
+        raise FixtureBuildFailure(f"Fixture {case.case_id} has no channel-identity generation recipe.")
+    layout, channels = recipe
+    duration_seconds = 2 * IDENTITY_GUARD_SECONDS + len(channels) * IDENTITY_SLOT_SECONDS
+    create_channel_identity_audio(
+        output,
+        layout,
+        tuple(_channel_frequency(channel) for channel in channels),
+        duration_seconds=duration_seconds,
+        cycle_seconds=duration_seconds,
+        slot_seconds=IDENTITY_SLOT_SECONDS,
+        burst_seconds=IDENTITY_BURST_SECONDS,
+        start_offset_seconds=IDENTITY_GUARD_SECONDS,
+    )
+
+
+def _audio_encoding_command(track: TrackSpec, source: Path, output: Path) -> list[str | Path]:
+    command: list[str | Path] = [
+        config.FFMPEG_PATH,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        source,
+        "-map",
+        "0:a:0",
+        "-map_metadata",
+        "-1",
+        "-map_chapters",
+        "-1",
+        "-fflags",
+        "+bitexact",
+    ]
+    if track.codec_name == "aac":
+        command.extend(["-c:a", "aac", "-profile:a", "aac_low", "-b:a", "384k"])
+    elif track.codec_name == "flac":
+        command.extend(["-c:a", "flac"])
+    elif track.codec_name == "pcm_s24le":
+        command.extend(["-c:a", "pcm_s24le"])
+        if track.source_layout is None:
+            command.extend(["-ch_layout", f"{track.channels}c"])
+    else:
+        raise FixtureBuildFailure(f"Unsupported fixture audio codec: {track.codec_name}")
+    command.extend(["-y", output])
+    return command
+
+
+def _mux_command(
+    mvc_source: Path,
+    case: FixtureCase,
+    audio_sources: Sequence[Path],
+    output: Path,
+) -> list[str | Path]:
+    command: list[str | Path] = [config.FFMPEG_PATH, "-hide_banner", "-loglevel", "error", "-i", mvc_source]
+    for audio_source in audio_sources:
+        command.extend(["-i", audio_source])
+    command.extend(["-map", "0:v:0"])
+    for index in range(len(audio_sources)):
+        command.extend(["-map", f"{index + 1}:a:0"])
+    command.extend(
+        [
+            "-c",
+            "copy",
+            "-map_metadata",
+            "-1",
+            "-map_chapters",
+            "-1",
+            "-fflags",
+            "+bitexact",
+        ]
+    )
+    for index, track in enumerate(case.tracks):
+        command.extend([f"-metadata:s:a:{index}", f"language={track.language}"])
+        command.extend([f"-metadata:s:a:{index}", f"title={track.handler_title}"])
+        command.extend([f"-disposition:a:{index}", "default" if track.default else "0"])
+    command.extend(["-y", output])
+    return command
+
+
+def _version_line(command: Path) -> str:
+    completed = _run([command, "-version"])
+    return completed.stdout.splitlines()[0]
+
+
+def create_packaged_aac_layout_fixtures(
+    mvc_source: Path,
+    output_directory: Path,
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+) -> Mapping[str, object]:
+    source = mvc_source.expanduser().resolve()
+    output = output_directory.expanduser().resolve()
+    manifest_path = manifest_path.expanduser().resolve()
+    if not source.is_file():
+        raise FixtureBuildFailure("MVC fixture source does not exist.")
+    if output.exists():
+        raise FixtureBuildFailure("Fixture output directory must not already exist.")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    source_video = _source_video_summary(source)
+    manifest = load_fixture_manifest(manifest_path)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    work_directory = temporary / ".work"
+    work_directory.mkdir()
+    fixture_evidence: list[dict[str, object]] = []
+    try:
+        for case in manifest.cases:
+            encoded_audio: list[Path] = []
+            for index, track in enumerate(case.tracks):
+                identity_source = work_directory / f"{case.case_id}-{index}.wav"
+                encoded_source = work_directory / f"{case.case_id}-{index}.mka"
+                _create_identity_source(case, track, identity_source)
+                _run(_audio_encoding_command(track, identity_source, encoded_source))
+                encoded_audio.append(encoded_source)
+            fixture_path = temporary / case.source_file
+            _run(_mux_command(source, case, encoded_audio, fixture_path))
+            observed_streams = _audio_streams(_probe_document(fixture_path))
+            _validate_streams(case, observed_streams, [_input_summary(track) for track in case.tracks])
+            fixture_evidence.append(
+                {
+                    "id": case.case_id,
+                    "file": case.source_file,
+                    "sha256": sha256_file(fixture_path),
+                    "size_bytes": fixture_path.stat().st_size,
+                    "audio_streams": observed_streams,
+                }
+            )
+        shutil.rmtree(work_directory)
+        receipt: dict[str, object] = {
+            "schema_version": 1,
+            "generated_at_utc": datetime.now(UTC).isoformat(),
+            "fixture_set_id": manifest.fixture_set_id,
+            "manifest_sha256": sha256_file(manifest_path),
+            "source": {
+                "sha256": sha256_file(source),
+                "size_bytes": source.stat().st_size,
+                "video": source_video,
+            },
+            "tools": {
+                "ffmpeg": _version_line(config.FFMPEG_PATH),
+                "ffprobe": _version_line(config.FFPROBE_PATH),
+            },
+            "fixtures": fixture_evidence,
+        }
+        (temporary / "fixture-receipt.json").write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if output.exists():
+            raise FixtureBuildFailure("Fixture output directory appeared during generation.")
+        os.replace(temporary, output)
+        return receipt
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create the private checked AAC package fixture set from a short real MVC MKV."
+    )
+    parser.add_argument("--mvc-source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    args = parser.parse_args()
+    try:
+        receipt = create_packaged_aac_layout_fixtures(
+            args.mvc_source,
+            args.output,
+            manifest_path=args.manifest,
+        )
+    except (FixtureBuildFailure, PackagedAacFailure, OSError) as error:
+        parser.exit(1, f"error: {error}\n")
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -63,9 +63,11 @@ PACKAGED_FIXTURE_GATE_LINES = (
     ),
     "",
     (
-        "Create the private fixture set from a short real MVC MKV. The generator writes atomically to a new "
-        "directory, validates every audio stream against the checked manifest, and records source, tool, and "
-        "fixture hashes without storing the private source path:"
+        "Create the private fixture set from a short real MVC MKV. The generator bounds source size and finite "
+        "duration, hashes inputs and tools before use, rechecks them before atomic publication, removes private "
+        "staging data after failures, Python interruptions, or handled termination signals, validates every audio "
+        "stream against the checked manifest, and records source, tool, and fixture hashes without storing the "
+        "private source path:"
     ),
     "",
     "```bash",
@@ -75,8 +77,11 @@ PACKAGED_FIXTURE_GATE_LINES = (
     "```",
     "",
     (
-        "The generator receipt records that direct-MVC routing remains unproven. The packaged verifier closes "
-        "that gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker."
+        "The schema-v2 generator receipt requires source, FFmpeg, FFprobe, and per-fixture provenance records while "
+        "recording that direct-MVC routing remains unproven. The receipt detects drift between generation and "
+        "verification; it is reproducibility evidence rather than a cryptographic signature. The packaged verifier "
+        "requires that receipt and exact fixture hashes before closing the routing gap by requiring every successful "
+        "case to report `direct_mv_hevc` from the packaged worker."
     ),
     "",
     "```bash",
@@ -88,12 +93,16 @@ PACKAGED_FIXTURE_GATE_LINES = (
     "```",
     "",
     (
-        "The verifier rejects package-policy drift, validates each fixture before execution, runs the packaged "
-        "worker with protocol v10, checks structured layout decisions and visible rejections, verifies final "
-        "AAC layout and metadata, runs Apple passthrough and LPCM identity analysis, and records bounded "
-        "package/source/output hashes. An ad-hoc package run is deterministic package evidence only. It does "
-        "not establish Developer ID/notarization provenance, physical Vision Pro surround placement, repeated "
-        "device seeks, or perceptual lip-sync; those remain exact signed-candidate gates under #382."
+        "The verifier rejects package-policy drift, requires failure coverage to match the declared rejection "
+        "semantics, binds every source to the generator receipt, validates each fixture before and after execution, "
+        "terminates the packaged worker on interruption, rechecks the package after the matrix, runs the packaged "
+        "worker with protocol v10, checks structured layout decisions and visible rejections, verifies final AAC "
+        "layout and metadata, runs Apple passthrough across the complete output, isolates each selected audio track "
+        "before Apple LPCM identity analysis, and records bounded package/source/output hashes. Final-output checks "
+        "own handler-title and default-disposition assertions; the Apple passthrough evidence names those fields as "
+        "not compared because Core Media normalizes them. An ad-hoc package run is deterministic package evidence "
+        "only. It does not establish Developer ID/notarization provenance, physical Vision Pro surround placement, "
+        "repeated device seeks, or perceptual lip-sync; those remain exact signed-candidate gates under #382."
     ),
 )
 

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -84,6 +84,13 @@ PACKAGED_FIXTURE_GATE_LINES = (
         "case to report `direct_mv_hevc` from the packaged worker."
     ),
     "",
+    (
+        "Schema v2 supersedes the earlier schema-v1 fixture receipts and package evidence. Existing schema-v1 "
+        "artifacts remain historical records only: regenerate the private fixture directory with the current "
+        "generator and rerun package verification before using the result for a current release gate. The verifier "
+        "intentionally rejects schema-v1 receipts rather than silently upgrading or reusing them."
+    ),
+    "",
     "```bash",
     "uv run python -m scripts.verify_packaged_aac_layouts \\",
     '  --app "$BD_TO_AVP_CANDIDATE_APP" \\',

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -62,6 +62,23 @@ PACKAGED_FIXTURE_GATE_LINES = (
         "candidate:"
     ),
     "",
+    (
+        "Create the private fixture set from a short real MVC MKV. The generator writes atomically to a new "
+        "directory, validates every audio stream against the checked manifest, and records source, tool, and "
+        "fixture hashes without storing the private source path:"
+    ),
+    "",
+    "```bash",
+    "uv run python -m scripts.create_packaged_aac_layout_fixtures \\",
+    '  --mvc-source "$BD_TO_AVP_REAL_MVC_SOURCE" \\',
+    '  --output "$BD_TO_AVP_AAC_FIXTURE_ROOT"',
+    "```",
+    "",
+    (
+        "The generator receipt records that direct-MVC routing remains unproven. The packaged verifier closes "
+        "that gap by requiring every successful case to report `direct_mv_hevc` from the packaged worker."
+    ),
+    "",
     "```bash",
     "uv run python -m scripts.verify_packaged_aac_layouts \\",
     '  --app "$BD_TO_AVP_CANDIDATE_APP" \\',

--- a/scripts/verify_packaged_aac_layouts.py
+++ b/scripts/verify_packaged_aac_layouts.py
@@ -403,18 +403,21 @@ def _audio_streams(probe: Mapping[str, object]) -> list[dict[str, object]]:
     for stream in streams:
         if not isinstance(stream, Mapping) or stream.get("codec_type") != "audio":
             continue
+        codec_name = stream.get("codec_name")
         raw_tags = stream.get("tags")
         tags: Mapping[str, object] = raw_tags if isinstance(raw_tags, Mapping) else {}
         raw_disposition = stream.get("disposition")
         disposition: Mapping[str, object] = raw_disposition if isinstance(raw_disposition, Mapping) else {}
         result.append(
             {
-                "codec_name": stream.get("codec_name"),
+                "codec_name": codec_name,
                 "profile": stream.get("profile"),
                 "sample_rate": _optional_int(stream.get("sample_rate")),
                 "channels": _optional_int(stream.get("channels")),
                 "channel_layout": stream.get("channel_layout") or None,
-                "aac_channel_configuration": parse_aac_channel_configuration(stream.get("extradata")),
+                "aac_channel_configuration": (
+                    parse_aac_channel_configuration(stream.get("extradata")) if codec_name == "aac" else None
+                ),
                 "language": tags.get("language"),
                 "handler_title": tags.get("title") or tags.get("handler_name"),
                 "default": bool(_optional_int(disposition.get("default")) or 0),
@@ -566,6 +569,17 @@ def _policy_evidence(case: FixtureCase, execution: WorkerExecution) -> list[dict
     return evidence
 
 
+def _direct_video_route_evidence(case: FixtureCase, result: Mapping[str, object]) -> dict[str, object]:
+    route = _mapping(result.get("video_route"), f"fixture {case.case_id} video route")
+    if route.get("selected") != "direct_mv_hevc":
+        raise PackagedAacFailure(f"Fixture {case.case_id} did not exercise the direct MVC package route.")
+    return {
+        key: route.get(key)
+        for key in ("intent", "selected", "reason", "rate_control", "quality")
+        if route.get(key) is not None
+    }
+
+
 def _decode_track(app: AppBundle, source: Path, index: int, output: Path) -> array.array[float]:
     _run(
         [
@@ -601,23 +615,42 @@ def _identity_evidence(
     output: Path,
     work_directory: Path,
 ) -> list[Mapping[str, object]]:
-    apple_lpcm = work_directory / "apple-lpcm.mov"
-    report = inspect_apple_media_conversion(output, apple_lpcm, preset=APPLE_LPCM_PRESET)
-    if report.output_streams["audio"] != len(case.selected_tracks):
-        raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM conversion dropped audio.")
-    apple_streams = _audio_streams(_probe(app, apple_lpcm))
-    if len(apple_streams) != len(case.selected_tracks):
-        raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM stream count changed.")
     evidence: list[Mapping[str, object]] = []
     for index, track in enumerate(case.selected_tracks):
+        apple_input = work_directory / f"apple-input-{index}.mov"
+        apple_lpcm = work_directory / f"apple-lpcm-{index}.mov"
+        _run(
+            [
+                app.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-i",
+                output,
+                "-map",
+                "0:v:0",
+                "-map",
+                f"0:a:{index}",
+                "-c",
+                "copy",
+                "-y",
+                apple_input,
+            ]
+        )
+        report = inspect_apple_media_conversion(apple_input, apple_lpcm, preset=APPLE_LPCM_PRESET)
+        if report.source_streams["audio"] != 1 or report.output_streams["audio"] != 1:
+            raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM conversion dropped audio track {index}.")
+        apple_streams = _audio_streams(_probe(app, apple_lpcm))
+        if len(apple_streams) != 1:
+            raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM stream count changed for track {index}.")
         policy = track.policy
         assert policy is not None
         configuration = CANONICAL_AAC_CONFIGURATION[policy.target_layout]
         output_channel_names = AAC_CHANNEL_CONFIGURATION_LAYOUTS[configuration]
-        actual_channel_count = apple_streams[index].get("channels")
+        actual_channel_count = apple_streams[0].get("channels")
         if actual_channel_count != len(output_channel_names):
-            raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM channel count changed.")
-        samples = _decode_track(app, apple_lpcm, index, work_directory / f"audio-{index}.f32")
+            raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM channel count changed for track {index}.")
+        samples = _decode_track(app, apple_lpcm, 0, work_directory / f"audio-{index}.f32")
         if len(samples) % len(output_channel_names) != 0:
             raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM samples are incomplete.")
         result = analyze_identity_samples(
@@ -628,7 +661,7 @@ def _identity_evidence(
         )
         if result.get("status") != "passed":
             raise PackagedAacFailure(f"Fixture {case.case_id} failed channel-identity analysis.")
-        evidence.append(result)
+        evidence.append({"track_index": index, **result})
     return evidence
 
 
@@ -663,6 +696,7 @@ def _completed_case(
 ) -> dict[str, object]:
     payload = _terminal(execution, "job.completed")
     result = _mapping(payload.get("conversion_result"), "packaged worker conversion result")
+    video_route = _direct_video_route_evidence(case, result)
     raw_output = result.get("output_path")
     if execution.returncode != 0 or not isinstance(raw_output, str):
         raise PackagedAacFailure(f"Fixture {case.case_id} did not complete successfully.")
@@ -686,6 +720,7 @@ def _completed_case(
     return {
         "passed": True,
         "terminal": "job.completed",
+        "video_route": video_route,
         "policy_decisions": _policy_evidence(case, execution),
         "output": {
             "file": artifact.name,
@@ -778,16 +813,20 @@ def verify_packaged_aac_layouts(
         },
         "package": package,
         "cases": case_evidence,
-        "acceptance": {
+        "package_gate": {
             "fixture_manifest_checked": True,
             "packaged_worker_executed": True,
             "apple_passthrough_retained_audio": True,
             "channel_identity_passed": True,
             "metadata_preserved": True,
             "fail_closed_visible": True,
+            "direct_mvc_route_executed": True,
+            "passed": True,
+        },
+        "remaining_gates": {
             "signed_candidate_proven": False,
             "physical_vision_pro_proven": False,
-            "passed": True,
+            "issue_382_complete": False,
         },
     }
     if len(_render_evidence(evidence).encode("utf-8")) > MAX_EVIDENCE_BYTES:

--- a/scripts/verify_packaged_aac_layouts.py
+++ b/scripts/verify_packaged_aac_layouts.py
@@ -5,17 +5,21 @@ from __future__ import annotations
 import argparse
 import array
 import json
+import math
 import os
+import signal
 import shutil
 import subprocess
 import sys
 import tempfile
 import uuid
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from types import FrameType
 
 from bd_to_avp.modules.aac_layout_policy import (
     AAC_LAYOUT_POLICIES,
@@ -33,7 +37,7 @@ from scripts.qualify_apple_aac_layouts import (
     policy_digest,
 )
 from scripts.qualify_mv_hevc_quality_match import sha256_file
-from scripts.verify_apple_media import AppleMediaFailure, inspect_apple_media_conversion
+from scripts.verify_apple_media import AppleMediaConversionReport, AppleMediaFailure, inspect_apple_media_conversion
 from scripts.verify_packaged_mv_hevc_routes import (
     AppBundle,
     PackagedRouteFailure,
@@ -52,6 +56,9 @@ DEFAULT_MANIFEST = REPO_ROOT / "docs/qualification/apple-aac-package-fixtures-v1
 IDENTITY_SIGNAL_PATH = REPO_ROOT / "docs/qualification/apple-aac-layouts-v1.json"
 SOURCE_POLICY_PATH = REPO_ROOT / "bd_to_avp/modules/aac_layout_policy.py"
 PACKAGED_POLICY_PATH = Path("Contents/Resources/app/bd_to_avp/modules/aac_layout_policy.py")
+FIXTURE_RECEIPT_NAME = "fixture-receipt.json"
+FIXTURE_RECEIPT_SCHEMA_VERSION = 2
+EVIDENCE_SCHEMA_VERSION = 2
 MAX_EVIDENCE_BYTES = 256 * 1024
 COMMAND_TIMEOUT_SECONDS = 30 * 60
 POLICY_BY_ID = {policy.id: policy for policy in AAC_LAYOUT_POLICIES}
@@ -69,6 +76,11 @@ REQUIRED_COVERAGE = frozenset(
         "default-disposition",
     }
 )
+FAILURE_COVERAGE_REASONS = {
+    "fail-missing-layout": "channel_layout_missing",
+    "fail-unknown-layout": "channel_layout_not_qualified",
+    "fail-pce-layout": "channel_layout_missing",
+}
 
 
 class PackagedAacFailure(RuntimeError):
@@ -115,6 +127,12 @@ class FixtureManifest:
 
 
 @dataclass(frozen=True)
+class FixtureReceipt:
+    sha256: str
+    entries: Mapping[str, Mapping[str, object]]
+
+
+@dataclass(frozen=True)
 class WorkerExecution:
     returncode: int
     events: tuple[Mapping[str, object], ...]
@@ -155,6 +173,22 @@ def _strings(value: object, label: str) -> tuple[str, ...]:
     return items
 
 
+def _sha256_string(value: object, label: str) -> str:
+    digest = str(_string(value, label))
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise PackagedAacFailure(f"{label} must be a lowercase SHA-256 digest.")
+    return digest
+
+
+def _finite_number(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PackagedAacFailure(f"{label} must be a finite number.")
+    number = float(value)
+    if not math.isfinite(number):
+        raise PackagedAacFailure(f"{label} must be a finite number.")
+    return number
+
+
 def _parse_track(raw: object, label: str) -> TrackSpec:
     track = _mapping(raw, label)
     policy_id = _string(track.get("policy_id"), f"{label}.policy_id", optional=True)
@@ -177,7 +211,10 @@ def _parse_track(raw: object, label: str) -> TrackSpec:
 def _validate_case(case: FixtureCase) -> None:
     if not case.tracks or not case.selected_tracks:
         raise PackagedAacFailure(f"Fixture {case.case_id} must select at least one audio track.")
+    failure_coverage = set(case.coverage).intersection(FAILURE_COVERAGE_REASONS)
     if case.expected_rejection is None:
+        if failure_coverage:
+            raise PackagedAacFailure(f"Fixture {case.case_id} completed cases must not claim failure coverage.")
         for track in case.selected_tracks:
             policy = track.policy
             if policy is None:
@@ -194,6 +231,11 @@ def _validate_case(case: FixtureCase) -> None:
             elif track.aac_channel_configuration is not None:
                 raise PackagedAacFailure(f"Fixture {case.case_id} non-AAC input must not declare AAC configuration.")
         return
+    if len(failure_coverage) != 1:
+        raise PackagedAacFailure(f"Fixture {case.case_id} rejected cases must claim one failure coverage reason.")
+    failure_label = next(iter(failure_coverage))
+    if case.expected_rejection != FAILURE_COVERAGE_REASONS[failure_label]:
+        raise PackagedAacFailure(f"Fixture {case.case_id} rejection does not match its failure coverage.")
     if case.expected_rejection not in {"channel_layout_missing", "channel_layout_not_qualified"}:
         raise PackagedAacFailure(f"Fixture {case.case_id} uses an unsupported rejection reason.")
     if len(case.tracks) != 1 or case.tracks[0].policy_id is not None:
@@ -239,8 +281,10 @@ def _validate_coverage(cases: Sequence[FixtureCase]) -> None:
 def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> FixtureManifest:
     try:
         document = _mapping(json.loads(path.read_text(encoding="utf-8")), "fixture manifest")
-    except (OSError, json.JSONDecodeError) as error:
-        raise PackagedAacFailure(f"Could not read AAC package fixture manifest: {error}") from error
+    except OSError as error:
+        raise PackagedAacFailure("Could not read AAC package fixture manifest.") from error
+    except json.JSONDecodeError as error:
+        raise PackagedAacFailure("AAC package fixture manifest is not valid JSON.") from error
     if document.get("schema_version") != 1:
         raise PackagedAacFailure("Fixture manifest schema_version must be 1.")
     fixture_set_id = str(_string(document.get("fixture_set_id"), "fixture manifest.fixture_set_id"))
@@ -320,6 +364,118 @@ def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> FixtureManifest:
     return FixtureManifest(fixture_set_id, tuple(cases))
 
 
+def _load_fixture_receipt(
+    fixture_root: Path,
+    manifest: FixtureManifest,
+    manifest_path: Path,
+) -> FixtureReceipt:
+    receipt_path = (fixture_root / FIXTURE_RECEIPT_NAME).resolve()
+    if not receipt_path.is_file() or not receipt_path.is_relative_to(fixture_root):
+        raise PackagedAacFailure("AAC fixture receipt is unavailable.")
+    try:
+        receipt = _mapping(json.loads(receipt_path.read_text(encoding="utf-8")), "AAC fixture receipt")
+    except OSError as error:
+        raise PackagedAacFailure("AAC fixture receipt could not be read.") from error
+    except json.JSONDecodeError as error:
+        raise PackagedAacFailure("AAC fixture receipt is not valid JSON.") from error
+    if _integer(receipt.get("schema_version"), "AAC fixture receipt.schema_version") != FIXTURE_RECEIPT_SCHEMA_VERSION:
+        raise PackagedAacFailure("AAC fixture receipt uses an unsupported schema version.")
+    _string(receipt.get("generated_at_utc"), "AAC fixture receipt.generated_at_utc")
+    if receipt.get("fixture_set_id") != manifest.fixture_set_id:
+        raise PackagedAacFailure("AAC fixture receipt names the wrong fixture set.")
+    if _sha256_string(receipt.get("manifest_sha256"), "AAC fixture receipt.manifest_sha256") != sha256_file(
+        manifest_path
+    ):
+        raise PackagedAacFailure("AAC fixture receipt does not match the checked manifest.")
+
+    source = _mapping(receipt.get("source"), "AAC fixture receipt.source")
+    _sha256_string(source.get("sha256"), "AAC fixture receipt.source.sha256")
+    source_size = _integer(source.get("size_bytes"), "AAC fixture receipt.source.size_bytes")
+    if source_size == 0:
+        raise PackagedAacFailure("AAC fixture receipt names an empty generator source.")
+    source_video = _mapping(source.get("video"), "AAC fixture receipt.source.video")
+    if source_video.get("codec_name") != "h264":
+        raise PackagedAacFailure("AAC fixture receipt generator source must be H.264.")
+    if (
+        _finite_number(
+            source_video.get("duration_seconds"),
+            "AAC fixture receipt.source.video.duration_seconds",
+        )
+        <= 0
+    ):
+        raise PackagedAacFailure("AAC fixture receipt generator source duration must be positive.")
+    if source_video.get("direct_mvc_route_proven") is not False:
+        raise PackagedAacFailure("AAC fixture receipt must defer direct MVC route proof to package verification.")
+
+    tools = _mapping(receipt.get("tools"), "AAC fixture receipt.tools")
+    for tool_name in ("ffmpeg", "ffprobe"):
+        tool = _mapping(tools.get(tool_name), f"AAC fixture receipt.tools.{tool_name}")
+        _sha256_string(tool.get("sha256"), f"AAC fixture receipt.tools.{tool_name}.sha256")
+        _string(tool.get("version"), f"AAC fixture receipt.tools.{tool_name}.version")
+
+    entries: dict[str, Mapping[str, object]] = {}
+    for index, raw_entry in enumerate(_sequence(receipt.get("fixtures"), "AAC fixture receipt.fixtures")):
+        entry = _mapping(raw_entry, f"AAC fixture receipt.fixtures[{index}]")
+        case_id = str(_string(entry.get("id"), f"AAC fixture receipt.fixtures[{index}].id"))
+        if case_id in entries:
+            raise PackagedAacFailure("AAC fixture receipt contains duplicate case identifiers.")
+        size_bytes = _integer(entry.get("size_bytes"), f"AAC fixture receipt.fixtures[{index}].size_bytes")
+        if size_bytes == 0:
+            raise PackagedAacFailure("AAC fixture receipt contains an empty fixture.")
+        entries[case_id] = {
+            "file": str(_string(entry.get("file"), f"AAC fixture receipt.fixtures[{index}].file")),
+            "sha256": _sha256_string(
+                entry.get("sha256"),
+                f"AAC fixture receipt.fixtures[{index}].sha256",
+            ),
+            "size_bytes": size_bytes,
+        }
+        for stream_index, raw_stream in enumerate(
+            _sequence(entry.get("audio_streams"), f"AAC fixture receipt.fixtures[{index}].audio_streams")
+        ):
+            _mapping(raw_stream, f"AAC fixture receipt.fixtures[{index}].audio_streams[{stream_index}]")
+
+    expected_files = {case.case_id: case.source_file for case in manifest.cases}
+    if set(entries) != set(expected_files):
+        raise PackagedAacFailure("AAC fixture receipt does not cover the checked fixture cases.")
+    if any(entries[case_id].get("file") != source_file for case_id, source_file in expected_files.items()):
+        raise PackagedAacFailure("AAC fixture receipt does not match the checked fixture filenames.")
+    return FixtureReceipt(sha256_file(receipt_path), entries)
+
+
+def _verified_fixture_identity(
+    case: FixtureCase,
+    source: Path,
+    receipt_entry: Mapping[str, object],
+) -> tuple[str, int]:
+    try:
+        size_bytes = source.stat().st_size
+    except OSError as error:
+        raise PackagedAacFailure(f"Fixture {case.case_id} source metadata is unavailable.") from error
+    try:
+        digest = sha256_file(source)
+    except OSError as error:
+        raise PackagedAacFailure(f"Fixture {case.case_id} could not be hashed.") from error
+    if size_bytes != receipt_entry.get("size_bytes") or digest != receipt_entry.get("sha256"):
+        raise PackagedAacFailure(f"Fixture {case.case_id} does not match its generator receipt.")
+    return digest, size_bytes
+
+
+def _verified_fixture_sources(
+    fixture_root: Path,
+    manifest: FixtureManifest,
+    receipt: FixtureReceipt,
+) -> dict[str, tuple[Path, str, int]]:
+    sources: dict[str, tuple[Path, str, int]] = {}
+    for case in manifest.cases:
+        source = (fixture_root / case.source_file).resolve()
+        if not source.is_file() or not source.is_relative_to(fixture_root):
+            raise PackagedAacFailure(f"Fixture {case.case_id} source is unavailable.")
+        digest, size_bytes = _verified_fixture_identity(case, source, receipt.entries[case.case_id])
+        sources[case.case_id] = (source, digest, size_bytes)
+    return sources
+
+
 def validate_paths(
     app_path: Path,
     fixture_root: Path,
@@ -357,6 +513,18 @@ def _render_evidence(evidence: Mapping[str, object]) -> str:
     return json.dumps(evidence, indent=2, sort_keys=True) + "\n"
 
 
+def _redact_command_paths(detail: str, command: Sequence[str | Path]) -> str:
+    redacted = detail
+    paths = {
+        str(item) for item in command if isinstance(item, Path) or (isinstance(item, str) and item.startswith("/"))
+    }
+    paths.add(str(Path.home()))
+    for path in sorted(paths, key=len, reverse=True):
+        if path:
+            redacted = redacted.replace(path, "<redacted-path>")
+    return redacted
+
+
 def _run(command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
@@ -371,7 +539,48 @@ def _run(command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
         raise PackagedAacFailure(f"AAC package command timed out: {Path(str(command[0])).name}") from error
     except subprocess.CalledProcessError as error:
         detail = (error.stderr or error.stdout or "").strip()
-        raise PackagedAacFailure(f"AAC package command failed: {detail or 'no diagnostic output'}") from error
+        safe_detail = _redact_command_paths(detail, command)
+        raise PackagedAacFailure(f"AAC package command failed: {safe_detail or 'no diagnostic output'}") from error
+    except OSError as error:
+        raise PackagedAacFailure(f"AAC package command could not start: {Path(str(command[0])).name}") from error
+
+
+def _inspect_apple_media_conversion(
+    source: Path,
+    output: Path,
+    *,
+    preset: str = "PresetPassthrough",
+) -> AppleMediaConversionReport:
+    try:
+        return inspect_apple_media_conversion(source, output, preset=preset)
+    except AppleMediaFailure as error:
+        safe_detail = _redact_command_paths(str(error), (source, output))
+        raise PackagedAacFailure(f"Apple media verification failed: {safe_detail}") from error
+
+
+@contextmanager
+def _managed_artifact_directory(path: Path) -> Iterator[None]:
+    path.mkdir(mode=0o700, parents=True)
+    completed = False
+    try:
+        yield
+        completed = True
+    finally:
+        if not completed:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _exit_on_sigterm(signum: int, _frame: FrameType | None) -> None:
+    raise SystemExit(128 + signum)
+
+
+@contextmanager
+def _managed_sigterm_exit() -> Iterator[None]:
+    previous = signal.signal(signal.SIGTERM, _exit_on_sigterm)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
 
 
 def _probe(app: AppBundle, path: Path) -> Mapping[str, object]:
@@ -510,6 +719,12 @@ def _execute_worker(
     except subprocess.TimeoutExpired as error:
         _terminate_worker_process(process)
         raise PackagedAacFailure("Packaged worker timed out during AAC fixture verification.") from error
+    except BaseException:
+        try:
+            _terminate_worker_process(process)
+        except Exception:
+            pass
+        raise
     if process.returncode is None:
         raise PackagedAacFailure("Packaged worker did not report an exit status.")
     return WorkerExecution(
@@ -637,7 +852,7 @@ def _identity_evidence(
                 apple_input,
             ]
         )
-        report = inspect_apple_media_conversion(apple_input, apple_lpcm, preset=APPLE_LPCM_PRESET)
+        report = _inspect_apple_media_conversion(apple_input, apple_lpcm, preset=APPLE_LPCM_PRESET)
         if report.source_streams["audio"] != 1 or report.output_streams["audio"] != 1:
             raise PackagedAacFailure(f"Fixture {case.case_id} Apple LPCM conversion dropped audio track {index}.")
         apple_streams = _audio_streams(_probe(app, apple_lpcm))
@@ -709,7 +924,7 @@ def _completed_case(
     _validate_streams(case, output_streams, expected)
 
     passthrough = work_directory / "apple-passthrough.mov"
-    report = inspect_apple_media_conversion(output, passthrough)
+    report = _inspect_apple_media_conversion(output, passthrough)
     passthrough_streams = _audio_streams(_probe(app, passthrough))
     if report.output_streams["audio"] != len(expected):
         raise PackagedAacFailure(f"Fixture {case.case_id} lost audio in Apple passthrough.")
@@ -728,8 +943,28 @@ def _completed_case(
             "size_bytes": artifact.stat().st_size,
             "audio_streams": output_streams,
         },
-        "apple_passthrough": {"passed": True, "audio_streams": passthrough_streams},
+        "apple_passthrough": {
+            "passed": True,
+            "audio_streams": passthrough_streams,
+            "metadata_fields_not_compared": ["default", "handler_title"],
+        },
         "identity": _identity_evidence(app, case, output, work_directory),
+    }
+
+
+def _package_identity(app: AppBundle) -> dict[str, object]:
+    packaged_policy = app.path / PACKAGED_POLICY_PATH
+    if not packaged_policy.is_file() or sha256_file(packaged_policy) != sha256_file(SOURCE_POLICY_PATH):
+        raise PackagedAacFailure("Packaged AAC policy does not match the verifier checkout.")
+    return {
+        "app_tree_sha256": app_tree_sha256(app.path),
+        "bundle_identifier": app.bundle_identifier,
+        "version": app.version,
+        "worker_sha256": sha256_file(app.worker),
+        "ffmpeg_sha256": sha256_file(app.ffmpeg),
+        "ffprobe_sha256": sha256_file(app.ffprobe),
+        "helper_sha256": sha256_file(app.helper),
+        "aac_policy_sha256": sha256_file(packaged_policy),
     }
 
 
@@ -742,29 +977,17 @@ def verify_packaged_aac_layouts(
 ) -> dict[str, object]:
     _require_apple_tools()
     manifest = load_fixture_manifest(manifest_path)
+    receipt = _load_fixture_receipt(fixture_root, manifest, manifest_path)
+    fixture_sources = _verified_fixture_sources(fixture_root, manifest, receipt)
     app = read_app_bundle(app_path)
-    packaged_policy = app.path / PACKAGED_POLICY_PATH
-    if not packaged_policy.is_file() or sha256_file(packaged_policy) != sha256_file(SOURCE_POLICY_PATH):
-        raise PackagedAacFailure("Packaged AAC policy does not match the verifier checkout.")
-    package = {
-        "app_tree_sha256": app_tree_sha256(app.path),
-        "bundle_identifier": app.bundle_identifier,
-        "version": app.version,
-        "worker_sha256": sha256_file(app.worker),
-        "ffmpeg_sha256": sha256_file(app.ffmpeg),
-        "ffprobe_sha256": sha256_file(app.ffprobe),
-        "helper_sha256": sha256_file(app.helper),
-        "aac_policy_sha256": sha256_file(packaged_policy),
-    }
-    artifact_directory.mkdir(parents=True)
-    case_evidence: list[dict[str, object]] = []
-    try:
+    package = _package_identity(app)
+    with _managed_artifact_directory(artifact_directory):
+        case_evidence: list[dict[str, object]] = []
         with tempfile.TemporaryDirectory(prefix="bd-to-avp-aac-package-") as temporary_directory:
             temporary_root = Path(temporary_directory)
             for case in manifest.cases:
-                source = (fixture_root / case.source_file).resolve()
-                if not source.is_file() or not source.is_relative_to(fixture_root):
-                    raise PackagedAacFailure(f"Fixture {case.case_id} source is unavailable.")
+                source, source_sha256, source_size_bytes = fixture_sources[case.case_id]
+                _verified_fixture_identity(case, source, receipt.entries[case.case_id])
                 input_streams = _audio_streams(_probe(app, source))
                 _validate_streams(case, input_streams, [_input_summary(track) for track in case.tracks])
                 destination = temporary_root / case.case_id / "destination"
@@ -787,52 +1010,55 @@ def verify_packaged_aac_layouts(
                         temporary_root / case.case_id,
                     )
                 )
+                _verified_fixture_identity(case, source, receipt.entries[case.case_id])
                 case_evidence.append(
                     {
                         "id": case.case_id,
                         "coverage": list(case.coverage),
                         "source": {
-                            "sha256": sha256_file(source),
-                            "size_bytes": source.stat().st_size,
+                            "sha256": source_sha256,
+                            "size_bytes": source_size_bytes,
                             "audio_streams": input_streams,
                         },
                         "result": result,
                     }
                 )
-    except Exception:
-        shutil.rmtree(artifact_directory, ignore_errors=True)
-        raise
 
-    evidence = {
-        "schema_version": 1,
-        "generated_at_utc": datetime.now(UTC).isoformat(),
-        "fixture_set": {
-            "id": manifest.fixture_set_id,
-            "manifest_sha256": sha256_file(manifest_path),
-            "identity_signal_sha256": sha256_file(IDENTITY_SIGNAL_PATH),
-        },
-        "package": package,
-        "cases": case_evidence,
-        "package_gate": {
-            "fixture_manifest_checked": True,
-            "packaged_worker_executed": True,
-            "apple_passthrough_retained_audio": True,
-            "channel_identity_passed": True,
-            "metadata_preserved": True,
-            "fail_closed_visible": True,
-            "direct_mvc_route_executed": True,
-            "passed": True,
-        },
-        "remaining_gates": {
-            "signed_candidate_proven": False,
-            "physical_vision_pro_proven": False,
-            "issue_382_complete": False,
-        },
-    }
-    if len(_render_evidence(evidence).encode("utf-8")) > MAX_EVIDENCE_BYTES:
-        shutil.rmtree(artifact_directory, ignore_errors=True)
-        raise PackagedAacFailure("AAC package evidence exceeded its bounded size limit.")
-    return evidence
+        if _package_identity(app) != package:
+            raise PackagedAacFailure("Packaged application changed during AAC fixture verification.")
+
+        evidence = {
+            "schema_version": EVIDENCE_SCHEMA_VERSION,
+            "generated_at_utc": datetime.now(UTC).isoformat(),
+            "fixture_set": {
+                "id": manifest.fixture_set_id,
+                "manifest_sha256": sha256_file(manifest_path),
+                "identity_signal_sha256": sha256_file(IDENTITY_SIGNAL_PATH),
+                "receipt_schema_version": FIXTURE_RECEIPT_SCHEMA_VERSION,
+                "receipt_sha256": receipt.sha256,
+            },
+            "package": package,
+            "cases": case_evidence,
+            "package_gate": {
+                "fixture_manifest_checked": True,
+                "fixture_receipt_checked": True,
+                "packaged_worker_executed": True,
+                "apple_passthrough_retained_audio": True,
+                "channel_identity_passed": True,
+                "metadata_preserved": True,
+                "fail_closed_visible": True,
+                "direct_mvc_route_executed": True,
+                "passed": True,
+            },
+            "remaining_gates": {
+                "signed_candidate_proven": False,
+                "physical_vision_pro_proven": False,
+                "issue_382_complete": False,
+            },
+        }
+        if len(_render_evidence(evidence).encode("utf-8")) > MAX_EVIDENCE_BYTES:
+            raise PackagedAacFailure("AAC package evidence exceeded its bounded size limit.")
+        return evidence
 
 
 def main() -> int:
@@ -846,29 +1072,26 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     args = parser.parse_args()
     try:
-        app, fixtures, output, artifacts = validate_paths(
-            args.app,
-            args.fixture_root,
-            args.output,
-            args.artifacts,
-        )
-        evidence = verify_packaged_aac_layouts(
-            app,
-            fixtures,
-            artifacts,
-            manifest_path=args.manifest.resolve(),
-        )
-        text = _render_evidence(evidence)
-        atomic_write_text(output, text)
-        print(text, end="")
-    except (
-        AppleMediaFailure,
-        PackagedAacFailure,
-        PackagedRouteFailure,
-        OSError,
-        subprocess.SubprocessError,
-    ) as error:
+        with _managed_sigterm_exit():
+            app, fixtures, output, artifacts = validate_paths(
+                args.app,
+                args.fixture_root,
+                args.output,
+                args.artifacts,
+            )
+            evidence = verify_packaged_aac_layouts(
+                app,
+                fixtures,
+                artifacts,
+                manifest_path=args.manifest.resolve(),
+            )
+            text = _render_evidence(evidence)
+            atomic_write_text(output, text)
+            print(text, end="")
+    except (AppleMediaFailure, PackagedAacFailure, PackagedRouteFailure, subprocess.SubprocessError) as error:
         parser.exit(1, f"error: {error}\n")
+    except OSError:
+        parser.exit(1, "error: AAC package verification encountered a filesystem error.\n")
     return 0
 
 

--- a/scripts/verify_packaged_aac_layouts.py
+++ b/scripts/verify_packaged_aac_layouts.py
@@ -15,7 +15,7 @@ import tempfile
 import uuid
 
 from collections.abc import Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -720,10 +720,8 @@ def _execute_worker(
         _terminate_worker_process(process)
         raise PackagedAacFailure("Packaged worker timed out during AAC fixture verification.") from error
     except BaseException:
-        try:
+        with suppress(Exception):
             _terminate_worker_process(process)
-        except Exception:
-            pass
         raise
     if process.returncode is None:
         raise PackagedAacFailure("Packaged worker did not report an exit status.")

--- a/tests/test_create_packaged_aac_layout_fixtures.py
+++ b/tests/test_create_packaged_aac_layout_fixtures.py
@@ -1,3 +1,5 @@
+import json
+import subprocess
 import tempfile
 import unittest
 
@@ -5,10 +7,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts.create_packaged_aac_layout_fixtures import (
+    MAX_SOURCE_DURATION_SECONDS,
+    MAX_SOURCE_SIZE_BYTES,
     FixtureBuildFailure,
     _audio_encoding_command,
     _create_identity_source,
     _mux_command,
+    _run,
     _source_video_summary,
     create_packaged_aac_layout_fixtures,
 )
@@ -60,9 +65,50 @@ class PackagedAacFixtureCommandTests(unittest.TestCase):
             "format": {"duration": "4.0"},
         }
 
-        with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
-            with self.assertRaisesRegex(FixtureBuildFailure, "H.264"):
-                _source_video_summary(Path("source.mkv"))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            source.write_bytes(b"video")
+            with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
+                with self.assertRaisesRegex(FixtureBuildFailure, "H.264"):
+                    _source_video_summary(source)
+
+    def test_source_video_rejects_oversized_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            with source.open("wb") as file:
+                file.truncate(MAX_SOURCE_SIZE_BYTES + 1)
+
+            with self.assertRaisesRegex(FixtureBuildFailure, "size limit"):
+                _source_video_summary(source)
+
+    def test_source_video_rejects_overlong_input(self) -> None:
+        document = {
+            "streams": [{"codec_type": "video", "codec_name": "h264"}],
+            "format": {"duration": str(MAX_SOURCE_DURATION_SECONDS + 1)},
+        }
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            source.write_bytes(b"mvc")
+            with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
+                with self.assertRaisesRegex(FixtureBuildFailure, "duration limit"):
+                    _source_video_summary(source)
+
+    def test_source_video_rejects_non_finite_duration(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            source.write_bytes(b"mvc")
+            for duration in ("nan", "inf", "-inf"):
+                document = {
+                    "streams": [{"codec_type": "video", "codec_name": "h264"}],
+                    "format": {"duration": duration},
+                }
+                with (
+                    self.subTest(duration=duration),
+                    patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document),
+                ):
+                    with self.assertRaisesRegex(FixtureBuildFailure, "finite"):
+                        _source_video_summary(source)
 
     def test_source_video_receipt_defers_direct_route_proof(self) -> None:
         document = {
@@ -78,8 +124,11 @@ class PackagedAacFixtureCommandTests(unittest.TestCase):
             "format": {"duration": "4.213"},
         }
 
-        with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
-            summary = _source_video_summary(Path("source.mkv"))
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "source.mkv"
+            source.write_bytes(b"video")
+            with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
+                summary = _source_video_summary(source)
 
         self.assertFalse(summary["direct_mvc_route_proven"])
 
@@ -93,3 +142,81 @@ class PackagedAacFixtureCommandTests(unittest.TestCase):
 
             with self.assertRaisesRegex(FixtureBuildFailure, "must not already exist"):
                 create_packaged_aac_layout_fixtures(source, output)
+
+    def test_command_failure_redacts_private_paths(self) -> None:
+        private_source = Path("/Users/example/Private Movie/source.mkv")
+        error = subprocess.CalledProcessError(
+            1,
+            ["ffprobe", private_source.as_posix()],
+            stderr=f"{private_source}: Invalid data found",
+        )
+
+        with patch("scripts.create_packaged_aac_layout_fixtures.subprocess.run", side_effect=error):
+            with self.assertRaises(FixtureBuildFailure) as context:
+                _run([Path("/private/tools/ffprobe"), private_source])
+
+        self.assertNotIn(private_source.as_posix(), str(context.exception))
+        self.assertIn("<redacted-path>", str(context.exception))
+
+    def test_interrupted_generation_removes_private_staging_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source.mkv"
+            output = root / "fixtures"
+            source.write_bytes(b"mvc")
+            with (
+                patch(
+                    "scripts.create_packaged_aac_layout_fixtures._source_video_summary",
+                    return_value={"duration_seconds": 4.213, "direct_mvc_route_proven": False},
+                ),
+                patch("scripts.create_packaged_aac_layout_fixtures._hash_file", return_value="a" * 64),
+                patch("scripts.create_packaged_aac_layout_fixtures._version_line", return_value="tool version"),
+                patch(
+                    "scripts.create_packaged_aac_layout_fixtures._create_identity_source",
+                    side_effect=KeyboardInterrupt,
+                ),
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    create_packaged_aac_layout_fixtures(source, output)
+
+            self.assertFalse(output.exists())
+            self.assertEqual(list(root.glob(".fixtures.*")), [])
+
+    def test_success_receipt_versions_and_hashes_generator_inputs(self) -> None:
+        def create_identity(_case: object, _track: object, output: Path) -> None:
+            output.write_bytes(b"identity")
+
+        def run_command(command: list[str | Path]) -> subprocess.CompletedProcess[str]:
+            output = command[-1]
+            if isinstance(output, Path) and output.suffix in {".mka", ".mkv"}:
+                output.write_bytes(output.name.encode("utf-8"))
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source.mkv"
+            output = root / "fixtures"
+            source.write_bytes(b"mvc")
+            with (
+                patch(
+                    "scripts.create_packaged_aac_layout_fixtures._source_video_summary",
+                    return_value={"duration_seconds": 4.213, "direct_mvc_route_proven": False},
+                ),
+                patch("scripts.create_packaged_aac_layout_fixtures._hash_file", return_value="a" * 64),
+                patch("scripts.create_packaged_aac_layout_fixtures._version_line", return_value="tool version"),
+                patch(
+                    "scripts.create_packaged_aac_layout_fixtures._create_identity_source", side_effect=create_identity
+                ),
+                patch("scripts.create_packaged_aac_layout_fixtures._run", side_effect=run_command),
+                patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value={"streams": []}),
+                patch("scripts.create_packaged_aac_layout_fixtures._audio_streams", return_value=[]),
+                patch("scripts.create_packaged_aac_layout_fixtures._validate_streams"),
+            ):
+                receipt = create_packaged_aac_layout_fixtures(source, output)
+
+            persisted = json.loads((output / "fixture-receipt.json").read_text(encoding="utf-8"))
+            self.assertEqual(receipt, persisted)
+            self.assertEqual(receipt["schema_version"], 2)
+            self.assertEqual(receipt["tools"]["ffmpeg"]["sha256"], "a" * 64)
+            self.assertEqual(receipt["tools"]["ffprobe"]["version"], "tool version")
+            self.assertFalse((output / ".work").exists())

--- a/tests/test_create_packaged_aac_layout_fixtures.py
+++ b/tests/test_create_packaged_aac_layout_fixtures.py
@@ -1,0 +1,95 @@
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.create_packaged_aac_layout_fixtures import (
+    FixtureBuildFailure,
+    _audio_encoding_command,
+    _create_identity_source,
+    _mux_command,
+    _source_video_summary,
+    create_packaged_aac_layout_fixtures,
+)
+from scripts.verify_packaged_aac_layouts import load_fixture_manifest
+
+
+class PackagedAacFixtureCommandTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cases = {case.case_id: case for case in load_fixture_manifest().cases}
+
+    def test_missing_layout_encoding_strips_channel_positions(self) -> None:
+        track = self.cases["fail-missing-layout"].tracks[0]
+
+        command = _audio_encoding_command(track, Path("source.wav"), Path("output.mka"))
+
+        self.assertIn("pcm_s24le", command)
+        self.assertEqual(command[command.index("-ch_layout") + 1], "6c")
+
+    def test_pce_fixture_uses_side_layout_identity_source(self) -> None:
+        case = self.cases["fail-pce-layout"]
+        track = case.tracks[0]
+
+        with patch("scripts.create_packaged_aac_layout_fixtures.create_channel_identity_audio") as create:
+            _create_identity_source(case, track, Path("source.wav"))
+
+        self.assertEqual(create.call_args.args[1], "5.1(side)")
+
+    def test_mux_command_preserves_track_metadata_and_default(self) -> None:
+        case = self.cases["preserve-multilingual"]
+
+        command = _mux_command(
+            Path("source.mkv"),
+            case,
+            [Path("english.mka"), Path("japanese.mka")],
+            Path("fixture.mkv"),
+        )
+
+        self.assertIn("language=eng", command)
+        self.assertIn("title=English Stereo", command)
+        self.assertIn("language=jpn", command)
+        self.assertIn("title=Japanese 5.1", command)
+        self.assertEqual(command[command.index("-disposition:a:0") + 1], "default")
+        self.assertEqual(command[command.index("-disposition:a:1") + 1], "0")
+
+    def test_source_video_requires_h264_mkv_long_enough(self) -> None:
+        document = {
+            "streams": [{"codec_type": "video", "codec_name": "hevc"}],
+            "format": {"duration": "4.0"},
+        }
+
+        with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
+            with self.assertRaisesRegex(FixtureBuildFailure, "H.264"):
+                _source_video_summary(Path("source.mkv"))
+
+    def test_source_video_receipt_defers_direct_route_proof(self) -> None:
+        document = {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "profile": "High",
+                    "width": 1920,
+                    "height": 1080,
+                }
+            ],
+            "format": {"duration": "4.213"},
+        }
+
+        with patch("scripts.create_packaged_aac_layout_fixtures._probe_document", return_value=document):
+            summary = _source_video_summary(Path("source.mkv"))
+
+        self.assertFalse(summary["direct_mvc_route_proven"])
+
+    def test_output_directory_must_be_new(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source.mkv"
+            output = root / "fixtures"
+            source.touch()
+            output.mkdir()
+
+            with self.assertRaisesRegex(FixtureBuildFailure, "must not already exist"):
+                create_packaged_aac_layout_fixtures(source, output)

--- a/tests/test_packaged_aac_layouts.py
+++ b/tests/test_packaged_aac_layouts.py
@@ -1,3 +1,4 @@
+import array
 import json
 import tempfile
 import unittest
@@ -11,7 +12,9 @@ from scripts.verify_packaged_aac_layouts import (
     REQUIRED_COVERAGE,
     PackagedAacFailure,
     WorkerExecution,
+    _audio_streams,
     _build_request,
+    _direct_video_route_evidence,
     _execute_worker,
     _failed_case,
     _identity_evidence,
@@ -170,6 +173,51 @@ class PackagedAacRequestTests(unittest.TestCase):
 
 
 class PackagedAacEvidenceTests(unittest.TestCase):
+    def test_completed_case_requires_direct_mvc_route(self) -> None:
+        case = next(case for case in load_fixture_manifest().cases if case.case_id == "remap-5_1-side")
+
+        with self.assertRaisesRegex(PackagedAacFailure, "direct MVC package route"):
+            _direct_video_route_evidence(case, {"video_route": {"selected": "generated_mv_hevc"}})
+
+        evidence = _direct_video_route_evidence(
+            case,
+            {
+                "video_route": {
+                    "intent": "automatic",
+                    "selected": "direct_mv_hevc",
+                    "reason": "direct_eligible",
+                    "rate_control": "quality",
+                    "quality": 0.7,
+                }
+            },
+        )
+        self.assertEqual(evidence["selected"], "direct_mv_hevc")
+
+    def test_audio_streams_parse_configuration_only_for_aac(self) -> None:
+        probe = {
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "flac",
+                    "channels": 6,
+                    "channel_layout": "5.1(side)",
+                    "extradata": "\n00000000: 1200 1200 0000 2000\n",
+                },
+                {
+                    "codec_type": "audio",
+                    "codec_name": "aac",
+                    "channels": 2,
+                    "channel_layout": "stereo",
+                    "extradata": "\n00000000: 1190 56e5 00\n",
+                },
+            ]
+        }
+
+        streams = _audio_streams(probe)
+
+        self.assertIsNone(streams[0]["aac_channel_configuration"])
+        self.assertEqual(streams[1]["aac_channel_configuration"], 2)
+
     def test_evidence_renderer_matches_persisted_format(self) -> None:
         evidence = {"cases": [{"passed": True}], "schema_version": 1}
 
@@ -287,11 +335,12 @@ class PackagedAacEvidenceTests(unittest.TestCase):
 
     def test_identity_evidence_rejects_apple_channel_count_mismatch(self) -> None:
         case = next(case for case in load_fixture_manifest().cases if case.case_id == "remap-5_1-side")
-        report = Mock(output_streams={"audio": 1})
+        report = Mock(source_streams={"audio": 1}, output_streams={"audio": 1})
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             work_directory = Path(temporary_directory)
             with (
+                patch("scripts.verify_packaged_aac_layouts._run"),
                 patch("scripts.verify_packaged_aac_layouts.inspect_apple_media_conversion", return_value=report),
                 patch(
                     "scripts.verify_packaged_aac_layouts._probe",
@@ -303,6 +352,50 @@ class PackagedAacEvidenceTests(unittest.TestCase):
                     _identity_evidence(Mock(), case, work_directory / "output.mov", work_directory)
 
         decode_track.assert_not_called()
+
+    def test_identity_evidence_converts_each_track_separately(self) -> None:
+        case = next(case for case in load_fixture_manifest().cases if case.case_id == "preserve-multilingual")
+        report = Mock(source_streams={"audio": 1}, output_streams={"audio": 1})
+        probes = [
+            {"streams": [{"codec_type": "audio", "channels": 2}]},
+            {"streams": [{"codec_type": "audio", "channels": 6}]},
+        ]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            work_directory = Path(temporary_directory)
+            app = Mock(ffmpeg=Path("/app/ffmpeg"))
+            with (
+                patch("scripts.verify_packaged_aac_layouts._run") as run,
+                patch(
+                    "scripts.verify_packaged_aac_layouts.inspect_apple_media_conversion",
+                    return_value=report,
+                ) as inspect,
+                patch("scripts.verify_packaged_aac_layouts._probe", side_effect=probes),
+                patch(
+                    "scripts.verify_packaged_aac_layouts._decode_track",
+                    return_value=array.array("f"),
+                ) as decode,
+                patch(
+                    "scripts.verify_packaged_aac_layouts.analyze_identity_samples",
+                    return_value={"status": "passed"},
+                ),
+            ):
+                evidence = _identity_evidence(app, case, work_directory / "output.mov", work_directory)
+
+        self.assertEqual([item["track_index"] for item in evidence], [0, 1])
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("0:a:0", run.call_args_list[0].args[0])
+        self.assertIn("0:a:1", run.call_args_list[1].args[0])
+        self.assertEqual(inspect.call_count, 2)
+        self.assertEqual(
+            [call.args[0].name for call in inspect.call_args_list],
+            ["apple-input-0.mov", "apple-input-1.mov"],
+        )
+        self.assertEqual(
+            [call.args[1].name for call in inspect.call_args_list],
+            ["apple-lpcm-0.mov", "apple-lpcm-1.mov"],
+        )
+        self.assertEqual([call.args[2] for call in decode.call_args_list], [0, 0])
 
 
 class PackagedAacPathTests(unittest.TestCase):

--- a/tests/test_packaged_aac_layouts.py
+++ b/tests/test_packaged_aac_layouts.py
@@ -1,5 +1,8 @@
 import array
+import hashlib
 import json
+import stat
+import subprocess
 import tempfile
 import unittest
 
@@ -7,9 +10,13 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from bd_to_avp.modules.aac_layout_policy import LAYOUT_CHANNELS
+from scripts.verify_apple_media import AppleMediaFailure
 from scripts.verify_packaged_aac_layouts import (
     DEFAULT_MANIFEST,
+    EVIDENCE_SCHEMA_VERSION,
+    FIXTURE_RECEIPT_SCHEMA_VERSION,
     REQUIRED_COVERAGE,
+    FixtureReceipt,
     PackagedAacFailure,
     WorkerExecution,
     _audio_streams,
@@ -18,9 +25,15 @@ from scripts.verify_packaged_aac_layouts import (
     _execute_worker,
     _failed_case,
     _identity_evidence,
+    _inspect_apple_media_conversion,
+    _load_fixture_receipt,
+    _managed_artifact_directory,
     _policy_evidence,
     _render_evidence,
+    _run,
     _validate_streams,
+    _verified_fixture_identity,
+    _verified_fixture_sources,
     load_fixture_manifest,
     validate_paths,
 )
@@ -40,6 +53,39 @@ def worker_event(
         "job_id": job_id,
         "sequence": sequence,
         "payload": payload,
+    }
+
+
+def fixture_receipt_document() -> dict[str, object]:
+    manifest = load_fixture_manifest()
+    return {
+        "schema_version": FIXTURE_RECEIPT_SCHEMA_VERSION,
+        "generated_at_utc": "2026-07-28T00:00:00+00:00",
+        "fixture_set_id": manifest.fixture_set_id,
+        "manifest_sha256": hashlib.sha256(DEFAULT_MANIFEST.read_bytes()).hexdigest(),
+        "source": {
+            "sha256": "b" * 64,
+            "size_bytes": 1,
+            "video": {
+                "codec_name": "h264",
+                "duration_seconds": 4.213,
+                "direct_mvc_route_proven": False,
+            },
+        },
+        "tools": {
+            "ffmpeg": {"sha256": "c" * 64, "version": "ffmpeg test"},
+            "ffprobe": {"sha256": "d" * 64, "version": "ffprobe test"},
+        },
+        "fixtures": [
+            {
+                "id": case.case_id,
+                "file": case.source_file,
+                "sha256": "a" * 64,
+                "size_bytes": 1,
+                "audio_streams": [],
+            }
+            for case in manifest.cases
+        ],
     }
 
 
@@ -112,6 +158,31 @@ class PackagedAacManifestTests(unittest.TestCase):
             with self.assertRaisesRegex(PackagedAacFailure, "wrong policy"):
                 load_fixture_manifest(manifest_path)
 
+    def test_manifest_rejects_failure_coverage_on_success_case(self) -> None:
+        document = json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+        document["cases"][0]["coverage"].append("fail-missing-layout")
+        failure_case = next(case for case in document["cases"] if case["id"] == "fail-missing-layout")
+        failure_case["coverage"] = ["handler-titles"]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest_path = Path(temporary_directory) / "manifest.json"
+            manifest_path.write_text(json.dumps(document), encoding="utf-8")
+
+            with self.assertRaisesRegex(PackagedAacFailure, "must not claim failure coverage"):
+                load_fixture_manifest(manifest_path)
+
+    def test_manifest_rejects_failure_coverage_reason_mismatch(self) -> None:
+        document = json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+        failure_case = next(case for case in document["cases"] if case["id"] == "fail-unknown-layout")
+        failure_case["expected_rejection"] = "channel_layout_missing"
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest_path = Path(temporary_directory) / "manifest.json"
+            manifest_path.write_text(json.dumps(document), encoding="utf-8")
+
+            with self.assertRaisesRegex(PackagedAacFailure, "does not match its failure coverage"):
+                load_fixture_manifest(manifest_path)
+
     def test_manifest_rejects_unqualified_policy_digest(self) -> None:
         document = json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
         document["identity_signal"]["policy_sha256"] = "0" * 64
@@ -135,6 +206,124 @@ class PackagedAacManifestTests(unittest.TestCase):
 
             with self.assertRaisesRegex(PackagedAacFailure, "unqualified layout"):
                 load_fixture_manifest(manifest_path)
+
+
+class PackagedAacReceiptTests(unittest.TestCase):
+    def test_receipt_binds_checked_manifest_and_all_cases(self) -> None:
+        manifest = load_fixture_manifest()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            (root / "fixture-receipt.json").write_text(
+                json.dumps(fixture_receipt_document()),
+                encoding="utf-8",
+            )
+
+            receipt = _load_fixture_receipt(root, manifest, DEFAULT_MANIFEST)
+
+        self.assertEqual(set(receipt.entries), {case.case_id for case in manifest.cases})
+        self.assertEqual(len(receipt.sha256), 64)
+
+    def test_receipt_requires_generator_source_and_tool_provenance(self) -> None:
+        manifest = load_fixture_manifest()
+        for missing_field in ("source", "tools"):
+            document = fixture_receipt_document()
+            del document[missing_field]
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory).resolve()
+                (root / "fixture-receipt.json").write_text(json.dumps(document), encoding="utf-8")
+
+                with self.subTest(missing_field=missing_field):
+                    with self.assertRaisesRegex(PackagedAacFailure, missing_field):
+                        _load_fixture_receipt(root, manifest, DEFAULT_MANIFEST)
+
+    def test_receipt_rejects_stale_manifest_digest(self) -> None:
+        manifest = load_fixture_manifest()
+        document = fixture_receipt_document()
+        document["manifest_sha256"] = "0" * 64
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            (root / "fixture-receipt.json").write_text(json.dumps(document), encoding="utf-8")
+
+            with self.assertRaisesRegex(PackagedAacFailure, "checked manifest"):
+                _load_fixture_receipt(root, manifest, DEFAULT_MANIFEST)
+
+    def test_fixture_identity_rejects_tampered_bytes(self) -> None:
+        case = load_fixture_manifest().cases[0]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / case.source_file
+            source.write_bytes(b"fixture")
+            entry = {
+                "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+                "size_bytes": source.stat().st_size,
+            }
+            self.assertEqual(_verified_fixture_identity(case, source, entry), (entry["sha256"], 7))
+            source.write_bytes(b"tampered")
+
+            with self.assertRaisesRegex(PackagedAacFailure, "generator receipt"):
+                _verified_fixture_identity(case, source, entry)
+
+    def test_all_fixture_hashes_are_checked_before_execution(self) -> None:
+        manifest = load_fixture_manifest()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            entries: dict[str, dict[str, object]] = {}
+            for case in manifest.cases:
+                source = root / case.source_file
+                source.write_bytes(case.case_id.encode("utf-8"))
+                entries[case.case_id] = {
+                    "file": case.source_file,
+                    "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+                    "size_bytes": source.stat().st_size,
+                }
+            (root / manifest.cases[-1].source_file).write_bytes(b"tampered later fixture")
+            receipt = FixtureReceipt("a" * 64, entries)
+
+            with self.assertRaisesRegex(PackagedAacFailure, "generator receipt"):
+                _verified_fixture_sources(root, manifest, receipt)
+
+    def test_evidence_schema_versions_the_gate_split(self) -> None:
+        self.assertEqual(EVIDENCE_SCHEMA_VERSION, 2)
+
+
+class PackagedAacSafetyTests(unittest.TestCase):
+    def test_command_failure_redacts_private_paths(self) -> None:
+        private_source = Path("/Users/example/private/fixture.mkv")
+        error = subprocess.CalledProcessError(
+            1,
+            ["ffprobe", private_source.as_posix()],
+            stderr=f"{private_source}: Invalid data found",
+        )
+
+        with patch("scripts.verify_packaged_aac_layouts.subprocess.run", side_effect=error):
+            with self.assertRaises(PackagedAacFailure) as context:
+                _run([Path("/private/tools/ffprobe"), private_source])
+
+        self.assertNotIn(private_source.as_posix(), str(context.exception))
+        self.assertIn("<redacted-path>", str(context.exception))
+
+    def test_apple_media_failure_redacts_private_paths(self) -> None:
+        source = Path("/Users/example/private/output.mov")
+        converted = Path("/Users/example/private/apple.mov")
+        with patch(
+            "scripts.verify_packaged_aac_layouts.inspect_apple_media_conversion",
+            side_effect=AppleMediaFailure(f"Could not open {source}"),
+        ):
+            with self.assertRaises(PackagedAacFailure) as context:
+                _inspect_apple_media_conversion(source, converted)
+
+        self.assertNotIn(source.as_posix(), str(context.exception))
+        self.assertIn("<redacted-path>", str(context.exception))
+
+    def test_artifact_directory_is_private_and_cleans_interruptions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifacts = Path(temporary_directory) / "artifacts"
+            with self.assertRaises(KeyboardInterrupt):
+                with _managed_artifact_directory(artifacts):
+                    self.assertEqual(stat.S_IMODE(artifacts.stat().st_mode), 0o700)
+                    (artifacts / "private.mov").write_bytes(b"private")
+                    raise KeyboardInterrupt
+
+            self.assertFalse(artifacts.exists())
 
 
 class PackagedAacRequestTests(unittest.TestCase):
@@ -170,6 +359,24 @@ class PackagedAacRequestTests(unittest.TestCase):
 
         self.assertEqual(execution.returncode, 1)
         self.assertEqual(execution.events[-1]["type"], "job.failed")
+
+    def test_worker_interrupt_terminates_process_group(self) -> None:
+        process = Mock(returncode=None)
+        process.communicate.side_effect = KeyboardInterrupt
+
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            patch("scripts.verify_packaged_aac_layouts.subprocess.Popen", return_value=process),
+            patch("scripts.verify_packaged_aac_layouts._terminate_worker_process") as terminate,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                _execute_worker(
+                    Mock(worker=Path("/tmp/worker")),
+                    {"job_id": "job", "operation": "convert_source"},
+                    home_directory=Path(temporary_directory) / "home",
+                )
+
+        terminate.assert_called_once_with(process)
 
 
 class PackagedAacEvidenceTests(unittest.TestCase):
@@ -219,7 +426,7 @@ class PackagedAacEvidenceTests(unittest.TestCase):
         self.assertEqual(streams[1]["aac_channel_configuration"], 2)
 
     def test_evidence_renderer_matches_persisted_format(self) -> None:
-        evidence = {"cases": [{"passed": True}], "schema_version": 1}
+        evidence = {"cases": [{"passed": True}], "schema_version": EVIDENCE_SCHEMA_VERSION}
 
         self.assertEqual(_render_evidence(evidence), json.dumps(evidence, indent=2, sort_keys=True) + "\n")
 

--- a/tests/test_packaged_aac_layouts.py
+++ b/tests/test_packaged_aac_layouts.py
@@ -317,12 +317,14 @@ class PackagedAacSafetyTests(unittest.TestCase):
     def test_artifact_directory_is_private_and_cleans_interruptions(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             artifacts = Path(temporary_directory) / "artifacts"
+            interrupt = Mock(side_effect=KeyboardInterrupt)
             with self.assertRaises(KeyboardInterrupt):
                 with _managed_artifact_directory(artifacts):
                     self.assertEqual(stat.S_IMODE(artifacts.stat().st_mode), 0o700)
                     (artifacts / "private.mov").write_bytes(b"private")
-                    raise KeyboardInterrupt
+                    interrupt()
 
+            interrupt.assert_called_once_with()
             self.assertFalse(artifacts.exists())
 
 


### PR DESCRIPTION
## Summary
- add a repo-owned generator that atomically builds the six private AAC package fixtures from a bounded real MVC MKV and validates their exact manifest metadata
- bind a schema-v2 receipt to the checked manifest, generator source, FFmpeg/FFprobe provenance, and every fixture's hash, size, filename, and stream record without storing the private source path
- reject non-finite inputs, mismatched failure coverage, fixture/package mutation, and incomplete provenance while cleaning private staging data and worker processes on interruption
- fix real-media verifier failures by decoding Apple LPCM one audio track at a time and parsing AAC channel configuration only for AAC streams
- require successful fixture conversions to report the packaged worker's `direct_mv_hevc` route and separate the passed package gate from still-open signing/device gates
- document that schema-v1 receipts are historical only and must be regenerated for a current release gate

## Qualified Head Evidence
- qualified head: `b40c4773dc210d8214d7d34140eedc9979941031`
- unsigned Release app-tree SHA-256: `f19529a38f14ed329dc3c3952bc13f3c4619d727fe223b59385a63f8f0bf5531`
- packaged MV-HEVC route evidence SHA-256: `90acef98ff0deb7107e8e24a17af48efbe9f5871dd8701bb1932ad0de9bf1f7c`
- retained 4K route fixture SHA-256: `cb56a09f0b4482c2317942a4f0ca12945043b5a3d55fb10d947606bfcb0a322c` (`101016663` bytes)
- schema-v2 AAC receipt SHA-256: `4acc8d702ac14c18a40e95e8eb283caba07ef3bfc7e98623f2351440d8ed3e50`
- schema-v2 AAC evidence SHA-256: `ab1329c80fd2328af008bfead4f170626994ad895d2fc6da99ccfeb4a9d528ba`
- fixture manifest SHA-256: `fbe2547b3e4fd08ecef63bd5ff6bcbcdbe126c998c947ef3b8dc55f7842ba279`
- all eight ordinary/MetalFX direct/fallback full/preview routes passed through the packaged worker; the final head changes only AAC verifier interruption cleanup and its unit test, so package and route inputs are unchanged from that immediate-parent replay
- all six preserve/remap/downmix/fail AAC cases passed on the exact final head; successful cases selected `direct_mv_hevc`, Apple passthrough retained expected tracks, per-track LPCM identity passed, and missing/unqualified/PCE cases failed closed visibly
- evidence leaves signed-candidate, physical Vision Pro, and issue-completion gates false

## Validation
- `uv run python -m unittest discover -s tests -t .` — 1108 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 307 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv build`
- observability and import smoke checks
- unsigned Release package build, code-signing smoke, eight-route packaged matrix, and exact-head six-case schema-v2 AAC matrix
- JetBrains changed-files inspection — GREEN, 0 findings
- independent Opus review — APPROVE; Google-family review produced no finding

## Remaining Boundary
This PR closes deterministic fixture construction and unsigned/package automation only. The exact signed/notarized Beta 8 candidate and physical Vision Pro surround, seek, language/default-track, and lip-sync evidence remain under #382/#392 and still require the guarded release approval flow plus device access.

Refs #382
Refs #388
Refs #392