### PR TITLE
Add packaged preview presentation smoke

### DIFF
--- a/bd_to_avp/worker/__main__.py
+++ b/bd_to_avp/worker/__main__.py
@@ -26,6 +26,24 @@ from bd_to_avp.worker.protocol import (
 )
 
 OperationRunner = Callable[[JobSpec, WorkerProcessOwner, WorkerActivityReporter], dict[str, object]]
+APPLE_VISION_OCR_SMOKE_ARGUMENT = "--smoke-apple-vision-ocr"
+
+
+def run_smoke_command(
+    arguments: list[str],
+    output_stream: TextIO,
+    *,
+    apple_vision_loader: Callable[[], object] | None = None,
+) -> int | None:
+    if arguments != [APPLE_VISION_OCR_SMOKE_ARGUMENT]:
+        return None
+    if apple_vision_loader is None:
+        from bd_to_avp.vendor.pgsrip.ocr import AppleVisionOcr
+
+        apple_vision_loader = AppleVisionOcr._load_frameworks
+    apple_vision_loader()
+    output_stream.write("Apple Vision OCR import smoke passed\n")
+    return 0
 
 
 def run_worker(
@@ -180,6 +198,9 @@ def _emit_heartbeats(
 
 
 def main() -> None:
+    smoke_result = run_smoke_command(sys.argv[1:], sys.stdout)
+    if smoke_result is not None:
+        raise SystemExit(smoke_result)
     raise SystemExit(run_worker(sys.stdin, sys.stdout, sys.stderr))
 
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -62,16 +62,15 @@ that first user-approved launch, quit the app and run the automated smoke.
 
 ## Automated App Smoke
 
-Run the shell smoke script from a checkout, copied script, or downloaded source
-archive. It uses macOS system tools and the packaged app, so it is the preferred
-VM command:
+Run the shell smoke script from a checkout or downloaded source archive. It
+delegates to the maintained Python harness through `uv` when available and
+otherwise uses `python3`, so both commands execute the same checks:
 
 ```bash
 sh scripts/smoke_release_app.sh "/Applications/3D Blu-ray to Vision Pro.app"
 ```
 
-For an in-repo Python harness with the same core checks, use a machine that
-already has Python available:
+The Python entrypoint can also be invoked directly:
 
 ```bash
 python3 scripts/smoke_release_app.py \
@@ -86,9 +85,21 @@ Expected result:
 - If Xcode Command Line Tools are available, bundled tools do not link to
   `/opt/homebrew` or `/usr/local`. If developer tools are not installed, the
   scripts say the linkage check was skipped.
-- The packaged CLI `--version` matches `Info.plist`.
-- The packaged CLI `--help` runs with a sanitized `PATH`.
-- The packaged Apple Vision OCR smoke runs with a sanitized `PATH`.
+- Every executable probe has a bounded timeout, including the native GUI host.
+- The native launcher starts through its supported `--startup-smoke` contract;
+  the smoke never sends legacy CLI `--version` or `--help` arguments to the GUI.
+- The player probe opens a fresh app instance through macOS LaunchServices so
+  SwiftUI creates the real window scene; direct executable launch is retained
+  only for the non-UI startup contract.
+- `Info.plist` supplies the package version, and the packaged worker reports the
+  same version through a protocol-v10 inspection request.
+- The packaged Apple Vision OCR smoke runs through the bundled worker entrypoint
+  with a sanitized `PATH`.
+- A one-second local H.264 fixture is presented through the existing
+  `PreviewPlayerView`. The receipt proves the player view attached, AVFoundation
+  accepted the media, the app remained alive, and the isolated artifact
+  workspace was removed before exit. This is a packaged player-presentation
+  smoke, not a second preview feature or a NAS/conversion qualification.
 - If MakeMKV is absent, the script records that the first-run path should ask
   the user to install MakeMKV.
 

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -3,6 +3,7 @@ import AppKit
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     nonisolated static let startupSmokeArgument = "--startup-smoke"
+    nonisolated static let previewPresentationSmokeArgument = "--preview-presentation-smoke"
 
     weak var workCoordinator: AppWorkCoordinator?
     var observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared
@@ -23,6 +24,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     nonisolated static func isStartupSmoke(arguments: [String]) -> Bool {
         arguments.contains(startupSmokeArgument)
+    }
+
+    nonisolated static func isPreviewPresentationSmoke(arguments: [String]) -> Bool {
+        arguments.contains(previewPresentationSmokeArgument)
+    }
+
+    nonisolated static func isAutomationSmoke(arguments: [String]) -> Bool {
+        isStartupSmoke(arguments: arguments) || isPreviewPresentationSmoke(arguments: arguments)
     }
 
     func attach(window: NSWindow, workCoordinator: AppWorkCoordinator) {
@@ -65,7 +74,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        if Self.isStartupSmoke(arguments: ProcessInfo.processInfo.arguments) {
+        if Self.isAutomationSmoke(arguments: ProcessInfo.processInfo.arguments) {
             return .terminateNow
         }
         if isStoppingForTermination {

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -17,6 +17,7 @@ struct BluRayToVisionProApp: App {
     private let capabilities = AppCapabilities.current
     private let workCoordinator: AppWorkCoordinator
     private let observabilityEventStore: any ObservabilityEventPersisting
+    private let previewPresentationSmokeConfiguration: PreviewPresentationSmokeConfiguration?
 
     init() {
         let observabilityEventStore = ObservabilityEventStore.automatic()
@@ -42,30 +43,38 @@ struct BluRayToVisionProApp: App {
         _updater = StateObject(wrappedValue: UpdateController(installPostponer: workCoordinator))
         self.workCoordinator = workCoordinator
         self.observabilityEventStore = observabilityEventStore
+        previewPresentationSmokeConfiguration = PreviewPresentationSmokeConfiguration.parse(
+            arguments: ProcessInfo.processInfo.arguments
+        )
         appDelegate.observabilityEventStore = observabilityEventStore
     }
 
     var body: some Scene {
         WindowGroup {
-            ContentView(
-                viewModel: viewModel,
-                previewViewModel: previewViewModel,
-                diagnosticReportViewModel: diagnosticReportViewModel,
-                settings: settings,
-                profileStore: profileStore,
-                capabilities: capabilities
-            )
-                .frame(minWidth: 1_080, minHeight: 680)
-                .background(
-                    WindowAccessor { window in
-                        appDelegate.attach(window: window, workCoordinator: workCoordinator)
-                    }
+            if let previewPresentationSmokeConfiguration {
+                PreviewPresentationSmokeView(configuration: previewPresentationSmokeConfiguration)
+                    .frame(width: 820, height: 620)
+            } else {
+                ContentView(
+                    viewModel: viewModel,
+                    previewViewModel: previewViewModel,
+                    diagnosticReportViewModel: diagnosticReportViewModel,
+                    settings: settings,
+                    profileStore: profileStore,
+                    capabilities: capabilities
                 )
-                .onAppear {
-                    updater.startIfNeeded()
-                    settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
-                    appDelegate.workCoordinator = workCoordinator
-                }
+                    .frame(minWidth: 1_080, minHeight: 680)
+                    .background(
+                        WindowAccessor { window in
+                            appDelegate.attach(window: window, workCoordinator: workCoordinator)
+                        }
+                    )
+                    .onAppear {
+                        updater.startIfNeeded()
+                        settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
+                        appDelegate.workCoordinator = workCoordinator
+                    }
+            }
         }
         .defaultSize(width: 1_120, height: 820)
         .windowResizability(.contentMinSize)

--- a/macos/BluRayToVisionPro/App/PreviewPresentationSmoke.swift
+++ b/macos/BluRayToVisionPro/App/PreviewPresentationSmoke.swift
@@ -1,0 +1,312 @@
+import AppKit
+import AVFoundation
+import AVKit
+import SwiftUI
+
+struct PreviewPresentationSmokeConfiguration: Equatable {
+    let mediaURL: URL
+    let resultURL: URL
+
+    static func parse(arguments: [String]) -> PreviewPresentationSmokeConfiguration? {
+        guard let argumentIndex = arguments.firstIndex(of: AppDelegate.previewPresentationSmokeArgument),
+              arguments.indices.contains(argumentIndex + 2) else {
+            return nil
+        }
+        let mediaPath = arguments[argumentIndex + 1]
+        let resultPath = arguments[argumentIndex + 2]
+        guard !mediaPath.isEmpty, !resultPath.isEmpty else {
+            return nil
+        }
+        return PreviewPresentationSmokeConfiguration(
+            mediaURL: URL(fileURLWithPath: mediaPath).standardizedFileURL,
+            resultURL: URL(fileURLWithPath: resultPath).standardizedFileURL
+        )
+    }
+}
+
+@MainActor
+final class PreviewPresentationSmokeController: ObservableObject {
+    @Published private(set) var lease: PreviewArtifactLease?
+
+    private let configuration: PreviewPresentationSmokeConfiguration
+    private let initializationError: String?
+    private var completionStarted = false
+
+    init(configuration: PreviewPresentationSmokeConfiguration, fileManager: FileManager = .default) {
+        self.configuration = configuration
+        let mediaURL = configuration.mediaURL
+        let directoryURL = mediaURL.deletingLastPathComponent()
+        let rootURL = directoryURL.deletingLastPathComponent()
+        let cache = PreviewCache(rootURL: rootURL, fileManager: fileManager)
+
+        guard fileManager.fileExists(atPath: mediaURL.path), cache.contains(mediaURL, in: directoryURL) else {
+            lease = nil
+            initializationError = "The preview smoke media is missing or outside its isolated workspace."
+            return
+        }
+
+        let attributes = try? fileManager.attributesOfItem(atPath: mediaURL.path)
+        let sizeBytes = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        let artifact = PreviewArtifact(
+            sourcePath: mediaURL.path,
+            destinationPath: directoryURL.path,
+            outputPath: mediaURL.path,
+            sizeBytes: sizeBytes,
+            parentJobID: UUID(),
+            position: "middle",
+            startSeconds: 0,
+            durationSeconds: 1,
+            sourceDurationSeconds: 1
+        )
+        lease = PreviewArtifactLease(
+            artifact: artifact,
+            directoryURL: directoryURL,
+            cache: cache
+        )
+        initializationError = nil
+    }
+
+    func viewAttached(playerView: AVPlayerView?) {
+        guard !completionStarted else {
+            return
+        }
+        completionStarted = true
+        Task {
+            await finish(playerView: playerView)
+        }
+    }
+
+    private func finish(playerView: AVPlayerView?) async {
+        guard initializationError == nil, lease != nil else {
+            writeReceipt(
+                playerPresented: false,
+                mediaReady: false,
+                cleanupComplete: false,
+                message: initializationError ?? "The preview smoke could not create an artifact lease."
+            )
+            NSApp.terminate(nil)
+            return
+        }
+
+        guard let playerView else {
+            let cleanupComplete = await releaseLeaseAndWaitForCleanup()
+            writeReceipt(
+                playerPresented: false,
+                mediaReady: false,
+                cleanupComplete: cleanupComplete,
+                message: PreviewPresentationSmokeError.playerViewNotFound.localizedDescription
+            )
+            NSApp.terminate(nil)
+            return
+        }
+
+        do {
+            try await waitForMediaReady(playerView)
+            let cleanupComplete = await releaseLeaseAndWaitForCleanup()
+            writeReceipt(
+                playerPresented: true,
+                mediaReady: true,
+                cleanupComplete: cleanupComplete,
+                message: cleanupComplete ? nil : "The preview artifact workspace was not removed before the deadline."
+            )
+        } catch {
+            let cleanupComplete = await releaseLeaseAndWaitForCleanup()
+            writeReceipt(
+                playerPresented: true,
+                mediaReady: false,
+                cleanupComplete: cleanupComplete,
+                message: error.localizedDescription
+            )
+        }
+        NSApp.terminate(nil)
+    }
+
+    private func waitForMediaReady(_ playerView: AVPlayerView) async throws {
+        for _ in 0..<100 {
+            if let currentItem = playerView.player?.currentItem {
+                switch currentItem.status {
+                case .readyToPlay:
+                    return
+                case .failed:
+                    throw PreviewPresentationSmokeError.mediaFailed(
+                        currentItem.error?.localizedDescription ?? "AVPlayer rejected the preview smoke media."
+                    )
+                case .unknown:
+                    break
+                @unknown default:
+                    break
+                }
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw PreviewPresentationSmokeError.mediaReadinessTimedOut
+    }
+
+    private func releaseLeaseAndWaitForCleanup() async -> Bool {
+        guard let cleanupContext = releaseLease() else {
+            return false
+        }
+        return await waitForRemoval(cleanupContext.directoryURL, fileManager: cleanupContext.fileManager)
+    }
+
+    private func releaseLease() -> (directoryURL: URL, fileManager: FileManager)? {
+        guard let lease else {
+            return nil
+        }
+        let cleanupContext = (directoryURL: lease.directoryURL, fileManager: lease.fileManager)
+        self.lease = nil
+        return cleanupContext
+    }
+
+    private func waitForRemoval(_ directoryURL: URL, fileManager: FileManager) async -> Bool {
+        for _ in 0..<50 {
+            if !fileManager.fileExists(atPath: directoryURL.path) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        return !fileManager.fileExists(atPath: directoryURL.path)
+    }
+
+    private func writeReceipt(
+        playerPresented: Bool,
+        mediaReady: Bool,
+        cleanupComplete: Bool,
+        message: String?
+    ) {
+        let receipt = PreviewPresentationSmokeReceipt(
+            schemaVersion: 1,
+            playerPresented: playerPresented,
+            mediaReady: mediaReady,
+            cleanupComplete: cleanupComplete,
+            message: message
+        )
+        guard let data = try? JSONEncoder().encode(receipt) else {
+            return
+        }
+        try? data.write(to: configuration.resultURL, options: .atomic)
+    }
+}
+
+struct PreviewPresentationSmokeView: View {
+    @StateObject private var controller: PreviewPresentationSmokeController
+
+    init(configuration: PreviewPresentationSmokeConfiguration) {
+        _controller = StateObject(
+            wrappedValue: PreviewPresentationSmokeController(configuration: configuration)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if let lease = controller.lease {
+                PreviewPlayerView(
+                    lease: lease,
+                    videoRoute: nil,
+                    generateAgain: {},
+                    removePreview: {},
+                    startFullConversion: {}
+                )
+                .background(PreviewPresentationAttachmentProbe(onAttached: controller.viewAttached))
+            } else {
+                ProgressView("Completing preview smoke…")
+                    .onAppear {
+                        controller.viewAttached(playerView: nil)
+                    }
+            }
+        }
+        .padding(22)
+    }
+}
+
+private struct PreviewPresentationSmokeReceipt: Codable {
+    let schemaVersion: Int
+    let playerPresented: Bool
+    let mediaReady: Bool
+    let cleanupComplete: Bool
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case playerPresented = "player_presented"
+        case mediaReady = "media_ready"
+        case cleanupComplete = "cleanup_complete"
+        case message
+    }
+}
+
+private enum PreviewPresentationSmokeError: LocalizedError {
+    case playerViewNotFound
+    case mediaFailed(String)
+    case mediaReadinessTimedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .playerViewNotFound:
+            "The existing preview player did not attach an AVPlayerView before the deadline."
+        case let .mediaFailed(message):
+            message
+        case .mediaReadinessTimedOut:
+            "The existing preview player did not make the smoke media ready before the deadline."
+        }
+    }
+}
+
+private struct PreviewPresentationAttachmentProbe: NSViewRepresentable {
+    let onAttached: @MainActor (AVPlayerView?) -> Void
+
+    func makeNSView(context: Context) -> ProbeView {
+        ProbeView(onAttached: onAttached)
+    }
+
+    func updateNSView(_ nsView: ProbeView, context: Context) {}
+
+    final class ProbeView: NSView {
+        private let onAttached: @MainActor (AVPlayerView?) -> Void
+        private var hasAttached = false
+
+        init(onAttached: @escaping @MainActor (AVPlayerView?) -> Void) {
+            self.onAttached = onAttached
+            super.init(frame: .zero)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            nil
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard window != nil, !hasAttached else {
+                return
+            }
+            hasAttached = true
+            Task { @MainActor [weak self] in
+                for _ in 0..<50 {
+                    guard let self else {
+                        return
+                    }
+                    if let contentView = window?.contentView,
+                       let playerView = findPlayerView(in: contentView) {
+                        onAttached(playerView)
+                        return
+                    }
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+                onAttached(nil)
+            }
+        }
+
+        private func findPlayerView(in view: NSView) -> AVPlayerView? {
+            if let playerView = view as? AVPlayerView {
+                return playerView
+            }
+            for subview in view.subviews {
+                if let playerView = findPlayerView(in: subview) {
+                    return playerView
+                }
+            }
+            return nil
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/UpdateController.swift
+++ b/macos/BluRayToVisionPro/Feature/UpdateController.swift
@@ -125,7 +125,7 @@ struct UpdateEnvironment: Equatable {
         allowsAutomaticUpdates = boolValue("SUAllowsAutomaticUpdates")
         verifiesBeforeExtraction = boolValue("SUVerifyUpdateBeforeExtraction")
         automaticChecksSettingPresent = bundle.object(forInfoDictionaryKey: "SUEnableAutomaticChecks") != nil
-        startupSuppressed = AppDelegate.isStartupSmoke(arguments: arguments)
+        startupSuppressed = AppDelegate.isAutomationSmoke(arguments: arguments)
             || processEnvironment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
     }
 

--- a/macos/BluRayToVisionPro/Views/PreviewSheet.swift
+++ b/macos/BluRayToVisionPro/Views/PreviewSheet.swift
@@ -364,7 +364,7 @@ struct PreviewSheet: View {
     }
 }
 
-private struct PreviewPlayerView: View {
+struct PreviewPlayerView: View {
     let lease: PreviewArtifactLease
     let videoRoute: VideoRouteReport?
     let generateAgain: () -> Void

--- a/macos/BluRayToVisionProTests/AppDelegateTests.swift
+++ b/macos/BluRayToVisionProTests/AppDelegateTests.swift
@@ -6,4 +6,21 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertTrue(AppDelegate.isStartupSmoke(arguments: ["app", AppDelegate.startupSmokeArgument]))
         XCTAssertFalse(AppDelegate.isStartupSmoke(arguments: ["app"]))
     }
+
+    func testPreviewPresentationSmokeArgumentIsExplicit() {
+        XCTAssertTrue(
+            AppDelegate.isPreviewPresentationSmoke(
+                arguments: ["app", AppDelegate.previewPresentationSmokeArgument, "/tmp/media.mov", "/tmp/result.json"]
+            )
+        )
+        XCTAssertFalse(AppDelegate.isPreviewPresentationSmoke(arguments: ["app"]))
+    }
+
+    func testAutomationSmokeIncludesStartupAndPreviewPresentation() {
+        XCTAssertTrue(AppDelegate.isAutomationSmoke(arguments: ["app", AppDelegate.startupSmokeArgument]))
+        XCTAssertTrue(
+            AppDelegate.isAutomationSmoke(arguments: ["app", AppDelegate.previewPresentationSmokeArgument])
+        )
+        XCTAssertFalse(AppDelegate.isAutomationSmoke(arguments: ["app"]))
+    }
 }

--- a/macos/BluRayToVisionProTests/PreviewPresentationSmokeTests.swift
+++ b/macos/BluRayToVisionProTests/PreviewPresentationSmokeTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+final class PreviewPresentationSmokeTests: XCTestCase {
+    func testParsesPreviewPresentationSmokeArguments() throws {
+        let configuration = try XCTUnwrap(
+            PreviewPresentationSmokeConfiguration.parse(
+                arguments: [
+                    "app",
+                    AppDelegate.previewPresentationSmokeArgument,
+                    "/tmp/smoke/job/preview.mov",
+                    "/tmp/smoke/result.json",
+                ]
+            )
+        )
+
+        XCTAssertEqual(configuration.mediaURL.path, "/tmp/smoke/job/preview.mov")
+        XCTAssertEqual(configuration.resultURL.path, "/tmp/smoke/result.json")
+    }
+
+    func testRejectsIncompletePreviewPresentationSmokeArguments() {
+        XCTAssertNil(
+            PreviewPresentationSmokeConfiguration.parse(
+                arguments: ["app", AppDelegate.previewPresentationSmokeArgument, "/tmp/preview.mov"]
+            )
+        )
+    }
+}

--- a/scripts/macos_release.py
+++ b/scripts/macos_release.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 from scripts.native_app import (
     NATIVE_APP_NAME,
-    NATIVE_EXECUTABLE_NAME,
     NATIVE_PRODUCT_NAME,
+    smoke_packaged_native_app,
     smoke_packaged_worker,
     verify_layout,
 )
@@ -51,7 +51,7 @@ def verify_release_app(
         run(["xcrun", "stapler", "validate", str(app_path)])
         run(["spctl", "--assess", "--type", "execute", "--verbose=4", str(app_path)])
     if smoke_app:
-        smoke_native_app_startup(app_path)
+        smoke_native_app(app_path)
     if smoke_tools:
         smoke_packaged_tools(app_path)
     if smoke_worker:
@@ -59,26 +59,11 @@ def verify_release_app(
     return metadata
 
 
-def smoke_native_app_startup(app_path: Path) -> None:
-    executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
-    with tempfile.TemporaryDirectory(prefix="macos-release-startup-") as temporary_directory:
-        environment = os.environ.copy()
-        environment["HOME"] = temporary_directory
-        environment["TMPDIR"] = temporary_directory
-        try:
-            completed = subprocess.run(
-                [str(executable), "--startup-smoke"],
-                cwd=temporary_directory,
-                env=environment,
-                capture_output=True,
-                text=True,
-                timeout=20,
-            )
-        except subprocess.TimeoutExpired as error:
-            raise MacOSReleaseError("macOS app startup smoke did not exit within 20 seconds.") from error
-    if completed.returncode != 0:
-        details = (completed.stderr or completed.stdout).strip()
-        raise MacOSReleaseError(f"macOS app startup smoke exited with status {completed.returncode}: {details}")
+def smoke_native_app(app_path: Path) -> None:
+    try:
+        smoke_packaged_native_app(app_path)
+    except (RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        raise MacOSReleaseError(f"macOS native app smoke failed: {error}") from error
 
 
 def smoke_packaged_tools(app_path: Path) -> None:

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -140,6 +140,7 @@ def run(
     *,
     cwd: Path = REPO_ROOT,
     environment: dict[str, str] | None = None,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
@@ -147,6 +148,7 @@ def run(
         cwd=cwd,
         env=environment,
         text=True,
+        timeout=timeout,
     )
 
 
@@ -595,9 +597,12 @@ def verify_codesign(app_path: Path) -> None:
 
 
 def smoke_packaged_native_app(app_path: Path) -> None:
+    from scripts.smoke_release_app import build_clean_env, read_bundle, verify_preview_presentation
+
     app_path = app_path.resolve()
     native_executable = app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME
-    run([str(native_executable), "--startup-smoke"], cwd=app_path)
+    run([str(native_executable), "--startup-smoke"], cwd=app_path, timeout=20)
+    verify_preview_presentation(read_bundle(app_path), build_clean_env())
 
 
 def smoke_packaged_mv_hevc_encoder(app_path: Path) -> None:

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import time
 
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
@@ -306,17 +307,13 @@ def wait_for_preview_process_exit(result_path: Path, *, timeout: float) -> bool:
 def terminate_preview_processes(result_path: Path) -> None:
     process_ids = preview_process_ids(result_path)
     for process_id in process_ids:
-        try:
+        with suppress(ProcessLookupError):
             os.kill(process_id, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
     if not process_ids or wait_for_preview_process_exit(result_path, timeout=2):
         return
     for process_id in preview_process_ids(result_path):
-        try:
+        with suppress(ProcessLookupError):
             os.kill(process_id, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
 
 
 def verify_native_startup(bundle: AppBundle, clean_env: dict[str, str]) -> None:

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import plistlib
 import re
 import shutil
+import signal
 import subprocess
 import sys
+import tempfile
+import time
 
 from dataclasses import dataclass
 from pathlib import Path
+from uuid import uuid4
 
 
 DEFAULT_APP_PATHS = [
@@ -18,7 +23,13 @@ DEFAULT_APP_PATHS = [
 ]
 APP_RESOURCE_APP_PATH = Path("Contents/Resources/app")
 APP_BIN_PATH = APP_RESOURCE_APP_PATH / "bd_to_avp" / "bin"
-PACKAGE_VERSION_RE = re.compile(r"\bVersion\s+(?P<version>\S+)")
+WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
+EXPECTED_WORKER_PROTOCOL_VERSION = 10
+PREVIEW_PRESENTATION_SMOKE_ARGUMENT = "--preview-presentation-smoke"
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 20
+PREVIEW_PRESENTATION_TIMEOUT_SECONDS = 30
+PREVIEW_PROCESS_EXIT_TIMEOUT_SECONDS = 5
+PREVIEW_POLL_INTERVAL_SECONDS = 0.1
 REQUIRED_BUNDLED_TOOLS = {
     "ffmpeg": ["-hide_banner", "-version"],
     "ffprobe": ["-hide_banner", "-version"],
@@ -36,6 +47,7 @@ MINIMAL_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
 class AppBundle:
     path: Path
     executable: Path
+    worker_executable: Path
     resources_app: Path
     bin_dir: Path
     bundle_identifier: str
@@ -46,15 +58,37 @@ class SmokeFailure(RuntimeError):
     pass
 
 
-def run(command: list[str | Path], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [str(item) for item in command],
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        env=env,
-    )
+def run(
+    command: list[str | Path],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    input_text: str | None = None,
+    timeout: float = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    combine_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    serialized_command = [str(item) for item in command]
+    try:
+        return subprocess.run(
+            serialized_command,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT if combine_output else subprocess.PIPE,
+            env=env,
+            cwd=cwd,
+            input=input_text,
+            timeout=timeout,
+        )
+    except FileNotFoundError as error:
+        raise SmokeFailure(f"Smoke command is unavailable: {serialized_command[0]}") from error
+    except subprocess.TimeoutExpired as error:
+        raise SmokeFailure(f"Smoke command exceeded {timeout:g} seconds: {' '.join(serialized_command)}") from error
+    except subprocess.CalledProcessError as error:
+        output = "\n".join(part.strip() for part in (error.stdout, error.stderr) if part and part.strip())
+        raise SmokeFailure(
+            f"Smoke command failed with status {error.returncode}: {' '.join(serialized_command)}\n{output}"
+        ) from error
 
 
 def build_clean_env() -> dict[str, str]:
@@ -78,6 +112,7 @@ def find_default_app() -> Path:
 
 
 def read_bundle(app_path: Path) -> AppBundle:
+    app_path = app_path.expanduser().resolve()
     info_plist_path = app_path / "Contents" / "Info.plist"
     if not info_plist_path.is_file():
         raise SmokeFailure(f"Missing app Info.plist: {info_plist_path}")
@@ -89,11 +124,13 @@ def read_bundle(app_path: Path) -> AppBundle:
     bundle_identifier = require_plist_string(info, "CFBundleIdentifier", info_plist_path)
     short_version = require_plist_string(info, "CFBundleShortVersionString", info_plist_path)
     executable = app_path / "Contents" / "MacOS" / executable_name
+    worker_executable = app_path / "Contents" / "MacOS" / WORKER_EXECUTABLE_NAME
     resources_app = app_path / APP_RESOURCE_APP_PATH
     bin_dir = app_path / APP_BIN_PATH
     return AppBundle(
         path=app_path,
         executable=executable,
+        worker_executable=worker_executable,
         resources_app=resources_app,
         bin_dir=bin_dir,
         bundle_identifier=bundle_identifier,
@@ -109,11 +146,12 @@ def require_plist_string(info: dict[str, object], key: str, plist_path: Path) ->
 
 
 def verify_app_layout(bundle: AppBundle) -> None:
-    for path in [bundle.executable, bundle.resources_app, bundle.bin_dir]:
+    for path in [bundle.executable, bundle.worker_executable, bundle.resources_app, bundle.bin_dir]:
         if not path.exists():
             raise SmokeFailure(f"Missing expected app bundle path: {path}")
-    if not os.access(bundle.executable, os.X_OK):
-        raise SmokeFailure(f"App executable is not executable: {bundle.executable}")
+    for executable in (bundle.executable, bundle.worker_executable):
+        if not os.access(executable, os.X_OK):
+            raise SmokeFailure(f"App executable is not executable: {executable}")
 
 
 def verify_gatekeeper(app_path: Path, *, skip_spctl: bool) -> None:
@@ -121,14 +159,14 @@ def verify_gatekeeper(app_path: Path, *, skip_spctl: bool) -> None:
         return
     try:
         run(["spctl", "--assess", "--type", "execute", "--verbose=4", app_path])
-    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+    except SmokeFailure as error:
         raise SmokeFailure(f"Gatekeeper assessment failed for {app_path}: {error}") from error
 
 
 def developer_tools_available() -> bool:
     try:
         run(["xcode-select", "-p"])
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except SmokeFailure:
         return False
     return shutil.which("otool", path=MINIMAL_PATH) is not None
 
@@ -142,9 +180,8 @@ def verify_bundled_tool(
         raise SmokeFailure(f"Bundled tool is not executable: {tool_path}")
     try:
         run([tool_path, *probe_args], env=clean_env)
-    except (FileNotFoundError, subprocess.CalledProcessError) as error:
-        output = getattr(error, "output", "") or ""
-        raise SmokeFailure(f"Bundled tool did not run: {tool_path}\n{output.strip()}") from error
+    except SmokeFailure as error:
+        raise SmokeFailure(f"Bundled tool did not run: {tool_path}\n{error}") from error
 
     if tool_path.name == "ffmpeg":
         encoders = run([tool_path, "-hide_banner", "-encoders"], env=clean_env).stdout
@@ -159,7 +196,7 @@ def verify_bundled_tool(
 
     try:
         linked_libraries = run(["otool", "-L", tool_path], env=clean_env).stdout
-    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+    except SmokeFailure as error:
         raise SmokeFailure(f"Could not inspect linked libraries for {tool_path}: {error}") from error
     for forbidden_path in ["/opt/homebrew", "/usr/local"]:
         if forbidden_path in linked_libraries:
@@ -189,29 +226,253 @@ def verify_no_homebrew_requirement(bundle: AppBundle) -> None:
     print("Homebrew present on this machine; smoke used sanitized PATH to avoid it")
 
 
-def verify_cli_version(bundle: AppBundle, clean_env: dict[str, str]) -> None:
-    output = run([bundle.executable, "--version"], env=clean_env).stdout.strip()
-    match = PACKAGE_VERSION_RE.search(output)
-    if not match:
-        raise SmokeFailure(f"Could not parse app version output: {output}")
-    package_version = match.group("version")
-    if package_version != bundle.short_version:
-        raise SmokeFailure(
-            f"App version mismatch: Info.plist has {bundle.short_version}, CLI reported {package_version}"
+def verify_package_version(bundle: AppBundle) -> None:
+    print(f"Package version metadata passed: {bundle.short_version}")
+
+
+def native_smoke_environment(clean_env: dict[str, str], temporary_directory: Path) -> dict[str, str]:
+    environment = clean_env.copy()
+    environment.pop("__CFBundleIdentifier", None)
+    environment["HOME"] = str(temporary_directory)
+    environment["TMPDIR"] = str(temporary_directory)
+    return environment
+
+
+def launch_preview_application(
+    bundle: AppBundle,
+    media_path: Path,
+    result_path: Path,
+    *,
+    environment: dict[str, str],
+    cwd: Path,
+) -> None:
+    run(
+        [
+            "/usr/bin/open",
+            "-g",
+            "-n",
+            bundle.path,
+            "--args",
+            PREVIEW_PRESENTATION_SMOKE_ARGUMENT,
+            media_path,
+            result_path,
+        ],
+        env=environment,
+        cwd=cwd,
+    )
+
+
+def wait_for_path(path: Path, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.is_file():
+            return True
+        time.sleep(PREVIEW_POLL_INTERVAL_SECONDS)
+    return path.is_file()
+
+
+def preview_process_ids(result_path: Path) -> set[int]:
+    command = ["/usr/bin/pgrep", "-f", re.escape(str(result_path))]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
         )
-    print(f"CLI version smoke passed: {package_version}")
+    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+        raise SmokeFailure("Could not inspect the packaged preview smoke process") from error
+    if completed.returncode == 1:
+        return set()
+    if completed.returncode != 0:
+        raise SmokeFailure(f"Could not inspect the packaged preview smoke process: {completed.stderr.strip()}")
+    try:
+        return {int(line) for line in completed.stdout.splitlines() if line.strip()}
+    except ValueError as error:
+        raise SmokeFailure("The packaged preview smoke process lookup returned an invalid PID") from error
 
 
-def verify_cli_help(bundle: AppBundle, clean_env: dict[str, str]) -> None:
-    output = run([bundle.executable, "--help"], env=clean_env).stdout
-    if "Process 3D Blu-ray" not in output or "--source" not in output:
-        raise SmokeFailure("CLI help output did not include expected BD_to_AVP options")
+def wait_for_preview_process_exit(result_path: Path, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not preview_process_ids(result_path):
+            return True
+        time.sleep(PREVIEW_POLL_INTERVAL_SECONDS)
+    return not preview_process_ids(result_path)
+
+
+def terminate_preview_processes(result_path: Path) -> None:
+    process_ids = preview_process_ids(result_path)
+    for process_id in process_ids:
+        try:
+            os.kill(process_id, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    if not process_ids or wait_for_preview_process_exit(result_path, timeout=2):
+        return
+    for process_id in preview_process_ids(result_path):
+        try:
+            os.kill(process_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def verify_native_startup(bundle: AppBundle, clean_env: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="bd-to-avp-installed-startup-") as temporary_directory:
+        temporary_path = Path(temporary_directory)
+        run(
+            [bundle.executable, "--startup-smoke"],
+            env=native_smoke_environment(clean_env, temporary_path),
+            cwd=temporary_path,
+        )
+    print("Native startup smoke passed")
+
+
+def verify_worker_protocol(bundle: AppBundle, clean_env: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="bd-to-avp-installed-worker-") as temporary_directory:
+        temporary_path = Path(temporary_directory)
+        source_path = temporary_path / "smoke.m2ts"
+        run(
+            [
+                bundle.bin_dir / "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=160x90:rate=24",
+                "-t",
+                "0.25",
+                "-c:v",
+                "mpeg2video",
+                "-f",
+                "mpegts",
+                source_path,
+            ],
+            env=clean_env,
+        )
+        job_id = str(uuid4())
+        request = {
+            "protocol_version": EXPECTED_WORKER_PROTOCOL_VERSION,
+            "type": "job.start",
+            "job_id": job_id,
+            "operation": "inspect_source",
+            "source": {"kind": "direct_file", "path": str(source_path)},
+        }
+        completed = run(
+            [bundle.worker_executable],
+            env=clean_env,
+            cwd=temporary_path,
+            input_text=json.dumps(request) + "\n",
+            timeout=30,
+            combine_output=False,
+        )
+
+    try:
+        events = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    except json.JSONDecodeError as error:
+        raise SmokeFailure(f"Packaged worker returned invalid JSON: {completed.stdout}") from error
+    if len(events) < 4 or not all(isinstance(event, dict) for event in events):
+        raise SmokeFailure("Packaged worker did not return the required event stream")
+    if [event.get("sequence") for event in events] != list(range(len(events))):
+        raise SmokeFailure("Packaged worker event sequence was not contiguous")
+    if any(event.get("protocol_version") != EXPECTED_WORKER_PROTOCOL_VERSION for event in events):
+        raise SmokeFailure(f"Packaged worker protocol did not match v{EXPECTED_WORKER_PROTOCOL_VERSION}")
+    ready_payload = events[0].get("payload")
+    worker_version = ready_payload.get("worker_version") if isinstance(ready_payload, dict) else None
+    if events[0].get("type") != "worker.ready" or worker_version != bundle.short_version:
+        raise SmokeFailure(
+            f"Packaged worker version mismatch: expected {bundle.short_version}, found {worker_version!r}"
+        )
+    if events[-1].get("type") != "job.completed":
+        raise SmokeFailure("Packaged worker inspect smoke did not complete")
+    print(f"Packaged worker v{EXPECTED_WORKER_PROTOCOL_VERSION} smoke passed")
 
 
 def verify_apple_vision_ocr(bundle: AppBundle, clean_env: dict[str, str]) -> None:
-    output = run([bundle.executable, "--smoke-apple-vision-ocr"], env=clean_env).stdout
+    output = run([bundle.worker_executable, "--smoke-apple-vision-ocr"], env=clean_env).stdout
     if "Apple Vision OCR import smoke passed" not in output:
         raise SmokeFailure(f"Apple Vision OCR smoke output was unexpected: {output}")
+
+
+def verify_preview_presentation(bundle: AppBundle, clean_env: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="bd-to-avp-installed-preview-") as temporary_directory:
+        temporary_path = Path(temporary_directory)
+        workspace_root = temporary_path / "workspace"
+        artifact_directory = workspace_root / "artifact"
+        artifact_directory.mkdir(parents=True)
+        media_path = artifact_directory / "preview.mov"
+        result_path = temporary_path / "result.json"
+        run(
+            [
+                bundle.bin_dir / "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x180:rate=24",
+                "-f",
+                "lavfi",
+                "-i",
+                "anullsrc=channel_layout=stereo:sample_rate=48000",
+                "-t",
+                "1",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "ultrafast",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-movflags",
+                "+faststart",
+                "-y",
+                media_path,
+            ],
+            env=clean_env,
+        )
+        launch_preview_application(
+            bundle,
+            media_path,
+            result_path,
+            environment=native_smoke_environment(clean_env, temporary_path),
+            cwd=temporary_path,
+        )
+        if not wait_for_path(result_path, timeout=PREVIEW_PRESENTATION_TIMEOUT_SECONDS):
+            terminate_preview_processes(result_path)
+            raise SmokeFailure("Packaged preview presentation smoke did not write its result receipt")
+        if not wait_for_preview_process_exit(result_path, timeout=PREVIEW_PROCESS_EXIT_TIMEOUT_SECONDS):
+            terminate_preview_processes(result_path)
+            raise SmokeFailure("Packaged preview presentation smoke did not terminate after writing its receipt")
+        try:
+            receipt = json.loads(result_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise SmokeFailure("Packaged preview presentation smoke wrote invalid JSON") from error
+        expected = {
+            "schema_version": 1,
+            "player_presented": True,
+            "media_ready": True,
+            "cleanup_complete": True,
+        }
+        mismatches = [
+            f"{key}: expected {value!r}, found {receipt.get(key)!r}"
+            for key, value in expected.items()
+            if receipt.get(key) != value
+        ]
+        if mismatches:
+            message = receipt.get("message")
+            if isinstance(message, str) and message:
+                mismatches.append(message)
+            raise SmokeFailure("Packaged preview presentation smoke failed:\n" + "\n".join(mismatches))
+        if artifact_directory.exists():
+            raise SmokeFailure("Packaged preview presentation smoke left its artifact workspace behind")
+    print("Packaged preview presentation smoke passed")
 
 
 def verify_makemkv_probe(bundle: AppBundle, clean_env: dict[str, str]) -> None:
@@ -235,9 +496,11 @@ def smoke_app(app_path: Path, *, skip_spctl: bool) -> None:
     verify_gatekeeper(bundle.path, skip_spctl=skip_spctl)
     verify_no_homebrew_requirement(bundle)
     verify_bundled_tools(bundle, clean_env)
-    verify_cli_version(bundle, clean_env)
-    verify_cli_help(bundle, clean_env)
+    verify_package_version(bundle)
+    verify_native_startup(bundle, clean_env)
+    verify_worker_protocol(bundle, clean_env)
     verify_apple_vision_ocr(bundle, clean_env)
+    verify_preview_presentation(bundle, clean_env)
     verify_makemkv_probe(bundle, clean_env)
     print("Release app smoke passed")
 

--- a/scripts/smoke_release_app.sh
+++ b/scripts/smoke_release_app.sh
@@ -2,87 +2,16 @@
 set -eu
 
 APP_PATH="${1:-/Applications/3D Blu-ray to Vision Pro.app}"
-MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
-INFO_PLIST="$APP_PATH/Contents/Info.plist"
-APP_BIN_DIR="$APP_PATH/Contents/Resources/app/bd_to_avp/bin"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-fail() {
-  printf 'Release app smoke failed: %s\n' "$1" >&2
-  exit 1
-}
-
-pass() {
-  printf 'ok - %s\n' "$1"
-}
-
-plist_value() {
-  /usr/libexec/PlistBuddy -c "Print :$1" "$INFO_PLIST"
-}
-
-[ -d "$APP_PATH" ] || fail "app bundle not found: $APP_PATH"
-[ -f "$INFO_PLIST" ] || fail "Info.plist not found: $INFO_PLIST"
-
-EXECUTABLE_NAME="$(plist_value CFBundleExecutable)"
-SHORT_VERSION="$(plist_value CFBundleShortVersionString)"
-APP_EXECUTABLE="$APP_PATH/Contents/MacOS/$EXECUTABLE_NAME"
-
-[ -x "$APP_EXECUTABLE" ] || fail "app executable is missing or not executable: $APP_EXECUTABLE"
-[ -d "$APP_BIN_DIR" ] || fail "app tool directory is missing: $APP_BIN_DIR"
-pass "app bundle layout"
-
-spctl --assess --type execute --verbose=4 "$APP_PATH" >/dev/null 2>&1 || fail "Gatekeeper assessment failed"
-pass "Gatekeeper assessment"
-
-if [ -e /opt/homebrew ] || [ -e /usr/local/Homebrew ]; then
-  printf 'note - Homebrew exists on this machine; smoke uses sanitized PATH\n'
-else
-  pass "Homebrew absent"
+if command -v uv >/dev/null 2>&1; then
+  exec uv run --project "$REPO_ROOT" python "$SCRIPT_DIR/smoke_release_app.py" --app-path "$APP_PATH"
 fi
 
-CHECK_LINKS=false
-if xcode-select -p >/dev/null 2>&1 && command -v otool >/dev/null 2>&1; then
-  CHECK_LINKS=true
-else
-  printf 'note - developer tools unavailable; skipping otool linkage checks\n'
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$SCRIPT_DIR/smoke_release_app.py" --app-path "$APP_PATH"
 fi
 
-for tool in ffmpeg ffprobe edge264_test MP4Box spatial-media-kit-tool; do
-  TOOL_PATH="$APP_BIN_DIR/$tool"
-  [ -x "$TOOL_PATH" ] || fail "missing or non-executable bundled tool: $TOOL_PATH"
-  case "$tool" in
-    ffmpeg|ffprobe) "$TOOL_PATH" -hide_banner -version >/dev/null 2>&1 || fail "$tool did not run" ;;
-    MP4Box) "$TOOL_PATH" -version >/dev/null 2>&1 || fail "$tool did not run" ;;
-    *) "$TOOL_PATH" --help >/dev/null 2>&1 || fail "$tool did not run" ;;
-  esac
-  if [ "$CHECK_LINKS" = true ]; then
-    LINKED_LIBRARIES="$(otool -L "$TOOL_PATH")"
-    case "$LINKED_LIBRARIES" in
-      *"/opt/homebrew"*) fail "$tool links to /opt/homebrew" ;;
-      *"/usr/local"*) fail "$tool links to /usr/local" ;;
-    esac
-  fi
-done
-pass "bundled tools"
-
-VERSION_OUTPUT="$(PATH="$MINIMAL_PATH" "$APP_EXECUTABLE" --version 2>&1)"
-case "$VERSION_OUTPUT" in
-  *"Version $SHORT_VERSION"*) pass "CLI version" ;;
-  *) fail "CLI version '$VERSION_OUTPUT' did not match Info.plist version '$SHORT_VERSION'" ;;
-esac
-
-PATH="$MINIMAL_PATH" "$APP_EXECUTABLE" --help >/dev/null 2>&1 || fail "CLI help failed"
-pass "CLI help with sanitized PATH"
-
-OCR_OUTPUT="$(PATH="$MINIMAL_PATH" "$APP_EXECUTABLE" --smoke-apple-vision-ocr 2>&1)"
-case "$OCR_OUTPUT" in
-  *"Apple Vision OCR import smoke passed"*) pass "Apple Vision OCR smoke" ;;
-  *) fail "Apple Vision OCR smoke output was unexpected: $OCR_OUTPUT" ;;
-esac
-
-if [ -x /Applications/MakeMKV.app/Contents/MacOS/makemkvcon ]; then
-  pass "MakeMKV installed"
-else
-  printf 'note - MakeMKV absent; GUI preflight should ask the user to install MakeMKV\n'
-fi
-
-printf 'Release app smoke passed: %s\n' "$APP_PATH"
+printf 'Release app smoke failed: uv or python3 is required.\n' >&2
+exit 1

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -19,11 +19,11 @@ from scripts.macos_release import (
     notarize_and_staple,
     parse_args,
     run,
-    smoke_native_app_startup,
+    smoke_native_app,
     smoke_packaged_tools,
     verify_release_app,
 )
-from scripts.native_app import NATIVE_APP_NAME, NATIVE_EXECUTABLE_NAME
+from scripts.native_app import NATIVE_APP_NAME
 from scripts.sparkle_bundle import SparkleBundleMetadata
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -104,7 +104,7 @@ class MacOSReleaseArtifactTests(unittest.TestCase):
         with (
             patch("scripts.macos_release.verify_layout") as verify_layout,
             patch("scripts.macos_release.inspect_app_bundle", return_value=metadata) as inspect_bundle,
-            patch("scripts.macos_release.smoke_native_app_startup") as smoke_app,
+            patch("scripts.macos_release.smoke_native_app") as smoke_app,
             patch("scripts.macos_release.smoke_packaged_tools") as smoke_tools,
             patch("scripts.macos_release.smoke_packaged_worker") as smoke_worker,
         ):
@@ -123,14 +123,12 @@ class MacOSReleaseArtifactTests(unittest.TestCase):
         smoke_tools.assert_called_once_with(app_path)
         smoke_worker.assert_called_once_with(app_path)
 
-    def test_native_startup_smoke_uses_explicit_exit_argument(self) -> None:
-        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    def test_native_app_smoke_uses_packaged_native_smoke(self) -> None:
         app_path = Path("/tmp") / NATIVE_APP_NAME
-        with patch("scripts.macos_release.subprocess.run", return_value=completed) as run_mock:
-            smoke_native_app_startup(app_path)
+        with patch("scripts.macos_release.smoke_packaged_native_app") as packaged_smoke:
+            smoke_native_app(app_path)
 
-        command = run_mock.call_args.args[0]
-        self.assertEqual(command, [str(app_path / "Contents" / "MacOS" / NATIVE_EXECUTABLE_NAME), "--startup-smoke"])
+        packaged_smoke.assert_called_once_with(app_path)
 
     def test_packaged_tool_smoke_probes_release_tool_set(self) -> None:
         app_path = Path("/tmp") / NATIVE_APP_NAME

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -816,7 +816,13 @@ Load command 3
             absolute_app_path = temporary_path / relative_app_path
             absolute_app_path.mkdir(parents=True)
             resolved_app_path = absolute_app_path.resolve()
-            with chdir(temporary_path), patch("scripts.native_app.run") as run_mock:
+            with (
+                chdir(temporary_path),
+                patch("scripts.native_app.run") as run_mock,
+                patch("scripts.smoke_release_app.read_bundle", return_value=object()) as read_bundle,
+                patch("scripts.smoke_release_app.build_clean_env", return_value={"PATH": "/usr/bin"}) as build_env,
+                patch("scripts.smoke_release_app.verify_preview_presentation") as verify_preview,
+            ):
                 smoke_packaged_native_app(relative_app_path)
 
         run_mock.assert_called_once_with(
@@ -825,7 +831,11 @@ Load command 3
                 "--startup-smoke",
             ],
             cwd=resolved_app_path,
+            timeout=20,
         )
+        read_bundle.assert_called_once_with(resolved_app_path)
+        build_env.assert_called_once_with()
+        verify_preview.assert_called_once_with(read_bundle.return_value, build_env.return_value)
 
     def test_mv_hevc_encoder_smoke_uses_the_signed_packaged_tool(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_native_worker.py
+++ b/tests/test_native_worker.py
@@ -26,7 +26,7 @@ from bd_to_avp.modules.video_route import DirectMVHEVCCapability, VideoRouteInte
 from bd_to_avp.observability import ObservabilityEmitter
 from bd_to_avp.process_runner import ChildProcessRunner, ProcessCancelled, ProcessSpec
 from bd_to_avp.runtime import ObservabilityStream
-from bd_to_avp.worker.__main__ import run_worker
+from bd_to_avp.worker.__main__ import APPLE_VISION_OCR_SMOKE_ARGUMENT, run_smoke_command, run_worker
 from bd_to_avp.worker.operations import (
     WorkerDecisionRequired,
     WorkerOperationError,
@@ -845,6 +845,23 @@ class WorkerActivityReporterTests(unittest.TestCase):
 
 
 class WorkerRuntimeTests(unittest.TestCase):
+    def test_apple_vision_ocr_smoke_uses_worker_entrypoint(self) -> None:
+        output = io.StringIO()
+        calls: list[str] = []
+
+        result = run_smoke_command(
+            [APPLE_VISION_OCR_SMOKE_ARGUMENT],
+            output,
+            apple_vision_loader=lambda: calls.append("loaded"),
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(calls, ["loaded"])
+        self.assertEqual(output.getvalue(), "Apple Vision OCR import smoke passed\n")
+
+    def test_unknown_worker_argument_falls_through_to_protocol(self) -> None:
+        self.assertIsNone(run_smoke_command(["--unknown"], io.StringIO(), apple_vision_loader=lambda: None))
+
     def test_tool_output_reaches_diagnostic_stream_before_operation_finishes(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             source_path = Path(temporary_directory) / "movie.m2ts"

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,4 +1,6 @@
+import json
 import plistlib
+import shutil
 import tempfile
 import unittest
 
@@ -15,8 +17,9 @@ class ReleaseSmokeTests(unittest.TestCase):
 
             bundle = smoke_release_app.read_bundle(app_path)
 
-        self.assertEqual(bundle.path, app_path)
+        self.assertEqual(bundle.path, app_path.resolve())
         self.assertEqual(bundle.executable.name, "SmokeApp")
+        self.assertEqual(bundle.worker_executable.name, smoke_release_app.WORKER_EXECUTABLE_NAME)
         self.assertEqual(bundle.bundle_identifier, "com.example.smoke")
         self.assertEqual(bundle.short_version, "1.2.3")
 
@@ -24,7 +27,11 @@ class ReleaseSmokeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_fake_app(Path(temp_dir), version="1.2.3")
 
-            smoke_release_app.smoke_app(app_path, skip_spctl=True)
+            with (
+                patch.object(smoke_release_app, "launch_preview_application", side_effect=complete_preview_smoke),
+                patch.object(smoke_release_app, "wait_for_preview_process_exit", return_value=True),
+            ):
+                smoke_release_app.smoke_app(app_path, skip_spctl=True)
 
     def test_smoke_app_fails_when_default_gui_tool_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -34,13 +41,18 @@ class ReleaseSmokeTests(unittest.TestCase):
             with self.assertRaisesRegex(smoke_release_app.SmokeFailure, "MP4Box"):
                 smoke_release_app.smoke_app(app_path, skip_spctl=True)
 
-    def test_cli_version_must_match_info_plist(self) -> None:
+    def test_native_startup_uses_supported_smoke_flag(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            app_path = make_fake_app(Path(temp_dir), version="1.2.3", executable_version="9.9.9")
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
             bundle = smoke_release_app.read_bundle(app_path)
 
-            with self.assertRaisesRegex(smoke_release_app.SmokeFailure, "version mismatch"):
-                smoke_release_app.verify_cli_version(bundle, smoke_release_app.build_clean_env())
+            with patch.object(smoke_release_app, "run") as run:
+                run.return_value = smoke_release_app.subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+                smoke_release_app.verify_native_startup(bundle, smoke_release_app.build_clean_env())
+
+        self.assertEqual(run.call_args.args[0], [bundle.executable, "--startup-smoke"])
+        self.assertNotIn("--version", run.call_args.args[0])
+        self.assertNotIn("--help", run.call_args.args[0])
 
     def test_apple_vision_ocr_smoke_requires_expected_cli_output(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -50,7 +62,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             with self.assertRaisesRegex(smoke_release_app.SmokeFailure, "Apple Vision OCR"):
                 smoke_release_app.verify_apple_vision_ocr(bundle, smoke_release_app.build_clean_env())
 
-    def test_apple_vision_ocr_smoke_uses_app_smoke_flag(self) -> None:
+    def test_apple_vision_ocr_smoke_uses_worker_smoke_flag(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             app_path = make_fake_app(Path(temp_dir), version="1.2.3")
             bundle = smoke_release_app.read_bundle(app_path)
@@ -61,7 +73,76 @@ class ReleaseSmokeTests(unittest.TestCase):
                 )
                 smoke_release_app.verify_apple_vision_ocr(bundle, smoke_release_app.build_clean_env())
 
-        self.assertEqual(run.call_args.args[0], [bundle.executable, "--smoke-apple-vision-ocr"])
+        self.assertEqual(run.call_args.args[0], [bundle.worker_executable, "--smoke-apple-vision-ocr"])
+
+    def test_preview_presentation_uses_native_smoke_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+
+            with (
+                patch.object(
+                    smoke_release_app,
+                    "launch_preview_application",
+                    side_effect=complete_preview_smoke,
+                ) as launch_preview,
+                patch.object(smoke_release_app, "wait_for_preview_process_exit", return_value=True),
+            ):
+                smoke_release_app.verify_preview_presentation(bundle, smoke_release_app.build_clean_env())
+
+        self.assertEqual(launch_preview.call_args.args[0], bundle)
+
+    def test_preview_presentation_launches_bundle_through_launchservices(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+            media_path = Path(temp_dir) / "preview.mov"
+            result_path = Path(temp_dir) / "result.json"
+            environment = {"HOME": temp_dir}
+
+            with patch.object(smoke_release_app, "run") as run:
+                smoke_release_app.launch_preview_application(
+                    bundle,
+                    media_path,
+                    result_path,
+                    environment=environment,
+                    cwd=Path(temp_dir),
+                )
+
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                "/usr/bin/open",
+                "-g",
+                "-n",
+                bundle.path,
+                "--args",
+                smoke_release_app.PREVIEW_PRESENTATION_SMOKE_ARGUMENT,
+                media_path,
+                result_path,
+            ],
+        )
+        self.assertEqual(run.call_args.kwargs["env"], environment)
+
+    def test_preview_presentation_timeout_terminates_matching_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+            with (
+                patch.object(smoke_release_app, "launch_preview_application"),
+                patch.object(smoke_release_app, "wait_for_path", return_value=False),
+                patch.object(smoke_release_app, "terminate_preview_processes") as terminate,
+                self.assertRaisesRegex(smoke_release_app.SmokeFailure, "result receipt"),
+            ):
+                smoke_release_app.verify_preview_presentation(bundle, smoke_release_app.build_clean_env())
+
+        terminate.assert_called_once()
+
+    def test_command_timeout_becomes_smoke_failure(self) -> None:
+        timeout = smoke_release_app.subprocess.TimeoutExpired([], 1)
+        with patch("scripts.smoke_release_app.subprocess.run", side_effect=timeout):
+            with self.assertRaisesRegex(smoke_release_app.SmokeFailure, "exceeded 1 seconds"):
+                smoke_release_app.run(["tool"], timeout=1)
 
     def test_default_app_search_uses_first_existing_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -171,7 +252,6 @@ def make_fake_app(
     root: Path,
     *,
     version: str,
-    executable_version: str | None = None,
     apple_vision_smoke: bool = True,
 ) -> Path:
     app_path = root / "3D Blu-ray to Vision Pro.app"
@@ -194,20 +274,43 @@ def make_fake_app(
         macos_path / "SmokeApp",
         [
             "#!/bin/sh",
-            'if [ "$1" = "--version" ]; then',
-            f"  echo 'BD-to_AVP Version {executable_version or version}'",
+            'if [ "$1" = "--startup-smoke" ]; then',
             "  exit 0",
             "fi",
-            'if [ "$1" = "--help" ]; then',
-            "  echo 'Process 3D Blu-ray to MV-HEVC compatible with the Apple Vision Pro.'",
-            "  echo '--source SOURCE'",
+            'if [ "$1" = "--preview-presentation-smoke" ]; then',
+            '  artifact_directory="$(dirname "$2")"',
+            '  rm -rf "$artifact_directory"',
+            (
+                "  printf '%s\\n' "
+                '\'{"schema_version":1,"player_presented":true,"media_ready":true,'
+                '"cleanup_complete":true,"message":null}\' '
+                '> "$3"'
+            ),
             "  exit 0",
             "fi",
-            'if [ "$1" = "--smoke-apple-vision-ocr" ]; then',
-            f"  echo '{'Apple Vision OCR import smoke passed' if apple_vision_smoke else 'Apple Vision unavailable'}'",
-            "  exit 0",
-            "fi",
-            "exit 0",
+            "exit 91",
+        ],
+    )
+
+    write_executable(
+        macos_path / smoke_release_app.WORKER_EXECUTABLE_NAME,
+        [
+            "#!/usr/bin/python3",
+            "import json",
+            "import sys",
+            f"version = {version!r}",
+            f"apple_vision_smoke = {apple_vision_smoke!r}",
+            "if sys.argv[1:] == ['--smoke-apple-vision-ocr']:",
+            "    print('Apple Vision OCR import smoke passed' if apple_vision_smoke else 'Apple Vision unavailable')",
+            "    raise SystemExit(0)",
+            "request = json.loads(sys.stdin.readline())",
+            "job_id = request['job_id']",
+            "event_types = ['worker.ready', 'job.started', 'stage.started', 'job.completed']",
+            "for sequence, event_type in enumerate(event_types):",
+            "    payload = {'worker_version': version, 'process_group_id': 1} if event_type == 'worker.ready' else {}",
+            "    event = {'protocol_version': 10, 'type': event_type, 'job_id': job_id}",
+            "    event.update(sequence=sequence, payload=payload)",
+            "    print(json.dumps(event))",
         ],
     )
 
@@ -216,13 +319,13 @@ def make_fake_app(
         if tool_name == "ffmpeg":
             lines = [
                 "#!/bin/sh",
-                " ".join(
-                    [
-                        'if [ "$2" = "-encoders" ]; then echo " V..... libsvtav1";',
-                        'elif [ "$2" = "-bsfs" ]; then echo "av1_metadata";',
-                        "else echo ok; fi",
-                    ]
-                ),
+                'if [ "$2" = "-encoders" ]; then echo " V..... libsvtav1"; exit 0; fi',
+                'if [ "$2" = "-bsfs" ]; then echo "av1_metadata"; exit 0; fi',
+                'if [ "$2" = "-version" ]; then echo "ffmpeg version smoke"; exit 0; fi',
+                "output=''",
+                'for argument in "$@"; do output="$argument"; done',
+                ': > "$output"',
+                "echo ok",
             ]
         write_executable(bin_path / tool_name, lines)
 
@@ -232,6 +335,30 @@ def make_fake_app(
 def write_executable(path: Path, lines: list[str]) -> None:
     path.write_text("\n".join(lines) + "\n")
     path.chmod(path.stat().st_mode | 0o111)
+
+
+def complete_preview_smoke(
+    bundle: smoke_release_app.AppBundle,
+    media_path: Path,
+    result_path: Path,
+    *,
+    environment: dict[str, str],
+    cwd: Path,
+) -> None:
+    del bundle, environment, cwd
+    shutil.rmtree(media_path.parent)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "player_presented": True,
+                "media_ready": True,
+                "cleanup_complete": True,
+                "message": None,
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace legacy GUI `--version`/`--help` probes with native startup, packaged worker protocol/version, and worker OCR checks
- add a bounded LaunchServices smoke that renders the existing `PreviewPlayerView`, finds the real `AVPlayerView`, waits for media readiness, verifies lease cleanup, and reaps the exact smoke process
- wire the same smoke into native packaging and release verification, consolidate the shell wrapper, and document the hybrid package entrypoints

## Validation
- `uv sync --all-groups --python 3.12`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp scripts/native_app.py scripts/macos_release.py scripts/smoke_release_app.py`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python -m unittest discover -s tests -t .` — 1117 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 311 passed
- `uv build`, import smoke, and CLI help smoke
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — package, codesign verification, and packaged preview presentation smoke passed
- standalone smoke against the built app passed in about 4 seconds with `--skip-spctl`
- JetBrains changed-files closeout: clean, 0 findings
- independent Claude review: no blockers; Antigravity was invoked twice but returned no textual report

No Stable or Prerelease workflow was dispatched. The future exact signed-beta qualification remains tracked by #392.

Refs #399.