### PR TITLE
fix(deps): update GitPython to 3.1.57

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -382,14 +382,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update the locked GitPython version from 3.1.50 to 3.1.57
- retain Briefcase 0.4.4 and every other resolved dependency
- remediate the nine GitPython advisories currently duplicated across `pyproject.toml` and `uv.lock` alerts

GitPython remains a transitive development/release dependency through Briefcase; it is not included in the application runtime requirements.

## Validation
- `uv lock --check`
- `uv sync --locked --all-groups --python 3.12`
- verified `briefcase=0.4.4` and `gitpython=3.1.57`
- `uv run python -m scripts.briefcase_cli --version`
- `uv run python -m unittest discover -s tests -t .` (1,140 passed; 3 skipped)
- `uv build`
- JetBrains inspection: green for `uv.lock`
