### PR TITLE
Prepare 0.3.0 beta 9 release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ and RC exclude it. Existing Stable or RC selections remain in place until you
 explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
 
-Beta 4 (`0.3.0b4`, build `149`), Beta 5 (`0.3.0b5`, build `150`), Beta 6
-(`0.3.0b6`, build `151`), and Beta 7 (`0.3.0b7`, build `152`) are published and
-immutable. Beta 8 metadata (`0.3.0b8`, build `153`) is prepared for the guarded
-Prerelease workflow. There is no Beta 8 tag, DMG, release, or updater item until exact-SHA signing,
-publication, and public verification complete.
+Beta 4 (`0.3.0b4`, build `149`) through Beta 8 (`0.3.0b8`, build `153`) are
+published and immutable. Beta 9 metadata (`0.3.0b9`, build `154`) is prepared
+for the guarded Prerelease workflow. There is no Beta 9 tag, DMG, release, or
+updater item until exact-SHA signing, publication, and public verification
+complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.

--- a/docs/0.3.0-beta.8-cut-packet.md
+++ b/docs/0.3.0-beta.8-cut-packet.md
@@ -1,22 +1,22 @@
 # 0.3.0 Beta 8 Cut Packet
 
-> **Authorized metadata; publication pending.** Issue #392 and the July 28,
-> 2026 instruction to proceed authorize repository preparation,
-> protected-main review, and exact-SHA Prerelease dispatch after this metadata
-> PR merges green and a merge hold is active. This packet does not assert that
-> a Beta 8 tag, draft, DMG, release, or appcast item exists. The
-> `macos-signing` environment remains a separate run-bound authorization that
-> requires explicit approval in the active conversation.
+> **Published and immutable.** Beta 8 was published on July 28, 2026 through
+> guarded Prerelease run `30341766419` from protected-`main` commit
+> `8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328`. The GitHub release, signed and
+> notarized DMG, `SHA256SUMS`, release `appcast.xml`, and cumulative production
+> appcast are historical release evidence. Issue #382 is complete; issue #392
+> retains the post-Beta-8 signed-candidate work exposed by the packaged preview
+> failure.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 8 packages the Apple-compatible
+[release-routes.md](release-routes.md). Beta 8 packaged the Apple-compatible
 AAC layout policy and release-package verifier together with the transactional
 artifact, destination-aware preview, and storage-diagnostic fixes tracked by
 #388 and qualified for one shared exact candidate under #392.
 
 ## Exact Metadata
 
-| Field | Reviewed value |
+| Field | Published value |
 | --- | --- |
 | Package and bundle short version | `0.3.0b8` |
 | Public version | `0.3.0-beta.8` |
@@ -34,11 +34,14 @@ artifact, destination-aware preview, and storage-diagnostic fixes tracked by
 | Privacy contract | Privacy rules version `4` |
 
 Build `153` is globally newer than immutable published Beta 7 build `152`. The
-July 28, 2026 live audit found immutable Beta 7 at protected-main commit
-`84036c7767fe3869e2fc9e709cddb3e132ed16bf`, no Beta 8 tag or release, no
-repository history consuming build `153`, and an empty release-freeze map. The
-public cumulative appcast remains rooted at Beta 7 build `152` until guarded
-publication succeeds.
+release was published at `2026-07-28T14:17:04Z` with DMG SHA-256
+`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`,
+release-appcast SHA-256
+`9004b5652bd2f06249c20c1df21edde026f3e2a7453b16df5ec7fdd1a0ac1d32`,
+and `SHA256SUMS` asset SHA-256
+`507b19bcedf9a7381894ba85e0323dcb4409705f633a1374c4075051fc1b5a92`.
+The cumulative appcast is ordered through builds
+`153,152,151,150,149,148,146,145,144`.
 
 ## Included Product Changes
 
@@ -59,7 +62,7 @@ publication succeeds.
 
 ## Cumulative Update Contract
 
-Publication must append Beta 8 above the immutable production history:
+Beta 8 is ordered above the immutable production history:
 
 | Order | Internal version | Build | Channel |
 | ---: | --- | ---: | --- |
@@ -91,38 +94,46 @@ prerelease.
 > artifacts transactionally, places heavy preview work on the selected
 > destination, and improves privacy-safe storage-capacity diagnostics.
 
-Do not describe Beta 8 as downloadable, signed, published, notarized, or
-Sparkle-discoverable until the guarded release verifies the immutable public
-state. The unsigned package gate does not establish physical Vision Pro
-surround placement, repeated seeks, or perceptual lip-sync.
+Beta 8 is downloadable, signed, notarized, published, and Sparkle-discoverable
+on the eligible Beta and Alpha routes. Its public artifacts and appcast item are
+immutable. The signed AAC package and physical Vision Pro gates passed, while
+the packaged GUI preview exposed the missing direct AVKit link later fixed by
+PR #404. Beta 8 must not be rebuilt to incorporate that fix.
+
+The release body embedded in Beta 8's immutable appcast item remains the
+publication-time snapshot and therefore says that later signed-candidate, NAS,
+and physical Vision Pro qualification were separate gates. Those gates were
+completed or refined after publication and are recorded in #382, #392, and this
+historical packet; do not rewrite the published Beta 8 item to backdate that
+evidence.
 
 ## Exact-Artifact Qualification
 
-The pre-release qualification package was version `0.3.0b7`, built from the
-same protected-main feature tree before this metadata bump. Unsigned app-tree
-SHA-256 `f19529a38f14ed329dc3c3952bc13f3c4619d727fe223b59385a63f8f0bf5531`
-passed all eight ordinary/MetalFX direct/fallback full/preview routes and all
-six schema-v2 AAC preserve/remap/downmix/fail cases. Packaged route evidence
-SHA-256 is `90acef98ff0deb7107e8e24a17af48efbe9f5871dd8701bb1932ad0de9bf1f7c`;
-AAC evidence SHA-256 is
-`ab1329c80fd2328af008bfead4f170626994ad895d2fc6da99ccfeb4a9d528ba`.
-This validates the release code path, not the exact Beta 8 artifact.
+The exact signed app-tree SHA-256 is
+`7e9d66d372bd94ea1d11a0990c3e070ba97268b2ce21794f1c46f04235dc7b93`;
+the signed-candidate binding receipt SHA-256 is
+`2245a1a0eaafc0a30d99919b9ded0f5e1ce374c8d3bb3aae034ede0722ccc392`.
+The worker inside that exact app passed the six-case schema-v2 AAC fixture
+manifest, and signed AAC evidence SHA-256 is
+`242fc84631b730acf5288a9f5b5fc05672f241dcc080c79245745de48df0947e`.
+Physical Vision Pro surround placement, multilingual/default-track behavior,
+repeated seeks, and real-content lip-sync passed; issue #382 records the
+immutable reports and receipts.
 
-The exact Beta 8 artifact remains pending. Issue #392 must bind one protected-
-`main` SHA to the signed and notarized DMG, release/appcast identity, and the
-same package evidence. It must also complete mounted-network/NAS and
-constrained-local-preview checks, #382's physical Vision Pro surround/seek/
-lip-sync evidence, and a #386-equivalent signed field run or reporter retest.
+The same signed Beta 8 candidate passed the generated local/NAS routes and the
+typed invalid-artifact/resume boundaries tracked by #392. Its worker completed
+the constrained-local-space preview route, but the GUI crashed while presenting
+the player because the production host lacked a direct AVKit link. PR #404
+fixed that package defect after publication, and PR #405 added an installed-app
+presentation smoke. A newer signed candidate must rerun #392's preview,
+capacity, cleanup, and final-output gates; source-tree or ad-hoc packages do not
+replace that evidence.
 
 ## Authorization Boundary
 
-Issue #392 and the July 28, 2026 instruction to proceed authorize metadata
-preparation, protected-main review, and exact-SHA Prerelease dispatch. The
-repository has no freeze entry for `v0.3.0-beta.8`.
-
-The workflow must be dispatched only from the exact protected `main` SHA that
-contains the reviewed metadata PR. `main` must remain fixed while the workflow
-is nonterminal. Before approving `macos-signing`, the release watcher must emit
-the run-bound approval fingerprint and the maintainer must explicitly authorize
-that approval in the active conversation. This packet does not pre-authorize
-that approval.
+Issue #392 and the July 28, 2026 instruction to proceed authorized metadata,
+protected-main dispatch, and the separately approved run-bound signing step for
+run `30341766419`. `v0.3.0-beta.8`, build `153`, and every published artifact
+above are immutable and must not be rebuilt, retagged, replaced, or reused.
+Later production-identity releases advance the global build counter from this
+history.

--- a/docs/0.3.0-beta.9-cut-packet.md
+++ b/docs/0.3.0-beta.9-cut-packet.md
@@ -1,0 +1,133 @@
+# 0.3.0 Beta 9 Cut Packet
+
+> **Authorized metadata; publication pending.** Issue #392 and the July 29,
+> 2026 instruction to proceed authorize repository preparation,
+> protected-main review, and exact-SHA Prerelease dispatch after this metadata
+> PR merges green and a merge hold is active. This packet does not assert that
+> a Beta 9 tag, draft, DMG, release, or appcast item exists. The
+> `macos-signing` environment remains a separate run-bound authorization that
+> requires explicit approval in the active conversation.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 9 is a focused field beta for the
+packaged-preview fix and its installed-app guard, retained activity history,
+durable validated local-build handoff, and generation-aware experimental AV1
+stereo boundary. It is not an RC nomination.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b9` |
+| Public version | `0.3.0-beta.9` |
+| Bundle and Sparkle build | `154` |
+| GitHub tag and release title | `v0.3.0-beta.9` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4` |
+
+Build `154` is globally newer than immutable published Beta 8 build `153`. The
+July 29, 2026 live audit found Beta 8 published from protected-main commit
+`8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328` by guarded Prerelease run
+`30341766419`, with DMG SHA-256
+`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`.
+Build `154` is introduced by this reviewed metadata change; there is no Beta 9
+tag, release, draft, asset, or earlier prepared release consuming it, and the
+release-freeze map is empty. The public cumulative appcast remains rooted at
+Beta 8 build `153` until guarded publication succeeds.
+
+## Included Product Changes
+
+- PR #404 links AVKit directly in the production host and makes package
+  verification reject a binary missing that load command, fixing the exact
+  packaged-preview crash exposed by Beta 8.
+- PR #405 runs a bounded LaunchServices presentation smoke against the packaged
+  app, proving that the real SwiftUI player attaches, accepts media, stays
+  alive, and cleans its isolated workspace.
+- PR #406 retains up to 200 deduplicated lifecycle messages for the current or
+  most recent job and presents quiet checks as nonterminal activity rather than
+  an apparent failure.
+- PR #410 publishes validated ad-hoc builds to an immutable commit directory and
+  atomically updates the durable local `Current.app` pointer without changing
+  the production installation.
+- PR #411 keeps MV-HEVC as the default, labels AV1 stereo as experimental and
+  M5 Vision Pro-targeted, marks M2 Vision Pro unsupported, and adds codec-aware
+  independent decode and sustained-playback evidence to Playback Check.
+
+## Cumulative Update Contract
+
+Publication must append Beta 9 above the immutable production history:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b9` | `154` | `beta` |
+| 2 | `0.3.0b8` | `153` | `beta` |
+| 3 | `0.3.0b7` | `152` | `beta` |
+| 4 | `0.3.0b6` | `151` | `beta` |
+| 5 | `0.3.0b5` | `150` | `beta` |
+| 6 | `0.3.0b4` | `149` | `beta` |
+| 7 | `0.3.0b3` | `148` | `beta` |
+| 8 | `0.2.143` | `146` | Stable / no channel |
+| 9 | `0.2.143rc5` | `145` | `rc` |
+| 10 | `0.2.143rc4` | `144` | `rc` |
+
+Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3
+through Beta 9, and an installed earlier Beta on either route may update forward
+to build `154`. Moving to a safer route never downgrades an installed
+prerelease.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.0-beta.9` fixes the packaged preview crash found in Beta 8
+> and adds an installed-app presentation smoke so future packages fail before
+> release if the player cannot attach and accept media. The native app now
+> retains recent conversion activity, and validated local builds have a durable
+> `Current.app` location. AV1 stereo remains experimental: it is explicitly
+> targeted to M5 Vision Pro, while M2 Vision Pro is marked unsupported after
+> physical testing found no usable hardware or software decode path. MV-HEVC
+> remains the default output.
+
+Do not describe Beta 9 as downloadable, signed, published, notarized, or
+Sparkle-discoverable until the guarded release verifies the immutable public
+state. Publishing the beta provides a signed test vehicle; it does not itself
+establish physical M5 Vision Pro AV1 playback.
+
+## Exact-Artifact Qualification
+
+The previous exact production artifact is immutable Beta 8: version `0.3.0b8`,
+protected-main SHA `8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328`, DMG SHA-256
+`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`,
+and signed app-tree SHA-256
+`7e9d66d372bd94ea1d11a0990c3e070ba97268b2ce21794f1c46f04235dc7b93`.
+It passed the #382 AAC package and physical Vision Pro matrix, but its packaged
+GUI preview crashed because the production host lacked the AVKit link fixed
+afterward. It is historical evidence, not qualification of the post-Beta-8
+code.
+
+The exact Beta 9 artifact remains pending. Issue #392 must bind one protected-
+`main` SHA to the signed and notarized DMG, release/appcast identity, and the
+packaged GUI preview, capacity, cleanup, and final-output matrix. The release
+package smoke must pass the installed-player presentation guard added by #405.
+Physical M5 Vision Pro AV1 stereo depth, eye order, seeks, sustained playback,
+thermals, audio, and subtitles remain external evidence tracked by #409; that
+evidence is additive and does not weaken #392 or turn Beta 9 into an RC.
+
+## Authorization Boundary
+
+Issue #392 and the July 29, 2026 instruction to proceed authorize metadata
+preparation, protected-main review, and exact-SHA Prerelease dispatch. The
+repository has no freeze entry for `v0.3.0-beta.9`.
+
+The workflow must be dispatched only from the exact protected `main` SHA that
+contains the reviewed metadata PR. `main` must remain fixed while the workflow
+is nonterminal. Before approving `macos-signing`, the release watcher must emit
+the run-bound approval fingerprint and the maintainer must explicitly authorize
+that approval in the active conversation. This packet does not pre-authorize
+that approval.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -93,12 +93,10 @@ document it as an external dependency with preflight behavior.
   production GUI path. The protected-main release workflow builds that app with
   the production name and bundle identifier on a pinned GitHub-hosted macOS 26
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
-- Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`), Beta 5
-  (`v0.3.0-beta.5`, internal version `0.3.0b5`, build `150`), Beta 6
-  (`v0.3.0-beta.6`, internal version `0.3.0b6`, build `151`), and Beta 7
-  (`v0.3.0-beta.7`, internal version `0.3.0b7`, build `152`) are published and
-  immutable. The next prepared production-identity field build is Beta 8
-  (`v0.3.0-beta.8`, internal version `0.3.0b8`, build `153`). It remains
+- Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`) through
+  Beta 8 (`v0.3.0-beta.8`, internal version `0.3.0b8`, build `153`) are
+  published and immutable. The next prepared production-identity field build
+  is Beta 9 (`v0.3.0-beta.9`, internal version `0.3.0b9`, build `154`). It remains
   unpublished until exact-SHA signing and public verification complete. Beta 3
   build `148` remains the manual-download seed and immutable appcast history
   below the later Beta releases.

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -112,13 +112,11 @@ missing or unknown values fail closed to Stable. Choosing a safer route affects
 only future newer builds and never downgrades the installed app. Published Beta
 3 (`0.3.0b3`, build `148`) is the one-time manual-download production seed:
 older Stable and RC installations cannot discover it, while an installed Beta
-3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`), Beta 5 (`0.3.0b5`,
-build `150`), Beta 6 (`0.3.0b6`, build `151`), and Beta 7 (`0.3.0b7`, build
-`152`) are published and immutable. Beta 8 (`0.3.0b8`, build `153`) is the next
-prepared target for the guarded exact-SHA Prerelease workflow. Its future
-cumulative item must sit above Beta 7, Beta 6, Beta 5, Beta 4, and Beta 3 and
-remain visible only to Beta and Alpha until a
-later newer Stable supersedes it.
+3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) through Beta 8
+(`0.3.0b8`, build `153`) are published and immutable. Beta 9 (`0.3.0b9`, build
+`154`) is the next prepared target for the guarded exact-SHA Prerelease
+workflow. Its future cumulative item must sit above Beta 8 through Beta 3 and
+remain visible only to Beta and Alpha until a later newer Stable supersedes it.
 
 ## Release Workflow
 
@@ -170,18 +168,21 @@ behavior and engine architecture rather than release branding.
 
 ## Remaining Field Evidence
 
-Beta 3 through Beta 7 publication is complete, and signed installed-app
-diagnostics qualification is complete. Beta 8 exact-artifact qualification must
-prove that:
+Beta 3 through Beta 8 publication is complete, signed installed-app diagnostics
+qualification is complete, and #382's signed AAC/package/physical Vision Pro
+matrix passed on the exact Beta 8 artifact. Beta 8 exposed a packaged GUI
+preview crash after its worker completed the preview route; PRs #404 and #405
+fixed the missing AVKit link and added an installed-player presentation smoke.
+Beta 9 exact-artifact qualification must prove that:
 
-- Beta 7 updates forward to Beta 8 on Beta and Alpha without changing the saved
+- Beta 8 updates forward to Beta 9 on Beta and Alpha without changing the saved
   route;
 - Stable and RC continue to exclude every Beta item;
 - the downloaded notarized DMG passes signature, staple, Gatekeeper, startup,
   bundled-helper, and worker-capability checks; and
-- packaged ordinary/direct-4K full conversion, finalized preview, visible
-  fallback, and short physical Vision Pro playback still match the qualified
-  pre-release candidate; and
-- the same exact package passes #392's field/NAS matrix and #382's packaged AAC
-  and physical Vision Pro gates without treating unsigned evidence as release
-  proof.
+- packaged GUI preview presentation, ordinary/direct-4K full conversion,
+  visible fallback, capacity, cleanup, and final output satisfy #392 without
+  treating unsigned evidence as release proof; and
+- the release package smoke executes the real installed player guard before
+  publication. Physical M5 Vision Pro AV1 evidence remains separately tracked
+  by #409 and is not inferred from publication.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,21 +4,21 @@ The normative production identity, version mapping, update routes, history
 boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
-The repository carries published, immutable Beta 3 through Beta 7 history at
-internal versions `0.3.0b3` through `0.3.0b7`, builds `148` through `152`, and a
-prepared Beta 8 target at `0.3.0b8`, build `153`. The failed, unpublished
+The repository carries published, immutable Beta 3 through Beta 8 history at
+internal versions `0.3.0b3` through `0.3.0b8`, builds `148` through `153`, and a
+prepared Beta 9 target at `0.3.0b9`, build `154`. The failed, unpublished
 `0.3.0rc1` build `147` attempt is preserved in the checked-in recovery evidence
 and its build number is permanently burned. The
-[Beta 7 cut packet](0.3.0-beta.7-cut-packet.md) records immutable publication
-history, while the reviewed [Beta 8 cut packet](0.3.0-beta.8-cut-packet.md)
-records metadata only and does not assert that a Beta 8 public artifact exists.
+[Beta 8 cut packet](0.3.0-beta.8-cut-packet.md) records immutable publication
+history, while the reviewed [Beta 9 cut packet](0.3.0-beta.9-cut-packet.md)
+records metadata only and does not assert that a Beta 9 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issue #392 and the explicit Beta 8 request authorize the
-reviewed metadata preparation and exact-SHA dispatch; run-bound signing approval
-remains a separate authorization boundary.
+implemented and regression-covered. Issue #392 and the explicit July 29, 2026
+Beta 9 request authorize the reviewed metadata preparation and exact-SHA
+dispatch; run-bound signing approval remains a separate authorization boundary.
 
 ## Release Preparation
 
@@ -34,9 +34,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b8` maps to public `0.3.0-beta.8`, tag/title
-`v0.3.0-beta.8`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg`. The numeric
+example, internal `0.3.0b9` maps to public `0.3.0-beta.9`, tag/title
+`v0.3.0-beta.9`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -77,11 +77,11 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 8 is authorized but not yet published.** Issue #392 and the explicit Beta 8 request
-> authorize guarded `v0.3.0-beta.8` dispatch, and the repository contains no
+> **Beta 9 is authorized but not yet published.** Issue #392 and the explicit
+> July 29, 2026 request authorize guarded `v0.3.0-beta.9` dispatch, and the repository contains no
 > freeze entry for that exact tag. Dispatch only from the exact protected `main`
-> commit containing the reviewed Beta 8 metadata, keep `main` fixed while the
-> workflow is nonterminal, and do not describe Beta 8 as public until signing,
+> commit containing the reviewed Beta 9 metadata, keep `main` fixed while the
+> workflow is nonterminal, and do not describe Beta 9 as public until signing,
 > notarization, appcast publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -6,11 +6,11 @@ closed when it cannot satisfy this contract.
 
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
-this four-route contract. Beta 3 through Beta 7 are published and immutable at
-builds `148` through `152`, with build `147` permanently burned. The next
-prepared target is Beta 8 at `0.3.0b8` build `153`. Issue #392 and the explicit
-Beta 8 request authorize reviewed exact-SHA dispatch; run-bound signing approval remains a
-separate authorization boundary.
+this four-route contract. Beta 3 through Beta 8 are published and immutable at
+builds `148` through `153`, with build `147` permanently burned. The next
+prepared target is Beta 9 at `0.3.0b9` build `154`. Issue #392 and the explicit
+July 29, 2026 Beta 9 request authorize reviewed exact-SHA dispatch; run-bound
+signing approval remains a separate authorization boundary.
 
 ## Production Identity
 
@@ -51,7 +51,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -138,9 +138,8 @@ prereleases. Beta 3 remains immutable production/feed history in the cumulative
 appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
-client waits for a newer eligible Stable build. Beta 4, Beta 5, Beta 6, and Beta
-7 are immutable production history, and Beta 8 reserves the next global build,
-`153`.
+client waits for a newer eligible Stable build. Beta 4 through Beta 8 are
+immutable production history, and Beta 9 reserves the next global build, `154`.
 
 ## Beta 6 Published History
 
@@ -178,9 +177,9 @@ The cumulative appcast places Beta 7 above immutable Beta 6 build `151`, Beta 5 
 admit them. Historical metadata and release evidence are in
 [the Beta 7 cut packet](0.3.0-beta.7-cut-packet.md).
 
-## Beta 8 Authorized Target
+## Beta 8 Published History
 
-The repository is prepared for the guarded `v0.3.0-beta.8` Prerelease workflow:
+Published `v0.3.0-beta.8` is immutable production history:
 
 - internal version `0.3.0b8`;
 - public tag and title `v0.3.0-beta.8`;
@@ -190,17 +189,36 @@ The repository is prepared for the guarded `v0.3.0-beta.8` Prerelease workflow:
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta 7.
 
-Publication must place Beta 8 above immutable Beta 7 build `152`, Beta 6 build
+The cumulative appcast places Beta 8 above immutable Beta 7 build `152`, Beta 6 build
 `151`, Beta 5 build `150`, Beta 4 build `149`, Beta 3 build `148`, Stable build
 `146`, RC5 build `145`, and RC4 build `144`. Stable and RC exclude all Beta
-items; Beta and Alpha admit them, allowing an installed earlier Beta to update
-forward to Beta 8 without changing the saved route.
-
-Issue #392 and the explicit Beta 8 request authorize metadata preparation and
-exact-SHA dispatch. The repository has no freeze entry for this exact tag; that absence
-authorizes workflow preflight but does not assert that a tag, draft, DMG,
-release, or appcast item exists. The reviewed metadata and release-note seed are
+items; Beta and Alpha admit them. Historical metadata and release evidence are
 in [the Beta 8 cut packet](0.3.0-beta.8-cut-packet.md).
+
+## Beta 9 Authorized Target
+
+The repository is prepared for the guarded `v0.3.0-beta.9` Prerelease workflow:
+
+- internal version `0.3.0b9`;
+- public tag and title `v0.3.0-beta.9`;
+- global build `154`;
+- Sparkle channel `beta`;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta 8.
+
+Publication must place Beta 9 above immutable Beta 8 build `153`, Beta 7 build
+`152`, Beta 6 build `151`, Beta 5 build `150`, Beta 4 build `149`, Beta 3 build
+`148`, Stable build `146`, RC5 build `145`, and RC4 build `144`. Stable and RC
+exclude all Beta items; Beta and Alpha admit them, allowing an installed earlier
+Beta to update forward to Beta 9 without changing the saved route.
+
+Issue #392 and the explicit July 29, 2026 Beta 9 request authorize metadata
+preparation and exact-SHA dispatch. The repository has no freeze entry for this
+exact tag; that absence authorizes workflow preflight but does not assert that a
+tag, draft, DMG, release, or appcast item exists. The reviewed metadata and
+release-note seed are in
+[the Beta 9 cut packet](0.3.0-beta.9-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -278,28 +278,29 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 8 Authorization Smoke
+### Beta 9 Authorization Smoke
 
-Run these checks after the Beta 8 metadata preparation lands and before workflow
+Run these checks after the Beta 9 metadata preparation lands and before workflow
 dispatch. They prove the committed target and authorization boundary, not a
 signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b8`, public `0.3.0-beta.8`, build `153`, Beta channel, prerelease,
+   `0.3.0b9`, public `0.3.0-beta.9`, build `154`, Beta channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 8 freeze is absent while all route, identity, and existing-release
+   Beta 9 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 8 build `153`, Beta 7
-   build `152`, Beta 6 build `151`, Beta 5 build `150`, Beta 4 build `149`, Beta
-   3 build `148`, then Stable build `146`, RC5 build `145`, and RC4 build `144`; Stable and RC must
-   exclude every Beta item while Beta and Alpha admit them.
-4. Confirm the live repository has no Beta 8 tag, release, draft, or asset and
-   the public appcast still ends at Beta 7 build `152`.
+3. Validate a cumulative appcast fixture ordered Beta 9 build `154`, Beta 8
+   build `153`, Beta 7 build `152`, Beta 6 build `151`, Beta 5 build `150`, Beta
+   4 build `149`, Beta 3 build `148`, then Stable build `146`, RC5 build `145`,
+   and RC4 build `144`; Stable and RC must exclude every Beta item while Beta
+   and Alpha admit them.
+4. Confirm the live repository has no Beta 9 tag, release, draft, or asset and
+   the public appcast still ends at Beta 8 build `153`.
 5. Continue only through the exact-SHA Prerelease workflow. Signed-app,
-   update-route, packaged direct/fallback, and physical-playback qualification
-   remain incomplete until the guarded workflow and exact-artifact checks
-   finish.
+   update-route, installed-player presentation, capacity, cleanup, and final-
+   output qualification remain incomplete until the guarded workflow and exact-
+   artifact checks finish. Physical M5 Vision Pro AV1 evidence stays in #409.
 
 ## Follow-Up Routing
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -69,8 +69,8 @@ Each new appcast item embeds the digest-bound draft release body as Markdown, so
 Sparkle uses its adaptive native text view without loading GitHub page chrome or
 making a second release-note request. A full-release link remains available for
 downloads and extended context, and historical external-link items remain valid.
-The live feed now carries cumulative production history through Beta 7 build
-`152`; prepared Beta 8 metadata does not alter it before guarded publication.
+The live feed now carries cumulative production history through Beta 8 build
+`153`; prepared Beta 9 metadata does not alter it before guarded publication.
 See [release-process.md](release-process.md) for the operator sequence.
 
 Stable `0.2.143` remains compatible with macOS 14. The production SwiftUI line
@@ -266,9 +266,9 @@ select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 `v0.3.0-beta.2` Preview identities remain separate, immutable, and unable to
 Sparkle-upgrade into Beta 3.
 
-Published `v0.3.0-beta.7` (`0.3.0b7`, build `152`) is the immutable head of the
-current cumulative feed above Beta 6, Beta 5, Beta 4, and Beta 3. The next prepared item
-is `v0.3.0-beta.8` (`0.3.0b8`, build `153`). Publication must append Beta 8
+Published `v0.3.0-beta.8` (`0.3.0b8`, build `153`) is the immutable head of the
+current cumulative feed above Beta 7 through Beta 3. The next prepared item is
+`v0.3.0-beta.9` (`0.3.0b9`, build `154`). Publication must append Beta 9
 above the existing Betas, remain excluded from Stable and RC, and be eligible to
 Beta and Alpha. The exact-SHA Prerelease workflow, signing approval,
 notarization, and public verification remain separate fail-closed boundaries.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 153
+        CURRENT_PROJECT_VERSION: 154
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b8
+        MARKETING_VERSION: 0.3.0b9
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b8"
+version = "0.3.0b9"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "153"
+CFBundleVersion = "154"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b8")
-        self.assertEqual(NATIVE_BUILD_VERSION, "153")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b9")
+        self.assertEqual(NATIVE_BUILD_VERSION, "154")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,35 +156,49 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_and_authorized_for_beta8(self) -> None:
+    def test_repository_is_prepared_and_authorized_for_beta9(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b8")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.8")
-        self.assertEqual(metadata.build_version, "153")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.8")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.8")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.8.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b9")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.9")
+        self.assertEqual(metadata.build_version, "154")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.9")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.9")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.8", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-beta.9", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.8-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b8`", cut_packet)
-        self.assertIn("Build `153`", cut_packet)
-        for pull_request in (383, 384, 393, 395, 396, 397, 400):
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.9-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b9`", cut_packet)
+        self.assertIn("Build `154`", cut_packet)
+        for pull_request in (404, 405, 406, 410, 411):
             self.assertIn(f"#{pull_request}", cut_packet)
         self.assertIn("Privacy rules version `4`", cut_packet)
         self.assertIn("Issue #392", cut_packet)
-        self.assertIn("July 28, 2026 instruction to proceed", cut_packet)
+        self.assertIn("July 29, 2026 instruction to proceed", cut_packet)
         self.assertIn("does not pre-authorize", cut_packet)
         self.assertIn("that approval", cut_packet)
-        self.assertIn("pre-release qualification package was version `0.3.0b7`", cut_packet)
-        self.assertIn("The exact Beta 8 artifact remains pending", cut_packet)
+        self.assertIn("previous exact production artifact is immutable Beta 8", cut_packet)
+        self.assertIn("The exact Beta 9 artifact remains pending", cut_packet)
+
+    def test_beta8_cut_packet_records_immutable_published_identity(self) -> None:
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.8-cut-packet.md").read_text(encoding="utf-8")
+
+        self.assertIn("Published and immutable", cut_packet)
+        self.assertIn("`30341766419`", cut_packet)
+        self.assertIn("`8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328`", cut_packet)
+        self.assertIn("`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`", cut_packet)
+        self.assertIn("`7e9d66d372bd94ea1d11a0990c3e070ba97268b2ce21794f1c46f04235dc7b93`", cut_packet)
+        self.assertIn("Issue #382 is complete", cut_packet)
+        self.assertIn("publication-time snapshot", cut_packet)
+        self.assertIn("must not be rebuilt", cut_packet)
+        self.assertNotIn("Authorized metadata; publication pending", cut_packet)
+        self.assertNotIn("The exact Beta 8 artifact remains pending", cut_packet)
 
     def test_repository_beta3_recovery_evidence_is_exact(self) -> None:
         evidence = release.validate_beta3_recovery_evidence()

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,7 +188,7 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
-    def test_beta8_appends_above_complete_immutable_production_history(self) -> None:
+    def test_beta9_appends_above_complete_immutable_production_history(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             base_feed = root / "base.xml"
@@ -198,6 +198,7 @@ class SparkleAppcastTests(unittest.TestCase):
             beta6_feed = root / "beta6.xml"
             beta7_feed = root / "beta7.xml"
             beta8_feed = root / "beta8.xml"
+            beta9_feed = root / "beta9.xml"
             base_feed.write_bytes(
                 (
                     Path(__file__).resolve().parents[1] / "docs" / "release-evidence" / "v0.2.143-appcast.xml"
@@ -233,19 +234,25 @@ class SparkleAppcastTests(unittest.TestCase):
                 beta8_feed,
                 item("153", "0.3.0b8", "beta", minimum_system_version="26.0"),
             )
+            sparkle_appcast.append_item(
+                beta8_feed,
+                beta9_feed,
+                item("154", "0.3.0b9", "beta", minimum_system_version="26.0"),
+            )
 
-            sparkle_appcast.validate_release_snapshot(beta8_feed, "0.3.0b8")
-            sparkle_appcast.validate_release_tag_snapshot(beta8_feed, "v0.3.0-beta.8")
-            _, channel = sparkle_appcast.load_appcast(beta8_feed)
+            sparkle_appcast.validate_release_snapshot(beta9_feed, "0.3.0b9")
+            sparkle_appcast.validate_release_tag_snapshot(beta9_feed, "v0.3.0-beta.9")
+            _, channel = sparkle_appcast.load_appcast(beta9_feed)
             items = channel.findall("item")
 
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
-            ["153", "152", "151", "150", "149", "148", "146", "145", "144"],
+            ["154", "153", "152", "151", "150", "149", "148", "146", "145", "144"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
             [
+                "0.3.0b9",
                 "0.3.0b8",
                 "0.3.0b7",
                 "0.3.0b6",
@@ -259,7 +266,7 @@ class SparkleAppcastTests(unittest.TestCase):
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
-            ["beta", "beta", "beta", "beta", "beta", "beta", None, "rc", "rc"],
+            ["beta", "beta", "beta", "beta", "beta", "beta", "beta", None, "rc", "rc"],
         )
 
     def test_rejects_non_monotonic_build(self) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "153")
+        self.assertEqual(info["CFBundleVersion"], "154")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b8"
+version = "0.3.0b9"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- advance the production prerelease identity to `0.3.0b9`, public `0.3.0-beta.9`, build `154`
- record Beta 8 as immutable published history and add the reviewed Beta 9 cut packet
- update release routes, process, smoke, package, distribution, and Sparkle contracts
- extend release/appcast/package tests through Beta 9 while locking Beta 8's exact published identity

## Included product changes

This focused field beta contains the already-merged work from PRs #404, #405, #406, #410, and #411: the packaged AVKit preview fix and installed-player guard, retained activity history, durable validated `Current.app`, and generation-aware experimental AV1 labeling. MV-HEVC remains the default. AV1 remains M5 Vision Pro-targeted and experimental; M2 Vision Pro is explicitly unsupported.

## Validation

- `uv run python -m scripts.release validate`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python -m unittest discover -s tests -t .` — 1,137 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 318 passed
- `uv build`
- import and CLI help smokes
- unsigned native package, deep code-sign verification, and packaged preview presentation smoke
- JetBrains changed-files inspection — GREEN, zero findings
- independent GPT- and Claude-family release reviews; Antigravity/Google-family review was invoked but returned no written findings

## Release boundary

No Stable or Prerelease workflow is dispatched by this PR. After merge and exact protected-main CI/CodeQL, `main` must remain fixed while the guarded Prerelease workflow is nonterminal. The repository watcher remains mandatory. Any `macos-signing` approval requires a fresh run-bound fingerprint and explicit maintainer authorization in the active conversation; this PR does not pre-authorize it.

The exact signed Beta 9 package must still complete #392's packaged preview, capacity, cleanup, and final-output gates. Physical M5 Vision Pro AV1 evidence remains separately tracked by #409 and is not an RC gate.

Refs #392
Refs #409
