### PR TITLE
Fix packaged preview AVKit linkage

### DIFF
--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -48,6 +48,9 @@ signature, launches the packaged app through `--startup-smoke`, and runs a real
 `inspect_source` request through the embedded worker. The worker smoke also
 requires canonical schema-v1 FFprobe observability in the protocol stream, so a
 package cannot pass while silently falling back to a legacy child-process path.
+Layout verification also checks the shipping Swift executable's direct platform
+framework links, including AVKit for the embedded preview player, so dead-linking
+cannot defer a missing superclass failure until the player is presented.
 Briefcase remains a runtime assembler; its Python GUI is no longer the shipping
 interface.
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -34,6 +34,7 @@ targets:
         buildPhase: resources
     dependencies:
       - package: Sparkle
+      - sdk: AVKit.framework
     settings:
       base:
         CODE_SIGN_STYLE: Automatic

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -87,6 +87,11 @@ BANNED_RELEASE_IDENTIFIERS = (
     "Native worker prototype",
     "Protocol v1",
 )
+REQUIRED_NATIVE_FRAMEWORK_LINKS = frozenset(
+    {
+        "/System/Library/Frameworks/AVKit.framework/Versions/A/AVKit",
+    }
+)
 MACH_O_MAGICS = {
     b"\xca\xfe\xba\xbe",
     b"\xbe\xba\xfe\xca",
@@ -361,6 +366,7 @@ def verify_layout(app_path: Path, *, environment: Mapping[str, str] | None = Non
     for executable in (native_executable, worker_executable, ffprobe_executable, mv_hevc_encoder):
         if executable_architectures(executable) != {"arm64"}:
             raise RuntimeError(f"Packaged executable must be arm64-only: {executable}")
+    verify_native_framework_links(native_executable)
     verify_mach_o_minimum_system_versions(app_path, native_executable)
     verify_exact_minimum_system_version(mv_hevc_encoder, "MV-HEVC encoder")
     verify_native_binary_paths(native_executable)
@@ -438,6 +444,26 @@ def executable_architectures(path: Path) -> set[str]:
         text=True,
     )
     return set(completed.stdout.split())
+
+
+def linked_libraries(path: Path) -> set[str]:
+    completed = subprocess.run(
+        ["otool", "-L", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        line.strip().split(" (compatibility version", maxsplit=1)[0]
+        for line in completed.stdout.splitlines()
+        if line.strip() and not line.strip().endswith(":")
+    }
+
+
+def verify_native_framework_links(native_executable: Path) -> None:
+    missing = sorted(REQUIRED_NATIVE_FRAMEWORK_LINKS - linked_libraries(native_executable))
+    if missing:
+        raise RuntimeError("macOS app is missing required framework links:\n" + "\n".join(missing))
 
 
 def minimum_macos_versions(path: Path) -> set[str]:

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -22,6 +22,7 @@ from scripts.native_app import (
     NATIVE_PRODUCT_NAME,
     NATIVE_SHORT_VERSION,
     NATIVE_UPDATE_INFO,
+    REQUIRED_NATIVE_FRAMEWORK_LINKS,
     SUPPORT_DIAGNOSTICS_ENDPOINT_ENV,
     SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY,
     WORKER_PROTOCOL_VERSION,
@@ -33,6 +34,7 @@ from scripts.native_app import (
     install_mv_hevc_encoder,
     native_build_settings,
     minimum_macos_versions,
+    linked_libraries,
     package,
     parse_args,
     sign_package,
@@ -41,6 +43,7 @@ from scripts.native_app import (
     smoke_packaged_worker,
     validate_smoke_events,
     verify_native_binary_paths,
+    verify_native_framework_links,
     verify_mach_o_minimum_system_versions,
     verify_exact_minimum_system_version,
     verify_package_paths,
@@ -178,6 +181,7 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertNotIn(".native-preview", project_spec)
         self.assertEqual(project["packages"]["Sparkle"]["exactVersion"], sparkle_manifest["version"])
         self.assertIn({"package": "Sparkle"}, project["targets"]["BluRayToVisionPro"]["dependencies"])
+        self.assertIn({"sdk": "AVKit.framework"}, project["targets"]["BluRayToVisionPro"]["dependencies"])
         update_keys = {
             "BDToAVPDistributionChannel",
             "SUAllowsAutomaticUpdates",
@@ -359,6 +363,46 @@ Load command 3
 
         with patch("scripts.native_app.subprocess.run", return_value=completed):
             self.assertEqual(minimum_macos_versions(Path("/tmp/tool")), {"11.0", "26.0"})
+
+    def test_reads_linked_frameworks_from_otool(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="""
+/tmp/app:
+\t/System/Library/Frameworks/AVKit.framework/Versions/A/AVKit (compatibility version 1.0.0, current version 1000.0.0)
+\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
+""",
+            stderr="",
+        )
+
+        with patch("scripts.native_app.subprocess.run", return_value=completed):
+            libraries = linked_libraries(Path("/tmp/app"))
+
+        self.assertEqual(
+            libraries,
+            {
+                "/System/Library/Frameworks/AVKit.framework/Versions/A/AVKit",
+                "/usr/lib/libSystem.B.dylib",
+            },
+        )
+        self.assertLessEqual(REQUIRED_NATIVE_FRAMEWORK_LINKS, libraries)
+
+    def test_rejects_native_app_without_required_framework_link(self) -> None:
+        native_executable = Path("/tmp/app")
+        with (
+            patch("scripts.native_app.linked_libraries", return_value=set()),
+            self.assertRaisesRegex(RuntimeError, "missing required framework links"),
+        ):
+            verify_native_framework_links(native_executable)
+
+    def test_accepts_native_app_with_required_framework_link(self) -> None:
+        native_executable = Path("/tmp/app")
+        with patch(
+            "scripts.native_app.linked_libraries",
+            return_value={"/System/Library/Frameworks/AVKit.framework/Versions/A/AVKit"},
+        ):
+            verify_native_framework_links(native_executable)
 
     def test_rejects_packaged_mach_o_requiring_newer_macos(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

- link `AVKit.framework` explicitly in the production macOS target
- reject packaged apps whose Swift host lacks the direct AVKit load command
- cover the XcodeGen dependency, real `otool -L` output shape, and fail/pass verifier paths
- document the package-time framework-link gate

## Why

Exact signed `v0.3.0-beta.8` build 153 completed the #392 local/NAS preview work, then crashed when SwiftUI presented the embedded player. The unified log reported failure to resolve `_AVKit_SwiftUI.VideoPlayerView`'s `AVPlayerView` superclass. The signed binary loaded `_AVKit_SwiftUI` but did not directly link `AVKit.framework`.

An ad-hoc Release package built with this change links `/System/Library/Frameworks/AVKit.framework/Versions/A/AVKit`. Repeating the same NAS-backed GUI preview presents the embedded player without a crash; success cleanup and cancellation cleanup both remove the preview workspace. This is package validation only, not a substitute for a new signed candidate.

## Validation

- `uv sync --all-groups --python 3.12`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp scripts/native_app.py`
- `uv run python -m unittest discover -s tests -t .` — 1,111 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 307 passed
- `uv run python scripts/validate_observability_migration.py`
- `uv build`
- import and CLI smokes
- `uv run python scripts/native_app.py package`
- ad-hoc packaged GUI preview success and cancellation against the disposable NAS fixture
- JetBrains whole-project review: only ignored generated-build empty directories; changed-file closeout clean after cleanup
- independent Claude review finding addressed with a non-tautological install-name test; Antigravity review was invoked but returned no written findings

## Release boundary

Beta 8 remains blocked for #392 because the exact signed candidate contains the missing link. This PR does not dispatch a release or claim signed-candidate qualification; a newer signed beta must rerun the packaged preview gate after merge.

Refs #392
