### PR TITLE
Harden large-file Vision Pro playback verification

### DIFF
--- a/docs/visionos-playback-validator.md
+++ b/docs/visionos-playback-validator.md
@@ -13,7 +13,7 @@ The validator asks the person wearing Apple Vision Pro to do four things:
 
 Nothing in the app publishes a build, approves a GitHub deployment, merges code, or authorizes a release. A passing report is playback evidence for the named movie and device; it is not a release approval by itself.
 
-Movies selected through Files are copied into the app's cache so playback can continue after the picker closes. The temporary copy is removed when replaced or when the app next launches. Nothing is uploaded.
+Movies selected through Files are copied into the app's cache so playback can continue after the picker closes. The temporary copy is removed when replaced or when the app next launches. A movie transferred into the app's Documents directory for autorun is validated in place instead of being duplicated into cache. Nothing is uploaded.
 
 ## What It Checks Automatically
 
@@ -158,7 +158,7 @@ xcrun devicectl device process launch \
   com.shinycomputers.bd-to-avp.spatial-playback-probe
 ```
 
-Autorun starts the automatic sequence after the player is ready. It stops at the three human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
+Autorun starts the automatic sequence only after the player is ready and the full-file SHA-256 fingerprint is complete. Large movies can remain in the preparing state for several minutes while the cooperative background fingerprint pass runs. It stops at the three human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
 
 After the operator selects **Finish Check**, retrieve the report directly without asking them to save share-sheet text manually:
 

--- a/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
@@ -98,6 +98,11 @@ private final class ProbeSeekCompletion: @unchecked Sendable {
 
 @MainActor
 final class PlaybackProbeModel: ObservableObject {
+    private struct PendingImportedAsset {
+        let url: URL
+        let replacedURL: URL?
+    }
+
     static let defaultTransferredAssetName = "Probe.mov"
 
     let player = AVPlayer()
@@ -117,6 +122,7 @@ final class PlaybackProbeModel: ObservableObject {
     @Published private(set) var durationSeconds = 0.0
     @Published private(set) var sourceFileSizeBytes: Int64?
     @Published private(set) var sourceSHA256 = ""
+    @Published private(set) var sourceFingerprintReady = false
     @Published private(set) var sourceVideoFormat = PlaybackVideoFormat.unknown
     @Published private(set) var failure: ProbeFailure?
     @Published private(set) var audioOptions: [ProbeMediaOption] = []
@@ -143,6 +149,7 @@ final class PlaybackProbeModel: ObservableObject {
     private var timeObserver: Any?
     private var statusTask: Task<Void, Never>?
     private var loadTask: Task<Void, Never>?
+    private var fingerprintTask: Task<Void, Never>?
     private var validationTask: Task<Void, Never>?
     private var logSequence = 0
     private var audioGroup: AVMediaSelectionGroup?
@@ -154,6 +161,8 @@ final class PlaybackProbeModel: ObservableObject {
     private var validationGeneration = 0
     private var componentStatusSampleSequence = 0
     private var currentImportedURL: URL?
+    private var pendingImportedAsset: PendingImportedAsset?
+    private var assetLoadedEventEmitted = false
     private var hasBootstrapped = false
     private var actualViewingModeValue = "unknown"
     private var actualSpatialVideoModeValue = "screen"
@@ -205,6 +214,12 @@ final class PlaybackProbeModel: ObservableObject {
         player.currentItem?.status == .readyToPlay && validationPhase != .running
     }
 
+    var canChooseMovie: Bool {
+        !isLoading
+            && validationPhase != .running
+            && (!hasLoadedAsset || sourceFingerprintReady)
+    }
+
     var canSeek: Bool {
         canControlPlayback && durationSeconds.isFinite && durationSeconds > 0
     }
@@ -216,6 +231,7 @@ final class PlaybackProbeModel: ObservableObject {
             && player.currentItem?.status == .readyToPlay
             && durationSeconds.isFinite
             && durationSeconds > 0
+            && sourceFingerprintReady
             && validationPhase != .preparing
             && validationPhase != .running
             && validationPhase != .observations
@@ -261,6 +277,7 @@ final class PlaybackProbeModel: ObservableObject {
     deinit {
         statusTask?.cancel()
         loadTask?.cancel()
+        fingerprintTask?.cancel()
         validationTask?.cancel()
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
@@ -304,20 +321,37 @@ final class PlaybackProbeModel: ObservableObject {
                     ? requestedDisplayName ?? automaticAssetURL.lastPathComponent
                     : automaticAssetURL.lastPathComponent
                 do {
-                    let localURL = try await Self.copyImportedAsset(automaticAssetURL)
+                    let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                    let requiresCacheCopy = Self.requiresAutomaticAssetCacheCopy(
+                        sourceURL: automaticAssetURL,
+                        documentsURL: documentsURL
+                    )
+                    let localURL = requiresCacheCopy
+                        ? try await Self.copyImportedAsset(automaticAssetURL)
+                        : automaticAssetURL
                     guard generation == loadGeneration else {
-                        removeImportedAsset(localURL, reason: "superseded_automatic_import")
+                        if requiresCacheCopy {
+                            removeImportedAsset(localURL, reason: "superseded_automatic_import")
+                        }
                         return
                     }
+                    emit(
+                        "automatic_asset_prepared",
+                        values: ["storage": requiresCacheCopy ? "cache_copy" : "documents_direct"]
+                    )
                     let loaded = await loadAsset(
                         at: localURL,
                         displayName: displayName,
-                        generation: generation
+                        generation: generation,
+                        pendingImportedAsset: requiresCacheCopy
+                            ? PendingImportedAsset(url: localURL, replacedURL: currentImportedURL)
+                            : nil
                     )
-                    if loaded {
-                        currentImportedURL = localURL
-                    } else {
-                        removeImportedAsset(localURL, reason: "automatic_load_failed")
+                    if !loaded && requiresCacheCopy {
+                        discardPendingImportedAsset(
+                            matching: localURL,
+                            reason: "automatic_load_failed"
+                        )
                     }
                 } catch {
                     guard generation == loadGeneration else {
@@ -367,6 +401,10 @@ final class PlaybackProbeModel: ObservableObject {
     }
 
     func importAsset(from sourceURL: URL) {
+        guard canChooseMovie else {
+            return
+        }
+
         loadGeneration += 1
         let requestedGeneration = loadGeneration
         let displayName = sourceURL.lastPathComponent
@@ -395,20 +433,26 @@ final class PlaybackProbeModel: ObservableObject {
                 let loaded = await loadAsset(
                     at: localURL,
                     displayName: displayName,
-                    generation: requestedGeneration
+                    generation: requestedGeneration,
+                    pendingImportedAsset: PendingImportedAsset(
+                        url: localURL,
+                        replacedURL: previousImportedURL
+                    )
                 )
                 guard requestedGeneration == loadGeneration else {
-                    removeImportedAsset(localURL, reason: "superseded_load")
+                    discardPendingImportedAsset(
+                        matching: localURL,
+                        reason: "superseded_load"
+                    )
                     return
                 }
 
-                if loaded {
-                    currentImportedURL = localURL
-                    if let previousImportedURL, previousImportedURL != localURL {
-                        removeImportedAsset(previousImportedURL, reason: "replaced_movie")
-                    }
-                } else {
-                    removeImportedAsset(localURL, reason: "import_load_failed")
+                if !loaded {
+                    restorePreservedPlayerObservation(generation: requestedGeneration)
+                    discardPendingImportedAsset(
+                        matching: localURL,
+                        reason: "import_load_failed"
+                    )
                 }
             } catch {
                 guard requestedGeneration == loadGeneration else {
@@ -419,6 +463,7 @@ final class PlaybackProbeModel: ObservableObject {
                     title: "Movie import failed",
                     message: error.localizedDescription
                 )
+                restorePreservedPlayerObservation(generation: requestedGeneration)
             }
         }
     }
@@ -648,7 +693,12 @@ final class PlaybackProbeModel: ObservableObject {
         emit("subtitle_selected", values: ["name": option?.displayName ?? "Off"])
     }
 
-    private func loadAsset(at url: URL, displayName: String, generation: Int) async -> Bool {
+    private func loadAsset(
+        at url: URL,
+        displayName: String,
+        generation: Int,
+        pendingImportedAsset: PendingImportedAsset?
+    ) async -> Bool {
         guard FileManager.default.fileExists(atPath: url.path) else {
             if generation == loadGeneration {
                 reportLoadFailure(
@@ -661,8 +711,6 @@ final class PlaybackProbeModel: ObservableObject {
         }
 
         isLoading = true
-        independentFrameDecodeSucceeded = false
-        independentFrameDecodeDetail = "not_run"
         let asset = AVURLAsset(url: url)
         let item = AVPlayerItem(asset: asset)
 
@@ -671,14 +719,23 @@ final class PlaybackProbeModel: ObservableObject {
             guard generation == loadGeneration, !Task.isCancelled else {
                 return false
             }
+            emit("asset_load_stage", values: ["stage": "duration_loaded"])
             let videoFormat = try await loadVideoFormat(for: asset)
             guard generation == loadGeneration, !Task.isCancelled else {
                 return false
             }
+            emit("asset_load_stage", values: ["stage": "video_format_loaded"])
             let independentDecodeResult = await Self.decodeFirstVideoFrame(at: url)
             guard generation == loadGeneration, !Task.isCancelled else {
                 return false
             }
+            emit(
+                "asset_load_stage",
+                values: [
+                    "stage": "independent_decode_finished",
+                    "succeeded": String(independentDecodeResult.succeeded),
+                ]
+            )
             let preparedMediaSelections = try await prepareMediaSelections(
                 for: asset,
                 item: item,
@@ -687,14 +744,14 @@ final class PlaybackProbeModel: ObservableObject {
             guard generation == loadGeneration, !Task.isCancelled else {
                 return false
             }
-            let sourceHash = try await PlaybackArtifactHasher.sha256Hex(at: url)
-            guard generation == loadGeneration, !Task.isCancelled else {
-                return false
-            }
+            emit("asset_load_stage", values: ["stage": "media_selections_loaded"])
 
+            fingerprintTask?.cancel()
             validationTask?.cancel()
+            self.pendingImportedAsset = pendingImportedAsset
             failure = nil
             hasLoadedAsset = true
+            assetLoadedEventEmitted = false
             assetName = displayName
             playerItemStatusText = "Loading"
             renderingStatusText = "Loading"
@@ -705,7 +762,8 @@ final class PlaybackProbeModel: ObservableObject {
             currentSeconds = 0
             durationSeconds = duration.seconds.isFinite ? max(0, duration.seconds) : 0
             sourceFileSizeBytes = fileSize(at: url)
-            sourceSHA256 = sourceHash
+            sourceSHA256 = ""
+            sourceFingerprintReady = false
             sourceVideoFormat = videoFormat
             independentFrameDecodeSucceeded = independentDecodeResult.succeeded
             independentFrameDecodeDetail = independentDecodeResult.detail
@@ -723,20 +781,36 @@ final class PlaybackProbeModel: ObservableObject {
             observe(item, generation: generation)
             player.replaceCurrentItem(with: item)
             emit(
-                "asset_loaded",
+                "asset_load_stage",
                 values: [
-                    "file": displayName,
-                    "sha256": sourceHash,
-                    "duration_seconds": formatNumber(durationSeconds),
+                    "stage": "sha256_started",
                     "file_size_bytes": sourceFileSizeBytes.map(String.init) ?? "unknown",
-                    "video_codec": videoFormat.codec.rawValue,
-                    "video_codec_tag": videoFormat.codecTag,
-                    "independent_frame_decode": String(independentDecodeResult.succeeded),
-                    "independent_frame_decode_detail": independentDecodeResult.detail,
-                    "audio_options": String(audioOptions.count),
-                    "subtitle_options": String(max(0, subtitleOptions.count - 1)),
                 ]
             )
+            fingerprintTask = Task { [weak self] in
+                do {
+                    let sourceHash = try await PlaybackArtifactHasher.sha256Hex(at: url)
+                    guard let self, generation == self.loadGeneration, !Task.isCancelled else {
+                        return
+                    }
+                    self.sourceSHA256 = sourceHash
+                    self.sourceFingerprintReady = true
+                    self.emit("asset_load_stage", values: ["stage": "sha256_finished"])
+                    self.markReadyIfPrepared()
+                    self.scheduleAutomatedValidationIfNeeded()
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard let self, generation == self.loadGeneration, !Task.isCancelled else {
+                        return
+                    }
+                    self.setFailure(
+                        category: .transferFailure,
+                        title: "Movie fingerprint could not be created",
+                        message: error.localizedDescription
+                    )
+                }
+            }
         } catch is CancellationError {
             return false
         } catch {
@@ -790,9 +864,6 @@ final class PlaybackProbeModel: ObservableObject {
         case .readyToPlay:
             playerItemStatusText = "Ready to play"
             isLoading = false
-            if validationPhase == .preparing {
-                validationPhase = .ready
-            }
             let assessment = decodeAssessment
             emit(
                 "player_item",
@@ -812,6 +883,7 @@ final class PlaybackProbeModel: ObservableObject {
                     ]
                 )
             }
+            markReadyIfPrepared()
             scheduleAutomatedValidationIfNeeded()
         case .failed:
             setFailure(
@@ -821,6 +893,83 @@ final class PlaybackProbeModel: ObservableObject {
             )
         @unknown default:
             playerItemStatusText = "Unknown"
+        }
+    }
+
+    private func markReadyIfPrepared() {
+        guard validationPhase == .preparing,
+              PlaybackValidationRules.preparationCompleted(
+                  playerReady: player.currentItem?.status == .readyToPlay,
+                  fingerprintReady: sourceFingerprintReady
+              )
+        else {
+            return
+        }
+
+        finalizePendingImportedAsset()
+        validationPhase = .ready
+        if !assetLoadedEventEmitted {
+            assetLoadedEventEmitted = true
+            emit(
+                "asset_loaded",
+                values: [
+                    "file": assetName,
+                    "sha256": sourceSHA256,
+                    "duration_seconds": formatNumber(durationSeconds),
+                    "file_size_bytes": sourceFileSizeBytes.map(String.init) ?? "unknown",
+                    "video_codec": sourceVideoFormat.codec.rawValue,
+                    "video_codec_tag": sourceVideoFormat.codecTag,
+                    "independent_frame_decode": String(independentFrameDecodeSucceeded),
+                    "independent_frame_decode_detail": independentFrameDecodeDetail,
+                    "audio_options": String(audioOptions.count),
+                    "subtitle_options": String(max(0, subtitleOptions.count - 1)),
+                ]
+            )
+        }
+    }
+
+    private func restorePreservedPlayerObservation(generation: Int) {
+        guard hasLoadedAsset,
+              sourceFingerprintReady,
+              let currentItem = player.currentItem
+        else {
+            return
+        }
+
+        observe(currentItem, generation: generation)
+    }
+
+    private func finalizePendingImportedAsset() {
+        guard let pendingImportedAsset else {
+            return
+        }
+
+        self.pendingImportedAsset = nil
+        currentImportedURL = pendingImportedAsset.url
+        if let replacedURL = pendingImportedAsset.replacedURL,
+           replacedURL != pendingImportedAsset.url
+        {
+            removeImportedAsset(replacedURL, reason: "replaced_movie")
+        }
+    }
+
+    private func discardPendingImportedAsset(matching url: URL? = nil, reason: String) {
+        guard let pendingImportedAsset else {
+            if let url {
+                removeImportedAsset(url, reason: reason)
+            }
+            return
+        }
+        guard url == nil || pendingImportedAsset.url == url else {
+            if let url {
+                removeImportedAsset(url, reason: reason)
+            }
+            return
+        }
+
+        self.pendingImportedAsset = nil
+        if pendingImportedAsset.url != currentImportedURL {
+            removeImportedAsset(pendingImportedAsset.url, reason: reason)
         }
     }
 
@@ -1505,11 +1654,9 @@ final class PlaybackProbeModel: ObservableObject {
 
     private func reportLoadFailure(category: ProbeFailureCategory, title: String, message: String) {
         isLoading = false
-        if hasLoadedAsset {
+        if hasLoadedAsset && sourceFingerprintReady {
             failure = ProbeFailure(category: category, title: title, message: message)
-            if validationPhase == .preparing {
-                validationPhase = .ready
-            }
+            markReadyIfPrepared()
             emit(
                 "failure",
                 values: [
@@ -1524,7 +1671,10 @@ final class PlaybackProbeModel: ObservableObject {
     }
 
     private func setFailure(category: ProbeFailureCategory, title: String, message: String) {
+        fingerprintTask?.cancel()
         validationTask?.cancel()
+        let preservedImportedURL = pendingImportedAsset?.replacedURL
+        discardPendingImportedAsset(reason: "failed_movie")
         isLoading = false
         hasLoadedAsset = false
         player.pause()
@@ -1543,6 +1693,8 @@ final class PlaybackProbeModel: ObservableObject {
         requestSpatialPresentation(false)
         sourceFileSizeBytes = nil
         sourceSHA256 = ""
+        sourceFingerprintReady = false
+        assetLoadedEventEmitted = false
         sourceVideoFormat = .unknown
         independentFrameDecodeSucceeded = false
         independentFrameDecodeDetail = "not_run"
@@ -1552,7 +1704,7 @@ final class PlaybackProbeModel: ObservableObject {
         subtitleGroup = nil
         audioSelectionByID.removeAll()
         subtitleSelectionByID.removeAll()
-        if let currentImportedURL {
+        if let currentImportedURL, currentImportedURL != preservedImportedURL {
             removeImportedAsset(currentImportedURL, reason: "failed_movie")
             self.currentImportedURL = nil
         }
@@ -1653,5 +1805,14 @@ final class PlaybackProbeModel: ObservableObject {
             try fileManager.copyItem(at: sourceURL, to: destinationURL)
             return destinationURL
         }.value
+    }
+
+    nonisolated static func requiresAutomaticAssetCacheCopy(
+        sourceURL: URL,
+        documentsURL: URL
+    ) -> Bool {
+        let sourcePath = sourceURL.standardizedFileURL.path
+        let documentsPath = documentsURL.standardizedFileURL.path
+        return sourcePath != documentsPath && !sourcePath.hasPrefix(documentsPath + "/")
     }
 }

--- a/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
@@ -63,7 +63,7 @@ struct PlaybackProbeView: View {
             Button("Choose Movie…") {
                 isImporting = true
             }
-            .disabled(model.validationPhase == .running || model.isLoading)
+            .disabled(!model.canChooseMovie)
             .accessibilityIdentifier("choose-movie-button")
         }
         .padding(.horizontal, 24)
@@ -232,6 +232,7 @@ struct PlaybackProbeView: View {
                 Label("Choose a Movie", systemImage: "folder")
                     .frame(maxWidth: .infinity)
             }
+            .disabled(!model.canChooseMovie)
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
         }
@@ -243,7 +244,7 @@ struct PlaybackProbeView: View {
                 .controlSize(.large)
             Text("Preparing the movie")
                 .font(.title2.bold())
-            Text("The app is preparing a temporary local copy, reading its playback options, and creating a SHA-256 fingerprint. A full-length movie can take several minutes.")
+            Text("The app is reading playback options and creating a full-file SHA-256 fingerprint before checks begin. Files chosen through Files are copied into app storage; transferred Documents files are read in place. A full-length movie can take several minutes.")
                 .foregroundStyle(.secondary)
             assuranceCard
         }

--- a/macos/SpatialPlaybackProbe/PlaybackValidation.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackValidation.swift
@@ -376,6 +376,10 @@ struct PlaybackSustainedEvidence: Equatable {
 }
 
 enum PlaybackValidationRules {
+    static func preparationCompleted(playerReady: Bool, fingerprintReady: Bool) -> Bool {
+        playerReady && fingerprintReady
+    }
+
     static func result(
         checks: [PlaybackCheck],
         observations: PlaybackObservations
@@ -470,8 +474,11 @@ enum PlaybackReportStore {
 }
 
 enum PlaybackArtifactHasher {
+    private static let chunkSizeBytes = 4 * 1_024 * 1_024
+    private static let interChunkDelayNanoseconds: UInt64 = 25_000_000
+
     static func sha256Hex(at url: URL) async throws -> String {
-        try await Task.detached(priority: .utility) {
+        let hashTask = Task.detached(priority: .background) {
             let fileHandle = try FileHandle(forReadingFrom: url)
             defer {
                 try? fileHandle.close()
@@ -482,14 +489,23 @@ enum PlaybackArtifactHasher {
                 if Task.isCancelled {
                     throw CancellationError()
                 }
-                let data = try fileHandle.read(upToCount: 4 * 1_024 * 1_024) ?? Data()
+                let data = try fileHandle.read(upToCount: chunkSizeBytes) ?? Data()
                 if data.isEmpty {
                     break
                 }
                 hasher.update(data: data)
+                if data.count == chunkSizeBytes {
+                    try await Task.sleep(nanoseconds: interChunkDelayNanoseconds)
+                }
             }
 
             return hasher.finalize().map { String(format: "%02x", $0) }.joined()
-        }.value
+        }
+
+        return try await withTaskCancellationHandler {
+            try await hashTask.value
+        } onCancel: {
+            hashTask.cancel()
+        }
     }
 }

--- a/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
+++ b/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
@@ -3,6 +3,44 @@ import XCTest
 @testable import SpatialPlaybackProbe
 
 final class PlaybackValidationTests: XCTestCase {
+    func testPreparationRequiresPlayerAndFingerprint() {
+        XCTAssertFalse(
+            PlaybackValidationRules.preparationCompleted(playerReady: false, fingerprintReady: false)
+        )
+        XCTAssertFalse(
+            PlaybackValidationRules.preparationCompleted(playerReady: true, fingerprintReady: false)
+        )
+        XCTAssertFalse(
+            PlaybackValidationRules.preparationCompleted(playerReady: false, fingerprintReady: true)
+        )
+        XCTAssertTrue(
+            PlaybackValidationRules.preparationCompleted(playerReady: true, fingerprintReady: true)
+        )
+    }
+
+    func testTransferredDocumentMovieDoesNotRequireSecondFullFileCopy() {
+        let documentsURL = URL(fileURLWithPath: "/container/Documents", isDirectory: true)
+
+        XCTAssertFalse(
+            PlaybackProbeModel.requiresAutomaticAssetCacheCopy(
+                sourceURL: documentsURL.appendingPathComponent("Probe.mov"),
+                documentsURL: documentsURL
+            )
+        )
+        XCTAssertFalse(
+            PlaybackProbeModel.requiresAutomaticAssetCacheCopy(
+                sourceURL: documentsURL.appendingPathComponent("Nested/Probe.mov"),
+                documentsURL: documentsURL
+            )
+        )
+        XCTAssertTrue(
+            PlaybackProbeModel.requiresAutomaticAssetCacheCopy(
+                sourceURL: URL(fileURLWithPath: "/external/Probe.mov"),
+                documentsURL: documentsURL
+            )
+        )
+    }
+
     func testPresentationExpectationDefaultsToStereoAndAcceptsSpatialOverride() {
         XCTAssertEqual(PlaybackPresentationExpectation.resolve(environment: [:]), .stereo)
         XCTAssertEqual(
@@ -350,6 +388,28 @@ final class PlaybackValidationTests: XCTestCase {
             digest,
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         )
+    }
+
+    func testArtifactHasherPropagatesCancellation() async throws {
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("playback-validator-cancelled-hash-\(UUID().uuidString).bin")
+        defer {
+            try? FileManager.default.removeItem(at: temporaryURL)
+        }
+        try Data(repeating: 0xA5, count: 5 * 1_024 * 1_024).write(to: temporaryURL)
+
+        let task = Task {
+            try await PlaybackArtifactHasher.sha256Hex(at: temporaryURL)
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected hashing to stop when its caller is cancelled.")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Expected CancellationError, got \(error).")
+        }
     }
 
     func testReportStoreWritesNamedArchiveAndLatestCopy() throws {

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -88,7 +88,7 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 4
+        CURRENT_PROJECT_VERSION: 9
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: SpatialPlaybackProbe/Info.plist
         MARKETING_VERSION: 0.2.0


### PR DESCRIPTION
## Summary
- validate `Documents/Probe.mov` in place so 20+ GB physical-device fixtures are not duplicated into Cache
- move full-file SHA-256 work to a cooperative background task with cancellation propagation and explicit readiness gating
- make cached movie replacement transactional so prior cache deletion occurs only after the new player and fingerprint are ready
- document the large-file preparing state and add cancellation/readiness coverage

## Validation
- `uv run python -m scripts.release validate`
- `uv run python scripts/validate_observability_migration.py`
- `uv run python scripts/validate_video_quality_ladder.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` — 1,202 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 323 passed
- `xcodebuild test -project macos/BluRayToVisionPro.xcodeproj -scheme SpatialPlaybackProbe -destination 'platform=visionOS Simulator,name=Apple Vision Pro' -derivedDataPath macos/build/SpatialPlaybackProbeTestsDerivedData CODE_SIGNING_ALLOWED=NO` — 15 unit tests passed; simulator UI test passed; physical-only UI test skipped
- JetBrains changed-files closeout — clean

## Physical Vision Pro evidence
Probe `0.2.0 (9)`, Apple Development CDHash `d52b490e2f533ac7b4dc6f89b211a1ee78686a9c2e531a89150f24182f6806c0`, on `RealityDevice14,1`, visionOS 27.0 (24M5326g):

- q0.40, 1,658,647,203 bytes, SHA-256 `0f9f7d45e240a59d8e95187aa5ac108428ea93b9239b139962580d3872eca25c` — automatic pass
- q0.70, 5,548,367,349 bytes, SHA-256 `3b1e277ecdd251f633ca1bce331c5d97c4c8af6de4f0d64d6561a12aad565ad6` — automatic pass
- q0.85, 21,830,584,441 bytes, SHA-256 `86f127c2dd681a96a6c64da77551a9ed08e8636c63aaa207fd4968c50485f03c` — automatic pass

All three verified exact device bytes, hardware HEVC decode, stereo rendering, beginning/middle/end seeks, at least 30 seconds sustained playback, and nominal thermal state. Private immutable receipt SHA-256: `343eabd5637ec6e2f59310d2c26314293d26d48b5dfed4d8c1db80dce10242a6`.

This is automatic development-probe evidence, not production-signed package evidence. Wearer confirmation of visible corruption, perceived depth, eye order/depth direction, lip sync, and surround placement remains required for #419.

Refs #419
