### PR TITLE
Prepare 0.3.0 Beta 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ explicitly choose another route. Choosing Stable later does not downgrade the
 installed Beta 3 app—it waits for a newer eligible Stable build.
 
 Beta 4 (`0.3.0b4`, build `149`) through Beta 8 (`0.3.0b8`, build `153`) are
-published and immutable. Beta 9 metadata (`0.3.0b9`, build `154`) is prepared
-for the guarded Prerelease workflow. There is no Beta 9 tag, DMG, release, or
-updater item until exact-SHA signing, publication, and public verification
-complete.
+published and immutable. Beta 9 (`0.3.0b9`, build `154`) failed after production
+signing but before DMG creation and is permanently burned without publication.
+Beta 10 metadata (`0.3.0b10`, build `155`) is prepared for the guarded
+Prerelease workflow. There is no Beta 10 tag, DMG, release, or updater item
+until exact-SHA signing, publication, and public verification complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.

--- a/docs/0.3.0-beta.10-cut-packet.md
+++ b/docs/0.3.0-beta.10-cut-packet.md
@@ -1,0 +1,129 @@
+# 0.3.0 Beta 10 Cut Packet
+
+> **Authorized metadata; publication pending.** Issue #392 and the July 29,
+> 2026 authorization to continue the beta release after the failed Beta 9
+> attempt authorize repository preparation, protected-main review, and exact-SHA
+> Prerelease dispatch after this metadata PR merges green and a merge hold is
+> active. This packet does not assert that a Beta 10 tag, draft, DMG, release,
+> or appcast item exists. The `macos-signing` environment remains a separate
+> run-bound authorization requiring explicit approval in the active
+> conversation.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). Beta 10 replaces failed Beta 9 without
+reusing its version or build. It packages the post-Beta-8 field changes plus the
+fresh-profile installed-player repair from PR #413. It is not an RC nomination.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0b10` |
+| Public version | `0.3.0-beta.10` |
+| Bundle and Sparkle build | `155` |
+| GitHub tag and release title | `v0.3.0-beta.10` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.10.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
+| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
+| Privacy contract | Privacy rules version `4` |
+
+Build `155` is globally newer than immutable published Beta 8 build `153` and
+burned failed Beta 9 build `154`. The July 29, 2026 live audit found Beta 8
+published from protected-main commit
+`8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328` by guarded Prerelease run
+`30341766419`, while Beta 9 run `30426833488` failed before DMG creation and
+publication. There is no Beta 9 or Beta 10 tag, release, draft, or asset, and the
+release-freeze map is empty. The public cumulative appcast remains rooted at
+Beta 8 build `153` until guarded publication succeeds.
+
+## Included Product Changes
+
+- PR #404 links AVKit directly in the production host and makes package
+  verification reject a binary missing that load command.
+- PR #405 adds an installed-app smoke for the existing `PreviewPlayerView`.
+- PR #406 retains recent conversion activity with bounded, deduplicated
+  lifecycle history.
+- PR #410 publishes validated ad-hoc builds to an immutable commit directory and
+  atomically updates the durable local `Current.app` pointer.
+- PR #411 keeps MV-HEVC as the default, labels AV1 stereo as experimental and
+  M5 Vision Pro-targeted, and marks M2 Vision Pro unsupported.
+- PR #413 removes fresh-profile window-restoration dependence from the packaged
+  player smoke, captures launch diagnostics, and runs the full package gate in
+  required hosted macOS CI.
+
+## Cumulative Update Contract
+
+Publication must append Beta 10 above immutable public history while omitting
+burned Beta 9 build `154`:
+
+| Order | Internal version | Build | Channel |
+| ---: | --- | ---: | --- |
+| 1 | `0.3.0b10` | `155` | `beta` |
+| 2 | `0.3.0b8` | `153` | `beta` |
+| 3 | `0.3.0b7` | `152` | `beta` |
+| 4 | `0.3.0b6` | `151` | `beta` |
+| 5 | `0.3.0b5` | `150` | `beta` |
+| 6 | `0.3.0b4` | `149` | `beta` |
+| 7 | `0.3.0b3` | `148` | `beta` |
+| 8 | `0.2.143` | `146` | Stable / no channel |
+| 9 | `0.2.143rc5` | `145` | `rc` |
+| 10 | `0.2.143rc4` | `144` | `rc` |
+
+Stable and RC continue to exclude every Beta item. Beta and Alpha admit the
+published Betas plus Beta 10 if publication succeeds. An installed earlier Beta
+may update directly to build `155`; build `154` is never offered. Moving to a
+safer route never downgrades an installed prerelease.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.0-beta.10` fixes the packaged preview crash found in Beta 8
+> and makes the installed-player gate reliable for fresh profiles and hosted
+> macOS runners. The native app retains recent conversion activity, and
+> validated local builds have a durable `Current.app` location. AV1 stereo
+> remains experimental and targets M5 Vision Pro; M2 Vision Pro is unsupported.
+> MV-HEVC remains the default output. Beta 9 was never published and is skipped.
+
+Do not describe Beta 10 as downloadable, signed, published, notarized, or
+Sparkle-discoverable until the guarded release verifies the immutable public
+state. Publishing the beta provides a signed M5 AV1 test vehicle; it does not
+itself establish physical M5 Vision Pro playback.
+
+## Exact-Artifact Qualification
+
+The last exact public artifact is immutable Beta 8: version `0.3.0b8`,
+protected-main SHA `8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328`, DMG SHA-256
+`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`,
+and signed app-tree SHA-256
+`7e9d66d372bd94ea1d11a0990c3e070ba97268b2ce21794f1c46f04235dc7b93`.
+It passed #382's signed AAC/package/physical Vision Pro matrix but exposed the
+packaged preview defect later fixed by #404 and #413.
+
+Failed Beta 9 run `30426833488` produced no distributable artifact and cannot
+qualify the corrected source. The exact Beta 10 artifact remains pending. Issue
+#392 must bind one protected-`main` SHA to the signed and notarized DMG,
+release/appcast identity, and the packaged GUI preview, capacity, cleanup, and
+final-output matrix. The release package smoke must pass the fresh-profile
+installed-player gate added to required CI by #413. Physical M5 Vision Pro AV1
+stereo depth, eye order, seeks, sustained playback, thermals, audio, and
+subtitles remain external evidence tracked by #409; that evidence is additive
+and does not turn Beta 10 into an RC.
+
+## Authorization Boundary
+
+Issue #392 and the July 29, 2026 authorization to continue the beta release
+authorize replacement metadata preparation, protected-main review, and
+exact-SHA Prerelease dispatch. The repository has no freeze entry for
+`v0.3.0-beta.10`.
+
+The workflow must be dispatched only from the exact protected `main` SHA that
+contains the reviewed metadata PR. `main` must remain fixed while the workflow
+is nonterminal. Before approving `macos-signing`, the release watcher must emit
+the new run-bound approval fingerprint and the maintainer must explicitly
+authorize that approval in the active conversation. This packet does not pre-authorize
+that approval.

--- a/docs/0.3.0-beta.9-cut-packet.md
+++ b/docs/0.3.0-beta.9-cut-packet.md
@@ -1,133 +1,84 @@
 # 0.3.0 Beta 9 Cut Packet
 
-> **Authorized metadata; publication pending.** Issue #392 and the July 29,
-> 2026 instruction to proceed authorize repository preparation,
-> protected-main review, and exact-SHA Prerelease dispatch after this metadata
-> PR merges green and a merge hold is active. This packet does not assert that
-> a Beta 9 tag, draft, DMG, release, or appcast item exists. The
-> `macos-signing` environment remains a separate run-bound authorization that
-> requires explicit approval in the active conversation.
+> **Failed, unpublished, and permanently burned.** Guarded Prerelease run
+> `30426833488`, attempt 1, used protected-`main` commit
+> `355a5f559ba36d4e6862ad93c7d48527f8c7d5c0`. The workflow built and
+> production-signed Beta 9 build `154`, then failed its packaged preview
+> presentation smoke before DMG creation. Signing-material cleanup succeeded.
+> No tag, draft, release, DMG, appcast item, Pages mutation, Latest change,
+> PyPI, or Homebrew publication occurred.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 9 is a focused field beta for the
-packaged-preview fix and its installed-app guard, retained activity history,
-durable validated local-build handoff, and generation-aware experimental AV1
-stereo boundary. It is not an RC nomination.
+[release-routes.md](release-routes.md). Beta 9 was the first signed attempt to
+package the post-Beta-8 preview, activity-history, durable-current-build, and
+generation-aware AV1 work. Its failure exposed a fresh-profile automation-window
+dependency that was repaired by PR #413 before the replacement release.
 
-## Exact Metadata
+## Attempted Metadata
 
-| Field | Reviewed value |
+| Field | Burned value |
 | --- | --- |
 | Package and bundle short version | `0.3.0b9` |
-| Public version | `0.3.0-beta.9` |
+| Intended public version | `0.3.0-beta.9` |
 | Bundle and Sparkle build | `154` |
-| GitHub tag and release title | `v0.3.0-beta.9` |
-| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg` |
+| Intended GitHub tag and release title | `v0.3.0-beta.9` |
+| Intended DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg` |
 | Sparkle channel | `beta` |
-| GitHub prerelease | `true` |
-| GitHub Latest | `false` |
-| Publish to PyPI or Homebrew | `false` |
+| Intended GitHub prerelease | `true` |
+| Intended GitHub Latest | `false` |
+| Intended PyPI or Homebrew publication | `false` |
 | Product name | `3D Blu-ray to Vision Pro` |
 | Bundle identifier | `com.shinycomputers.bd-to-avp` |
 | Apple signing authority | `Developer ID Application: Shiny Computers Leasing LLC (MM5YXC7T6E)` |
-| Feed, Sparkle key, diagnostics endpoint | Existing pinned production values |
 | Privacy contract | Privacy rules version `4` |
 
-Build `154` is globally newer than immutable published Beta 8 build `153`. The
-July 29, 2026 live audit found Beta 8 published from protected-main commit
-`8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328` by guarded Prerelease run
-`30341766419`, with DMG SHA-256
-`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`.
-Build `154` is introduced by this reviewed metadata change; there is no Beta 9
-tag, release, draft, asset, or earlier prepared release consuming it, and the
-release-freeze map is empty. The public cumulative appcast remains rooted at
-Beta 8 build `153` until guarded publication succeeds.
+Build `154` was globally newer than immutable published Beta 8 build `153`, but
+it never entered public release history. The public cumulative appcast remains
+ordered through builds `153,152,151,150,149,148,146,145,144`.
 
 ## Included Product Changes
 
-- PR #404 links AVKit directly in the production host and makes package
-  verification reject a binary missing that load command, fixing the exact
-  packaged-preview crash exposed by Beta 8.
-- PR #405 runs a bounded LaunchServices presentation smoke against the packaged
-  app, proving that the real SwiftUI player attaches, accepts media, stays
-  alive, and cleans its isolated workspace.
+- PR #404 links AVKit directly in the production host and rejects a packaged
+  binary missing that load command.
+- PR #405 adds the installed-app `PreviewPlayerView` presentation smoke.
 - PR #406 retains up to 200 deduplicated lifecycle messages for the current or
-  most recent job and presents quiet checks as nonterminal activity rather than
-  an apparent failure.
+  most recent job.
 - PR #410 publishes validated ad-hoc builds to an immutable commit directory and
-  atomically updates the durable local `Current.app` pointer without changing
-  the production installation.
+  atomically updates the durable local `Current.app` pointer.
 - PR #411 keeps MV-HEVC as the default, labels AV1 stereo as experimental and
-  M5 Vision Pro-targeted, marks M2 Vision Pro unsupported, and adds codec-aware
-  independent decode and sustained-playback evidence to Playback Check.
+  M5 Vision Pro-targeted, and marks M2 Vision Pro unsupported.
 
-## Cumulative Update Contract
+These changes remain part of the later replacement beta because Beta 9 was not
+published.
 
-Publication must append Beta 9 above the immutable production history:
+## Failure Evidence
 
-| Order | Internal version | Build | Channel |
-| ---: | --- | ---: | --- |
-| 1 | `0.3.0b9` | `154` | `beta` |
-| 2 | `0.3.0b8` | `153` | `beta` |
-| 3 | `0.3.0b7` | `152` | `beta` |
-| 4 | `0.3.0b6` | `151` | `beta` |
-| 5 | `0.3.0b5` | `150` | `beta` |
-| 6 | `0.3.0b4` | `149` | `beta` |
-| 7 | `0.3.0b3` | `148` | `beta` |
-| 8 | `0.2.143` | `146` | Stable / no channel |
-| 9 | `0.2.143rc5` | `145` | `rc` |
-| 10 | `0.2.143rc4` | `144` | `rc` |
+The release helper validated the exact route, actors, workflow definitions, and
+protected-main SHA. Run actor and triggering actor were `shiny-code-bot`. The
+`macos-signing` environment was explicitly approved for the run with fingerprint
+`1d8ca100cc43bdcf6dc678838de2cb99cf5c018024e871b06dec87b606a6f2a2`.
 
-Stable and RC continue to exclude every Beta item. Beta and Alpha admit Beta 3
-through Beta 9, and an installed earlier Beta on either route may update forward
-to build `154`. Moving to a safer route never downgrades an installed
-prerelease.
+The package job built and signed the production app, verified its code-signing
+structure, and then timed out waiting for the installed-player receipt. The app
+process remained alive in AppKit's event loop but a fresh profile produced no
+content window, so the existing preview attachment probe never ran. No release
+artifact was uploaded. PR #413 made smoke mode create and retain a dedicated
+AppKit window hosting the existing preview view, strengthened timeout
+diagnostics, and added the full native package smoke to required `macos-26` CI.
+PR #413 merged as `4313b95146c4e7ca89c6cc0fd6838708a3d4a904`; post-merge CI run
+`30435001983` and CodeQL run `30435001999` passed.
 
-## Reviewed Release-Note Seed
+## Public History Boundary
 
-> BD_to_AVP `v0.3.0-beta.9` fixes the packaged preview crash found in Beta 8
-> and adds an installed-app presentation smoke so future packages fail before
-> release if the player cannot attach and accept media. The native app now
-> retains recent conversion activity, and validated local builds have a durable
-> `Current.app` location. AV1 stereo remains experimental: it is explicitly
-> targeted to M5 Vision Pro, while M2 Vision Pro is marked unsupported after
-> physical testing found no usable hardware or software decode path. MV-HEVC
-> remains the default output.
-
-Do not describe Beta 9 as downloadable, signed, published, notarized, or
-Sparkle-discoverable until the guarded release verifies the immutable public
-state. Publishing the beta provides a signed test vehicle; it does not itself
-establish physical M5 Vision Pro AV1 playback.
-
-## Exact-Artifact Qualification
-
-The previous exact production artifact is immutable Beta 8: version `0.3.0b8`,
-protected-main SHA `8e10dc38f935fe7deb7bbe4f6e1095f18b6cf328`, DMG SHA-256
-`f16bd1c6f2d4820b0bdb985d8e9fc9617a7f7601ed69d0c203302063c29c23cc`,
-and signed app-tree SHA-256
-`7e9d66d372bd94ea1d11a0990c3e070ba97268b2ce21794f1c46f04235dc7b93`.
-It passed the #382 AAC package and physical Vision Pro matrix, but its packaged
-GUI preview crashed because the production host lacked the AVKit link fixed
-afterward. It is historical evidence, not qualification of the post-Beta-8
-code.
-
-The exact Beta 9 artifact remains pending. Issue #392 must bind one protected-
-`main` SHA to the signed and notarized DMG, release/appcast identity, and the
-packaged GUI preview, capacity, cleanup, and final-output matrix. The release
-package smoke must pass the installed-player presentation guard added by #405.
-Physical M5 Vision Pro AV1 stereo depth, eye order, seeks, sustained playback,
-thermals, audio, and subtitles remain external evidence tracked by #409; that
-evidence is additive and does not weaken #392 or turn Beta 9 into an RC.
+Beta 9 must not be appended to the appcast, offered by Sparkle, rebuilt,
+retagged, published, or reused. Build `154` and internal version `0.3.0b9` are
+burned failed-attempt identities. The replacement release advances to Beta 10
+build `155`, which appends directly above published Beta 8 build `153` if and
+only if its guarded workflow succeeds.
 
 ## Authorization Boundary
 
-Issue #392 and the July 29, 2026 instruction to proceed authorize metadata
-preparation, protected-main review, and exact-SHA Prerelease dispatch. The
-repository has no freeze entry for `v0.3.0-beta.9`.
-
-The workflow must be dispatched only from the exact protected `main` SHA that
-contains the reviewed metadata PR. `main` must remain fixed while the workflow
-is nonterminal. Before approving `macos-signing`, the release watcher must emit
-the run-bound approval fingerprint and the maintainer must explicitly authorize
-that approval in the active conversation. This packet does not pre-authorize
-that approval.
+The explicit approval applied only to run `30426833488`, attempt 1, at the exact
+SHA and fingerprint above. It does not authorize another signing attempt. Any
+replacement run requires a new watcher fingerprint and fresh explicit
+maintainer authorization in the active conversation.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -95,11 +95,14 @@ document it as an external dependency with preflight behavior.
   toolchain, then verifies the exact DMG again in a separate macOS 26 job.
 - Beta 4 (`v0.3.0-beta.4`, internal version `0.3.0b4`, build `149`) through
   Beta 8 (`v0.3.0-beta.8`, internal version `0.3.0b8`, build `153`) are
-  published and immutable. The next prepared production-identity field build
-  is Beta 9 (`v0.3.0-beta.9`, internal version `0.3.0b9`, build `154`). It remains
-  unpublished until exact-SHA signing and public verification complete. Beta 3
-  build `148` remains the manual-download seed and immutable appcast history
-  below the later Beta releases.
+  published and immutable. Beta 9 (`v0.3.0-beta.9`, internal version
+  `0.3.0b9`, build `154`) failed after production signing but before DMG
+  creation and is permanently burned without publication. The next prepared
+  production-identity field build is Beta 10 (`v0.3.0-beta.10`, internal
+  version `0.3.0b10`, build `155`). It remains unpublished until exact-SHA
+  signing and public verification complete. Beta 3 build `148` remains the
+  manual-download seed and immutable appcast history below the later Beta
+  releases.
 - Stable, RC, Beta, and Alpha are routes for the same product, bundle identifier,
   feed, Sparkle key, signing team, and diagnostics endpoint. Stable is default;
   broader routes include progressively earlier stages without permitting

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -114,9 +114,11 @@ only future newer builds and never downgrades the installed app. Published Beta
 older Stable and RC installations cannot discover it, while an installed Beta
 3 exposes all four routes. Beta 4 (`0.3.0b4`, build `149`) through Beta 8
 (`0.3.0b8`, build `153`) are published and immutable. Beta 9 (`0.3.0b9`, build
-`154`) is the next prepared target for the guarded exact-SHA Prerelease
-workflow. Its future cumulative item must sit above Beta 8 through Beta 3 and
-remain visible only to Beta and Alpha until a later newer Stable supersedes it.
+`154`) failed after production signing and is burned without a public appcast
+item. Beta 10 (`0.3.0b10`, build `155`) is the next prepared target for the
+guarded exact-SHA Prerelease workflow. Its future cumulative item must sit above
+Beta 8 through Beta 3, skip burned build `154`, and remain visible only to Beta
+and Alpha until a later newer Stable supersedes it.
 
 ## Release Workflow
 
@@ -173,9 +175,9 @@ qualification is complete, and #382's signed AAC/package/physical Vision Pro
 matrix passed on the exact Beta 8 artifact. Beta 8 exposed a packaged GUI
 preview crash after its worker completed the preview route; PRs #404 and #405
 fixed the missing AVKit link and added an installed-player presentation smoke.
-Beta 9 exact-artifact qualification must prove that:
+Beta 10 exact-artifact qualification must prove that:
 
-- Beta 8 updates forward to Beta 9 on Beta and Alpha without changing the saved
+- Beta 8 updates forward to Beta 10 on Beta and Alpha without changing the saved
   route;
 - Stable and RC continue to exclude every Beta item;
 - the downloaded notarized DMG passes signature, staple, Gatekeeper, startup,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,20 +5,23 @@ boundary, and publication policy are defined in
 [Production Release Routes](release-routes.md).
 
 The repository carries published, immutable Beta 3 through Beta 8 history at
-internal versions `0.3.0b3` through `0.3.0b8`, builds `148` through `153`, and a
-prepared Beta 9 target at `0.3.0b9`, build `154`. The failed, unpublished
-`0.3.0rc1` build `147` attempt is preserved in the checked-in recovery evidence
-and its build number is permanently burned. The
+internal versions `0.3.0b3` through `0.3.0b8`, builds `148` through `153`.
+Failed, unpublished Beta 9 (`0.3.0b9`, build `154`) and the earlier
+`0.3.0rc1` build `147` attempt are permanently burned. The prepared replacement
+target is Beta 10 at `0.3.0b10`, build `155`. The
 [Beta 8 cut packet](0.3.0-beta.8-cut-packet.md) records immutable publication
-history, while the reviewed [Beta 9 cut packet](0.3.0-beta.9-cut-packet.md)
-records metadata only and does not assert that a Beta 9 public artifact exists.
+history, [the Beta 9 cut packet](0.3.0-beta.9-cut-packet.md) records the failed
+unpublished attempt, and the reviewed
+[Beta 10 cut packet](0.3.0-beta.10-cut-packet.md) records replacement metadata
+only and does not assert that a Beta 10 public artifact exists.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issue #392 and the explicit July 29, 2026
-Beta 9 request authorize the reviewed metadata preparation and exact-SHA
-dispatch; run-bound signing approval remains a separate authorization boundary.
+implemented and regression-covered. Issue #392 and the July 29, 2026
+authorization to continue the beta release after the failed Beta 9 attempt
+authorize the reviewed Beta 10 metadata preparation and exact-SHA dispatch;
+run-bound signing approval remains a separate authorization boundary.
 
 ## Release Preparation
 
@@ -34,9 +37,9 @@ uv run python -m scripts.release prepare \
 The internal version, public version, tag/title, DMG name, release stage,
 Sparkle channel, and publication effects are derived independently by
 `scripts/release.py metadata` from the mapping in `release-routes.md`. For
-example, internal `0.3.0b9` maps to public `0.3.0-beta.9`, tag/title
-`v0.3.0-beta.9`, and DMG
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg`. The numeric
+example, internal `0.3.0b10` maps to public `0.3.0-beta.10`, tag/title
+`v0.3.0-beta.10`, and DMG
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.10.dmg`. The numeric
 `CFBundleVersion` must increase for every production-identity build across all
 routes, including failed unpublished attempts. The command stages a refreshed
 `uv.lock`, validates the staged metadata, and updates `pyproject.toml`,
@@ -77,11 +80,12 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 9 is authorized but not yet published.** Issue #392 and the explicit
-> July 29, 2026 request authorize guarded `v0.3.0-beta.9` dispatch, and the repository contains no
+> **Beta 10 is authorized but not yet published.** Issue #392 and the July 29,
+> 2026 authorization to continue the beta release authorize guarded
+> `v0.3.0-beta.10` dispatch, and the repository contains no
 > freeze entry for that exact tag. Dispatch only from the exact protected `main`
-> commit containing the reviewed Beta 9 metadata, keep `main` fixed while the
-> workflow is nonterminal, and do not describe Beta 9 as public until signing,
+> commit containing the reviewed Beta 10 metadata, keep `main` fixed while the
+> workflow is nonterminal, and do not describe Beta 10 as public until signing,
 > notarization, appcast publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -7,10 +7,11 @@ closed when it cannot satisfy this contract.
 The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
 this four-route contract. Beta 3 through Beta 8 are published and immutable at
-builds `148` through `153`, with build `147` permanently burned. The next
-prepared target is Beta 9 at `0.3.0b9` build `154`. Issue #392 and the explicit
-July 29, 2026 Beta 9 request authorize reviewed exact-SHA dispatch; run-bound
-signing approval remains a separate authorization boundary.
+builds `148` through `153`, with builds `147` and `154` permanently burned.
+Failed Beta 9 (`0.3.0b9`, build `154`) was never published. The next prepared
+target is Beta 10 at `0.3.0b10` build `155`. Issue #392 and the July 29, 2026
+authorization to continue the beta release authorize reviewed exact-SHA
+dispatch; run-bound signing approval remains a separate authorization boundary.
 
 ## Production Identity
 
@@ -51,7 +52,7 @@ only the public tag forms above. Historical compact production RC tags such as
 `v0.2.143rc5` remain valid read-only history inputs and are never renamed.
 
 Externally visible DMG names use the public version stem, for example
-`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg`. Workflow names and operator intent
+`3D-Blu-ray-to-Vision-Pro-0.3.0-beta.10.dmg`. Workflow names and operator intent
 must not appear in versions, release titles, notes, artifact names, app metadata,
 or appcast content.
 
@@ -82,6 +83,14 @@ metadata with `0.3.0b3` build `148`. Build `147` is permanently burned and
 normal forward-only enforcement has resumed. The ordinary release preparation
 command still rejects that backward stage move, and the recovery command
 rejects every other source, target, evidence record, and rerun.
+
+Guarded Beta 9 run `30426833488` built and production-signed the app at
+protected-main commit `355a5f559ba36d4e6862ad93c7d48527f8c7d5c0`, then failed its
+packaged preview presentation smoke before DMG creation. It left no tag,
+release, draft, DMG, appcast item, Pages mutation, Latest change, or package
+publication. Build `154` and prerelease version `0.3.0b9` are permanently
+burned; the corrected source advances to Beta 10 build `155` rather than
+reusing either identity.
 
 ## Sparkle Route Eligibility
 
@@ -139,7 +148,8 @@ appcast even though older clients cannot discover it.
 
 Selecting Stable after installing Beta 3 does not downgrade to `0.2.143`; the
 client waits for a newer eligible Stable build. Beta 4 through Beta 8 are
-immutable production history, and Beta 9 reserves the next global build, `154`.
+immutable production history. Failed Beta 9 burns build `154`, and Beta 10
+reserves the next global build, `155`.
 
 ## Beta 6 Published History
 
@@ -195,30 +205,48 @@ The cumulative appcast places Beta 8 above immutable Beta 7 build `152`, Beta 6 
 items; Beta and Alpha admit them. Historical metadata and release evidence are
 in [the Beta 8 cut packet](0.3.0-beta.8-cut-packet.md).
 
-## Beta 9 Authorized Target
+## Beta 9 Failed Attempt
 
-The repository is prepared for the guarded `v0.3.0-beta.9` Prerelease workflow:
+Beta 9 is failed, unpublished, and permanently burned:
 
 - internal version `0.3.0b9`;
-- public tag and title `v0.3.0-beta.9`;
+- intended public tag and title `v0.3.0-beta.9`;
 - global build `154`;
+- guarded Prerelease run `30426833488`, attempt 1;
+- exact protected-main commit `355a5f559ba36d4e6862ad93c7d48527f8c7d5c0`;
+- production signing completed before the package smoke failed; and
+- no tag, release, draft, DMG, appcast item, Pages mutation, Latest change,
+  PyPI, or Homebrew publication.
+
+Beta 9 never entered cumulative production history and must not be rebuilt,
+retagged, published, or represented as an updater item. Its failed-attempt
+evidence is in [the Beta 9 cut packet](0.3.0-beta.9-cut-packet.md).
+
+## Beta 10 Authorized Target
+
+The repository is prepared for the guarded `v0.3.0-beta.10` Prerelease workflow:
+
+- internal version `0.3.0b10`;
+- public tag and title `v0.3.0-beta.10`;
+- global build `155`;
 - Sparkle channel `beta`;
 - GitHub prerelease, never Latest, PyPI, or Homebrew; and
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta 8.
 
-Publication must place Beta 9 above immutable Beta 8 build `153`, Beta 7 build
+Publication must place Beta 10 above immutable Beta 8 build `153`, Beta 7 build
 `152`, Beta 6 build `151`, Beta 5 build `150`, Beta 4 build `149`, Beta 3 build
-`148`, Stable build `146`, RC5 build `145`, and RC4 build `144`. Stable and RC
-exclude all Beta items; Beta and Alpha admit them, allowing an installed earlier
-Beta to update forward to Beta 9 without changing the saved route.
+`148`, Stable build `146`, RC5 build `145`, and RC4 build `144`, with burned
+build `154` absent. Stable and RC exclude all Beta items; Beta and Alpha admit
+them, allowing an installed earlier Beta to update forward to Beta 10 without
+changing the saved route.
 
-Issue #392 and the explicit July 29, 2026 Beta 9 request authorize metadata
-preparation and exact-SHA dispatch. The repository has no freeze entry for this
-exact tag; that absence authorizes workflow preflight but does not assert that a
-tag, draft, DMG, release, or appcast item exists. The reviewed metadata and
-release-note seed are in
-[the Beta 9 cut packet](0.3.0-beta.9-cut-packet.md).
+Issue #392 and the July 29, 2026 authorization to continue the beta release
+authorize replacement metadata preparation and exact-SHA dispatch. The
+repository has no freeze entry for this exact tag; that absence authorizes
+workflow preflight but does not assert that a tag, draft, DMG, release, or
+appcast item exists. The reviewed metadata and release-note seed are in
+[the Beta 10 cut packet](0.3.0-beta.10-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -282,25 +282,25 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 9 Authorization Smoke
+### Beta 10 Authorization Smoke
 
-Run these checks after the Beta 9 metadata preparation lands and before workflow
+Run these checks after the Beta 10 metadata preparation lands and before workflow
 dispatch. They prove the committed target and authorization boundary, not a
 signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b9`, public `0.3.0-beta.9`, build `154`, Beta channel, prerelease,
+   `0.3.0b10`, public `0.3.0-beta.10`, build `155`, Beta channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 9 freeze is absent while all route, identity, and existing-release
+   Beta 10 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 9 build `154`, Beta 8
+3. Validate a cumulative appcast fixture ordered Beta 10 build `155`, Beta 8
    build `153`, Beta 7 build `152`, Beta 6 build `151`, Beta 5 build `150`, Beta
    4 build `149`, Beta 3 build `148`, then Stable build `146`, RC5 build `145`,
-   and RC4 build `144`; Stable and RC must exclude every Beta item while Beta
-   and Alpha admit them.
-4. Confirm the live repository has no Beta 9 tag, release, draft, or asset and
-   the public appcast still ends at Beta 8 build `153`.
+   and RC4 build `144`; burned Beta 9 build `154` must be absent, Stable and RC
+   must exclude every Beta item, and Beta and Alpha must admit them.
+4. Confirm the live repository has no Beta 9 or Beta 10 tag, release, draft, or
+   asset and the public appcast still ends at Beta 8 build `153`.
 5. Continue only through the exact-SHA Prerelease workflow. Signed-app,
    update-route, installed-player presentation, capacity, cleanup, and final-
    output qualification remain incomplete until the guarded workflow and exact-

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -70,7 +70,8 @@ Sparkle uses its adaptive native text view without loading GitHub page chrome or
 making a second release-note request. A full-release link remains available for
 downloads and extended context, and historical external-link items remain valid.
 The live feed now carries cumulative production history through Beta 8 build
-`153`; prepared Beta 9 metadata does not alter it before guarded publication.
+`153`. Failed Beta 9 build `154` never entered the feed; prepared Beta 10
+metadata does not alter it before guarded publication.
 See [release-process.md](release-process.md) for the operator sequence.
 
 Stable `0.2.143` remains compatible with macOS 14. The production SwiftUI line
@@ -267,10 +268,11 @@ select Beta or Alpha for future prereleases. Retired `v0.3.0-beta.1` and
 Sparkle-upgrade into Beta 3.
 
 Published `v0.3.0-beta.8` (`0.3.0b8`, build `153`) is the immutable head of the
-current cumulative feed above Beta 7 through Beta 3. The next prepared item is
-`v0.3.0-beta.9` (`0.3.0b9`, build `154`). Publication must append Beta 9
-above the existing Betas, remain excluded from Stable and RC, and be eligible to
-Beta and Alpha. The exact-SHA Prerelease workflow, signing approval,
+current cumulative feed above Beta 7 through Beta 3. Failed Beta 9 build `154`
+is burned and omitted from public history. The next prepared item is
+`v0.3.0-beta.10` (`0.3.0b10`, build `155`). Publication must append Beta 10
+above the existing Betas, remain excluded from Stable and RC, and be eligible
+to Beta and Alpha. The exact-SHA Prerelease workflow, signing approval,
 notarization, and public verification remain separate fail-closed boundaries.
 
 ## Runtime Integration and UX

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 154
+        CURRENT_PROJECT_VERSION: 155
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b9
+        MARKETING_VERSION: 0.3.0b10
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b9"
+version = "0.3.0b10"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -110,7 +110,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "154"
+CFBundleVersion = "155"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b9")
-        self.assertEqual(NATIVE_BUILD_VERSION, "154")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b10")
+        self.assertEqual(NATIVE_BUILD_VERSION, "155")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,35 +156,49 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_and_authorized_for_beta9(self) -> None:
+    def test_repository_is_prepared_and_authorized_for_beta10(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b9")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.9")
-        self.assertEqual(metadata.build_version, "154")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.9")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.9")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.9.dmg")
+        self.assertEqual(metadata.package_version, "0.3.0b10")
+        self.assertEqual(metadata.public_version, "0.3.0-beta.10")
+        self.assertEqual(metadata.build_version, "155")
+        self.assertEqual(metadata.release_tag, "v0.3.0-beta.10")
+        self.assertEqual(metadata.release_name, "v0.3.0-beta.10")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.10.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.9", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-beta.10", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.9-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b9`", cut_packet)
-        self.assertIn("Build `154`", cut_packet)
-        for pull_request in (404, 405, 406, 410, 411):
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.10-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0b10`", cut_packet)
+        self.assertIn("Build `155`", cut_packet)
+        for pull_request in (404, 405, 406, 410, 411, 413):
             self.assertIn(f"#{pull_request}", cut_packet)
         self.assertIn("Privacy rules version `4`", cut_packet)
         self.assertIn("Issue #392", cut_packet)
-        self.assertIn("July 29, 2026 instruction to proceed", cut_packet)
+        self.assertIn("July 29, 2026 authorization to continue", cut_packet)
         self.assertIn("does not pre-authorize", cut_packet)
         self.assertIn("that approval", cut_packet)
-        self.assertIn("previous exact production artifact is immutable Beta 8", cut_packet)
-        self.assertIn("The exact Beta 9 artifact remains pending", cut_packet)
+        self.assertIn("last exact public artifact is immutable Beta 8", cut_packet)
+        self.assertIn("The exact Beta 10 artifact remains pending", cut_packet)
+
+    def test_beta9_cut_packet_records_failed_burned_identity(self) -> None:
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.9-cut-packet.md").read_text(encoding="utf-8")
+
+        self.assertIn("Failed, unpublished, and permanently burned", cut_packet)
+        self.assertIn("`30426833488`", cut_packet)
+        self.assertIn("`355a5f559ba36d4e6862ad93c7d48527f8c7d5c0`", cut_packet)
+        self.assertIn("Build `154`", cut_packet)
+        self.assertIn("`1d8ca100cc43bdcf6dc678838de2cb99cf5c018024e871b06dec87b606a6f2a2`", cut_packet)
+        self.assertIn("`4313b95146c4e7ca89c6cc0fd6838708a3d4a904`", cut_packet)
+        self.assertIn("No tag, draft, release, DMG, appcast item", cut_packet)
+        self.assertIn("must not be appended to the appcast", cut_packet)
+        self.assertNotIn("Authorized metadata; publication pending", cut_packet)
+        self.assertNotIn("The exact Beta 9 artifact remains pending", cut_packet)
 
     def test_beta8_cut_packet_records_immutable_published_identity(self) -> None:
         cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.8-cut-packet.md").read_text(encoding="utf-8")

--- a/tests/test_sparkle_appcast.py
+++ b/tests/test_sparkle_appcast.py
@@ -188,7 +188,7 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertNotIn("v0.3.0-beta.1", appcast_text)
         self.assertNotIn("v0.3.0-beta.2", appcast_text)
 
-    def test_beta9_appends_above_complete_immutable_production_history(self) -> None:
+    def test_beta10_appends_above_history_without_burned_beta9(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             base_feed = root / "base.xml"
@@ -198,7 +198,7 @@ class SparkleAppcastTests(unittest.TestCase):
             beta6_feed = root / "beta6.xml"
             beta7_feed = root / "beta7.xml"
             beta8_feed = root / "beta8.xml"
-            beta9_feed = root / "beta9.xml"
+            beta10_feed = root / "beta10.xml"
             base_feed.write_bytes(
                 (
                     Path(__file__).resolve().parents[1] / "docs" / "release-evidence" / "v0.2.143-appcast.xml"
@@ -236,23 +236,23 @@ class SparkleAppcastTests(unittest.TestCase):
             )
             sparkle_appcast.append_item(
                 beta8_feed,
-                beta9_feed,
-                item("154", "0.3.0b9", "beta", minimum_system_version="26.0"),
+                beta10_feed,
+                item("155", "0.3.0b10", "beta", minimum_system_version="26.0"),
             )
 
-            sparkle_appcast.validate_release_snapshot(beta9_feed, "0.3.0b9")
-            sparkle_appcast.validate_release_tag_snapshot(beta9_feed, "v0.3.0-beta.9")
-            _, channel = sparkle_appcast.load_appcast(beta9_feed)
+            sparkle_appcast.validate_release_snapshot(beta10_feed, "0.3.0b10")
+            sparkle_appcast.validate_release_tag_snapshot(beta10_feed, "v0.3.0-beta.10")
+            _, channel = sparkle_appcast.load_appcast(beta10_feed)
             items = channel.findall("item")
 
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items],
-            ["154", "153", "152", "151", "150", "149", "148", "146", "145", "144"],
+            ["155", "153", "152", "151", "150", "149", "148", "146", "145", "144"],
         )
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
             [
-                "0.3.0b9",
+                "0.3.0b10",
                 "0.3.0b8",
                 "0.3.0b7",
                 "0.3.0b6",
@@ -267,6 +267,11 @@ class SparkleAppcastTests(unittest.TestCase):
         self.assertEqual(
             [entry.findtext(f"{sparkle_appcast.SPARKLE}channel") for entry in items],
             ["beta", "beta", "beta", "beta", "beta", "beta", "beta", None, "rc", "rc"],
+        )
+        self.assertNotIn("154", [entry.findtext(f"{sparkle_appcast.SPARKLE}version") for entry in items])
+        self.assertNotIn(
+            "0.3.0b9",
+            [entry.findtext(f"{sparkle_appcast.SPARKLE}shortVersionString") for entry in items],
         )
 
     def test_rejects_non_monotonic_build(self) -> None:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "154")
+        self.assertEqual(info["CFBundleVersion"], "155")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b9"
+version = "0.3.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- Record guarded Prerelease run `30426833488` as failed, unpublished Beta 9 and permanently burn `0.3.0b9` / build `154`.
- Advance the next beta to internal `0.3.0b10`, public `0.3.0-beta.10`, and build `155` without inserting Beta 9 into public appcast history.
- Bind the replacement release plan to the packaged-preview smoke repair merged in PR #413 at `4313b95146c4e7ca89c6cc0fd6838708a3d4a904`.
- Keep this as a beta, not an RC, and preserve separate run-bound signing and physical M5 Vision Pro AV1 gates.

Tracks #392.

## Validation

- `uv run python -m scripts.release validate`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python -m unittest discover -s tests -t .` — 1140 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 318 passed
- `uv build`
- Python import smoke and `uv run bd-to-avp --help`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`
  - packaged native startup smoke passed
  - packaged worker smoke passed
  - packaged preview presentation smoke passed
- JetBrains changed-files inspection — clean
- Independent release-risk reviews — no merge blockers

## Release Boundary

This PR does not create a tag, DMG, release, or appcast item. After it merges green, `main` must remain fixed during the guarded `Prerelease` workflow. Any `macos-signing` approval requires a fresh watcher fingerprint and explicit run-bound authorization in the active conversation.
