### PR TITLE
Fix packaged preview smoke on fresh macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,12 @@ jobs:
       - name: macOS app tests
         run: uv run python scripts/native_app.py test
 
+      - name: Package native macOS app smoke
+        env:
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: https://diagnostics.shinycomputers.com
+          DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+        run: uv run python scripts/native_app.py package
+
       - name: Import smoke
         run: >-
           uv run python -c

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -88,9 +88,13 @@ Expected result:
 - Every executable probe has a bounded timeout, including the native GUI host.
 - The native launcher starts through its supported `--startup-smoke` contract;
   the smoke never sends legacy CLI `--version` or `--help` arguments to the GUI.
-- The player probe opens a fresh app instance through macOS LaunchServices so
-  SwiftUI creates the real window scene; direct executable launch is retained
-  only for the non-UI startup contract.
+- The player probe opens a fresh foreground app instance through macOS
+  LaunchServices. Smoke mode creates a dedicated AppKit window hosting the
+  existing `PreviewPlayerView`, so a fresh profile does not depend on saved
+  SwiftUI window restoration; direct executable launch is retained only for the
+  non-UI startup contract. The harness forwards its isolated environment
+  explicitly, captures app stdout/stderr, and reports process plus log-tail
+  evidence if the bounded receipt wait expires.
 - `Info.plist` supplies the package version, and the packaged worker reports the
   same version through a protocol-v10 inspection request.
 - The packaged Apple Vision OCR smoke runs through the bundled worker entrypoint

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
@@ -12,9 +13,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var allowManagedWindowClose = false
     private var isStoppingForWindowClose = false
     private var isStoppingForTermination = false
+    private var previewPresentationSmokeWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        guard Self.isStartupSmoke(arguments: ProcessInfo.processInfo.arguments) else {
+        let arguments = ProcessInfo.processInfo.arguments
+        if let configuration = PreviewPresentationSmokeConfiguration.parse(arguments: arguments) {
+            let window = NSWindow(
+                contentViewController: NSHostingController(
+                    rootView: PreviewPresentationSmokeView(configuration: configuration)
+                        .frame(width: 820, height: 620)
+                )
+            )
+            window.title = "Preview Presentation Smoke"
+            window.isReleasedWhenClosed = false
+            window.center()
+            previewPresentationSmokeWindow = window
+            window.orderFrontRegardless()
+            return
+        }
+        guard Self.isStartupSmoke(arguments: arguments) else {
             return
         }
         DispatchQueue.main.async {

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -51,32 +51,28 @@ struct BluRayToVisionProApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if let previewPresentationSmokeConfiguration {
-                PreviewPresentationSmokeView(configuration: previewPresentationSmokeConfiguration)
-                    .frame(width: 820, height: 620)
-            } else {
-                ContentView(
-                    viewModel: viewModel,
-                    previewViewModel: previewViewModel,
-                    diagnosticReportViewModel: diagnosticReportViewModel,
-                    settings: settings,
-                    profileStore: profileStore,
-                    capabilities: capabilities
-                )
-                    .frame(minWidth: 1_080, minHeight: 680)
-                    .background(
-                        WindowAccessor { window in
-                            appDelegate.attach(window: window, workCoordinator: workCoordinator)
-                        }
-                    )
-                    .onAppear {
-                        updater.startIfNeeded()
-                        settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
-                        appDelegate.workCoordinator = workCoordinator
+            ContentView(
+                viewModel: viewModel,
+                previewViewModel: previewViewModel,
+                diagnosticReportViewModel: diagnosticReportViewModel,
+                settings: settings,
+                profileStore: profileStore,
+                capabilities: capabilities
+            )
+                .frame(minWidth: 1_080, minHeight: 680)
+                .background(
+                    WindowAccessor { window in
+                        appDelegate.attach(window: window, workCoordinator: workCoordinator)
                     }
-            }
+                )
+                .onAppear {
+                    updater.startIfNeeded()
+                    settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
+                    appDelegate.workCoordinator = workCoordinator
+                }
         }
         .defaultSize(width: 1_120, height: 820)
+        .defaultLaunchBehavior(previewPresentationSmokeConfiguration == nil ? .automatic : .suppressed)
         .windowResizability(.contentMinSize)
         .windowToolbarStyle(.unified)
         .commands {

--- a/scripts/smoke_release_app.py
+++ b/scripts/smoke_release_app.py
@@ -28,9 +28,11 @@ WORKER_EXECUTABLE_NAME = "BluRayToVisionProEngine"
 EXPECTED_WORKER_PROTOCOL_VERSION = 10
 PREVIEW_PRESENTATION_SMOKE_ARGUMENT = "--preview-presentation-smoke"
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 20
-PREVIEW_PRESENTATION_TIMEOUT_SECONDS = 30
+PREVIEW_LAUNCH_TIMEOUT_SECONDS = 60
+PREVIEW_PRESENTATION_TIMEOUT_SECONDS = 90
 PREVIEW_PROCESS_EXIT_TIMEOUT_SECONDS = 5
 PREVIEW_POLL_INTERVAL_SECONDS = 0.1
+PREVIEW_LOG_TAIL_CHARACTERS = 4_000
 REQUIRED_BUNDLED_TOOLS = {
     "ffmpeg": ["-hide_banner", "-version"],
     "ffprobe": ["-hide_banner", "-version"],
@@ -243,23 +245,37 @@ def launch_preview_application(
     bundle: AppBundle,
     media_path: Path,
     result_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
     *,
     environment: dict[str, str],
     cwd: Path,
 ) -> None:
-    run(
+    command: list[str | Path] = [
+        "/usr/bin/open",
+        "-F",
+        "-n",
+        "-o",
+        stdout_path,
+        "--stderr",
+        stderr_path,
+    ]
+    for name, value in sorted(environment.items()):
+        command.extend(["--env", f"{name}={value}"])
+    command.extend(
         [
-            "/usr/bin/open",
-            "-g",
-            "-n",
             bundle.path,
             "--args",
             PREVIEW_PRESENTATION_SMOKE_ARGUMENT,
             media_path,
             result_path,
-        ],
+        ]
+    )
+    run(
+        command,
         env=environment,
         cwd=cwd,
+        timeout=PREVIEW_LAUNCH_TIMEOUT_SECONDS,
     )
 
 
@@ -314,6 +330,53 @@ def terminate_preview_processes(result_path: Path) -> None:
     for process_id in preview_process_ids(result_path):
         with suppress(ProcessLookupError):
             os.kill(process_id, signal.SIGKILL)
+
+
+def read_preview_log_tail(path: Path) -> str:
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return "(not created)"
+    except OSError as error:
+        return f"(unreadable: {error})"
+    if not content:
+        return "(empty)"
+    return content[-PREVIEW_LOG_TAIL_CHARACTERS:]
+
+
+def preview_process_summary(result_path: Path) -> str:
+    process_ids = sorted(preview_process_ids(result_path))
+    if not process_ids:
+        return "matching process IDs: none"
+    try:
+        completed = subprocess.run(
+            [
+                "/bin/ps",
+                "-p",
+                ",".join(str(process_id) for process_id in process_ids),
+                "-o",
+                "pid=,ppid=,stat=,etime=,command=",
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+        return f"matching process IDs: {', '.join(str(process_id) for process_id in process_ids)}\n{error}"
+    details = completed.stdout.strip() or completed.stderr.strip() or "process details unavailable"
+    return f"matching process IDs: {', '.join(str(process_id) for process_id in process_ids)}\n{details}"
+
+
+def preview_timeout_diagnostics(result_path: Path, stdout_path: Path, stderr_path: Path) -> str:
+    return "\n".join(
+        [
+            preview_process_summary(result_path),
+            f"app stdout tail:\n{read_preview_log_tail(stdout_path)}",
+            f"app stderr tail:\n{read_preview_log_tail(stderr_path)}",
+        ]
+    )
 
 
 def verify_native_startup(bundle: AppBundle, clean_env: dict[str, str]) -> None:
@@ -403,6 +466,8 @@ def verify_preview_presentation(bundle: AppBundle, clean_env: dict[str, str]) ->
         artifact_directory.mkdir(parents=True)
         media_path = artifact_directory / "preview.mov"
         result_path = temporary_path / "result.json"
+        stdout_path = temporary_path / "preview.stdout.log"
+        stderr_path = temporary_path / "preview.stderr.log"
         run(
             [
                 bundle.bin_dir / "ffmpeg",
@@ -438,12 +503,15 @@ def verify_preview_presentation(bundle: AppBundle, clean_env: dict[str, str]) ->
             bundle,
             media_path,
             result_path,
+            stdout_path,
+            stderr_path,
             environment=native_smoke_environment(clean_env, temporary_path),
             cwd=temporary_path,
         )
         if not wait_for_path(result_path, timeout=PREVIEW_PRESENTATION_TIMEOUT_SECONDS):
+            diagnostics = preview_timeout_diagnostics(result_path, stdout_path, stderr_path)
             terminate_preview_processes(result_path)
-            raise SmokeFailure("Packaged preview presentation smoke did not write its result receipt")
+            raise SmokeFailure("Packaged preview presentation smoke did not write its result receipt\n" + diagnostics)
         if not wait_for_preview_process_exit(result_path, timeout=PREVIEW_PROCESS_EXIT_TIMEOUT_SECONDS):
             terminate_preview_processes(result_path)
             raise SmokeFailure("Packaged preview presentation smoke did not terminate after writing its receipt")

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -98,6 +98,8 @@ class ReleaseSmokeTests(unittest.TestCase):
             bundle = smoke_release_app.read_bundle(app_path)
             media_path = Path(temp_dir) / "preview.mov"
             result_path = Path(temp_dir) / "result.json"
+            stdout_path = Path(temp_dir) / "stdout.log"
+            stderr_path = Path(temp_dir) / "stderr.log"
             environment = {"HOME": temp_dir}
 
             with patch.object(smoke_release_app, "run") as run:
@@ -105,6 +107,8 @@ class ReleaseSmokeTests(unittest.TestCase):
                     bundle,
                     media_path,
                     result_path,
+                    stdout_path,
+                    stderr_path,
                     environment=environment,
                     cwd=Path(temp_dir),
                 )
@@ -113,8 +117,14 @@ class ReleaseSmokeTests(unittest.TestCase):
             run.call_args.args[0],
             [
                 "/usr/bin/open",
-                "-g",
+                "-F",
                 "-n",
+                "-o",
+                stdout_path,
+                "--stderr",
+                stderr_path,
+                "--env",
+                f"HOME={temp_dir}",
                 bundle.path,
                 "--args",
                 smoke_release_app.PREVIEW_PRESENTATION_SMOKE_ARGUMENT,
@@ -123,6 +133,7 @@ class ReleaseSmokeTests(unittest.TestCase):
             ],
         )
         self.assertEqual(run.call_args.kwargs["env"], environment)
+        self.assertEqual(run.call_args.kwargs["timeout"], smoke_release_app.PREVIEW_LAUNCH_TIMEOUT_SECONDS)
 
     def test_preview_presentation_timeout_terminates_matching_process(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -131,8 +142,35 @@ class ReleaseSmokeTests(unittest.TestCase):
             with (
                 patch.object(smoke_release_app, "launch_preview_application"),
                 patch.object(smoke_release_app, "wait_for_path", return_value=False),
+                patch.object(smoke_release_app, "preview_process_summary", return_value="matching process IDs: 42"),
+                patch.object(
+                    smoke_release_app, "read_preview_log_tail", side_effect=["launch stdout", "launch stderr"]
+                ),
                 patch.object(smoke_release_app, "terminate_preview_processes") as terminate,
-                self.assertRaisesRegex(smoke_release_app.SmokeFailure, "result receipt"),
+            ):
+                with self.assertRaises(smoke_release_app.SmokeFailure) as raised:
+                    smoke_release_app.verify_preview_presentation(bundle, smoke_release_app.build_clean_env())
+
+        terminate.assert_called_once()
+        message = str(raised.exception)
+        self.assertIn("result receipt", message)
+        self.assertIn("matching process IDs: 42", message)
+        self.assertIn("launch stdout", message)
+        self.assertIn("launch stderr", message)
+
+    def test_preview_presentation_exit_timeout_terminates_matching_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_path = make_fake_app(Path(temp_dir), version="1.2.3")
+            bundle = smoke_release_app.read_bundle(app_path)
+            with (
+                patch.object(
+                    smoke_release_app,
+                    "launch_preview_application",
+                    side_effect=complete_preview_smoke,
+                ),
+                patch.object(smoke_release_app, "wait_for_preview_process_exit", return_value=False),
+                patch.object(smoke_release_app, "terminate_preview_processes") as terminate,
+                self.assertRaisesRegex(smoke_release_app.SmokeFailure, "did not terminate"),
             ):
                 smoke_release_app.verify_preview_presentation(bundle, smoke_release_app.build_clean_env())
 
@@ -341,11 +379,13 @@ def complete_preview_smoke(
     bundle: smoke_release_app.AppBundle,
     media_path: Path,
     result_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
     *,
     environment: dict[str, str],
     cwd: Path,
 ) -> None:
-    del bundle, environment, cwd
+    del bundle, stdout_path, stderr_path, environment, cwd
     shutil.rmtree(media_path.parent)
     result_path.write_text(
         json.dumps(


### PR DESCRIPTION
## Summary

- create and retain a dedicated AppKit window hosting the existing `PreviewPresentationSmokeView` only for automation smoke mode
- suppress the automatic SwiftUI smoke scene so a fresh profile no longer depends on saved window-restoration state
- launch the packaged app through LaunchServices with an explicitly isolated environment and captured stdout/stderr
- report matching process state and bounded log tails when the receipt wait expires
- run the full native package smoke in required macOS CI before another signing attempt

## Root cause

Guarded Prerelease run `30426833488` attempt 1 at protected-main SHA `355a5f559ba36d4e6862ad93c7d48527f8c7d5c0` built and production-signed Beta 9/build 154, then failed before DMG creation because the preview smoke wrote no receipt. No tag, release, DMG, appcast, Pages update, or other publication occurred, and signing cleanup succeeded.

The packaged process was alive in its AppKit event loop for the full timeout, but a fresh profile created only menu-bar helper windows and no SwiftUI content window. The receipt path was therefore never reached. This PR removes that restoration-state dependency while still exercising the real packaged native executable, `PreviewPlayerView`, `AVPlayerView`, media readiness, lease cleanup, and process termination.

Under the forward-only failed-build contract, `0.3.0b9` / `v0.3.0-beta.9` / build `154` is burned. This PR does not reuse or replace that identity. After this fix merges, a separate reviewed metadata PR will prepare Beta 10/build 155.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp scripts/smoke_release_app.py`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python -m scripts.release validate`
- `uv run python -m unittest discover -s tests -t .` — 1,138 passed, 3 skipped before the final added exit-timeout case; focused suite now has 16 passing tests
- `uv run python scripts/native_app.py test` — 318 passed on the final diff
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — final ad-hoc package, deep code-sign verification, real LaunchServices player presentation, media-ready receipt, cleanup, and exit passed
- `uv build`, import smoke, and CLI help smoke
- `actionlint -no-color .github/workflows/ci.yml`
- JetBrains changed-files inspection — GREEN, zero findings
- independent GPT- and Claude-family final reviews: ship; Antigravity/Google-family review was invoked but returned no written findings

## Release boundary

No release workflow is dispatched by this PR. The next signing attempt must use new Beta 10/build 155 metadata, a new exact protected-main SHA, the required repository watcher, and a fresh run-bound `macos-signing` authorization.

Closes #399
Refs #392
