### PR TITLE
Qualify AV1 playback by Vision Pro generation

### DIFF
--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -393,7 +393,10 @@ class Config:
         parser.add_argument(
             "--video-mode",
             choices=[mode.value for mode in VideoMode],
-            help="Video output mode: mv_hevc for native Apple spatial video or av1_sbs for software AV1 stereo.",
+            help=(
+                "Video output mode: mv_hevc for native Apple spatial video or av1_sbs for experimental "
+                "software AV1 stereo targeting M5 Vision Pro; M2 Vision Pro cannot decode AV1."
+            ),
         )
         parser.add_argument(
             "--av1-crf",

--- a/docs/av1-stereo-feasibility.md
+++ b/docs/av1-stereo-feasibility.md
@@ -2,8 +2,11 @@
 
 ## Decision
 
-BD_to_AVP should offer an opt-in, software-encoded AV1 stereo export while
-retaining MV-HEVC as the default native Apple spatial-video output.
+BD_to_AVP may retain an opt-in, software-encoded AV1 stereo export only as an
+experimental M5 Apple Vision Pro path while retaining MV-HEVC as the default
+native Apple spatial-video output. Physical testing proves that M2 Apple Vision
+Pro cannot decode the AV1 output, even at a small control resolution. Physical
+M5 stereoscopic playback remains unqualified.
 
 AV1 can encode a full-resolution side-by-side raster, and the packaged FFmpeg
 build contains `libsvtav1`, `libaom-av1`, and `librav1e`. Apple's codec-agnostic
@@ -24,9 +27,10 @@ replacement for MV-HEVC spatial delivery:
 - AV1 hardware support is fragmented across the Apple devices this project
   targets, and Apple exposes no VideoToolbox AV1 encoder in the macOS 27 SDK.
 
-MV-HEVC therefore remains the native Apple spatial output. AV1 is a separate
-software stereo export for storage-conscious or custom-playback workflows; the
-UI and documentation must not describe it as MV-HEVC or native spatial video.
+MV-HEVC therefore remains the native Apple spatial output. AV1 is a separate,
+experimental software stereo export for M5 Vision Pro or custom-playback
+workflows; the UI and documentation must identify M2 Vision Pro as unsupported
+and must not describe AV1 as MV-HEVC or native spatial video.
 
 ## Standards Evidence
 
@@ -76,13 +80,15 @@ The macOS 27 SDK reinforces the distinction:
   MV-HEVC-specific.
 - `VTCopyVideoEncoderList` exposes no AV1 encoder on the tested M4 Max system.
 
-Apple's [M2 media-engine documentation][apple-m2] lists H.264, HEVC, and ProRes
-but not AV1. Apple introduced AV1 hardware decode in the
+Apple's [M2 media-engine documentation][apple-m2] and the original
+[M2 Vision Pro technical specifications][apple-vision-pro-m2] list H.264,
+HEVC, and ProRes but not AV1. Apple introduced AV1 hardware decode in the
 [M3 media engine][apple-m3]. Apple's [M5 Apple Vision Pro announcement][apple-vision-pro-m5-newsroom]
 and [technical specifications][apple-vision-pro-m5] list AV1 hardware decode.
-The original M2 Apple Vision Pro therefore cannot be assumed to have an AV1
-hardware path. Software fallback availability and performance are not a safe
-product contract for full-resolution stereo playback.
+Physical testing below confirms that the M2 Vision Pro has neither an AV1
+hardware path nor a usable AVFoundation software fallback. M5 hardware support
+is documented, but its packed-stereo RealityKit behavior still requires
+physical evidence.
 
 ## Repository And Toolchain Evidence
 
@@ -230,7 +236,7 @@ no playback configuration options. It did not return
 
 This proves an Apple-recognized packed-stereo asset contract. It does not prove
 stereoscopic rendering on every Apple Vision Pro generation; that device
-qualification remains separate in issue #200.
+qualification remains separate in issue #409.
 
 ### Implemented production-path probe
 
@@ -276,6 +282,26 @@ short run. The result cannot predict feature-film speed, size, thermals, or
 subjective quality. It does show that both completed defaults are decodable and
 that CRF 32 trades measurable quality for the storage-oriented AV1 mode.
 
+### Sustained encoder comparison
+
+On July 29, 2026, a longer encoding-only comparison used the same 60-second,
+24 fps, 1920x1080-per-eye synthetic source on an M4 Max Mac Studio. The AV1
+route encoded one 3840x1080 packed stream with `libsvtav1`, preset 9, CRF 32.
+The hardware HEVC route encoded two 1920x1080 eye streams concurrently with
+`hevc_videotoolbox` at 20 Mbps per eye. Both commands processed the same total
+pixel count and included the same synthetic source filters.
+
+| Mode | Run 1 | Run 2 | Run 3 | Mean | Relative elapsed time |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Software AV1 | 14.16 s | 14.65 s | 14.61 s | 14.47 s | 1.23× hardware HEVC |
+| Hardware HEVC eye streams | 11.82 s | 11.82 s | 11.78 s | 11.81 s | baseline |
+
+For this source and machine, the software AV1 encode stage was approximately
+23% slower than the two concurrent hardware HEVC eye encodes. Both completed
+faster than real time. This is not a quality-matched comparison and excludes
+the later MV-HEVC merge, stereo metadata finalization, and final audio/subtitle
+mux, so it should not be used as a universal whole-conversion estimate.
+
 The same source was swept at preset 9 to validate the exposed CRF control:
 
 | CRF | Encoded AV1 bytes | Mean PSNR | Mean SSIM |
@@ -290,12 +316,45 @@ CRF 32 remains the storage-conscious default; users can lower it when quality
 matters more than output size. The sweep is still synthetic and is not a
 feature-film recommendation by itself.
 
+### Physical M2 Vision Pro qualification
+
+On July 29, 2026, BD to AVP Playback Check 0.2.0 build 4 tested an immutable
+60-second production-contract candidate on physical `RealityDevice14,1`
+running visionOS 27.0 build `24M5326g`:
+
+- Source/tool package commit: `1eecfcfc9bd5b64c501976592db5b0516edfb6f4`.
+- Packaged app tree SHA-256:
+  `c8f053793a0f7f045a35de12e60ed2b46a96118b4ea1ccb77f0069bbbd9e25ef`.
+- Candidate: one 3840x1080 `av01` track, two AAC language tracks, English
+  subtitles, and Apple `vexu/eyes/pack` metadata.
+- Candidate SHA-256:
+  `bd67dab8ad3a5f4f88a4c555d576ffbbbec9d29662681bcf7c3ed1b33ee1f3ef`.
+
+The device reported `VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1) =
+false` and `VTIsStereoMVHEVCDecodeSupported() = true`. An independent
+`AVAssetReader` first-frame probe failed with `Cannot Decode` before RealityKit
+was involved. `AVPlayerItem` briefly became ready through a fallback route,
+then the RealityKit player also failed with `Cannot Decode` before rendering.
+
+A separate six-second 1280x360 packed AV1 control with SHA-256
+`4be7607cdda287b501e245e84681e5ba6962a482235ad36592812319f229a6e6`
+failed identically in both the independent AVFoundation decoder probe and the
+RealityKit renderer. This rules out full-resolution load and the MV-HEVC-derived
+test-player design as the cause. The tested M2 Vision Pro has no usable AV1
+decode path for this product.
+
+The M5 Vision Pro lists AV1 hardware decode in Apple's specifications, but no
+physical M5 packed-stereo run has been completed. The AV1 option therefore
+remains M5-targeted and experimental until an M5 wearer provides decode,
+stereoscopic presentation, eye-order, seek, sustained-playback, and thermal
+evidence.
+
 ## Result Matrix
 
 | Representation | Tool result | Apple-framework result | Product meaning |
 | --- | --- | --- | --- |
 | One side-by-side `av01` MP4 track | Encodes and muxes | Playable and seekable as 640x180; no stereo playback option | Unmarked packed video |
-| Side-by-side `av01` plus `vexu/eyes/pack` | Deterministic GPAC patch and final remux work | Left/right eyes and side-by-side packing recognized; `StereoVideo` option returned | Supported AV1 stereo asset, not spatial video |
+| Side-by-side `av01` plus `vexu/eyes/pack` | Deterministic GPAC patch and final remux work | macOS recognizes left/right eyes and `StereoVideo`; M2 Vision Pro returns `Cannot Decode` | Experimental M5-targeted AV1 stereo asset, not spatial video |
 | Two independent `av01` MP4 tracks | Encodes and muxes | Two selectable tracks; default track decoded | Alternatives, not eye views |
 | AV1 WebM with `StereoMode` | Standards-based packed metadata works | AVFoundation cannot open the container | Non-Apple delivery only |
 | MV-HEVC MOV | Existing pipeline works | Native stereo multiview and spatial metadata | Default Apple spatial output |
@@ -311,12 +370,13 @@ The first AV1 mode is deliberately narrow:
 4. No claim that AV1 is MV-HEVC, multiview-compressed, or Apple spatial video.
 5. MV-HEVC remains the default and retains the `_AVP.mov` filename; AV1 uses the
    distinct `_AV1_Stereo.mov` suffix.
+6. M2 Vision Pro is explicitly unsupported. The UI identifies M5 Vision Pro as
+   the experimental target while physical M5 qualification remains pending.
 
-Physical Apple Vision Pro testing should determine which device generations and
-renderers honor the recognized stereo contract at sustained feature-film
-resolution. Long-form compression, encode-time, thermal, file-size, and
-subjective-quality qualification remains separate from the bounded synthetic
-comparison above.
+The next physical gate is an M5 Vision Pro run using the immutable candidate or
+an equivalent finalized output. Long-form compression, file-size, and
+subjective-quality qualification remain separate from the bounded synthetic
+comparisons above.
 
 [av1-spec]: https://aomediacodec.github.io/av1-spec/av1-spec.pdf
 [av1-isobmff]: https://aomediacodec.github.io/av1-isobmff/v1.3.0.html
@@ -324,5 +384,6 @@ comparison above.
 [apple-sbs-to-mvhevc]: https://developer.apple.com/documentation/avfoundation/converting-side-by-side-3d-video-to-multiview-hevc-and-spatial-video
 [apple-m2]: https://www.apple.com/newsroom/2022/06/apple-unveils-m2-with-breakthrough-performance-and-capabilities/
 [apple-m3]: https://www.apple.com/newsroom/2023/10/apple-unveils-m3-m3-pro-and-m3-max-the-most-advanced-chips-for-a-personal-computer/
+[apple-vision-pro-m2]: https://support.apple.com/en-us/117810
 [apple-vision-pro-m5-newsroom]: https://www.apple.com/newsroom/2025/10/apple-vision-pro-upgraded-with-the-m5-chip-and-dual-knit-band/
 [apple-vision-pro-m5]: https://support.apple.com/en-us/125436

--- a/docs/visionos-playback-validator.md
+++ b/docs/visionos-playback-validator.md
@@ -8,7 +8,7 @@ The validator asks the person wearing Apple Vision Pro to do four things:
 
 1. Choose one finished movie.
 2. Select **Run Playback Check**.
-3. Watch three short playback sections and answer two plain-language questions.
+3. Watch sustained playback plus three short seek sections and answer three plain-language questions.
 4. Share the generated report when evidence is needed.
 
 Nothing in the app publishes a build, approves a GitHub deployment, merges code, or authorizes a release. A passing report is playback evidence for the named movie and device; it is not a release approval by itself.
@@ -17,17 +17,19 @@ Movies selected through Files are copied into the app's cache so playback can co
 
 ## What It Checks Automatically
 
-- `VTIsStereoMVHEVCDecodeSupported()` on the current device.
+- The selected codec and decode route. MV-HEVC remains gated by `VTIsStereoMVHEVCDecodeSupported()`; AV1 records `VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)` and independently attempts a first-frame decode with `AVAssetReader` before any RealityKit presentation.
 - `AVPlayerItem.status == .readyToPlay` for the selected movie.
 - `VideoPlayerComponent.currentRenderingStatus == .ready`.
 - Actual stereoscopic playback and whether the presentation matches the selected validation expectation.
+- Up to 30 seconds of continuous playback with ready rendering, stereoscopic presentation, and before/after thermal state preserved.
 - Beginning, middle, and end seeks, including preservation of stereoscopic playback and required spatial treatment.
 - Available audio and subtitle choices for manual review under **Technical details**.
 
 After the automatic sequence, the validator asks only:
 
-- Did the picture stay visible during the entire check?
+- Did the picture stay visible and free of obvious freezes or corruption?
 - Did the scene look three-dimensional rather than flat?
+- Did the depth direction look correct and comfortable rather than inside-out?
 
 **Not sure** is a valid answer and produces **One result needs review** rather than a false pass.
 
@@ -48,11 +50,11 @@ Apple requires spatial metadata to describe the true, constant properties of the
 
 ## Result Meanings
 
-- **Playback check passed**: every automatic check passed and both visible observations were **Yes**.
+- **Playback check passed**: every automatic check passed and all three visible observations were **Yes**.
 - **One result needs review**: the automatic checks did not fail, but at least one observation was **Not sure** or a check did not reach a final pass state.
-- **Playback check found a problem**: an automatic check failed or either visible observation was **No**.
+- **Playback check found a problem**: an automatic check failed or any visible observation was **No**.
 
-The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The schema-3 report contains the expected presentation, validator version and build, visionOS version, filename, full-file SHA-256 fingerprint, file size, duration, media-option counts, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
+The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The schema-4 report contains the expected presentation, validator version and build, visionOS version, hardware model, filename, full-file SHA-256 fingerprint, file size, duration, media-option counts, selected video codec and sample-entry tag, AV1 and MV-HEVC capability results, independent first-frame decode result, selected decode route, sustained-playback duration, before/after thermal state, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
 
 ## Build
 
@@ -156,7 +158,7 @@ xcrun devicectl device process launch \
   com.shinycomputers.bd-to-avp.spatial-playback-probe
 ```
 
-Autorun starts the automatic sequence after the player is ready. It stops at the two human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
+Autorun starts the automatic sequence after the player is ready. It stops at the three human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
 
 After the operator selects **Finish Check**, retrieve the report directly without asking them to save share-sheet text manually:
 
@@ -170,6 +172,32 @@ xcrun devicectl device copy from \
 ```
 
 Use both expectations before release. A normal finalized movie proves the production stereo, audio, subtitle, and seek path. The synthetic calibration fixture separately proves that the app and device can enter RealityKit spatial portal presentation. Keeping those contracts separate prevents either missing spatial treatment or fabricated camera metadata from producing misleading release evidence.
+
+## AV1 Device Boundary
+
+Physical `RealityDevice14,1` testing on visionOS 27.0 build `24M5326g`
+established that M2 Vision Pro cannot decode AV1 through this stack. Both the
+independent `AVAssetReader` first-frame probe and RealityKit returned `Cannot
+Decode` for a 3840x1080 production-contract candidate and a separate 1280x360
+control. The failure is therefore not caused by full-resolution load or by the
+validator's MV-HEVC-derived stereo presentation design.
+
+Apple lists AV1 hardware decode for M5 Vision Pro, but packed-stereo RealityKit
+presentation remains unverified on physical M5 hardware. An M5 qualification
+run must record:
+
+- `hardware_model` and the full visionOS build;
+- `av1_hardware_decode=true` and a successful independent first-frame decode;
+- the exact movie SHA-256 and `av01` sample-entry tag;
+- ready rendering, stereoscopic screen presentation, sustained playback, and
+  beginning/middle/end seeks;
+- wearer confirmation for visible video without corruption, visible depth, and
+  correct non-inverted eye order;
+- before/after thermal state plus usable audio and subtitle choices where
+  present.
+
+Until that report exists, AV1 remains an experimental M5-targeted export. M2
+Vision Pro is explicitly unsupported, and MV-HEVC remains the default.
 
 ## Audio Validation Matrix
 
@@ -187,7 +215,7 @@ Run **Playback Check** for each fixture. After the guided result, expand **Techn
 
 ## Structured Evidence
 
-Structured events use the `BD_TO_AVP_PLAYBACK_PROBE` prefix. `automated_probe_complete` records the automatic result after all three seeks. `guided_validation_complete` records the final result and the two human observations.
+Structured events use the `BD_TO_AVP_PLAYBACK_PROBE` prefix. `automated_probe_complete` records the automatic result after sustained playback and all three seeks. `guided_validation_complete` records the final result and the three human observations.
 
 Physical acceptance requires:
 

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -167,7 +167,7 @@ enum VideoOutputMode: String, CaseIterable, Codable, Identifiable {
         case .mvHEVC:
             "Apple Spatial (MV-HEVC)"
         case .av1Stereo:
-            "AV1 Stereo (Software)"
+            "AV1 Stereo — M5 Vision Pro (Experimental)"
         }
     }
 
@@ -176,7 +176,7 @@ enum VideoOutputMode: String, CaseIterable, Codable, Identifiable {
         case .mvHEVC:
             "Native Apple spatial-video output using hardware HEVC encoding by default."
         case .av1Stereo:
-            "Full-resolution side-by-side AV1 with Apple stereo metadata. Encoding is software-only and may take substantially longer."
+            "Full-resolution side-by-side AV1 with Apple stereo metadata. Encoding is software-only. M2 Vision Pro cannot decode AV1; M5 Vision Pro hardware is required, and stereoscopic playback remains experimental pending physical M5 validation."
         }
     }
 

--- a/macos/BluRayToVisionPro/Models/VideoRouting.swift
+++ b/macos/BluRayToVisionPro/Models/VideoRouting.swift
@@ -403,7 +403,7 @@ extension VideoRouteReport {
         case "field_of_view_requires_generated_route":
             "The selected field of view requires the generated route."
         case "av1_output_requested":
-            "AV1 stereo output was requested."
+            "Experimental AV1 stereo output for M5 Vision Pro was requested. M2 Vision Pro playback is unsupported."
         case "resume_uses_existing_video_artifact":
             "The selected restart stage uses an existing encoded video artifact."
         case "direct_capability_unavailable":

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -64,6 +64,16 @@ struct EncodingOptionsEditor: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
 
+                    if options.videoOutputMode == .av1Stereo {
+                        Label(
+                            "M2 Vision Pro is not supported. Use AV1 only for M5 Vision Pro testing until physical M5 stereo playback is confirmed.",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+
                     Divider()
                     VideoRouteSummaryView(plan: routePlan)
 

--- a/macos/BluRayToVisionPro/Views/PreviewSheet.swift
+++ b/macos/BluRayToVisionPro/Views/PreviewSheet.swift
@@ -136,7 +136,7 @@ struct PreviewSheet: View {
                     Divider()
                         .gridCellColumns(2)
                     Label(
-                        "AV1 previews contain a full side-by-side frame. Stereo presentation depends on the player and device.",
+                        "AV1 previews contain a full side-by-side frame. M2 Vision Pro cannot decode AV1; M5 Vision Pro stereo playback remains experimental pending physical validation.",
                         systemImage: "rectangle.split.2x1"
                     )
                     .font(.caption)

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -38,6 +38,13 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(draft.proposedOutputURL.path, "/Movies/Feature_AV1_Stereo.mov")
     }
 
+    func testAV1ModeCopyNamesM5RequirementAndM2UnsupportedBoundary() {
+        XCTAssertTrue(VideoOutputMode.av1Stereo.title.contains("M5 Vision Pro"))
+        XCTAssertTrue(VideoOutputMode.av1Stereo.title.contains("Experimental"))
+        XCTAssertTrue(VideoOutputMode.av1Stereo.detail.contains("M2 Vision Pro cannot decode AV1"))
+        XCTAssertTrue(VideoOutputMode.av1Stereo.detail.contains("pending physical M5 validation"))
+    }
+
     func testDraftPreservesDotsInExtensionlessInspectedName() {
         let draft = ConversionDraft(
             source: ConversionSource(
@@ -377,7 +384,10 @@ final class ConversionWorkflowTests: XCTestCase {
         )
         XCTAssertEqual(av1.displayTitle, "AV1 stereo")
         XCTAssertEqual(av1.settingsSummary, "CRF 32")
-        XCTAssertEqual(av1.displayDetail, "AV1 stereo output was requested.")
+        XCTAssertEqual(
+            av1.displayDetail,
+            "Experimental AV1 stereo output for M5 Vision Pro was requested. M2 Vision Pro playback is unsupported."
+        )
 
         let existing = VideoRouteReport(
             intent: "existing_artifact",

--- a/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Combine
+import CoreVideo
 import Foundation
 import RealityKit
 import VideoToolbox
@@ -70,6 +71,11 @@ private struct PreparedMediaSelections {
     let subtitleSelectionByID: [String: AVMediaSelectionOption]
 }
 
+private struct ProbeIndependentDecodeResult: Sendable {
+    let succeeded: Bool
+    let detail: String
+}
+
 private final class ProbeSeekCompletion: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<Bool, Never>?
@@ -111,6 +117,7 @@ final class PlaybackProbeModel: ObservableObject {
     @Published private(set) var durationSeconds = 0.0
     @Published private(set) var sourceFileSizeBytes: Int64?
     @Published private(set) var sourceSHA256 = ""
+    @Published private(set) var sourceVideoFormat = PlaybackVideoFormat.unknown
     @Published private(set) var failure: ProbeFailure?
     @Published private(set) var audioOptions: [ProbeMediaOption] = []
     @Published private(set) var subtitleOptions: [ProbeMediaOption] = []
@@ -126,7 +133,8 @@ final class PlaybackProbeModel: ObservableObject {
     @Published private(set) var currentValidationStepText = ""
     @Published private(set) var playerComponentInstalled = false
 
-    let stereoDecodeSupported = VTIsStereoMVHEVCDecodeSupported()
+    let stereoMVHEVCDecodeSupported = VTIsStereoMVHEVCDecodeSupported()
+    let av1HardwareDecodeSupported = VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)
     let presentationExpectation = PlaybackPresentationExpectation.resolve(
         environment: ProcessInfo.processInfo.environment
     )
@@ -156,6 +164,11 @@ final class PlaybackProbeModel: ObservableObject {
         spatialVideoMode: "screen",
         immersiveViewingMode: "none"
     )
+    private var sustainedPlaybackSeconds = 0.0
+    private var thermalStateBefore = "not_measured"
+    private var thermalStateAfter = "not_measured"
+    private var independentFrameDecodeSucceeded = false
+    private var independentFrameDecodeDetail = "not_run"
 
     private var environment: [String: String] {
         ProcessInfo.processInfo.environment
@@ -166,7 +179,18 @@ final class PlaybackProbeModel: ObservableObject {
     }
 
     var decodeSupportText: String {
-        stereoDecodeSupported ? "Supported" : "Unavailable"
+        decodeAssessment.detail
+    }
+
+    var sourceVideoCodecText: String {
+        switch sourceVideoFormat.codec {
+        case .av1:
+            return "AV1 (\(sourceVideoFormat.codecTag))"
+        case .hevc:
+            return "HEVC (\(sourceVideoFormat.codecTag))"
+        case .unknown:
+            return "Unknown (\(sourceVideoFormat.codecTag))"
+        }
     }
 
     var expectedPresentationText: String {
@@ -224,6 +248,16 @@ final class PlaybackProbeModel: ObservableObject {
         return "\(completedCheckCount) of \(validationChecks.count) checks complete"
     }
 
+    private var decodeAssessment: PlaybackDecodeAssessment {
+        PlaybackDecodeAssessment.evaluate(
+            format: sourceVideoFormat,
+            playerReady: player.currentItem?.status == .readyToPlay,
+            av1HardwareDecodeSupported: av1HardwareDecodeSupported,
+            stereoMVHEVCDecodeSupported: stereoMVHEVCDecodeSupported,
+            independentFrameDecodeSucceeded: independentFrameDecodeSucceeded
+        )
+    }
+
     deinit {
         statusTask?.cancel()
         loadTask?.cancel()
@@ -242,7 +276,9 @@ final class PlaybackProbeModel: ObservableObject {
         emit(
             "capability",
             values: [
-                "stereo_mv_hevc_decode": String(stereoDecodeSupported),
+                "stereo_mv_hevc_decode": String(stereoMVHEVCDecodeSupported),
+                "av1_hardware_decode": String(av1HardwareDecodeSupported),
+                "hardware_model": PlaybackDeviceIdentity.hardwareModel(),
                 "visionos_version": ProcessInfo.processInfo.operatingSystemVersionString,
             ]
         )
@@ -252,16 +288,6 @@ final class PlaybackProbeModel: ObservableObject {
                 values: [
                     "category": "cache_cleanup_failed",
                     "message": "A previous temporary movie could not be removed.",
-                ]
-            )
-        }
-
-        if !stereoDecodeSupported {
-            emit(
-                "warning",
-                values: [
-                    "category": ProbeFailureCategory.unsupportedDecode.rawValue,
-                    "message": "This device does not currently report stereo MV-HEVC decode support.",
                 ]
             )
         }
@@ -433,6 +459,9 @@ final class PlaybackProbeModel: ObservableObject {
             spatialVideoMode: "screen",
             immersiveViewingMode: "none"
         )
+        sustainedPlaybackSeconds = 0
+        thermalStateBefore = "not_measured"
+        thermalStateAfter = "not_measured"
         validationPhase = .running
         currentValidationStepText = "Preparing the playback check…"
         requestSpatialPresentation(true)
@@ -463,8 +492,9 @@ final class PlaybackProbeModel: ObservableObject {
         currentValidationStepText = ""
 
         let generatedAt = Date()
+        let assessment = decodeAssessment
         let report = PlaybackValidationReport(
-            schemaVersion: 3,
+            schemaVersion: 4,
             validatorVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "development",
             validatorBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "development",
             generatedAt: ISO8601DateFormatter().string(from: generatedAt),
@@ -476,6 +506,21 @@ final class PlaybackProbeModel: ObservableObject {
                 durationSeconds: durationSeconds,
                 audioOptionCount: audioOptions.count,
                 subtitleOptionCount: max(0, subtitleOptions.count - 1)
+            ),
+            decode: PlaybackDecodeSummary(
+                videoCodec: sourceVideoFormat.codec,
+                codecTag: sourceVideoFormat.codecTag,
+                route: assessment.route,
+                av1HardwareDecodeSupported: av1HardwareDecodeSupported,
+                stereoMVHEVCDecodeSupported: stereoMVHEVCDecodeSupported,
+                independentFrameDecodeSucceeded: independentFrameDecodeSucceeded,
+                independentFrameDecodeDetail: independentFrameDecodeDetail
+            ),
+            runtime: PlaybackRuntimeSummary(
+                hardwareModel: PlaybackDeviceIdentity.hardwareModel(),
+                sustainedPlaybackSeconds: sustainedPlaybackSeconds,
+                thermalStateBefore: thermalStateBefore,
+                thermalStateAfter: thermalStateAfter
             ),
             presentation: validatedPresentation,
             automaticChecks: validationChecks,
@@ -535,6 +580,7 @@ final class PlaybackProbeModel: ObservableObject {
                 "result": result.rawValue,
                 "video_remained_visible": observations.videoRemainedVisible.rawValue,
                 "appeared_three_dimensional": observations.appearedThreeDimensional.rawValue,
+                "eye_order_appeared_correct": observations.eyeOrderAppearedCorrect.rawValue,
             ]
         )
     }
@@ -615,11 +661,21 @@ final class PlaybackProbeModel: ObservableObject {
         }
 
         isLoading = true
+        independentFrameDecodeSucceeded = false
+        independentFrameDecodeDetail = "not_run"
         let asset = AVURLAsset(url: url)
         let item = AVPlayerItem(asset: asset)
 
         do {
             let duration = try await asset.load(.duration)
+            guard generation == loadGeneration, !Task.isCancelled else {
+                return false
+            }
+            let videoFormat = try await loadVideoFormat(for: asset)
+            guard generation == loadGeneration, !Task.isCancelled else {
+                return false
+            }
+            let independentDecodeResult = await Self.decodeFirstVideoFrame(at: url)
             guard generation == loadGeneration, !Task.isCancelled else {
                 return false
             }
@@ -650,6 +706,9 @@ final class PlaybackProbeModel: ObservableObject {
             durationSeconds = duration.seconds.isFinite ? max(0, duration.seconds) : 0
             sourceFileSizeBytes = fileSize(at: url)
             sourceSHA256 = sourceHash
+            sourceVideoFormat = videoFormat
+            independentFrameDecodeSucceeded = independentDecodeResult.succeeded
+            independentFrameDecodeDetail = independentDecodeResult.detail
             audioGroup = preparedMediaSelections.audioGroup
             subtitleGroup = preparedMediaSelections.subtitleGroup
             audioOptions = preparedMediaSelections.audioOptions
@@ -670,6 +729,10 @@ final class PlaybackProbeModel: ObservableObject {
                     "sha256": sourceHash,
                     "duration_seconds": formatNumber(durationSeconds),
                     "file_size_bytes": sourceFileSizeBytes.map(String.init) ?? "unknown",
+                    "video_codec": videoFormat.codec.rawValue,
+                    "video_codec_tag": videoFormat.codecTag,
+                    "independent_frame_decode": String(independentDecodeResult.succeeded),
+                    "independent_frame_decode_detail": independentDecodeResult.detail,
                     "audio_options": String(audioOptions.count),
                     "subtitle_options": String(max(0, subtitleOptions.count - 1)),
                 ]
@@ -730,7 +793,25 @@ final class PlaybackProbeModel: ObservableObject {
             if validationPhase == .preparing {
                 validationPhase = .ready
             }
-            emit("player_item", values: ["status": "ready_to_play"])
+            let assessment = decodeAssessment
+            emit(
+                "player_item",
+                values: [
+                    "status": "ready_to_play",
+                    "video_codec": sourceVideoFormat.codec.rawValue,
+                    "video_codec_tag": sourceVideoFormat.codecTag,
+                    "decode_route": assessment.route.rawValue,
+                ]
+            )
+            if assessment.route == .fallback {
+                emit(
+                    "warning",
+                    values: [
+                        "category": ProbeFailureCategory.unsupportedDecode.rawValue,
+                        "message": assessment.detail,
+                    ]
+                )
+            }
             scheduleAutomatedValidationIfNeeded()
         case .failed:
             setFailure(
@@ -834,15 +915,20 @@ final class PlaybackProbeModel: ObservableObject {
             return
         }
 
+        let playerReady = player.currentItem?.status == .readyToPlay
+        let assessment = PlaybackDecodeAssessment.evaluate(
+            format: sourceVideoFormat,
+            playerReady: playerReady,
+            av1HardwareDecodeSupported: av1HardwareDecodeSupported,
+            stereoMVHEVCDecodeSupported: stereoMVHEVCDecodeSupported,
+            independentFrameDecodeSucceeded: independentFrameDecodeSucceeded
+        )
         updateCheck(
             .stereoDecode,
-            status: stereoDecodeSupported ? .passed : .failed,
-            detail: stereoDecodeSupported
-                ? "This Vision Pro reports support for stereo MV-HEVC playback."
-                : "This device does not report support for stereo MV-HEVC playback."
+            status: assessment.passesCapabilityCheck ? .passed : .failed,
+            detail: assessment.detail
         )
 
-        let playerReady = player.currentItem?.status == .readyToPlay
         updateCheck(
             .playerReady,
             status: playerReady ? .passed : .failed,
@@ -890,6 +976,15 @@ final class PlaybackProbeModel: ObservableObject {
             status: presentationMatchesExpectation ? .passed : .failed,
             detail: presentationModeDetail(matchesExpectation: presentationMatchesExpectation)
         )
+
+        await runSustainedPlaybackCheck(
+            generation: generation,
+            item: validationItem,
+            presentationMatchesExpectation: presentationMatchesExpectation
+        )
+        guard isValidationCurrent(generation, item: validationItem) else {
+            return
+        }
 
         for position in ProbeSeekPosition.allCases {
             guard isValidationCurrent(generation, item: validationItem) else {
@@ -987,6 +1082,12 @@ final class PlaybackProbeModel: ObservableObject {
                 "rendering_status": renderingStatusText.lowercased(),
                 "actual_presentation": actualPresentationText.lowercased(),
                 "expected_presentation": presentationExpectation.rawValue,
+                "video_codec": sourceVideoFormat.codec.rawValue,
+                "video_codec_tag": sourceVideoFormat.codecTag,
+                "decode_route": assessment.route.rawValue,
+                "sustained_playback_seconds": formatNumber(sustainedPlaybackSeconds),
+                "thermal_state_before": thermalStateBefore,
+                "thermal_state_after": thermalStateAfter,
                 "checks_passed": String(automaticChecksPassed),
                 "audio_options": String(audioOptions.count),
                 "subtitle_options": String(max(0, subtitleOptions.count - 1)),
@@ -1007,6 +1108,87 @@ final class PlaybackProbeModel: ObservableObject {
             return
         }
         validationPhase = .observations
+    }
+
+    private func runSustainedPlaybackCheck(
+        generation: Int,
+        item: AVPlayerItem,
+        presentationMatchesExpectation: Bool
+    ) async {
+        currentValidationStepText = "Checking sustained playback…"
+        updateCheck(
+            .sustainedPlayback,
+            status: .running,
+            detail: "Watching up to 30 seconds for continuous stereoscopic playback."
+        )
+
+        let seekFinished = await seek(to: 0)
+        guard isValidationCurrent(generation, item: item) else {
+            return
+        }
+        let presentationReady = await waitForCondition(maxAttempts: 20) { [weak self] in
+            guard let self else {
+                return false
+            }
+            return self.renderingStatusText == "Ready"
+                && self.isActuallyStereo
+                && self.presentationExpectation.matches(
+                    isStereo: self.isActuallyStereo,
+                    isSpatial: self.isActuallySpatial
+                )
+        }
+        guard isValidationCurrent(generation, item: item) else {
+            return
+        }
+
+        let startSeconds = normalizedTime(player.currentTime().seconds)
+        let availablePlaybackSeconds = max(0, durationSeconds - startSeconds - 0.25)
+        let requiredPlaybackSeconds = min(30, max(0.25, availablePlaybackSeconds))
+        var renderingStayedReady = seekFinished && presentationReady
+        var stereoPresentationStayedActive = seekFinished && presentationReady
+        var expectedPresentationStayedActive = seekFinished
+            && presentationReady
+            && presentationMatchesExpectation
+
+        thermalStateBefore = currentThermalState()
+        player.play()
+        let maxAttempts = Int(ceil((requiredPlaybackSeconds + 5) / 0.25))
+        for _ in 0 ..< maxAttempts {
+            guard isValidationCurrent(generation, item: item) else {
+                return
+            }
+            let playbackAdvance = normalizedTime(player.currentTime().seconds) - startSeconds
+            if playbackAdvance >= requiredPlaybackSeconds {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            renderingStayedReady = renderingStayedReady && renderingStatusText == "Ready"
+            stereoPresentationStayedActive = stereoPresentationStayedActive && isActuallyStereo
+            expectedPresentationStayedActive = expectedPresentationStayedActive
+                && presentationExpectation.matches(
+                    isStereo: isActuallyStereo,
+                    isSpatial: isActuallySpatial
+                )
+        }
+        player.pause()
+        thermalStateAfter = currentThermalState()
+        sustainedPlaybackSeconds = max(0, normalizedTime(player.currentTime().seconds) - startSeconds)
+
+        let evidence = PlaybackSustainedEvidence(
+            playbackAdvanceSeconds: sustainedPlaybackSeconds,
+            requiredPlaybackAdvanceSeconds: requiredPlaybackSeconds,
+            renderingStayedReady: renderingStayedReady,
+            stereoPresentationStayedActive: stereoPresentationStayedActive,
+            expectedPresentationStayedActive: expectedPresentationStayedActive
+        )
+        let passed = PlaybackValidationRules.sustainedPlaybackPassed(evidence)
+        updateCheck(
+            .sustainedPlayback,
+            status: passed ? .passed : .failed,
+            detail: passed
+                ? "Playback advanced \(formatNumber(sustainedPlaybackSeconds)) seconds with stereoscopic rendering intact; thermal state was \(thermalStateBefore) before and \(thermalStateAfter) after."
+                : "Sustained playback did not remain ready in the expected stereoscopic mode for \(formatNumber(requiredPlaybackSeconds)) seconds."
+        )
     }
 
     private func waitForCondition(
@@ -1156,8 +1338,77 @@ final class PlaybackProbeModel: ObservableObject {
             spatialVideoMode: "screen",
             immersiveViewingMode: "none"
         )
+        sustainedPlaybackSeconds = 0
+        thermalStateBefore = "not_measured"
+        thermalStateAfter = "not_measured"
         currentValidationStepText = ""
         validationPhase = phase
+    }
+
+    nonisolated private static func decodeFirstVideoFrame(at url: URL) async -> ProbeIndependentDecodeResult {
+        await Task.detached(priority: .userInitiated) {
+            do {
+                let asset = AVURLAsset(url: url)
+                let videoTracks = try await asset.loadTracks(withMediaType: .video)
+                guard let videoTrack = videoTracks.first else {
+                    return ProbeIndependentDecodeResult(succeeded: false, detail: "no_video_track")
+                }
+
+                let reader = try AVAssetReader(asset: asset)
+                let output = AVAssetReaderTrackOutput(
+                    track: videoTrack,
+                    outputSettings: [
+                        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                    ]
+                )
+                output.alwaysCopiesSampleData = false
+                guard reader.canAdd(output) else {
+                    return ProbeIndependentDecodeResult(succeeded: false, detail: "asset_reader_rejected_output")
+                }
+                reader.add(output)
+                guard reader.startReading() else {
+                    return ProbeIndependentDecodeResult(
+                        succeeded: false,
+                        detail: reader.error?.localizedDescription ?? "asset_reader_start_failed"
+                    )
+                }
+                guard output.copyNextSampleBuffer() != nil else {
+                    let detail = reader.error?.localizedDescription ?? "asset_reader_returned_no_frame"
+                    reader.cancelReading()
+                    return ProbeIndependentDecodeResult(succeeded: false, detail: detail)
+                }
+                reader.cancelReading()
+                return ProbeIndependentDecodeResult(succeeded: true, detail: "decoded_first_frame")
+            } catch {
+                return ProbeIndependentDecodeResult(succeeded: false, detail: error.localizedDescription)
+            }
+        }.value
+    }
+
+    private func loadVideoFormat(for asset: AVAsset) async throws -> PlaybackVideoFormat {
+        let videoTracks = try await asset.loadTracks(withMediaType: .video)
+        guard let videoTrack = videoTracks.first else {
+            return .unknown
+        }
+        let formatDescriptions = try await videoTrack.load(.formatDescriptions)
+        return PlaybackVideoFormat(
+            mediaSubtype: formatDescriptions.first.map(CMFormatDescriptionGetMediaSubType)
+        )
+    }
+
+    private func currentThermalState() -> String {
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal:
+            return "nominal"
+        case .fair:
+            return "fair"
+        case .serious:
+            return "serious"
+        case .critical:
+            return "critical"
+        @unknown default:
+            return "unknown"
+        }
     }
 
     private func prepareMediaSelections(
@@ -1292,6 +1543,9 @@ final class PlaybackProbeModel: ObservableObject {
         requestSpatialPresentation(false)
         sourceFileSizeBytes = nil
         sourceSHA256 = ""
+        sourceVideoFormat = .unknown
+        independentFrameDecodeSucceeded = false
+        independentFrameDecodeDetail = "not_run"
         audioOptions = []
         subtitleOptions = []
         audioGroup = nil

--- a/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
@@ -255,7 +255,7 @@ struct PlaybackProbeView: View {
                 .font(.title2.bold())
                 .foregroundStyle(.green)
 
-            Text("The check takes about 15 seconds. Keep this window visible while it plays the beginning, middle, and end.")
+            Text("The check takes about 45 seconds for a full-length movie. Keep this window visible during sustained playback and the beginning, middle, and end seeks.")
                 .foregroundStyle(.secondary)
 
             Text(model.expectedPresentationGuidance)
@@ -264,8 +264,8 @@ struct PlaybackProbeView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 instructionRow(number: 1, text: "Start the guided check")
-                instructionRow(number: 2, text: "Watch the picture during three short seeks")
-                instructionRow(number: 3, text: "Answer two plain-language questions")
+                instructionRow(number: 2, text: "Watch sustained playback and three short seeks")
+                instructionRow(number: 3, text: "Answer three plain-language questions")
             }
 
             Button {
@@ -310,15 +310,15 @@ struct PlaybackProbeView: View {
             .accessibilityIdentifier("automatic-check-status")
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Two things only you can confirm")
+                Text("Three things only you can confirm")
                     .font(.title2.bold())
                 Text("These answers record what you saw. They do not approve a release or publish anything.")
                     .foregroundStyle(.secondary)
             }
 
             observationCard(
-                title: "Did the picture stay visible during the entire check?",
-                detail: "Answer No if the video disappeared, turned black, or moved into a window you could not find.",
+                title: "Did the picture stay visible and free of obvious freezes or corruption?",
+                detail: "Answer No if the video disappeared, turned black, froze, or showed obvious visual corruption during sustained playback or a seek.",
                 keyPath: \.videoRemainedVisible
             )
 
@@ -326,6 +326,12 @@ struct PlaybackProbeView: View {
                 title: "Did the scene look three-dimensional rather than flat?",
                 detail: "Answer Not sure if the clip does not contain an obvious foreground and background.",
                 keyPath: \.appearedThreeDimensional
+            )
+
+            observationCard(
+                title: "Did the depth direction look correct and comfortable rather than inside-out?",
+                detail: "Answer No if foreground and background appeared reversed or the 3D view felt strongly inverted.",
+                keyPath: \.eyeOrderAppearedCorrect
             )
 
             Button {
@@ -432,7 +438,8 @@ struct PlaybackProbeView: View {
     private var technicalDetails: some View {
         DisclosureGroup("Technical details", isExpanded: $showsTechnicalDetails) {
             VStack(alignment: .leading, spacing: 14) {
-                statusRow(title: "Stereo decode support", value: model.decodeSupportText)
+                statusRow(title: "Video codec", value: model.sourceVideoCodecText)
+                statusRow(title: "Decode route", value: model.decodeSupportText)
                 statusRow(title: "Player", value: model.playerItemStatusText)
                 statusRow(title: "Rendering", value: model.renderingStatusText)
                 statusRow(title: "Expected presentation", value: model.expectedPresentationText)

--- a/macos/SpatialPlaybackProbe/PlaybackValidation.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackValidation.swift
@@ -1,4 +1,6 @@
 import CryptoKit
+import CoreMedia
+import Darwin
 import Foundation
 
 enum PlaybackValidationPhase: Equatable {
@@ -52,12 +54,141 @@ enum PlaybackPresentationExpectation: String, Codable, Equatable {
     }
 }
 
+enum PlaybackVideoCodec: String, Codable, Equatable {
+    case av1
+    case hevc
+    case unknown
+}
+
+struct PlaybackVideoFormat: Equatable {
+    static let unknown = PlaybackVideoFormat(codec: .unknown, codecTag: "unknown")
+
+    let codec: PlaybackVideoCodec
+    let codecTag: String
+
+    init(mediaSubtype: FourCharCode?) {
+        codecTag = Self.codecTag(for: mediaSubtype)
+        switch codecTag {
+        case "av01":
+            codec = .av1
+        case "hvc1", "hev1":
+            codec = .hevc
+        default:
+            codec = .unknown
+        }
+    }
+
+    private init(codec: PlaybackVideoCodec, codecTag: String) {
+        self.codec = codec
+        self.codecTag = codecTag
+    }
+
+    static func codecTag(for mediaSubtype: FourCharCode?) -> String {
+        guard let mediaSubtype else {
+            return "unknown"
+        }
+        let bytes = [
+            UInt8((mediaSubtype >> 24) & 0xff),
+            UInt8((mediaSubtype >> 16) & 0xff),
+            UInt8((mediaSubtype >> 8) & 0xff),
+            UInt8(mediaSubtype & 0xff),
+        ]
+        guard bytes.allSatisfy({ 32 ... 126 ~= $0 }) else {
+            return String(format: "0x%08X", mediaSubtype)
+        }
+        return String(bytes: bytes, encoding: .ascii) ?? "unknown"
+    }
+}
+
+enum PlaybackDecodeRoute: String, Codable, Equatable {
+    case hardware
+    case fallback
+    case unavailable
+}
+
+struct PlaybackDecodeAssessment: Equatable {
+    let route: PlaybackDecodeRoute
+    let passesCapabilityCheck: Bool
+    let detail: String
+
+    static func evaluate(
+        format: PlaybackVideoFormat,
+        playerReady: Bool,
+        av1HardwareDecodeSupported: Bool,
+        stereoMVHEVCDecodeSupported: Bool,
+        independentFrameDecodeSucceeded: Bool
+    ) -> Self {
+        switch format.codec {
+        case .av1:
+            if av1HardwareDecodeSupported {
+                guard independentFrameDecodeSucceeded else {
+                    return Self(
+                        route: .unavailable,
+                        passesCapabilityCheck: false,
+                        detail: "This Vision Pro reports AV1 hardware decode support, but AVFoundation could not decode a frame from the selected movie."
+                    )
+                }
+                return Self(
+                    route: .hardware,
+                    passesCapabilityCheck: true,
+                    detail: "This Vision Pro reports AV1 hardware decode support."
+                )
+            }
+            if playerReady && independentFrameDecodeSucceeded {
+                return Self(
+                    route: .fallback,
+                    passesCapabilityCheck: true,
+                    detail: "This Vision Pro does not report AV1 hardware decode support, but AVFoundation decoded a frame and the movie became ready. Sustained playback must still verify the fallback path."
+                )
+            }
+            return Self(
+                route: .unavailable,
+                passesCapabilityCheck: false,
+                detail: independentFrameDecodeSucceeded
+                    ? "This Vision Pro does not report AV1 hardware decode support and the AV1 movie did not become ready."
+                    : "This Vision Pro does not report AV1 hardware decode support and could not decode an AV1 frame through AVFoundation."
+            )
+        case .hevc:
+            return Self(
+                route: stereoMVHEVCDecodeSupported ? .hardware : .unavailable,
+                passesCapabilityCheck: stereoMVHEVCDecodeSupported,
+                detail: stereoMVHEVCDecodeSupported
+                    ? "This Vision Pro reports support for stereo MV-HEVC playback."
+                    : "This Vision Pro does not report support for stereo MV-HEVC playback."
+            )
+        case .unknown:
+            return Self(
+                route: .unavailable,
+                passesCapabilityCheck: false,
+                detail: "The selected movie's video codec could not be identified, so decode support fails closed."
+            )
+        }
+    }
+}
+
+enum PlaybackDeviceIdentity {
+    static func hardwareModel(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        if let simulatorModel = environment["SIMULATOR_MODEL_IDENTIFIER"], !simulatorModel.isEmpty {
+            return simulatorModel
+        }
+
+        var systemInfo = utsname()
+        guard uname(&systemInfo) == 0 else {
+            return "unknown"
+        }
+        return withUnsafePointer(to: &systemInfo.machine) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+    }
+}
+
 enum PlaybackCheckID: String, Codable, CaseIterable {
     case stereoDecode
     case playerReady
     case renderingReady
     case stereoPresentation
     case presentationMode
+    case sustainedPlayback
     case beginningSeek
     case middleSeek
     case endSeek
@@ -74,6 +205,8 @@ enum PlaybackCheckID: String, Codable, CaseIterable {
             return "Stereoscopic playback is active"
         case .presentationMode:
             return "3D presentation matches the movie type"
+        case .sustainedPlayback:
+            return "Sustained playback remains stable"
         case .beginningSeek:
             return "Beginning plays"
         case .middleSeek:
@@ -126,9 +259,12 @@ enum PlaybackObservationAnswer: String, Codable, CaseIterable {
 struct PlaybackObservations: Codable, Equatable {
     var videoRemainedVisible: PlaybackObservationAnswer = .unanswered
     var appearedThreeDimensional: PlaybackObservationAnswer = .unanswered
+    var eyeOrderAppearedCorrect: PlaybackObservationAnswer = .unanswered
 
     var isComplete: Bool {
-        videoRemainedVisible != .unanswered && appearedThreeDimensional != .unanswered
+        videoRemainedVisible != .unanswered
+            && appearedThreeDimensional != .unanswered
+            && eyeOrderAppearedCorrect != .unanswered
     }
 }
 
@@ -151,7 +287,7 @@ enum PlaybackValidationResult: String, Codable {
     var summary: String {
         switch self {
         case .passed:
-            return "The movie played in the expected 3D mode, survived all three seeks, and matched what you saw."
+            return "The movie sustained the expected 3D mode, survived all three seeks, and matched what you saw."
         case .needsReview:
             return "The automatic checks completed, but one observation was uncertain. The report preserves the details without treating this as approval."
         case .failed:
@@ -180,6 +316,23 @@ struct PlaybackSourceSummary: Codable, Equatable {
     let subtitleOptionCount: Int
 }
 
+struct PlaybackDecodeSummary: Codable, Equatable {
+    let videoCodec: PlaybackVideoCodec
+    let codecTag: String
+    let route: PlaybackDecodeRoute
+    let av1HardwareDecodeSupported: Bool
+    let stereoMVHEVCDecodeSupported: Bool
+    let independentFrameDecodeSucceeded: Bool
+    let independentFrameDecodeDetail: String
+}
+
+struct PlaybackRuntimeSummary: Codable, Equatable {
+    let hardwareModel: String
+    let sustainedPlaybackSeconds: Double
+    let thermalStateBefore: String
+    let thermalStateAfter: String
+}
+
 struct PlaybackPresentationSummary: Codable, Equatable {
     let expectation: PlaybackPresentationExpectation
     let viewingMode: String
@@ -194,6 +347,8 @@ struct PlaybackValidationReport: Codable, Equatable {
     let generatedAt: String
     let operatingSystem: String
     let source: PlaybackSourceSummary
+    let decode: PlaybackDecodeSummary
+    let runtime: PlaybackRuntimeSummary
     let presentation: PlaybackPresentationSummary
     let automaticChecks: [PlaybackCheck]
     let observations: PlaybackObservations
@@ -212,6 +367,14 @@ struct PlaybackSeekEvidence: Equatable {
     let requiresSpatialPresentation: Bool
 }
 
+struct PlaybackSustainedEvidence: Equatable {
+    let playbackAdvanceSeconds: Double
+    let requiredPlaybackAdvanceSeconds: Double
+    let renderingStayedReady: Bool
+    let stereoPresentationStayedActive: Bool
+    let expectedPresentationStayedActive: Bool
+}
+
 enum PlaybackValidationRules {
     static func result(
         checks: [PlaybackCheck],
@@ -220,6 +383,7 @@ enum PlaybackValidationRules {
         if checks.contains(where: { $0.status == .failed })
             || observations.videoRemainedVisible == .no
             || observations.appearedThreeDimensional == .no
+            || observations.eyeOrderAppearedCorrect == .no
         {
             return .failed
         }
@@ -227,6 +391,7 @@ enum PlaybackValidationRules {
         if checks.contains(where: { $0.status != .passed })
             || observations.videoRemainedVisible != .yes
             || observations.appearedThreeDimensional != .yes
+            || observations.eyeOrderAppearedCorrect != .yes
         {
             return .needsReview
         }
@@ -241,6 +406,13 @@ enum PlaybackValidationRules {
             && evidence.renderingReady
             && evidence.stereoPresentation
             && (!evidence.requiresSpatialPresentation || evidence.spatialPresentation)
+    }
+
+    static func sustainedPlaybackPassed(_ evidence: PlaybackSustainedEvidence) -> Bool {
+        evidence.playbackAdvanceSeconds >= evidence.requiredPlaybackAdvanceSeconds
+            && evidence.renderingStayedReady
+            && evidence.stereoPresentationStayedActive
+            && evidence.expectedPresentationStayedActive
     }
 }
 

--- a/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
+++ b/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
@@ -1,3 +1,4 @@
+import CoreMedia
 import XCTest
 @testable import SpatialPlaybackProbe
 
@@ -21,7 +22,8 @@ final class PlaybackValidationTests: XCTestCase {
         }
         let observations = PlaybackObservations(
             videoRemainedVisible: .yes,
-            appearedThreeDimensional: .yes
+            appearedThreeDimensional: .yes,
+            eyeOrderAppearedCorrect: .yes
         )
 
         XCTAssertEqual(
@@ -37,7 +39,8 @@ final class PlaybackValidationTests: XCTestCase {
         checks[0].status = .failed
         let observations = PlaybackObservations(
             videoRemainedVisible: .yes,
-            appearedThreeDimensional: .yes
+            appearedThreeDimensional: .yes,
+            eyeOrderAppearedCorrect: .yes
         )
 
         XCTAssertEqual(
@@ -52,7 +55,8 @@ final class PlaybackValidationTests: XCTestCase {
         }
         let observations = PlaybackObservations(
             videoRemainedVisible: .no,
-            appearedThreeDimensional: .yes
+            appearedThreeDimensional: .yes,
+            eyeOrderAppearedCorrect: .yes
         )
 
         XCTAssertEqual(
@@ -67,7 +71,8 @@ final class PlaybackValidationTests: XCTestCase {
         }
         let observations = PlaybackObservations(
             videoRemainedVisible: .yes,
-            appearedThreeDimensional: .unsure
+            appearedThreeDimensional: .unsure,
+            eyeOrderAppearedCorrect: .yes
         )
 
         XCTAssertEqual(
@@ -78,7 +83,7 @@ final class PlaybackValidationTests: XCTestCase {
 
     func testReportContainsFilenameWithoutSourcePath() throws {
         let report = PlaybackValidationReport(
-            schemaVersion: 3,
+            schemaVersion: 4,
             validatorVersion: "0.1.0",
             validatorBuild: "42",
             generatedAt: "2026-07-17T20:00:00Z",
@@ -91,6 +96,21 @@ final class PlaybackValidationTests: XCTestCase {
                 audioOptionCount: 2,
                 subtitleOptionCount: 1
             ),
+            decode: PlaybackDecodeSummary(
+                videoCodec: .av1,
+                codecTag: "av01",
+                route: .fallback,
+                av1HardwareDecodeSupported: false,
+                stereoMVHEVCDecodeSupported: true,
+                independentFrameDecodeSucceeded: true,
+                independentFrameDecodeDetail: "decoded_first_frame"
+            ),
+            runtime: PlaybackRuntimeSummary(
+                hardwareModel: "RealityDevice14,1",
+                sustainedPlaybackSeconds: 30,
+                thermalStateBefore: "nominal",
+                thermalStateAfter: "fair"
+            ),
             presentation: PlaybackPresentationSummary(
                 expectation: .stereo,
                 viewingMode: "stereo",
@@ -100,7 +120,8 @@ final class PlaybackValidationTests: XCTestCase {
             automaticChecks: [],
             observations: PlaybackObservations(
                 videoRemainedVisible: .yes,
-                appearedThreeDimensional: .yes
+                appearedThreeDimensional: .yes,
+                eyeOrderAppearedCorrect: .yes
             ),
             result: .passed
         )
@@ -114,8 +135,104 @@ final class PlaybackValidationTests: XCTestCase {
         XCTAssertTrue(reportText.contains("subtitleOptionCount"))
         XCTAssertTrue(reportText.contains("spatialVideoMode"))
         XCTAssertTrue(reportText.contains("expectation"))
+        XCTAssertTrue(reportText.contains("av01"))
+        XCTAssertTrue(reportText.contains("fallback"))
+        XCTAssertTrue(reportText.contains("RealityDevice14,1"))
+        XCTAssertTrue(reportText.contains("eyeOrderAppearedCorrect"))
         XCTAssertFalse(reportText.contains("/Users/"))
         XCTAssertFalse(reportText.contains("sourcePath"))
+    }
+
+    func testCodecIdentificationAndDecodeAssessmentAreCodecAware() {
+        let av1Format = PlaybackVideoFormat(mediaSubtype: FourCharCode(0x6176_3031))
+        let hevcFormat = PlaybackVideoFormat(mediaSubtype: FourCharCode(0x6876_6331))
+        let unknownFormat = PlaybackVideoFormat(mediaSubtype: FourCharCode(0x7670_3039))
+
+        XCTAssertEqual(av1Format, PlaybackVideoFormat(mediaSubtype: FourCharCode(0x6176_3031)))
+        XCTAssertEqual(av1Format.codec, .av1)
+        XCTAssertEqual(av1Format.codecTag, "av01")
+        XCTAssertEqual(hevcFormat.codec, .hevc)
+        XCTAssertEqual(unknownFormat.codec, .unknown)
+
+        let fallback = PlaybackDecodeAssessment.evaluate(
+            format: av1Format,
+            playerReady: true,
+            av1HardwareDecodeSupported: false,
+            stereoMVHEVCDecodeSupported: true,
+            independentFrameDecodeSucceeded: true
+        )
+        XCTAssertEqual(fallback.route, .fallback)
+        XCTAssertTrue(fallback.passesCapabilityCheck)
+
+        let unsupportedHEVC = PlaybackDecodeAssessment.evaluate(
+            format: hevcFormat,
+            playerReady: true,
+            av1HardwareDecodeSupported: true,
+            stereoMVHEVCDecodeSupported: false,
+            independentFrameDecodeSucceeded: true
+        )
+        XCTAssertEqual(unsupportedHEVC.route, .unavailable)
+        XCTAssertFalse(unsupportedHEVC.passesCapabilityCheck)
+
+        let unknown = PlaybackDecodeAssessment.evaluate(
+            format: unknownFormat,
+            playerReady: true,
+            av1HardwareDecodeSupported: true,
+            stereoMVHEVCDecodeSupported: true,
+            independentFrameDecodeSucceeded: true
+        )
+        XCTAssertFalse(unknown.passesCapabilityCheck)
+
+        let failedFallback = PlaybackDecodeAssessment.evaluate(
+            format: av1Format,
+            playerReady: true,
+            av1HardwareDecodeSupported: false,
+            stereoMVHEVCDecodeSupported: true,
+            independentFrameDecodeSucceeded: false
+        )
+        XCTAssertEqual(failedFallback.route, .unavailable)
+        XCTAssertFalse(failedFallback.passesCapabilityCheck)
+
+        let failedHardwareDecode = PlaybackDecodeAssessment.evaluate(
+            format: av1Format,
+            playerReady: true,
+            av1HardwareDecodeSupported: true,
+            stereoMVHEVCDecodeSupported: true,
+            independentFrameDecodeSucceeded: false
+        )
+        XCTAssertEqual(failedHardwareDecode.route, .unavailable)
+        XCTAssertFalse(failedHardwareDecode.passesCapabilityCheck)
+
+        let notReadyFallback = PlaybackDecodeAssessment.evaluate(
+            format: av1Format,
+            playerReady: false,
+            av1HardwareDecodeSupported: false,
+            stereoMVHEVCDecodeSupported: true,
+            independentFrameDecodeSucceeded: true
+        )
+        XCTAssertEqual(notReadyFallback.route, .unavailable)
+        XCTAssertFalse(notReadyFallback.passesCapabilityCheck)
+    }
+
+    func testIncorrectEyeOrderFailsAndUnansweredEyeOrderIsIncomplete() {
+        let checks = PlaybackCheckID.allCases.map {
+            PlaybackCheck(id: $0, status: .passed, detail: "Passed")
+        }
+        let failedObservations = PlaybackObservations(
+            videoRemainedVisible: .yes,
+            appearedThreeDimensional: .yes,
+            eyeOrderAppearedCorrect: .no
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.result(checks: checks, observations: failedObservations),
+            .failed
+        )
+
+        let incompleteObservations = PlaybackObservations(
+            videoRemainedVisible: .yes,
+            appearedThreeDimensional: .yes
+        )
+        XCTAssertFalse(incompleteObservations.isComplete)
     }
 
     func testSeekRequiresPlaybackAdvanceAndFreshSpatialRendering() {
@@ -189,6 +306,31 @@ final class PlaybackValidationTests: XCTestCase {
                     stereoPresentation: false,
                     spatialPresentation: false,
                     requiresSpatialPresentation: false
+                )
+            )
+        )
+    }
+
+    func testSustainedPlaybackRequiresAdvanceRenderingAndPresentation() {
+        XCTAssertTrue(
+            PlaybackValidationRules.sustainedPlaybackPassed(
+                PlaybackSustainedEvidence(
+                    playbackAdvanceSeconds: 30,
+                    requiredPlaybackAdvanceSeconds: 30,
+                    renderingStayedReady: true,
+                    stereoPresentationStayedActive: true,
+                    expectedPresentationStayedActive: true
+                )
+            )
+        )
+        XCTAssertFalse(
+            PlaybackValidationRules.sustainedPlaybackPassed(
+                PlaybackSustainedEvidence(
+                    playbackAdvanceSeconds: 29,
+                    requiredPlaybackAdvanceSeconds: 30,
+                    renderingStayedReady: true,
+                    stereoPresentationStayedActive: true,
+                    expectedPresentationStayedActive: true
                 )
             )
         )

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -88,10 +88,10 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
+        CURRENT_PROJECT_VERSION: 4
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: SpatialPlaybackProbe/Info.plist
-        MARKETING_VERSION: 0.1.0
+        MARKETING_VERSION: 0.2.0
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.spatial-playback-probe
         PRODUCT_MODULE_NAME: SpatialPlaybackProbe
         PRODUCT_NAME: BD to AVP Playback Check


### PR DESCRIPTION
## Summary

- make BD to AVP Playback Check codec-aware for AV1 and MV-HEVC, including independent first-frame decode, sustained playback, thermal evidence, exact hardware identity, and correct-eye wearer confirmation
- fail AV1 closed when the selected asset cannot independently decode, while preserving the existing MV-HEVC capability contract
- label AV1 output as experimental and M5 Vision Pro-targeted; explicitly mark M2 Vision Pro unsupported in the picker, preview, route summary, CLI help, and runbooks
- document the physical M2 boundary and the remaining physical M5 validation gate

## Physical Evidence

- validator source: `9a7ec4194d80e43a26a48f9305befd9e2f800d7c`
- validator: BD to AVP Playback Check `0.2.0 (4)`; binary SHA-256 `aaec8a59f3a5ccc7fbeab87d333d00ad194f26e4a490294c918e63a79f425703`
- device: physical `RealityDevice14,1`, visionOS `27.0 (24M5326g)`
- production-contract AV1 candidate: 3840x1080, 60 seconds, two AAC language tracks, English subtitles, SHA-256 `bd67dab8ad3a5f4f88a4c555d576ffbbbec9d29662681bcf7c3ed1b33ee1f3ef`
- low-resolution control: 1280x360, 6 seconds, SHA-256 `4be7607cdda287b501e245e84681e5ba6962a482235ad36592812319f229a6e6`
- both files report `av1_hardware_decode=false`, independent AVFoundation `Cannot Decode`, `decode_route=unavailable`, and RealityKit `Cannot Decode`
- conclusion: the tested M2 Vision Pro has no usable hardware or software AV1 path; physical M5 stereo validation remains required

## Encode Timing

On the M4 Max test system, three 60-second encoding-only runs averaged:

- software AV1: `14.47 s`
- two concurrent hardware HEVC eye streams: `11.81 s`
- AV1 was approximately `23%` slower for the encode stage; this excludes MV-HEVC merge and final mux

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` — 1,137 tests passed, 3 skipped
- `uv run python scripts/native_app.py test` — 318 tests passed
- SpatialPlaybackProbe visionOS simulator suite passed; physical-only UI test skipped as designed
- `uv run python -m scripts.release validate`
- `uv run python scripts/validate_observability_migration.py`
- JetBrains changed-file inspection: green, zero findings
- two-agent final review: pass, no blockers

Refs #409
