### PR TITLE
fix(deps): constrain GitPython to patched releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 [tool.uv]
 required-version = "==0.11.29"
 default-groups = "all"
+constraint-dependencies = ["gitpython>=3.1.55,<4"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["bd_to_avp"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
+[manifest]
+constraints = [{ name = "gitpython", specifier = ">=3.1.55,<4" }]
+
 [[package]]
 name = "anyio"
 version = "4.14.1"


### PR DESCRIPTION
## Summary
- add an uv-only transitive constraint requiring `gitpython>=3.1.55,<4`
- record the constraint in `uv.lock` without changing any resolved package versions
- prevent future resolution to GitPython releases affected by the current advisories
- refresh GitHub's stale `pyproject.toml` dependency graph, which still reports old Briefcase, pgsrip, setuptools, and GitPython versions

The application still resolves GitPython 3.1.57 through Briefcase 0.4.4. The constraint is not published as an application runtime dependency.

## Validation
- `uv lock --check`
- `uv sync --locked --all-groups --python 3.12`
- `uv tree --locked --invert --package gitpython`
- verified GitPython remains 3.1.57 under Briefcase 0.4.4
- `uv build`
- JetBrains inspection: green for `pyproject.toml` and `uv.lock`
