### PR TITLE
fix: retain native activity history

### DIFF
--- a/docs/native-support-bundle-v1.md
+++ b/docs/native-support-bundle-v1.md
@@ -186,6 +186,18 @@ exposes:
 
 ## Native Submission Flow
 
+The Activity drawer retains up to 200 deduplicated lifecycle messages for the
+current or most recently completed job. It shows newest entries first so live
+status remains visible while earlier stage, warning, completion, and failure
+messages remain available by scrolling. Starting the next job clears the prior
+history. The drawer stores only structured worker messages, not raw tool output
+or observability paths.
+
+Quiet-tool health checks remain separate from lifecycle history. When no recent
+tool output or artifact growth is visible, the UI says that the operation is
+still running and identifies the message as a status check rather than a
+failure. Confirmed warnings and failures retain distinct severity treatment.
+
 The Activity footer exposes one support action whenever the current session has
 diagnostic evidence. Failed source cards repeat the same action as a low-noise
 secondary entry point. Capturing, reviewing, uploading, cancelling, saving, and

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -104,7 +104,22 @@ enum WorkerLifecycleError: Error, LocalizedError, Equatable {
     }
 }
 
+struct WorkerActivityEntry: Equatable, Identifiable, Sendable {
+    enum Severity: Equatable, Sendable {
+        case information
+        case success
+        case warning
+        case failure
+    }
+
+    let id: Int
+    let severity: Severity
+    let message: String
+}
+
 struct WorkerLifecycleState: Equatable {
+    static let maximumActivityEntries = 200
+
     private(set) var phase: WorkerPhase = .empty
     private(set) var operationKind: WorkerOperationKind = .inspection
     private(set) var sourceURL: URL?
@@ -124,6 +139,8 @@ struct WorkerLifecycleState: Equatable {
     private(set) var failureCode: String?
     private(set) var failureRetryable = false
     private(set) var recoveryDecision: WorkerDecision?
+    private(set) var activityHistory: [WorkerActivityEntry] = []
+    private var nextActivityEntryID = 0
 
     var elapsedText: String? {
         ElapsedTimeText.format(seconds: elapsedSeconds)
@@ -148,6 +165,7 @@ struct WorkerLifecycleState: Equatable {
         self.operationKind = operationKind
         phase = operationKind.isInspection ? .inspecting : .processing
         stageMessage = operationKind.preparingMessage
+        appendActivity(stageMessage)
     }
 
     mutating func receive(_ event: WorkerEvent) throws {
@@ -181,28 +199,35 @@ struct WorkerLifecycleState: Equatable {
                 phase = operationKind.isInspection ? .inspecting : .processing
             }
             stageMessage = operationKind.isInspection ? "Preparing source" : operationKind.preparingMessage
+            appendActivity(stageMessage)
         case .jobStarted:
             if phase != .stopping {
                 phase = operationKind.isInspection ? .inspecting : .processing
             }
             stageMessage = operationKind.startingMessage
+            appendActivity(stageMessage)
         case .stageStarted:
             phase = .processing
             stageMessage = event.payload.message ?? event.payload.stage ?? "Processing"
             progress = event.payload.progress?.normalized
+            appendActivity(stageMessage)
         case .heartbeat:
             phase = .processing
             elapsedSeconds = event.payload.elapsedSeconds ?? elapsedSeconds
             activityMessage = event.payload.message
+            appendActivity(activityMessage)
             if let incomingProgress = event.payload.progress {
                 progress = incomingProgress.normalized
             }
         case .log:
             activityMessage = event.payload.message
+            appendActivity(activityMessage)
         case .warning:
             warningMessage = event.payload.message ?? "The operation reported a warning."
+            appendActivity(warningMessage, severity: .warning)
         case .artifactReady:
             activityMessage = "Preview artifact is ready."
+            appendActivity(activityMessage)
         case .observability:
             break
         case .jobCompleted:
@@ -230,6 +255,7 @@ struct WorkerLifecycleState: Equatable {
             }
             progress = nil
             phase = .completed
+            appendActivity(stageMessage, severity: .success)
         case .jobFailed:
             guard let failure = event.payload.error else {
                 throw WorkerLifecycleError.missingPayload(event: event.type)
@@ -240,10 +266,12 @@ struct WorkerLifecycleState: Equatable {
             failureRetryable = failure.retryable
             progress = nil
             phase = .failed
+            appendActivity(failure.message, severity: .failure)
         case .jobCancelled:
             activityMessage = event.payload.message ?? operationKind.stoppedMessage
             progress = nil
             phase = .cancelled
+            appendActivity(activityMessage)
         case .jobDecisionRequired:
             guard let decision = event.payload.decision else {
                 throw WorkerLifecycleError.missingPayload(event: event.type)
@@ -255,6 +283,7 @@ struct WorkerLifecycleState: Equatable {
             failureRetryable = true
             progress = nil
             phase = .decisionRequired
+            appendActivity(decision.prompt, severity: .warning)
         }
     }
 
@@ -265,6 +294,7 @@ struct WorkerLifecycleState: Equatable {
         phase = .stopping
         stageMessage = "Stopping safely"
         progress = nil
+        appendActivity(stageMessage)
     }
 
     mutating func failTransport(message: String, details: String? = nil, retryable: Bool = true) {
@@ -275,12 +305,14 @@ struct WorkerLifecycleState: Equatable {
         recoveryDecision = nil
         progress = nil
         phase = .failed
+        appendActivity(message, severity: .failure)
     }
 
     mutating func completeStop() {
         activityMessage = operationKind == .inspection ? "Inspection stopped." : operationKind.stoppedMessage
         progress = nil
         phase = .cancelled
+        appendActivity(activityMessage)
     }
 
     mutating func prepareForRetry() {
@@ -307,6 +339,37 @@ struct WorkerLifecycleState: Equatable {
         self = WorkerLifecycleState()
     }
 
+    private mutating func appendActivity(
+        _ message: String?,
+        severity: WorkerActivityEntry.Severity = .information
+    ) {
+        guard let message else {
+            return
+        }
+        let normalizedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedMessage.isEmpty else {
+            return
+        }
+        if let lastEntry = activityHistory.last,
+           lastEntry.message == normalizedMessage,
+           lastEntry.severity == severity
+        {
+            return
+        }
+        activityHistory.append(
+            WorkerActivityEntry(
+                id: nextActivityEntryID,
+                severity: severity,
+                message: normalizedMessage
+            )
+        )
+        nextActivityEntryID += 1
+        let overflow = activityHistory.count - Self.maximumActivityEntries
+        if overflow > 0 {
+            activityHistory.removeFirst(overflow)
+        }
+    }
+
     private mutating func resetJobState() {
         jobID = nil
         lastSequence = nil
@@ -324,5 +387,7 @@ struct WorkerLifecycleState: Equatable {
         failureCode = nil
         failureRetryable = false
         recoveryDecision = nil
+        activityHistory.removeAll(keepingCapacity: true)
+        nextActivityEntryID = 0
     }
 }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1006,43 +1006,121 @@ private struct SaveProfileSheet: View {
     }
 }
 
-private struct ActivityDrawer: View {
+struct ActivityDrawer: View {
     let state: WorkerLifecycleState
     let observabilityStatus: LiveObservabilityStatus
     let showTechnicalDetails: Bool
 
-    private var activityText: String {
-        let entries = [
-            state.stageMessage,
-            state.activityMessage,
-            state.warningMessage,
-            state.failureMessage,
-            state.failureDetails,
-        ]
-            .compactMap { $0 }
-            .filter { !$0.isEmpty }
-        return entries.isEmpty ? "Activity will appear here when source analysis or conversion begins." : entries.joined(separator: "\n")
+    private var activityEntries: [WorkerActivityEntry] {
+        Array(state.activityHistory.reversed())
+    }
+
+    private var historySummary: String {
+        let count = activityEntries.count
+        return count == 1 ? "1 entry · newest first" : "\(count) entries · newest first"
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 10) {
-                Text(activityText)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-
-                if showTechnicalDetails, observabilityStatus.hasDetails {
-                    Divider()
-                    LiveObservabilityStatusView(status: observabilityStatus)
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Label("Activity History", systemImage: "clock.arrow.circlepath")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                if !activityEntries.isEmpty {
+                    Text(historySummary)
+                        .font(.caption2)
                 }
             }
-            .padding(12)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 9) {
+                    if showTechnicalDetails, observabilityStatus.hasDetails {
+                        LiveObservabilityStatusView(status: observabilityStatus)
+                        Divider()
+                    }
+
+                    if activityEntries.isEmpty {
+                        Text("Activity will appear here when source analysis or conversion begins.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                    } else {
+                        ForEach(activityEntries) { entry in
+                            ActivityEntryRow(entry: entry)
+                        }
+                    }
+                }
+                .padding(12)
+            }
         }
-        .frame(height: 145)
+        .frame(height: 190)
         .background(Color(nsColor: .textBackgroundColor))
         .accessibilityLabel("Activity details")
+    }
+}
+
+private struct ActivityEntryRow: View {
+    let entry: WorkerActivityEntry
+
+    private var symbolName: String {
+        switch entry.severity {
+        case .information:
+            "circle.fill"
+        case .success:
+            "checkmark.circle.fill"
+        case .warning:
+            "exclamationmark.triangle.fill"
+        case .failure:
+            "xmark.octagon.fill"
+        }
+    }
+
+    private var symbolColor: Color {
+        switch entry.severity {
+        case .information:
+            Color(nsColor: .secondaryLabelColor)
+        case .success:
+            .green
+        case .warning:
+            .orange
+        case .failure:
+            .red
+        }
+    }
+
+    private var severityLabel: String {
+        switch entry.severity {
+        case .information:
+            "Status"
+        case .success:
+            "Completed"
+        case .warning:
+            "Warning"
+        case .failure:
+            "Error"
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: symbolName)
+                .font(.caption2)
+                .foregroundStyle(symbolColor)
+                .accessibilityHidden(true)
+
+            Text(entry.message)
+                .font(.caption.monospaced())
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(severityLabel): \(entry.message)")
     }
 }
 
@@ -1071,7 +1149,7 @@ private struct LiveObservabilityStatusView: View {
         case .toolQuietArtifactsActive:
             return "Tool output quiet; artifact growth continues"
         case .stalled:
-            return "No recent tool output or artifact growth"
+            return "Waiting for tool output or artifact updates"
         }
     }
 
@@ -1095,9 +1173,12 @@ private struct LiveObservabilityStatusView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
             } else if activityState == .stalled {
-                Label("No recent tool output or artifact growth", systemImage: "clock.badge.exclamationmark")
+                Label("Still running; waiting for tool output or artifact updates", systemImage: "clock")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(.secondary)
+                Text("This is a status check, not a failure.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             statusRow("Stage", value: status.stageID)

--- a/macos/BluRayToVisionProTests/ActivityDrawerRenderTests.swift
+++ b/macos/BluRayToVisionProTests/ActivityDrawerRenderTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class ActivityDrawerRenderTests: XCTestCase {
+    func testActivityDrawerRendersBoundedHistory() throws {
+        let jobID = UUID(uuidString: "B78EE8D6-9740-40F9-B6F1-103C67287EC4")!
+        var state = WorkerLifecycleState()
+        state.selectSource(URL(fileURLWithPath: "/tmp/activity-history.m2ts"))
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        for sequence in 0..<12 {
+            try state.receive(
+                WorkerEvent(
+                    protocolVersion: WorkerJobSpec.protocolVersion,
+                    type: .log,
+                    jobID: jobID,
+                    sequence: sequence,
+                    payload: WorkerEventPayload(message: "Processed activity step \(sequence + 1)")
+                )
+            )
+        }
+        try state.receive(
+            WorkerEvent(
+                protocolVersion: WorkerJobSpec.protocolVersion,
+                type: .warning,
+                jobID: jobID,
+                sequence: 12,
+                payload: WorkerEventPayload(message: "Using a safe fallback for this source")
+            )
+        )
+        state.failTransport(
+            message: "The engine stopped before publishing an output.",
+            details: "Review the retained activity above, then capture diagnostics if needed."
+        )
+
+        let appearances: [(ColorScheme, NSAppearance.Name)] = [
+            (.light, .aqua),
+            (.dark, .darkAqua),
+        ]
+        for (colorScheme, appearanceName) in appearances {
+            let content = ActivityDrawer(
+                state: state,
+                observabilityStatus: .empty,
+                showTechnicalDetails: false
+            )
+            .frame(width: 900, height: 190)
+            .preferredColorScheme(colorScheme)
+            let hostingView = NSHostingView(rootView: content)
+            hostingView.appearance = NSAppearance(named: appearanceName)
+            hostingView.frame = NSRect(x: 0, y: 0, width: 900, height: 190)
+            hostingView.layoutSubtreeIfNeeded()
+            let bitmap = try XCTUnwrap(hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds))
+            hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+            let image = NSImage(size: hostingView.bounds.size)
+            image.addRepresentation(bitmap)
+
+            XCTAssertGreaterThanOrEqual(image.size.width, 900)
+            XCTAssertGreaterThanOrEqual(image.size.height, 190)
+        }
+    }
+}

--- a/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerLifecycleTests.swift
@@ -200,6 +200,9 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertEqual(state.failureDetails, "bad stream")
         XCTAssertEqual(state.failureCode, "probe_failed")
         XCTAssertFalse(state.failureRetryable)
+        XCTAssertEqual(state.activityHistory.last?.message, "Could not inspect source.")
+        XCTAssertEqual(state.activityHistory.last?.severity, .failure)
+        XCTAssertFalse(state.activityHistory.map(\.message).contains("bad stream"))
     }
 
     func testRetryableFailureIsExposedToTheInterface() throws {
@@ -333,6 +336,9 @@ final class WorkerLifecycleTests: XCTestCase {
         XCTAssertTrue(state.failureRetryable)
         XCTAssertEqual(state.recoveryDecision, decision)
         XCTAssertTrue(state.phase.isTerminal)
+        XCTAssertEqual(state.activityHistory.last?.message, "Subtitle extraction needs attention.")
+        XCTAssertEqual(state.activityHistory.last?.severity, .warning)
+        XCTAssertFalse(state.activityHistory.map(\.message).contains("Disable subtitle extraction to retry."))
     }
 
     func testCancellingRecoveryLeavesActionableFailureWithoutDecision() throws {
@@ -441,12 +447,120 @@ final class WorkerLifecycleTests: XCTestCase {
         try state.receive(event(.workerReady, sequence: 0))
         let phase = state.phase
         let stageMessage = state.stageMessage
+        let activityHistory = state.activityHistory
 
         try state.receive(event(.observability, sequence: 1))
 
         XCTAssertEqual(state.phase, phase)
         XCTAssertEqual(state.stageMessage, stageMessage)
+        XCTAssertEqual(state.activityHistory, activityHistory)
         XCTAssertEqual(state.lastSequence, 1)
+    }
+
+    func testActivityHistoryRetainsDistinctMessagesAndSeverity() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(
+            event(
+                .stageStarted,
+                sequence: 0,
+                payload: .init(message: "Encoding video")
+            )
+        )
+        try state.receive(
+            event(
+                .heartbeat,
+                sequence: 1,
+                payload: .init(message: "Encoding frame 100")
+            )
+        )
+        try state.receive(
+            event(
+                .warning,
+                sequence: 2,
+                payload: .init(message: "Using the fallback route")
+            )
+        )
+        try state.receive(
+            event(
+                .jobCompleted,
+                sequence: 3,
+                payload: .init(conversionResult: ConversionResult(outputPath: "/out.mov"))
+            )
+        )
+
+        XCTAssertEqual(
+            state.activityHistory.map(\.message),
+            [
+                "Preparing conversion",
+                "Encoding video",
+                "Encoding frame 100",
+                "Using the fallback route",
+                "Conversion complete",
+            ]
+        )
+        XCTAssertEqual(
+            state.activityHistory.map(\.severity),
+            [.information, .information, .information, .warning, .success]
+        )
+    }
+
+    func testActivityHistoryDeduplicatesConsecutiveMessages() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(event(.heartbeat, sequence: 0, payload: .init(message: "Encoding video")))
+        try state.receive(event(.heartbeat, sequence: 1, payload: .init(message: "Encoding video")))
+
+        XCTAssertEqual(
+            state.activityHistory.map(\.message),
+            ["Preparing conversion", "Encoding video"]
+        )
+    }
+
+    func testActivityHistoryDropsOldestEntriesAtItsBound() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        for sequence in 0...WorkerLifecycleState.maximumActivityEntries {
+            try state.receive(
+                event(
+                    .log,
+                    sequence: sequence,
+                    payload: .init(message: "Update \(sequence)")
+                )
+            )
+        }
+
+        XCTAssertEqual(state.activityHistory.count, WorkerLifecycleState.maximumActivityEntries)
+        XCTAssertEqual(state.activityHistory.first?.message, "Update 1")
+        XCTAssertEqual(state.activityHistory.last?.message, "Update 200")
+    }
+
+    func testStartingNewJobReplacesPriorActivityHistory() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+        try state.receive(event(.log, sequence: 0, payload: .init(message: "Old job activity")))
+
+        try state.begin(jobID: UUID(), operationKind: .conversion)
+
+        XCTAssertEqual(state.activityHistory.map(\.message), ["Preparing conversion"])
+    }
+
+    func testTransportFailureKeepsTechnicalDetailsOutOfActivityHistory() throws {
+        var state = WorkerLifecycleState()
+        state.selectSource(sourceURL)
+        try state.begin(jobID: jobID, operationKind: .conversion)
+
+        state.failTransport(message: "The engine stopped.", details: "No terminal event was received.")
+
+        XCTAssertEqual(state.failureDetails, "No terminal event was received.")
+        XCTAssertEqual(state.activityHistory.last?.message, "The engine stopped.")
+        XCTAssertEqual(state.activityHistory.last?.severity, .failure)
+        XCTAssertFalse(state.activityHistory.map(\.message).contains("No terminal event was received."))
     }
 
     private func event(


### PR DESCRIPTION
## Summary
- retain up to 200 deduplicated lifecycle messages for the current or most recently completed job
- show newest activity first with accessible informational, success, warning, and failure treatment
- present quiet tool/output checks as nonterminal status instead of an apparent failure
- keep technical diagnostics and failure details out of the visible activity history

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python -m unittest discover -s tests -t .` — 1,117 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 317 passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — unsigned packaged app and preview presentation smoke passed
- `uv build`, import smoke, and CLI help smoke passed
- headless light/dark native render review passed
- independent Claude, GPT, and Antigravity/Google-family reviews completed; final reviewers found no blockers

JetBrains inspection was attempted twice but remained `UNKNOWN` because IntelliJ could not background-open the exact worktree without a foreground project trust/open interaction. No mouse or keyboard automation was used.

Closes #403