### PR TITLE
Publish validated local app builds to Current.app

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -120,7 +120,8 @@
       "pythonPackage": "uv build",
       "briefcaseCreate": "uv run python -m scripts.briefcase_app create --no-input",
       "briefcaseBuild": "uv run python -m scripts.briefcase_app build --no-input",
-      "macosPackage": "uv run python scripts/native_app.py package"
+      "macosPackage": "uv run python scripts/native_app.py package",
+      "macosCurrent": "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current"
     },
     "inspection": {
       "tool": "jetbrains",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,16 @@
 - Keep `main` fixed while either release workflow is nonterminal. Coordinate a
   temporary merge hold on other pull requests because the workflows intentionally
   reject a release when protected `main` moves.
+
+# Local Current Build
+
+- When producing a user-launchable local build, use
+  `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current`
+  instead of leaving the app inside a disposable worktree.
+- The command requires a clean worktree, publishes an immutable commit-addressed
+  ad-hoc app, and refreshes
+  `~/Applications/3D Blu-ray to Vision Pro Current.app` plus its adjacent build
+  metadata link. It must never replace the production-signed app in
+  `/Applications`.
+- Keep `scripts/native_app.py package` as the underlying package/release
+  verification command; `publish-current` is the local durable handoff command.

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -39,6 +39,8 @@ uv run python scripts/native_app.py generate
 uv run python scripts/native_app.py test
 uv run python scripts/native_app.py build
 uv run python scripts/native_app.py package
+BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com \
+  uv run python scripts/native_app.py publish-current
 ```
 
 `package` builds or updates the Briefcase staging app, builds the Xcode
@@ -58,6 +60,18 @@ Ad-hoc packaging is the default for local validation. Developer ID packaging
 passes `--sign-identity` and `--sign-keychain`. Ad-hoc packages omit Hardened
 Runtime because they have no Team ID for dyld library validation; Developer ID
 packages retain Hardened Runtime.
+
+`publish-current` requires a clean Git worktree, runs the complete ad-hoc
+`package` pipeline, and publishes the validated result under
+`~/Applications/BD to AVP Builds/<full-commit>/`. The stable app and adjacent
+metadata links route through one hidden current-build pointer, so publishing a
+new validated build switches both paths at the same atomic filesystem step.
+The metadata records the source commit, merge base with `origin/main`, UTC build
+time, app-tree SHA-256, app version and build, and the local ad-hoc signing
+status. Existing commit-addressed builds are immutable and retained. The
+command serializes concurrent publishers, refuses symlinked or conflicting
+destination objects, and never modifies the production-signed app under
+`/Applications`.
 
 The auxiliary launcher receives the direct-distribution entitlements required
 by CPython and extension modules. Those entitlements belong only to the worker,

--- a/scripts/artifact_identity.py
+++ b/scripts/artifact_identity.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import hashlib
+import os
+
+from pathlib import Path
+
+
+def app_tree_sha256(app_path: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(app_path.rglob("*"), key=lambda item: item.relative_to(app_path).as_posix()):
+        relative = path.relative_to(app_path).as_posix().encode("utf-8")
+        status = path.lstat()
+        mode = status.st_mode & 0o7777
+        if path.is_symlink():
+            payload = os.readlink(path).encode("utf-8")
+            kind = b"symlink"
+        elif path.is_file():
+            payload_digest = hashlib.sha256()
+            with path.open("rb") as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    payload_digest.update(chunk)
+            payload = payload_digest.digest()
+            kind = b"file"
+        elif path.is_dir():
+            payload = b""
+            kind = b"directory"
+        else:
+            continue
+        for component in (kind, relative, f"{mode:o}".encode("ascii"), payload):
+            digest.update(len(component).to_bytes(8, "big"))
+            digest.update(component)
+    return digest.hexdigest()

--- a/scripts/native_app.py
+++ b/scripts/native_app.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import plistlib
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 import tomllib
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlsplit
@@ -19,6 +23,7 @@ from uuid import uuid4
 
 from bd_to_avp.observability import ObservabilityEvent
 from bd_to_avp.worker.protocol import PROTOCOL_VERSION
+from scripts.artifact_identity import app_tree_sha256
 from scripts.build_mv_hevc_encoder_macos import build_encoder as build_mv_hevc_encoder
 from scripts.production_identity import (
     PRODUCTION_BUNDLE_IDENTIFIER,
@@ -54,6 +59,12 @@ NATIVE_APP_NAME = f"{NATIVE_PRODUCT_NAME}.app"
 BRIEFCASE_APP = REPO_ROOT / "build" / "bd-to-avp" / "macos" / "app" / "3D Blu-ray to Vision Pro.app"
 PACKAGE_ROOT = MACOS_ROOT / "build" / "package"
 PACKAGED_APP = PACKAGE_ROOT / NATIVE_APP_NAME
+CURRENT_BUILD_DIRECTORY_NAME = "BD to AVP Builds"
+CURRENT_APP_LINK_NAME = "3D Blu-ray to Vision Pro Current.app"
+CURRENT_METADATA_LINK_NAME = "3D Blu-ray to Vision Pro Current.build.json"
+CURRENT_BUILD_METADATA_NAME = "build.json"
+CURRENT_POINTER_LINK_NAME = ".3D Blu-ray to Vision Pro Current"
+CURRENT_PUBLISH_LOCK_NAME = ".3D Blu-ray to Vision Pro Current.lock"
 MV_HEVC_ENCODER_NAME = "mv-hevc-encoder"
 PACKAGED_MV_HEVC_ENCODER = PACKAGE_ROOT / "native-tools" / MV_HEVC_ENCODER_NAME
 WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
@@ -783,7 +794,7 @@ def validate_smoke_events(events: list[object], job_id: str) -> None:
         raise ValueError("Worker smoke returned an invalid result shape.")
 
 
-def package(identity: str, keychain: str | None = None) -> None:
+def package(identity: str, keychain: str | None = None) -> Path:
     mv_hevc_encoder_path = build_packaged_mv_hevc_encoder()
     prepare_briefcase_runtime()
     xcodebuild("build", NATIVE_PACKAGE_CONFIGURATION)
@@ -794,6 +805,357 @@ def package(identity: str, keychain: str | None = None) -> None:
     smoke_packaged_worker(app_path)
     verify_codesign(app_path)
     print(app_path)
+    return app_path
+
+
+def git_output(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError(f"Git returned no value for: {' '.join(arguments)}")
+    return value
+
+
+def ensure_clean_worktree() -> None:
+    result = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        raise RuntimeError("Publishing the current app requires a clean Git worktree.")
+
+
+def validate_full_git_sha(value: str, description: str) -> str:
+    if re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise ValueError(f"{description} must be a full lowercase Git SHA.")
+    return value
+
+
+def bundle_versions(app_path: Path) -> tuple[str, str]:
+    info_path = app_path / "Contents" / "Info.plist"
+    with info_path.open("rb") as info_file:
+        info = plistlib.load(info_file)
+    short_version = info.get("CFBundleShortVersionString")
+    build_version = info.get("CFBundleVersion")
+    if not isinstance(short_version, str) or not isinstance(build_version, str):
+        raise RuntimeError("Packaged app is missing version identity.")
+    return short_version, build_version
+
+
+def require_replaceable_symlink(path: Path) -> None:
+    if os.path.lexists(path) and not path.is_symlink():
+        raise RuntimeError(f"Refusing to replace non-symlink path: {path}")
+
+
+def replace_symlink(target: Path, link_path: Path) -> None:
+    require_replaceable_symlink(link_path)
+    temporary_link = link_path.with_name(f".{link_path.name}.{uuid4().hex}.tmp")
+    try:
+        os.symlink(target, temporary_link)
+        require_replaceable_symlink(link_path)
+        os.replace(temporary_link, link_path)
+    finally:
+        temporary_link.unlink(missing_ok=True)
+
+
+def require_real_directory(path: Path, description: str) -> None:
+    try:
+        status = path.lstat()
+    except FileNotFoundError as error:
+        raise RuntimeError(f"{description} is missing: {path}") from error
+    if not stat.S_ISDIR(status.st_mode):
+        raise RuntimeError(f"{description} must be a real directory: {path}")
+
+
+def require_real_file(path: Path, description: str) -> None:
+    try:
+        status = path.lstat()
+    except FileNotFoundError as error:
+        raise RuntimeError(f"{description} is missing: {path}") from error
+    if not stat.S_ISREG(status.st_mode):
+        raise RuntimeError(f"{description} must be a real file: {path}")
+
+
+def validate_app_symlinks(app_path: Path) -> None:
+    app_root = app_path.resolve()
+    for directory, directory_names, file_names in os.walk(app_root, followlinks=False):
+        parent = Path(directory)
+        for name in (*directory_names, *file_names):
+            path = parent / name
+            if not path.is_symlink():
+                continue
+            try:
+                target = path.resolve(strict=True)
+            except (OSError, RuntimeError) as error:
+                raise RuntimeError(f"App bundle contains a broken symlink: {path}") from error
+            if not target.is_relative_to(app_root):
+                raise RuntimeError(f"App bundle symlink escapes the bundle: {path}")
+
+
+def validate_built_at_utc(value: object, metadata_path: Path) -> str:
+    if not isinstance(value, str) or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value) is None:
+        raise RuntimeError(f"Existing build metadata has an invalid UTC build time: {metadata_path}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RuntimeError(f"Existing build metadata has an invalid UTC build time: {metadata_path}") from error
+    normalized = parsed.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    if normalized != value:
+        raise RuntimeError(f"Existing build metadata has an invalid UTC build time: {metadata_path}")
+    return value
+
+
+def prepare_applications_directory(path: Path) -> Path:
+    requested_path = path.expanduser()
+    if os.path.lexists(requested_path) and requested_path.is_symlink():
+        raise RuntimeError(f"Applications destination must not be a symlink: {requested_path}")
+    resolved_path = requested_path.resolve(strict=False)
+    if resolved_path == Path("/Applications"):
+        raise RuntimeError("Refusing to publish a local current build into /Applications.")
+    requested_path.mkdir(parents=True, exist_ok=True)
+    resolved_path = requested_path.resolve()
+    require_real_directory(resolved_path, "Applications destination")
+    return resolved_path
+
+
+@contextmanager
+def current_publish_lock(applications_directory: Path) -> Iterator[None]:
+    lock_path = applications_directory / CURRENT_PUBLISH_LOCK_NAME
+    if os.path.lexists(lock_path) and lock_path.is_symlink():
+        raise RuntimeError(f"Current-build lock must not be a symlink: {lock_path}")
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as error:
+        raise RuntimeError(f"Unable to open current-build lock: {lock_path}") from error
+    with os.fdopen(descriptor, "r+") as lock_file:
+        if not stat.S_ISREG(os.fstat(lock_file.fileno()).st_mode):
+            raise RuntimeError(f"Current-build lock must be a real file: {lock_path}")
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def resolve_symlink(path: Path, description: str) -> Path:
+    if not path.is_symlink():
+        raise RuntimeError(f"{description} must be a symlink: {path}")
+    try:
+        return path.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError(f"{description} is broken: {path}") from error
+
+
+def validate_version_directory(path: Path, build_root: Path, description: str) -> Path:
+    resolved_path = path.resolve(strict=True)
+    require_real_directory(resolved_path, description)
+    if resolved_path.parent != build_root or re.fullmatch(r"[0-9a-f]{40}", resolved_path.name) is None:
+        raise RuntimeError(f"{description} is outside the immutable build root: {resolved_path}")
+    return resolved_path
+
+
+def publish_stable_current_links(
+    *,
+    build_root: Path,
+    version_directory: Path,
+    stable_app: Path,
+    stable_metadata: Path,
+) -> None:
+    current_pointer = stable_app.parent / CURRENT_POINTER_LINK_NAME
+    require_replaceable_symlink(current_pointer)
+    require_replaceable_symlink(stable_app)
+    require_replaceable_symlink(stable_metadata)
+
+    app_route = Path(CURRENT_POINTER_LINK_NAME) / NATIVE_APP_NAME
+    metadata_route = Path(CURRENT_POINTER_LINK_NAME) / CURRENT_BUILD_METADATA_NAME
+    version_route = Path(CURRENT_BUILD_DIRECTORY_NAME) / version_directory.name
+    pointer_directory: Path
+
+    if os.path.lexists(current_pointer):
+        pointer_directory = validate_version_directory(
+            resolve_symlink(current_pointer, "Current-build pointer"),
+            build_root,
+            "Current-build pointer target",
+        )
+    elif not os.path.lexists(stable_app) and not os.path.lexists(stable_metadata):
+        replace_symlink(version_route, current_pointer)
+        pointer_directory = version_directory
+    elif os.path.lexists(stable_app) and os.path.lexists(stable_metadata):
+        if os.readlink(stable_app) == str(app_route) and os.readlink(stable_metadata) == str(metadata_route):
+            replace_symlink(version_route, current_pointer)
+            pointer_directory = version_directory
+        else:
+            existing_app = resolve_symlink(stable_app, "Stable current app")
+            existing_metadata = resolve_symlink(stable_metadata, "Stable current metadata")
+            if (
+                existing_app.name != NATIVE_APP_NAME
+                or existing_metadata.name != CURRENT_BUILD_METADATA_NAME
+                or existing_app.parent != existing_metadata.parent
+            ):
+                raise RuntimeError("Existing stable current links do not identify one immutable build.")
+            pointer_directory = validate_version_directory(
+                existing_app.parent,
+                build_root,
+                "Existing stable current build",
+            )
+            replace_symlink(
+                Path(CURRENT_BUILD_DIRECTORY_NAME) / pointer_directory.name,
+                current_pointer,
+            )
+    else:
+        raise RuntimeError("Existing stable current links are incomplete.")
+
+    for path, route, expected_target in (
+        (stable_metadata, metadata_route, pointer_directory / CURRENT_BUILD_METADATA_NAME),
+        (stable_app, app_route, pointer_directory / NATIVE_APP_NAME),
+    ):
+        if os.path.lexists(path) and os.readlink(path) != str(route):
+            if resolve_symlink(path, f"Stable current path {path.name}") != expected_target:
+                raise RuntimeError(f"Existing stable current path disagrees with the current pointer: {path}")
+        if not os.path.lexists(path) or os.readlink(path) != str(route):
+            replace_symlink(route, path)
+
+    if stable_app.resolve(strict=True) != pointer_directory / NATIVE_APP_NAME:
+        raise RuntimeError("Stable current app did not resolve through the current-build pointer.")
+    if stable_metadata.resolve(strict=True) != pointer_directory / CURRENT_BUILD_METADATA_NAME:
+        raise RuntimeError("Stable current metadata did not resolve through the current-build pointer.")
+
+    if pointer_directory != version_directory:
+        replace_symlink(version_route, current_pointer)
+    if stable_app.resolve(strict=True) != version_directory / NATIVE_APP_NAME:
+        raise RuntimeError("Stable current app did not switch to the published build.")
+    if stable_metadata.resolve(strict=True) != version_directory / CURRENT_BUILD_METADATA_NAME:
+        raise RuntimeError("Stable current metadata did not switch to the published build.")
+
+
+def publish_current_app(
+    app_path: Path,
+    *,
+    applications_directory: Path,
+    source_commit: str,
+    base_main_commit: str,
+    built_at: datetime | None = None,
+) -> Path:
+    source_commit = validate_full_git_sha(source_commit, "Source commit")
+    base_main_commit = validate_full_git_sha(base_main_commit, "Base main commit")
+    require_real_directory(app_path, "Packaged app")
+    validate_app_symlinks(app_path)
+
+    applications_directory = prepare_applications_directory(applications_directory)
+    stable_app = applications_directory / CURRENT_APP_LINK_NAME
+    stable_metadata = applications_directory / CURRENT_METADATA_LINK_NAME
+
+    verify_codesign(app_path)
+    source_app_hash = app_tree_sha256(app_path)
+    short_version, build_version = bundle_versions(app_path)
+    build_time = built_at or datetime.now(UTC)
+    if build_time.utcoffset() is None:
+        raise ValueError("Build time must include a timezone.")
+    built_at_utc = build_time.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+    build_root = applications_directory / CURRENT_BUILD_DIRECTORY_NAME
+    version_directory = build_root / source_commit
+    versioned_app = version_directory / NATIVE_APP_NAME
+    metadata_path = version_directory / CURRENT_BUILD_METADATA_NAME
+    metadata = {
+        "app_tree_sha256": source_app_hash,
+        "base_main_commit": base_main_commit,
+        "build_version": build_version,
+        "built_at_utc": built_at_utc,
+        "release_status": "not a production-signed release",
+        "short_version": short_version,
+        "signing": "ad-hoc local",
+        "source_commit": source_commit,
+        "stable_path": str(stable_app),
+    }
+
+    with current_publish_lock(applications_directory):
+        require_replaceable_symlink(applications_directory / CURRENT_POINTER_LINK_NAME)
+        require_replaceable_symlink(stable_app)
+        require_replaceable_symlink(stable_metadata)
+        if os.path.lexists(build_root):
+            require_real_directory(build_root, "Current-build root")
+        else:
+            build_root.mkdir()
+        if os.path.lexists(version_directory):
+            require_real_directory(version_directory, "Existing current-build directory")
+            require_real_directory(versioned_app, "Existing current-build app")
+            require_real_file(metadata_path, "Existing current-build metadata")
+            validate_app_symlinks(versioned_app)
+            verify_codesign(versioned_app)
+            if app_tree_sha256(versioned_app) != source_app_hash:
+                raise RuntimeError(f"Existing build for {source_commit} has a different app tree.")
+            try:
+                existing_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                raise RuntimeError(f"Existing build metadata is invalid: {metadata_path}") from error
+            if not isinstance(existing_metadata, dict) or set(existing_metadata) != set(metadata):
+                raise RuntimeError(f"Existing build metadata has an unexpected schema: {metadata_path}")
+            existing_built_at = validate_built_at_utc(existing_metadata["built_at_utc"], metadata_path)
+            expected_metadata = {**metadata, "built_at_utc": existing_built_at}
+            if existing_metadata != expected_metadata:
+                mismatched_key = next(
+                    key for key, expected_value in expected_metadata.items() if existing_metadata[key] != expected_value
+                )
+                raise RuntimeError(f"Existing build metadata does not match {mismatched_key}: {metadata_path}")
+        else:
+            temporary_directory = Path(tempfile.mkdtemp(prefix=f".{source_commit}.", dir=build_root))
+            try:
+                temporary_app = temporary_directory / NATIVE_APP_NAME
+                shutil.copytree(app_path, temporary_app, symlinks=True)
+                require_real_directory(temporary_app, "Copied current-build app")
+                validate_app_symlinks(temporary_app)
+                verify_codesign(temporary_app)
+                if app_tree_sha256(temporary_app) != source_app_hash:
+                    raise RuntimeError("Copied current app does not match the packaged app tree.")
+                (temporary_directory / CURRENT_BUILD_METADATA_NAME).write_text(
+                    json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                if os.path.lexists(version_directory):
+                    raise RuntimeError(f"Current-build destination appeared during publication: {version_directory}")
+                os.replace(temporary_directory, version_directory)
+            finally:
+                shutil.rmtree(temporary_directory, ignore_errors=True)
+
+        publish_stable_current_links(
+            build_root=build_root,
+            version_directory=version_directory,
+            stable_app=stable_app,
+            stable_metadata=stable_metadata,
+        )
+    return stable_app
+
+
+def publish_current(applications_directory: Path | None = None) -> Path:
+    ensure_clean_worktree()
+    source_commit = git_output("rev-parse", "HEAD")
+    base_main_commit = git_output("merge-base", "HEAD", "origin/main")
+    app_path = package("-")
+    ensure_clean_worktree()
+    packaged_source_commit = git_output("rev-parse", "HEAD")
+    if packaged_source_commit != source_commit:
+        raise RuntimeError("Git HEAD changed while packaging the current app.")
+    packaged_base_main_commit = git_output("merge-base", "HEAD", "origin/main")
+    if packaged_base_main_commit != base_main_commit:
+        raise RuntimeError("The origin/main merge base changed while packaging the current app.")
+    stable_app = publish_current_app(
+        app_path,
+        applications_directory=applications_directory or Path.home() / "Applications",
+        source_commit=source_commit,
+        base_main_commit=base_main_commit,
+    )
+    print(f"Published current app: {stable_app}")
+    return stable_app
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -802,6 +1164,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     commands.add_parser("generate", help="Generate the Xcode project from macos/project.yml.")
     commands.add_parser("test", help="Run the macOS application unit tests.")
     commands.add_parser("build", help="Build the macOS Development app without embedding Python.")
+    commands.add_parser(
+        "publish-current",
+        help="Package and publish an immutable local app behind a stable Current.app link.",
+        description=(
+            "Package an ad-hoc local app and publish it behind a stable Current.app link. "
+            f"Requires {SUPPORT_DIAGNOSTICS_ENDPOINT_ENV}."
+        ),
+    )
     package_parser = commands.add_parser("package", help="Build, embed, sign, and smoke the Python worker.")
     package_parser.add_argument(
         "--sign-identity",
@@ -824,6 +1194,8 @@ def main(argv: list[str] | None = None) -> None:
         xcodebuild("test", "Debug")
     elif args.command == "build":
         xcodebuild("build", "Debug")
+    elif args.command == "publish-current":
+        publish_current()
     elif args.command == "package":
         package(args.sign_identity, args.sign_keychain)
 

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -7,11 +7,18 @@ import tomllib
 import unittest
 
 from contextlib import chdir
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
 from bd_to_avp.worker.protocol import PROTOCOL_VERSION
+from scripts.artifact_identity import app_tree_sha256
 from scripts.native_app import (
+    CURRENT_APP_LINK_NAME,
+    CURRENT_BUILD_DIRECTORY_NAME,
+    CURRENT_BUILD_METADATA_NAME,
+    CURRENT_METADATA_LINK_NAME,
+    CURRENT_POINTER_LINK_NAME,
     MV_HEVC_ENCODER_NAME,
     NATIVE_APP_NAME,
     NATIVE_BUNDLE_IDENTIFIER,
@@ -31,12 +38,15 @@ from scripts.native_app import (
     REPO_ROOT,
     SCHEME,
     build_packaged_mv_hevc_encoder,
+    ensure_clean_worktree,
     install_mv_hevc_encoder,
     native_build_settings,
     minimum_macos_versions,
     linked_libraries,
     package,
     parse_args,
+    publish_current,
+    publish_current_app,
     sign_package,
     smoke_packaged_mv_hevc_encoder,
     smoke_packaged_native_app,
@@ -50,6 +60,7 @@ from scripts.native_app import (
     verify_product_identity,
     verify_product_source_copy,
 )
+from scripts.verify_packaged_mv_hevc_routes import app_tree_sha256 as qualification_app_tree_sha256
 
 yaml = importlib.import_module("yaml")
 
@@ -88,6 +99,23 @@ def production_info(*, support_diagnostics_endpoint: object = "https://support.e
         **NATIVE_UPDATE_INFO,
         SUPPORT_DIAGNOSTICS_ENDPOINT_INFO_KEY: support_diagnostics_endpoint,
     }
+
+
+def test_app(root: Path, payload: bytes = b"current build") -> Path:
+    app_path = root / NATIVE_APP_NAME
+    contents = app_path / "Contents"
+    resources = contents / "Resources"
+    resources.mkdir(parents=True)
+    with (contents / "Info.plist").open("wb") as info_file:
+        plistlib.dump(
+            {
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "456",
+            },
+            info_file,
+        )
+    (resources / "payload.bin").write_bytes(payload)
+    return app_path
 
 
 class NativeAppPackagingTests(unittest.TestCase):
@@ -463,6 +491,13 @@ Load command 3
         self.assertEqual(args.sign_identity, "Developer ID Application: Example")
         self.assertEqual(args.sign_keychain, "/tmp/release.keychain-db")
 
+    def test_publish_current_command_has_no_signing_options(self) -> None:
+        args = parse_args(["publish-current"])
+
+        self.assertEqual(args.command, "publish-current")
+        self.assertFalse(hasattr(args, "sign_identity"))
+        self.assertFalse(hasattr(args, "sign_keychain"))
+
     def test_package_builds_installs_signs_and_smokes_mv_hevc_encoder(self) -> None:
         encoder_path = Path("/tmp/native-tools/mv-hevc-encoder")
         app_path = Path("/tmp") / NATIVE_APP_NAME
@@ -478,7 +513,7 @@ Load command 3
             patch("scripts.native_app.verify_codesign") as verify,
             patch("builtins.print"),
         ):
-            package("Developer ID Application: Example", "/tmp/release.keychain-db")
+            result = package("Developer ID Application: Example", "/tmp/release.keychain-db")
 
         build_encoder.assert_called_once_with()
         prepare_runtime.assert_called_once_with()
@@ -489,6 +524,509 @@ Load command 3
         smoke_encoder.assert_called_once_with(app_path)
         smoke_worker.assert_called_once_with(app_path)
         verify.assert_called_once_with(app_path)
+        self.assertEqual(result, app_path)
+
+    def test_publish_current_app_creates_immutable_build_and_stable_links(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        built_at = datetime(2026, 7, 29, 1, 2, 3, tzinfo=UTC)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+            retained_build = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / "retained"
+            retained_build.mkdir(parents=True)
+
+            with patch("scripts.native_app.verify_codesign") as verify:
+                stable_app = publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit=base_main_commit,
+                    built_at=built_at,
+                )
+
+            version_directory = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / source_commit
+            versioned_app = version_directory / NATIVE_APP_NAME
+            metadata_path = version_directory / CURRENT_BUILD_METADATA_NAME
+            stable_metadata = applications_directory / CURRENT_METADATA_LINK_NAME
+            current_pointer = applications_directory / CURRENT_POINTER_LINK_NAME
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(stable_app, applications_directory.resolve() / CURRENT_APP_LINK_NAME)
+            self.assertTrue(stable_app.is_symlink())
+            self.assertEqual(stable_app.readlink(), Path(CURRENT_POINTER_LINK_NAME) / NATIVE_APP_NAME)
+            self.assertEqual(stable_app.resolve(), versioned_app.resolve())
+            self.assertTrue(stable_metadata.is_symlink())
+            self.assertEqual(
+                stable_metadata.readlink(),
+                Path(CURRENT_POINTER_LINK_NAME) / CURRENT_BUILD_METADATA_NAME,
+            )
+            self.assertEqual(stable_metadata.resolve(), metadata_path.resolve())
+            self.assertEqual(
+                current_pointer.readlink(),
+                Path(CURRENT_BUILD_DIRECTORY_NAME) / source_commit,
+            )
+            self.assertTrue(retained_build.is_dir())
+            self.assertEqual(metadata["source_commit"], source_commit)
+            self.assertEqual(metadata["base_main_commit"], base_main_commit)
+            self.assertEqual(metadata["built_at_utc"], "2026-07-29T01:02:03Z")
+            self.assertEqual(metadata["app_tree_sha256"], app_tree_sha256(source_app))
+            self.assertEqual(metadata["short_version"], "1.2.3")
+            self.assertEqual(metadata["build_version"], "456")
+            self.assertEqual(metadata["signing"], "ad-hoc local")
+            self.assertEqual(metadata["release_status"], "not a production-signed release")
+            self.assertEqual(metadata["stable_path"], str(stable_app))
+            self.assertEqual(verify.call_count, 2)
+
+            with patch("scripts.native_app.verify_codesign"):
+                repeated_app = publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit=base_main_commit,
+                    built_at=built_at + timedelta(days=1),
+                )
+
+            repeated_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            self.assertEqual(repeated_app, stable_app)
+            self.assertEqual(repeated_metadata["built_at_utc"], "2026-07-29T01:02:03Z")
+            self.assertEqual(repeated_app.resolve(), versioned_app.resolve())
+            self.assertEqual(stable_metadata.resolve(), metadata_path.resolve())
+
+    def test_publish_current_app_switches_app_and_metadata_through_one_pointer(self) -> None:
+        first_commit = "a" * 40
+        second_commit = "c" * 40
+        base_main_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            applications_directory = root / "Applications"
+            first_app = test_app(root / "first", b"first build")
+            second_app = test_app(root / "second", b"second build")
+
+            with patch("scripts.native_app.verify_codesign"):
+                stable_app = publish_current_app(
+                    first_app,
+                    applications_directory=applications_directory,
+                    source_commit=first_commit,
+                    base_main_commit=base_main_commit,
+                )
+                stable_metadata = applications_directory / CURRENT_METADATA_LINK_NAME
+                app_route = stable_app.readlink()
+                metadata_route = stable_metadata.readlink()
+
+                publish_current_app(
+                    second_app,
+                    applications_directory=applications_directory,
+                    source_commit=second_commit,
+                    base_main_commit=base_main_commit,
+                )
+
+            second_directory = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / second_commit
+            self.assertEqual(stable_app.readlink(), app_route)
+            self.assertEqual(stable_metadata.readlink(), metadata_route)
+            self.assertEqual(stable_app.resolve(), second_directory.resolve() / NATIVE_APP_NAME)
+            self.assertEqual(
+                stable_metadata.resolve(),
+                second_directory.resolve() / CURRENT_BUILD_METADATA_NAME,
+            )
+            self.assertTrue((applications_directory / CURRENT_BUILD_DIRECTORY_NAME / first_commit).is_dir())
+
+    def test_publish_current_app_migrates_matching_direct_stable_links(self) -> None:
+        old_commit = "a" * 40
+        new_commit = "c" * 40
+        base_main_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            applications_directory = root / "Applications"
+            old_directory = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / old_commit
+            old_app = test_app(old_directory)
+            old_metadata = old_directory / CURRENT_BUILD_METADATA_NAME
+            old_metadata.write_text("{}", encoding="utf-8")
+            stable_app = applications_directory / CURRENT_APP_LINK_NAME
+            stable_metadata = applications_directory / CURRENT_METADATA_LINK_NAME
+            stable_app.symlink_to(old_app)
+            stable_metadata.symlink_to(old_metadata)
+            new_app = test_app(root / "new", b"new build")
+
+            with patch("scripts.native_app.verify_codesign"):
+                publish_current_app(
+                    new_app,
+                    applications_directory=applications_directory,
+                    source_commit=new_commit,
+                    base_main_commit=base_main_commit,
+                )
+
+            new_directory = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / new_commit
+            self.assertEqual(stable_app.readlink(), Path(CURRENT_POINTER_LINK_NAME) / NATIVE_APP_NAME)
+            self.assertEqual(
+                stable_metadata.readlink(),
+                Path(CURRENT_POINTER_LINK_NAME) / CURRENT_BUILD_METADATA_NAME,
+            )
+            self.assertEqual(stable_app.resolve(), new_directory.resolve() / NATIVE_APP_NAME)
+            self.assertEqual(stable_metadata.resolve(), new_directory.resolve() / CURRENT_BUILD_METADATA_NAME)
+
+    def test_publish_current_app_rejects_direct_links_outside_build_root(self) -> None:
+        old_commit = "a" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            applications_directory = root / "Applications"
+            applications_directory.mkdir()
+            outside_directory = root / old_commit
+            old_app = test_app(outside_directory)
+            old_metadata = outside_directory / CURRENT_BUILD_METADATA_NAME
+            old_metadata.write_text("{}", encoding="utf-8")
+            stable_app = applications_directory / CURRENT_APP_LINK_NAME
+            stable_metadata = applications_directory / CURRENT_METADATA_LINK_NAME
+            stable_app.symlink_to(old_app)
+            stable_metadata.symlink_to(old_metadata)
+
+            with (
+                patch("scripts.native_app.verify_codesign"),
+                self.assertRaisesRegex(RuntimeError, "outside the immutable build root"),
+            ):
+                publish_current_app(
+                    test_app(root / "new", b"new build"),
+                    applications_directory=applications_directory,
+                    source_commit="c" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+            self.assertEqual(stable_app.resolve(), old_app.resolve())
+            self.assertEqual(stable_metadata.resolve(), old_metadata.resolve())
+
+    def test_publish_current_app_rejects_same_commit_with_different_base(self) -> None:
+        source_commit = "a" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+
+            with patch("scripts.native_app.verify_codesign"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit="b" * 40,
+                )
+                with self.assertRaisesRegex(RuntimeError, "base_main_commit"):
+                    publish_current_app(
+                        source_app,
+                        applications_directory=applications_directory,
+                        source_commit=source_commit,
+                        base_main_commit="c" * 40,
+                    )
+
+    def test_publish_current_app_rejects_tampered_metadata_schema(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+
+            with patch("scripts.native_app.verify_codesign"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit=base_main_commit,
+                )
+                metadata_path = (
+                    applications_directory / CURRENT_BUILD_DIRECTORY_NAME / source_commit / CURRENT_BUILD_METADATA_NAME
+                )
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                metadata["unexpected"] = True
+                metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+                with self.assertRaisesRegex(RuntimeError, "unexpected schema"):
+                    publish_current_app(
+                        source_app,
+                        applications_directory=applications_directory,
+                        source_commit=source_commit,
+                        base_main_commit=base_main_commit,
+                    )
+
+    def test_publish_current_app_rejects_invalid_metadata_timestamp(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+
+            with patch("scripts.native_app.verify_codesign"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit=base_main_commit,
+                )
+                metadata_path = (
+                    applications_directory / CURRENT_BUILD_DIRECTORY_NAME / source_commit / CURRENT_BUILD_METADATA_NAME
+                )
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                metadata["built_at_utc"] = "not-a-time"
+                metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+                with self.assertRaisesRegex(RuntimeError, "invalid UTC build time"):
+                    publish_current_app(
+                        source_app,
+                        applications_directory=applications_directory,
+                        source_commit=source_commit,
+                        base_main_commit=base_main_commit,
+                    )
+
+    def test_publish_current_app_refuses_system_applications_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_app = test_app(Path(temporary_directory) / "source")
+
+            with self.assertRaisesRegex(RuntimeError, "Refusing to publish.* /Applications"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=Path("/Applications"),
+                    source_commit="a" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+    def test_publish_current_app_rejects_symlinked_build_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+            applications_directory.mkdir()
+            redirected_build_root = root / "redirected"
+            redirected_build_root.mkdir()
+            (applications_directory / CURRENT_BUILD_DIRECTORY_NAME).symlink_to(
+                redirected_build_root,
+                target_is_directory=True,
+            )
+
+            with (
+                patch("scripts.native_app.verify_codesign"),
+                self.assertRaisesRegex(RuntimeError, "Current-build root must be a real directory"),
+            ):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit="a" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+    def test_publish_current_app_rejects_symlinked_commit_app(self) -> None:
+        source_commit = "a" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+            version_directory = applications_directory / CURRENT_BUILD_DIRECTORY_NAME / source_commit
+            version_directory.mkdir(parents=True)
+            (version_directory / NATIVE_APP_NAME).symlink_to(source_app, target_is_directory=True)
+            (version_directory / CURRENT_BUILD_METADATA_NAME).write_text("{}", encoding="utf-8")
+
+            with (
+                patch("scripts.native_app.verify_codesign"),
+                self.assertRaisesRegex(RuntimeError, "Existing current-build app must be a real directory"),
+            ):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit="b" * 40,
+                )
+
+    def test_publish_current_app_rejects_bundle_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            outside = root / "outside"
+            outside.write_text("outside", encoding="utf-8")
+            (source_app / "Contents" / "Resources" / "escape").symlink_to(outside)
+
+            with self.assertRaisesRegex(RuntimeError, "symlink escapes the bundle"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=root / "Applications",
+                    source_commit="a" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+    def test_publish_current_app_rejects_commit_collision(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+            with patch("scripts.native_app.verify_codesign"):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit=source_commit,
+                    base_main_commit=base_main_commit,
+                )
+
+                (source_app / "Contents" / "Resources" / "payload.bin").write_bytes(b"different build")
+                with self.assertRaisesRegex(RuntimeError, "different app tree"):
+                    publish_current_app(
+                        source_app,
+                        applications_directory=applications_directory,
+                        source_commit=source_commit,
+                        base_main_commit=base_main_commit,
+                    )
+
+    def test_publish_current_app_refuses_non_symlink_stable_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+            stable_app = applications_directory / CURRENT_APP_LINK_NAME
+            stable_app.mkdir(parents=True)
+
+            with (
+                patch("scripts.native_app.verify_codesign"),
+                self.assertRaisesRegex(RuntimeError, "Refusing to replace non-symlink path"),
+            ):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit="a" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+            self.assertFalse((applications_directory / CURRENT_BUILD_DIRECTORY_NAME).exists())
+
+    def test_publish_current_app_cleans_partial_copy_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_app = test_app(root / "source")
+            applications_directory = root / "Applications"
+
+            def fail_copy(_source: Path, destination: Path, **_options: object) -> None:
+                destination.mkdir(parents=True)
+                (destination / "partial").write_text("partial", encoding="utf-8")
+                raise OSError("copy failed")
+
+            with (
+                patch("scripts.native_app.verify_codesign"),
+                patch("scripts.native_app.shutil.copytree", side_effect=fail_copy),
+                self.assertRaisesRegex(OSError, "copy failed"),
+            ):
+                publish_current_app(
+                    source_app,
+                    applications_directory=applications_directory,
+                    source_commit="a" * 40,
+                    base_main_commit="b" * 40,
+                )
+
+            build_root = applications_directory / CURRENT_BUILD_DIRECTORY_NAME
+            self.assertEqual(list(build_root.iterdir()), [])
+
+    def test_publish_current_packages_ad_hoc_from_clean_git_identity(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        packaged_app = Path("/tmp") / NATIVE_APP_NAME
+        stable_app = Path("/tmp/Applications") / CURRENT_APP_LINK_NAME
+        applications_directory = Path("/tmp/Applications")
+        with (
+            patch("scripts.native_app.ensure_clean_worktree") as ensure_clean,
+            patch(
+                "scripts.native_app.git_output",
+                side_effect=[source_commit, base_main_commit, source_commit, base_main_commit],
+            ) as git_value,
+            patch("scripts.native_app.package", return_value=packaged_app) as package_mock,
+            patch("scripts.native_app.publish_current_app", return_value=stable_app) as publish,
+            patch("builtins.print"),
+        ):
+            result = publish_current(applications_directory)
+
+        self.assertEqual(result, stable_app)
+        self.assertEqual(ensure_clean.call_count, 2)
+        self.assertEqual(
+            [call.args for call in git_value.call_args_list],
+            [
+                ("rev-parse", "HEAD"),
+                ("merge-base", "HEAD", "origin/main"),
+                ("rev-parse", "HEAD"),
+                ("merge-base", "HEAD", "origin/main"),
+            ],
+        )
+        package_mock.assert_called_once_with("-")
+        publish.assert_called_once_with(
+            packaged_app,
+            applications_directory=applications_directory,
+            source_commit=source_commit,
+            base_main_commit=base_main_commit,
+        )
+
+    def test_publish_current_rejects_head_change_during_package(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        packaged_app = Path("/tmp") / NATIVE_APP_NAME
+        with (
+            patch("scripts.native_app.ensure_clean_worktree"),
+            patch(
+                "scripts.native_app.git_output",
+                side_effect=[source_commit, base_main_commit, "c" * 40],
+            ),
+            patch("scripts.native_app.package", return_value=packaged_app),
+            patch("scripts.native_app.publish_current_app") as publish,
+            self.assertRaisesRegex(RuntimeError, "Git HEAD changed"),
+        ):
+            publish_current(Path("/tmp/Applications"))
+
+        publish.assert_not_called()
+
+    def test_publish_current_rejects_base_main_change_during_package(self) -> None:
+        source_commit = "a" * 40
+        base_main_commit = "b" * 40
+        packaged_app = Path("/tmp") / NATIVE_APP_NAME
+        with (
+            patch("scripts.native_app.ensure_clean_worktree"),
+            patch(
+                "scripts.native_app.git_output",
+                side_effect=[source_commit, base_main_commit, source_commit, "c" * 40],
+            ),
+            patch("scripts.native_app.package", return_value=packaged_app),
+            patch("scripts.native_app.publish_current_app") as publish,
+            self.assertRaisesRegex(RuntimeError, "origin/main merge base changed"),
+        ):
+            publish_current(Path("/tmp/Applications"))
+
+        publish.assert_not_called()
+
+    def test_ensure_clean_worktree_rejects_changes(self) -> None:
+        dirty_result = subprocess.CompletedProcess(
+            args=["git", "status"],
+            returncode=0,
+            stdout=" M scripts/native_app.py\n",
+            stderr="",
+        )
+        with (
+            patch("scripts.native_app.subprocess.run", return_value=dirty_result),
+            self.assertRaisesRegex(RuntimeError, "clean Git worktree"),
+        ):
+            ensure_clean_worktree()
+
+    def test_app_tree_sha256_is_deterministic_and_tracks_symlink_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_path = root / "Hash.app"
+            app_path.mkdir()
+            (app_path / "first").write_bytes(b"same")
+            (app_path / "second").write_bytes(b"same")
+            link_path = app_path / "current"
+            link_path.symlink_to("first")
+
+            first_hash = app_tree_sha256(app_path)
+            self.assertEqual(first_hash, app_tree_sha256(app_path))
+            self.assertEqual(first_hash, qualification_app_tree_sha256(app_path))
+
+            link_path.unlink()
+            link_path.symlink_to("second")
+            second_hash = app_tree_sha256(app_path)
+            self.assertNotEqual(first_hash, second_hash)
+            self.assertEqual(second_hash, qualification_app_tree_sha256(app_path))
 
     def test_package_signing_uses_the_explicit_keychain(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- add one `publish-current` command that reuses the complete ad-hoc package and smoke pipeline
- retain immutable full-commit builds and switch the stable app plus metadata through one atomic pointer
- fail closed on dirty Git state, identity drift, collisions, symlink escapes, partial copies, and production `/Applications`
- document and register the canonical durable local-build command

## Validation
- `uv run python -m unittest discover -s tests -t .` — 1,137 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 317 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp scripts/native_app.py scripts/artifact_identity.py`
- `uv run python scripts/validate_observability_migration.py`
- `uv build`
- JetBrains changed-files inspection — GREEN, 0 findings
- canonical `publish-current` completed for commit `307fe52f49fdddc24c39107532613f3d20ba399c`; app-tree SHA-256 `844ff8aab51881a9e17c29c027410f6d36a8dcd5972f236199f518e65a496029`; deep code-sign verification passed

## Scope
This is an ad-hoc local handoff only. It does not change release workflows, version metadata, production signing, or `/Applications/3D Blu-ray to Vision Pro.app`.

Closes #408