### PR TITLE
Prepare 0.3.0 Beta 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ and RC exclude it. Existing Stable or RC selections remain in place until you
 explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
 
-Beta 4 (`0.3.0b4`, build `149`), Beta 5 (`0.3.0b5`, build `150`), and Beta 6
-(`0.3.0b6`, build `151`) are published and immutable. Beta 7 metadata
-(`0.3.0b7`, build `152`) is prepared for the guarded Prerelease workflow. There
-is no Beta 7 tag, DMG, release, or updater item until exact-SHA signing,
+Beta 4 (`0.3.0b4`, build `149`), Beta 5 (`0.3.0b5`, build `150`), Beta 6
+(`0.3.0b6`, build `151`), and Beta 7 (`0.3.0b7`, build `152`) are published and
+immutable. Beta 8 metadata (`0.3.0b8`, build `153`) is prepared for the guarded
+Prerelease workflow. There is no Beta 8 tag, DMG, release, or updater item until exact-SHA signing,
 publication, and public verification complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI

--- a/docs/0.3.0-beta.7-cut-packet.md
+++ b/docs/0.3.0-beta.7-cut-packet.md
@@ -1,22 +1,20 @@
 # 0.3.0 Beta 7 Cut Packet
 
-> **Authorized metadata; publication pending.** Issue #377 and the July 26,
-> 2026 instruction to proceed authorize repository preparation,
-> protected-main review, and exact-SHA Prerelease dispatch after this metadata
-> PR merges green and a merge hold is active. This packet does not assert that
-> a Beta 7 tag, draft, DMG, release, or appcast item exists. The
-> `macos-signing` environment remains a separate run-bound authorization that
-> requires explicit approval in the active conversation.
+> **Published and immutable.** Beta 7 was published on July 26, 2026 through
+> guarded Prerelease run `30189682992` from protected-`main` commit
+> `84036c7767fe3869e2fc9e709cddb3e132ed16bf`. The GitHub release, signed and
+> notarized DMG, `SHA256SUMS`, release `appcast.xml`, and cumulative production
+> appcast are historical release evidence. Issue #377 is complete.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 7 packages the streamed native
+[release-routes.md](release-routes.md). Beta 7 was released with the streamed native
 MV-HEVC and direct MetalFX 4K work after production routing, fallback,
 finalized-preview, quality, resource, cancellation, and physical playback gates
 landed on protected `main` with exact-main CI and CodeQL green.
 
 ## Exact Metadata
 
-| Field | Reviewed value |
+| Field | Published value |
 | --- | --- |
 | Package and bundle short version | `0.3.0b7` |
 | Public version | `0.3.0-beta.7` |
@@ -34,10 +32,9 @@ landed on protected `main` with exact-main CI and CodeQL green.
 | Privacy contract | Privacy rules version `4` |
 
 Build `152` is globally newer than immutable published Beta 6 build `151`. The
-July 26, 2026 live audit found immutable Beta 6 at protected-main commit
-`7bf7858057e988a6eff753d2588bebe60dfd660e`, no Beta 7 tag, release, draft, or
-appcast item, no later release run or repository history consuming build `152`,
-an empty release-freeze map, and an enabled Pages appcast rooted at Beta 6.
+release was published at `2026-07-26T15:07:58Z` with DMG SHA-256
+`0a3105502c607d7052a655abc20e7e6a56aa424b543b73f423ae35c060a0b303`.
+The cumulative appcast is ordered through builds `152,151,150,149,148,146,145,144`.
 
 ## Included Product Changes
 
@@ -61,7 +58,7 @@ an empty release-freeze map, and an enabled Pages appcast rooted at Beta 6.
 
 ## Cumulative Update Contract
 
-Publication must append Beta 7 above the immutable production history:
+Beta 7 is ordered above the immutable production history:
 
 | Order | Internal version | Build | Channel |
 | ---: | --- | ---: | --- |
@@ -91,36 +88,23 @@ prerelease.
 > quality, feature-length resources, and cancellation; and physical Vision Pro
 > playback of the direct 4K fixture.
 
-Do not describe Beta 7 as downloadable, signed, published, or
-Sparkle-discoverable until the guarded release verifies the immutable public
-state. A built-in live processed-frame monitor remains separate future work in
+Beta 7 is downloadable, signed, notarized, published, and Sparkle-discoverable
+on the eligible Beta and Alpha routes. Its public artifacts and appcast item are
+immutable. A built-in live processed-frame monitor remains separate future work in
 #356; this release qualifies finalized preview output.
 
 ## Exact-Artifact Qualification
 
-The pre-release qualification package was version `0.3.0b6`, built from the
-same protected-main feature set before this metadata bump. Its matrix covers all
-eight packaged ordinary/direct-4K, full/finalized-preview, direct/fallback
-routes plus representative-MVC quality, feature-length direct-4K resources and
-cancellation, and physical playback of a separate direct-4K calibration
-fixture. It validates the release code path, not the exact Beta 7 artifact.
-
-The exact Beta 7 artifact remains pending. After publication, issue #377 must
-bind the downloaded notarized DMG to the release asset digest and repeat
-signature, staple, Gatekeeper, startup, helper/worker capability, packaged
-direct/fallback, and short physical playback checks. Repeat the complete
-private-source matrix if practical; otherwise record why the complete
-pre-release matrix plus artifact-bound smoke is sufficient.
+The exact downloaded Beta 7 artifact passed attestation, signature,
+notarization/staple, Gatekeeper, metadata, startup, bundled-tool, and worker
+checks. All eight ordinary/direct-4K × direct/fallback ×
+full/finalized-preview routes passed, and automatic physical Vision Pro
+playback passed beginning/middle/end seeks with spatial presentation. The
+complete immutable evidence is recorded in issue #377.
 
 ## Authorization Boundary
 
-Issue #377 and the July 26, 2026 instruction to proceed authorize metadata
-preparation, protected-main review, and exact-SHA Prerelease dispatch. The
-repository has no freeze entry for `v0.3.0-beta.7`.
-
-The workflow must be dispatched only from the exact protected `main` SHA that
-contains the reviewed metadata PR. `main` must remain fixed while the workflow
-is nonterminal. Before approving `macos-signing`, the release watcher must emit
-the run-bound approval fingerprint and the maintainer must explicitly authorize
-that approval in the active conversation. This packet does not pre-authorize
-that approval.
+Issue #377 completed the metadata, protected-main, signing, publication, and
+exact-artifact qualification boundaries. `v0.3.0-beta.7` and build `152` must
+not be rebuilt, retagged, replaced, or reused. Later production-identity
+releases advance the global build counter from this immutable history.

--- a/docs/0.3.0-beta.8-cut-packet.md
+++ b/docs/0.3.0-beta.8-cut-packet.md
@@ -1,0 +1,128 @@
+# 0.3.0 Beta 8 Cut Packet
+
+> **Authorized metadata; publication pending.** Issue #392 and the July 28,
+> 2026 instruction to proceed authorize repository preparation,
+> protected-main review, and exact-SHA Prerelease dispatch after this metadata
+> PR merges green and a merge hold is active. This packet does not assert that
+> a Beta 8 tag, draft, DMG, release, or appcast item exists. The
+> `macos-signing` environment remains a separate run-bound authorization that
+> requires explicit approval in the active conversation.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 8 packages the Apple-compatible
+AAC layout policy and release-package verifier together with the transactional
+artifact, destination-aware preview, and storage-diagnostic fixes tracked by
+#388 and qualified for one shared exact candidate under #392.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b8` |
+| Public version | `0.3.0-beta.8` |
+| Bundle and Sparkle build | `153` |
+| GitHub tag and release title | `v0.3.0-beta.8` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4` |
+
+Build `153` is globally newer than immutable published Beta 7 build `152`. The
+July 28, 2026 live audit found immutable Beta 7 at protected-main commit
+`84036c7767fe3869e2fc9e709cddb3e132ed16bf`, no Beta 8 tag or release, no
+repository history consuming build `153`, and an empty release-freeze map. The
+public cumulative appcast remains rooted at Beta 7 build `152` until guarded
+publication succeeds.
+
+## Included Product Changes
+
+- PR #383 qualifies Apple AAC channel layouts and records the canonical
+  channel-identity evidence used by the production policy.
+- PR #384 applies the fail-closed Apple-compatible AAC layout policy, preserving
+  qualified layouts, remapping `5.1(side)` to `5.1`, downmixing `7.1` to `5.1`,
+  and rejecting missing, unknown, PCE, custom, discrete, or unlisted layouts.
+- PR #393 makes generated MV-HEVC artifacts transactional and validates them
+  before publication or resume so partial output cannot masquerade as success.
+- PR #395 makes ISO and Blu-ray preview workspaces destination-aware and cleans
+  heavy temporary data from the selected storage location.
+- PR #396 makes local and mounted-volume capacity evidence conflict-aware,
+  exception-safe, and public-safe in diagnostics.
+- PRs #397 and #400 add the checked packaged-AAC fixture matrix, deterministic
+  schema-v2 fixture receipts, Apple passthrough/LPCM identity checks, visible
+  fail-closed evidence, and direct-MV-HEVC route binding for successful cases.
+
+## Cumulative Update Contract
+
+Publication must append Beta 8 above the immutable production history:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b8` | `153` | `beta` |
+| 2 | `0.3.0b7` | `152` | `beta` |
+| 3 | `0.3.0b6` | `151` | `beta` |
+| 4 | `0.3.0b5` | `150` | `beta` |
+| 5 | `0.3.0b4` | `149` | `beta` |
+| 6 | `0.3.0b3` | `148` | `beta` |
+| 7 | `0.2.143` | `146` | Stable / no channel |
+| 8 | `0.2.143rc5` | `145` | `rc` |
+| 9 | `0.2.143rc4` | `144` | `rc` |
+
+Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3
+through Beta 8, and an installed earlier Beta on either route may update forward
+to build `153`. Moving to a safer route never downgrades an installed
+prerelease.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.0-beta.8` tightens Apple-compatible AAC handling and
+> release-package validation. Automatic and Convert-to-AAC processing now use
+> the reviewed channel-layout policy: qualified canonical layouts are
+> preserved, `5.1(side)` is remapped to `5.1`, `7.1` is downmixed to `5.1`,
+> and missing or unqualified layouts fail before output is silently produced.
+> The package gate adds receipt-bound preserve/remap/downmix/fail fixtures,
+> multilingual metadata checks, Apple passthrough and LPCM identity analysis,
+> and direct-route evidence. This beta also publishes generated MV-HEVC
+> artifacts transactionally, places heavy preview work on the selected
+> destination, and improves privacy-safe storage-capacity diagnostics.
+
+Do not describe Beta 8 as downloadable, signed, published, notarized, or
+Sparkle-discoverable until the guarded release verifies the immutable public
+state. The unsigned package gate does not establish physical Vision Pro
+surround placement, repeated seeks, or perceptual lip-sync.
+
+## Exact-Artifact Qualification
+
+The pre-release qualification package was version `0.3.0b7`, built from the
+same protected-main feature tree before this metadata bump. Unsigned app-tree
+SHA-256 `f19529a38f14ed329dc3c3952bc13f3c4619d727fe223b59385a63f8f0bf5531`
+passed all eight ordinary/MetalFX direct/fallback full/preview routes and all
+six schema-v2 AAC preserve/remap/downmix/fail cases. Packaged route evidence
+SHA-256 is `90acef98ff0deb7107e8e24a17af48efbe9f5871dd8701bb1932ad0de9bf1f7c`;
+AAC evidence SHA-256 is
+`ab1329c80fd2328af008bfead4f170626994ad895d2fc6da99ccfeb4a9d528ba`.
+This validates the release code path, not the exact Beta 8 artifact.
+
+The exact Beta 8 artifact remains pending. Issue #392 must bind one protected-
+`main` SHA to the signed and notarized DMG, release/appcast identity, and the
+same package evidence. It must also complete mounted-network/NAS and
+constrained-local-preview checks, #382's physical Vision Pro surround/seek/
+lip-sync evidence, and a #386-equivalent signed field run or reporter retest.
+
+## Authorization Boundary
+
+Issue #392 and the July 28, 2026 instruction to proceed authorize metadata
+preparation, protected-main review, and exact-SHA Prerelease dispatch. The
+repository has no freeze entry for `v0.3.0-beta.8`.
+
+The workflow must be dispatched only from the exact protected `main` SHA that
+contains the reviewed metadata PR. `main` must remain fixed while the workflow
+is nonterminal. Before approving `macos-signing`, the release watcher must emit
+the run-bound approval fingerprint and the maintainer must explicitly authorize
+that approval in the active conversation. This packet does not pre-authorize
+that approval.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -94,10 +94,11 @@ document it as an external dependency with preflight behavior.
   the production name and bundle identifier on a pinned GitHub-hosted macOS 26
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
 - Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`), Beta 5
-  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`), and Beta 6
-  (`v0.3.0-beta.6`, internal version `0.3.0b6`, build `151`) are published and
-  immutable. The next prepared production-identity field build is Beta 7
-  (`v0.3.0-beta.7`, internal version `0.3.0b7`, build `152`). It remains
+  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`), Beta 6
+  (`v0.3.0-beta.6`, internal version `0.3.0b6`, build `151`), and Beta 7
+  (`v0.3.0-beta.7`, internal version `0.3.0b7`, build `152`) are published and
+  immutable. The next prepared production-identity field build is Beta 8
+  (`v0.3.0-beta.8`, internal version `0.3.0b8`, build `153`). It remains
   unpublished until exact-SHA signing and public verification complete. Beta 3
   build `148` remains the manual-download seed and immutable appcast history
   below the later Beta releases.

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -96,10 +96,11 @@ only future newer builds and never downgrades the installed app. Published Beta
 3 (`0.3.0b3`, build `148`) is the one-time manual-download production seed:
 older Stable and RC installations cannot discover it, while an installed Beta
 3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`), Beta 5 (`0.3.0b5`,
-build `150`), and Beta 6 (`0.3.0b6`, build `151`) are published and immutable.
-Beta 7 (`0.3.0b7`, build `152`) is the next prepared target for the guarded
-exact-SHA Prerelease workflow. Its future cumulative item must sit above Beta 6,
-Beta 5, Beta 4, and Beta 3 and remain visible only to Beta and Alpha until a
+build `150`), Beta 6 (`0.3.0b6`, build `151`), and Beta 7 (`0.3.0b7`, build
+`152`) are published and immutable. Beta 8 (`0.3.0b8`, build `153`) is the next
+prepared target for the guarded exact-SHA Prerelease workflow. Its future
+cumulative item must sit above Beta 7, Beta 6, Beta 5, Beta 4, and Beta 3 and
+remain visible only to Beta and Alpha until a
 later newer Stable supersedes it.
 
 ## Release Workflow
@@ -152,15 +153,18 @@ behavior and engine architecture rather than release branding.
 
 ## Remaining Field Evidence
 
-Beta 3 through Beta 6 publication is complete, and signed installed-app
-diagnostics qualification is complete. Beta 7 exact-artifact qualification must
+Beta 3 through Beta 7 publication is complete, and signed installed-app
+diagnostics qualification is complete. Beta 8 exact-artifact qualification must
 prove that:
 
-- Beta 6 updates forward to Beta 7 on Beta and Alpha without changing the saved
+- Beta 7 updates forward to Beta 8 on Beta and Alpha without changing the saved
   route;
 - Stable and RC continue to exclude every Beta item;
 - the downloaded notarized DMG passes signature, staple, Gatekeeper, startup,
   bundled-helper, and worker-capability checks; and
 - packaged ordinary/direct-4K full conversion, finalized preview, visible
   fallback, and short physical Vision Pro playback still match the qualified
-  pre-release candidate.
+  pre-release candidate; and
+- the same exact package passes #392's field/NAS matrix and #382's packaged AAC
+  and physical Vision Pro gates without treating unsigned evidence as release
+  proof.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,19 +4,19 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The repository carries published, immutable Beta 3 through Beta 6 history at
-internal versions `0.3.0b3` through `0.3.0b6`, builds `148` through `151`, and a
-prepared Beta 7 target at `0.3.0b7`, build `152`. The failed, unpublished
+The repository carries published, immutable Beta 3 through Beta 7 history at
+internal versions `0.3.0b3` through `0.3.0b7`, builds `148` through `152`, and a
+prepared Beta 8 target at `0.3.0b8`, build `153`. The failed, unpublished
 `0.3.0rc1` build `147` attempt is preserved in the checked-in recovery evidence
 and its build number is permanently burned. The
-[Beta 6 cut packet](0.3.0-beta.6-cut-packet.md) records immutable publication
-history, while the reviewed [Beta 7 cut packet](0.3.0-beta.7-cut-packet.md)
-records metadata only and does not assert that a Beta 7 public artifact exists.
+[Beta 7 cut packet](0.3.0-beta.7-cut-packet.md) records immutable publication
+history, while the reviewed [Beta 8 cut packet](0.3.0-beta.8-cut-packet.md)
+records metadata only and does not assert that a Beta 8 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. The explicit Beta 7 request authorizes the
+implemented and regression-covered. Issue #392 and the explicit Beta 8 request authorize the
 reviewed metadata preparation and exact-SHA dispatch; run-bound signing approval
 remains a separate authorization boundary.
 
@@ -34,9 +34,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b7` maps to public `0.3.0-beta.7`, tag/title
-`v0.3.0-beta.7`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.7.dmg`. The numeric
+example, internal `0.3.0b8` maps to public `0.3.0-beta.8`, tag/title
+`v0.3.0-beta.8`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -77,11 +77,11 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 7 is authorized but not yet published.** The explicit Beta 7 request
-> authorizes guarded `v0.3.0-beta.7` dispatch, and the repository contains no
+> **Beta 8 is authorized but not yet published.** Issue #392 and the explicit Beta 8 request
+> authorize guarded `v0.3.0-beta.8` dispatch, and the repository contains no
 > freeze entry for that exact tag. Dispatch only from the exact protected `main`
-> commit containing the reviewed Beta 7 metadata, keep `main` fixed while the
-> workflow is nonterminal, and do not describe Beta 7 as public until signing,
+> commit containing the reviewed Beta 8 metadata, keep `main` fixed while the
+> workflow is nonterminal, and do not describe Beta 8 as public until signing,
 > notarization, appcast publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,10 +6,10 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. Beta 3 through Beta 6 are published and immutable at
-builds `148` through `151`, with build `147` permanently burned. The next
-prepared target is Beta 7 at `0.3.0b7` build `152`. The explicit Beta 7 request
-authorizes reviewed exact-SHA dispatch; run-bound signing approval remains a
+this four-route contract. Beta 3 through Beta 7 are published and immutable at
+builds `148` through `152`, with build `147` permanently burned. The next
+prepared target is Beta 8 at `0.3.0b8` build `153`. Issue #392 and the explicit
+Beta 8 request authorize reviewed exact-SHA dispatch; run-bound signing approval remains a
 separate authorization boundary.
 
 ## Production Identity
@@ -51,7 +51,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.7.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -138,8 +138,9 @@ prereleases. Beta 3 remains immutable production/feed history in the cumulative
 appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
-client waits for a newer eligible Stable build. Beta 4, Beta 5, and Beta 6 are
-immutable production history, and Beta 7 reserves the next global build, `152`.
+client waits for a newer eligible Stable build. Beta 4, Beta 5, Beta 6, and Beta
+7 are immutable production history, and Beta 8 reserves the next global build,
+`153`.
 
 ## Beta 6 Published History
 
@@ -159,9 +160,9 @@ build `144`. Stable and RC exclude all Beta items; Beta and Alpha admit them.
 Historical metadata and release evidence are in
 [the Beta 6 cut packet](0.3.0-beta.6-cut-packet.md).
 
-## Beta 7 Authorized Target
+## Beta 7 Published History
 
-The repository is prepared for the guarded `v0.3.0-beta.7` Prerelease workflow:
+Published `v0.3.0-beta.7` is immutable production history:
 
 - internal version `0.3.0b7`;
 - public tag and title `v0.3.0-beta.7`;
@@ -171,17 +172,35 @@ The repository is prepared for the guarded `v0.3.0-beta.7` Prerelease workflow:
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta 6.
 
-Publication must place Beta 7 above immutable Beta 6 build `151`, Beta 5 build
+The cumulative appcast places Beta 7 above immutable Beta 6 build `151`, Beta 5 build
 `150`, Beta 4 build `149`, Beta 3 build `148`, Stable build `146`, RC5 build
 `145`, and RC4 build `144`. Stable and RC exclude all Beta items; Beta and Alpha
-admit them, allowing an installed earlier Beta to update forward to Beta 7
-without changing the saved route.
+admit them. Historical metadata and release evidence are in
+[the Beta 7 cut packet](0.3.0-beta.7-cut-packet.md).
 
-The explicit Beta 7 request authorizes metadata preparation and exact-SHA
-dispatch. The repository has no freeze entry for this exact tag; that absence
+## Beta 8 Authorized Target
+
+The repository is prepared for the guarded `v0.3.0-beta.8` Prerelease workflow:
+
+- internal version `0.3.0b8`;
+- public tag and title `v0.3.0-beta.8`;
+- global build `153`;
+- Sparkle channel `beta`;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta 7.
+
+Publication must place Beta 8 above immutable Beta 7 build `152`, Beta 6 build
+`151`, Beta 5 build `150`, Beta 4 build `149`, Beta 3 build `148`, Stable build
+`146`, RC5 build `145`, and RC4 build `144`. Stable and RC exclude all Beta
+items; Beta and Alpha admit them, allowing an installed earlier Beta to update
+forward to Beta 8 without changing the saved route.
+
+Issue #392 and the explicit Beta 8 request authorize metadata preparation and
+exact-SHA dispatch. The repository has no freeze entry for this exact tag; that absence
 authorizes workflow preflight but does not assert that a tag, draft, DMG,
 release, or appcast item exists. The reviewed metadata and release-note seed are
-in [the Beta 7 cut packet](0.3.0-beta.7-cut-packet.md).
+in [the Beta 8 cut packet](0.3.0-beta.8-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -267,24 +267,24 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 7 Authorization Smoke
+### Beta 8 Authorization Smoke
 
-Run these checks after the Beta 7 metadata preparation lands and before workflow
+Run these checks after the Beta 8 metadata preparation lands and before workflow
 dispatch. They prove the committed target and authorization boundary, not a
 signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b7`, public `0.3.0-beta.7`, build `152`, Beta channel, prerelease,
+   `0.3.0b8`, public `0.3.0-beta.8`, build `153`, Beta channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 7 freeze is absent while all route, identity, and existing-release
+   Beta 8 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 7 build `152`, Beta 6
-   build `151`, Beta 5 build `150`, Beta 4 build `149`, Beta 3 build `148`, then
-   Stable build `146`, RC5 build `145`, and RC4 build `144`; Stable and RC must
+3. Validate a cumulative appcast fixture ordered Beta 8 build `153`, Beta 7
+   build `152`, Beta 6 build `151`, Beta 5 build `150`, Beta 4 build `149`, Beta
+   3 build `148`, then Stable build `146`, RC5 build `145`, and RC4 build `144`; Stable and RC must
    exclude every Beta item while Beta and Alpha admit them.
-4. Confirm the live repository has no Beta 7 tag, release, draft, or asset and
-   the public appcast still ends at Beta 6 build `151`.
+4. Confirm the live repository has no Beta 8 tag, release, draft, or asset and
+   the public appcast still ends at Beta 7 build `152`.
 5. Continue only through the exact-SHA Prerelease workflow. Signed-app,
    update-route, packaged direct/fallback, and physical-playback qualification
    remain incomplete until the guarded workflow and exact-artifact checks

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -69,8 +69,8 @@ Each new appcast item embeds the digest-bound draft release body as Markdown, so
 Sparkle uses its adaptive native text view without loading GitHub page chrome or
 making a second release-note request. A full-release link remains available for
 downloads and extended context, and historical external-link items remain valid.
-The live feed now carries cumulative production history through Beta 6 build
-`151`; prepared Beta 7 metadata does not alter it before guarded publication.
+The live feed now carries cumulative production history through Beta 7 build
+`152`; prepared Beta 8 metadata does not alter it before guarded publication.
 See [release-process.md](release-process.md) for the operator sequence.
 
 Stable `0.2.143` remains compatible with macOS 14. The production SwiftUI line
@@ -266,9 +266,9 @@ select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 `v0.3.0-beta.2` Preview identities remain separate, immutable, and unable to
 Sparkle-upgrade into Beta 3.
 
-Published `v0.3.0-beta.6` (`0.3.0b6`, build `151`) is the immutable head of the
-current cumulative feed above Beta 5, Beta 4, and Beta 3. The next prepared item
-is `v0.3.0-beta.7` (`0.3.0b7`, build `152`). Publication must append Beta 7
+Published `v0.3.0-beta.7` (`0.3.0b7`, build `152`) is the immutable head of the
+current cumulative feed above Beta 6, Beta 5, Beta 4, and Beta 3. The next prepared item
+is `v0.3.0-beta.8` (`0.3.0b8`, build `153`). Publication must append Beta 8
 above the existing Betas, remain excluded from Stable and RC, and be eligible to
 Beta and Alpha. The exact-SHA Prerelease workflow, signing approval,
 notarization, and public verification remain separate fail-closed boundaries.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,13 +37,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 152
+        CURRENT_PROJECT_VERSION: 153
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b7
+        MARKETING_VERSION: 0.3.0b8
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b7"
+version = "0.3.0b8"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "152"
+CFBundleVersion = "153"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -98,8 +98,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b7")
-        self.assertEqual(NATIVE_BUILD_VERSION, "152")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b8")
+        self.assertEqual(NATIVE_BUILD_VERSION, "153")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,34 +156,35 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_and_authorized_for_beta7(self) -> None:
+    def test_repository_is_prepared_and_authorized_for_beta8(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b7")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.7")
-        self.assertEqual(metadata.build_version, "152")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.7")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.7")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.7.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b8")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.8")
+        self.assertEqual(metadata.build_version, "153")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.8")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.8")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.7", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-beta.8", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.7-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b7`", cut_packet)
-        self.assertIn("Build `152`", cut_packet)
-        for pull_request in (349, 350, 360, 361, 362, 365, 368, 371, 372, 373, 374, 375, 378):
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.8-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b8`", cut_packet)
+        self.assertIn("Build `153`", cut_packet)
+        for pull_request in (383, 384, 393, 395, 396, 397, 400):
             self.assertIn(f"#{pull_request}", cut_packet)
         self.assertIn("Privacy rules version `4`", cut_packet)
-        self.assertIn("July 26, 2026 instruction to proceed", cut_packet)
+        self.assertIn("Issue #392", cut_packet)
+        self.assertIn("July 28, 2026 instruction to proceed", cut_packet)
         self.assertIn("does not pre-authorize", cut_packet)
         self.assertIn("that approval", cut_packet)
-        self.assertIn("pre-release qualification package was version `0.3.0b6`", cut_packet)
-        self.assertIn("The exact Beta 7 artifact remains pending", cut_packet)
+        self.assertIn("pre-release qualification package was version `0.3.0b7`", cut_packet)
+        self.assertIn("The exact Beta 8 artifact remains pending", cut_packet)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
         evidence = release.validate_beta3_recovery_evidence()

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,7 +188,7 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
-    def test_beta7_appends_above_complete_immutable_production_history(self) -> None:
+    def test_beta8_appends_above_complete_immutable_production_history(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             base_feed = root / "base.xml"
@@ -197,6 +197,7 @@ class SparkleAppcastTests(unittest.TestCase):
             beta5_feed = root / "beta5.xml"
             beta6_feed = root / "beta6.xml"
             beta7_feed = root / "beta7.xml"
+            beta8_feed = root / "beta8.xml"
             base_feed.write_bytes(
                 (
                     Path(__file__).resolve().parents[1] / "docs" / "release-evidence" / "v0.2.143-appcast.xml"
@@ -227,19 +228,25 @@ class SparkleAppcastTests(unittest.TestCase):
                 beta7_feed,
                 item("152", "0.3.0b7", "beta", minimum_system_version="26.0"),
             )
+            sparkle_appcast.append_item(
+                beta7_feed,
+                beta8_feed,
+                item("153", "0.3.0b8", "beta", minimum_system_version="26.0"),
+            )
 
-            sparkle_appcast.validate_release_snapshot(beta7_feed, "0.3.0b7")
-            sparkle_appcast.validate_release_tag_snapshot(beta7_feed, "v0.3.0-beta.7")
-            _, channel = sparkle_appcast.load_appcast(beta7_feed)
+            sparkle_appcast.validate_release_snapshot(beta8_feed, "0.3.0b8")
+            sparkle_appcast.validate_release_tag_snapshot(beta8_feed, "v0.3.0-beta.8")
+            _, channel = sparkle_appcast.load_appcast(beta8_feed)
             items = channel.findall("item")
 
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
-            ["152", "151", "150", "149", "148", "146", "145", "144"],
+            ["153", "152", "151", "150", "149", "148", "146", "145", "144"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
             [
+                "0.3.0b8",
                 "0.3.0b7",
                 "0.3.0b6",
                 "0.3.0b5",
@@ -252,7 +259,7 @@ class SparkleAppcastTests(unittest.TestCase):
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
-            ["beta", "beta", "beta", "beta", "beta", None, "rc", "rc"],
+            ["beta", "beta", "beta", "beta", "beta", "beta", None, "rc", "rc"],
         )
 
     def test_rejects_non_monotonic_build(self) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "152")
+        self.assertEqual(info["CFBundleVersion"], "153")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b7"
+version = "0.3.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- advance release metadata to `0.3.0b8` / public `0.3.0-beta.8` / build `153`
- move Beta 7 to immutable published history with its exact release and DMG evidence
- add the Beta 8 cut packet and cumulative appcast expectations
- describe protected-main changes since Beta 7, including receipt-bound packaged AAC validation

## Validation
- `uv run python -m scripts.release validate`
- 1,108 Python tests (3 skipped)
- 307 native tests
- Ruff format/check, mypy, observability migration, import and CLI install smoke
- `uv build`, Briefcase create/build, packaged-tool verification
- JetBrains inspection attempted; timed out with zero reported problems and no actionable finding
- independent GPT and Claude release-risk reviews; no content blocker after the cut packet was staged

## Evidence boundary
This PR prepares another beta, not an RC. It does **not** claim a signed/notarized Beta 8 candidate, NAS/constrained-preview proof, or physical Vision Pro surround, repeated-seek, or lip-sync evidence. Those remain explicit gates under #392 and #382. `macos-signing` approval remains a separate run-bound authorization.

Relates #392
Supports #382 and #367