### PR TITLE
Add checked generated MV-HEVC collapse analysis

### DIFF
--- a/docs/qualification/generated-mv-hevc-collapse-analysis-v1.json
+++ b/docs/qualification/generated-mv-hevc-collapse-analysis-v1.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "analysis_id": "generated-mv-hevc-collapse-analysis-v1",
+  "source_receipt": {
+    "schema_version": 1,
+    "experiment_id": "generated-mv-hevc-merge-refinement-v1",
+    "sha256": "e6b4d5a8908352f1667c092e199853f3cfc25256f22d803e56f94b30783dcbdf",
+    "source_git_sha": "1a3b2c3b25351a9f981bf7bd65415bd8f5688f85",
+    "required_file_mode": "0444"
+  },
+  "source_plan": {
+    "path": "docs/qualification/generated-mv-hevc-merge-refinement-v1.json",
+    "sha256": "a2dabc8afc72356e67f40ef9416a087103db3674cb12359fd8632959f5bee5d4",
+    "schema_version": 2
+  },
+  "balanced_required": {
+    "cell_id": "b020-m075",
+    "eye_bitrate_mbps": 20,
+    "merge_quality": 75
+  },
+  "candidate_policy": {
+    "use_only_technically_eligible_cells": true,
+    "require_balanced_cell": true,
+    "boundary_quality_threshold": "pre_registered_thresholds.aggregate_quality_distinguishability",
+    "boundary_storage_threshold": "pre_registered_thresholds.storage_distinguishability_ratio",
+    "every_case_required": true,
+    "non_adjacent_boundaries_allowed": true,
+    "no_new_encodes": true,
+    "ladder_mapping_selected": false
+  },
+  "selection_policy": {
+    "primary": "maximum_cardinality_ordered_subset",
+    "tie_breaks": [
+      "wider_minimum_case_storage_coverage",
+      "larger_minimum_boundary_quality_margin",
+      "larger_minimum_boundary_storage_margin",
+      "lower_first_merge_quality",
+      "lexicographic_cell_ids"
+    ],
+    "target_named_step_count": 7
+  }
+}

--- a/docs/video-quality-ladder-calibration.md
+++ b/docs/video-quality-ladder-calibration.md
@@ -143,6 +143,33 @@ pre-registered per-case quality and storage thresholds. It exits `1` with a comp
 must be collapsed or escalated to blinded review, when no cell remains technically eligible, or when only a subset
 was run. Fatal identity, source, tool, privacy, or evidence errors exit `2`.
 
+## Generated Collapse Analysis
+
+`docs/qualification/generated-mv-hevc-collapse-analysis-v1.json` binds the completed refinement receipt and its
+source plan by SHA-256. `scripts/qualify_generated_mv_hevc_collapse.py` performs no encoding and cannot modify the
+ladder. It verifies the frozen read-only source receipt, unchanged thresholds, source Git and plan identities,
+successful refinement gates, technically eligible cells, and production `Balanced = 20/75` before analysis.
+
+The analyzer evaluates every ordered boundary between technically eligible cells, including wider non-adjacent
+boundaries, with the same pre-registered every-case quality and storage thresholds. This is a collapse operation over
+existing measurements, not a new threshold search: skipped interior cells are not promoted or reclassified. It then
+selects the maximum-cardinality ordered subset containing `Balanced`. Deterministic ties prefer wider guaranteed
+storage coverage, larger minimum quality and storage margins, a lower first merge quality, then lexicographic cell
+IDs.
+
+Run the checked analysis from a clean commit with:
+
+```bash
+uv run python scripts/qualify_generated_mv_hevc_collapse.py \
+  --source-receipt /private/generated-mv-hevc-merge-refinement-receipt.json \
+  --output build/qualification/generated-mv-hevc-collapse-analysis-v1.json
+```
+
+The output records every evaluated boundary and valid subset but never records the private source path. It exits `0`
+only if seven technically defensible cells survive. It exits `1` with a frozen immutable receipt when fewer survive,
+setting `product_decision_required` and leaving bitrate search and ladder selection false. Fatal provenance, schema,
+privacy, threshold, Balanced, or evidence inconsistencies exit `2`.
+
 ## Validation
 
 Run the structural and production-anchor check with:

--- a/scripts/qualify_generated_mv_hevc_collapse.py
+++ b/scripts/qualify_generated_mv_hevc_collapse.py
@@ -1,0 +1,815 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import math
+import os
+import stat
+import statistics
+import subprocess
+import sys
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from itertools import combinations, pairwise
+from pathlib import Path
+from typing import Iterator, Mapping, Sequence
+
+from scripts.qualify_direct_mv_hevc import QualificationFailure
+from scripts.qualify_generated_mv_hevc_calibration import (
+    REPOSITORY_ROOT,
+    _assert_private_values_absent,
+    _atomic_write,
+    _freeze_receipt,
+    _git_head_from_clean_worktree,
+    _require_head_tracked_file,
+)
+
+
+DEFAULT_ANALYSIS_PLAN = REPOSITORY_ROOT / "docs/qualification/generated-mv-hevc-collapse-analysis-v1.json"
+OUTPUT_SCHEMA_VERSION = 1
+LOCK_SUFFIX = ".bd-to-avp-generated-mv-hevc-collapse.lock"
+EXPECTED_TIE_BREAKS = (
+    "wider_minimum_case_storage_coverage",
+    "larger_minimum_boundary_quality_margin",
+    "larger_minimum_boundary_storage_margin",
+    "lower_first_merge_quality",
+    "lexicographic_cell_ids",
+)
+
+
+@dataclass(frozen=True)
+class SourceReceiptBinding:
+    schema_version: int
+    experiment_id: str
+    sha256: str
+    source_git_sha: str
+    required_file_mode: int
+
+
+@dataclass(frozen=True)
+class SourcePlanBinding:
+    path: Path
+    sha256: str
+    schema_version: int
+
+
+@dataclass(frozen=True)
+class BalancedRequirement:
+    cell_id: str
+    eye_bitrate_mbps: int
+    merge_quality: int
+
+
+@dataclass(frozen=True)
+class SourceCorpusBinding:
+    path: Path
+    sha256: str
+    binding_id: str
+    selected_case_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CollapsePlan:
+    analysis_id: str
+    source_receipt: SourceReceiptBinding
+    source_plan: SourcePlanBinding
+    balanced: BalancedRequirement
+    target_named_step_count: int
+    relative_path: str | None = None
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise QualificationFailure(f"{label} must be an object.")
+    return value
+
+
+def _array(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise QualificationFailure(f"{label} must be an array.")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise QualificationFailure(f"{label} must be a non-empty string.")
+    return value.strip()
+
+
+def _integer(value: object, label: str, *, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise QualificationFailure(f"{label} must be an integer between {minimum} and {maximum}.")
+    return value
+
+
+def _number(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise QualificationFailure(f"{label} must be numeric.")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise QualificationFailure(f"{label} must be finite.")
+    return parsed
+
+
+def _sha256_identity(value: object, label: str) -> str:
+    digest = _string(value, label)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise QualificationFailure(f"{label} must be a lowercase SHA-256 identity.")
+    return digest
+
+
+def _git_sha_identity(value: object, label: str) -> str:
+    digest = _string(value, label)
+    if len(digest) != 40 or any(character not in "0123456789abcdef" for character in digest):
+        raise QualificationFailure(f"{label} must be a lowercase full Git SHA.")
+    return digest
+
+
+def _repository_path(value: object, label: str) -> Path:
+    relative_path = _string(value, label)
+    path = (REPOSITORY_ROOT / relative_path).resolve()
+    try:
+        path.relative_to(REPOSITORY_ROOT)
+    except ValueError as error:
+        raise QualificationFailure(f"{label} escapes the repository.") from error
+    return path
+
+
+def _strict_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise QualificationFailure(f"JSON contains duplicate key: {key}")
+        document[key] = value
+    return document
+
+
+def _loads_json(data: bytes, label: str) -> Mapping[str, object]:
+    try:
+        return _mapping(
+            json.loads(data.decode("utf-8"), object_pairs_hook=_strict_object),
+            label,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationFailure(f"Could not parse {label}.") from error
+
+
+def parse_analysis_plan(raw: object) -> CollapsePlan:
+    document = _mapping(raw, "collapse analysis plan")
+    if document.get("schema_version") != 1:
+        raise QualificationFailure("collapse analysis plan schema_version must be 1.")
+    analysis_id = _string(document.get("analysis_id"), "analysis_id")
+    if analysis_id != "generated-mv-hevc-collapse-analysis-v1":
+        raise QualificationFailure("collapse analysis_id is unsupported.")
+
+    source_receipt = _mapping(document.get("source_receipt"), "source_receipt")
+    mode_value = _string(source_receipt.get("required_file_mode"), "source_receipt.required_file_mode")
+    if mode_value != "0444":
+        raise QualificationFailure("source_receipt.required_file_mode must be '0444'.")
+    receipt_binding = SourceReceiptBinding(
+        schema_version=_integer(
+            source_receipt.get("schema_version"),
+            "source_receipt.schema_version",
+            minimum=1,
+            maximum=1,
+        ),
+        experiment_id=_string(source_receipt.get("experiment_id"), "source_receipt.experiment_id"),
+        sha256=_sha256_identity(source_receipt.get("sha256"), "source_receipt.sha256"),
+        source_git_sha=_git_sha_identity(source_receipt.get("source_git_sha"), "source_receipt.source_git_sha"),
+        required_file_mode=0o444,
+    )
+    if receipt_binding.experiment_id != "generated-mv-hevc-merge-refinement-v1":
+        raise QualificationFailure("source_receipt.experiment_id is unsupported.")
+
+    source_plan = _mapping(document.get("source_plan"), "source_plan")
+    plan_binding = SourcePlanBinding(
+        path=_repository_path(source_plan.get("path"), "source_plan.path"),
+        sha256=_sha256_identity(source_plan.get("sha256"), "source_plan.sha256"),
+        schema_version=_integer(source_plan.get("schema_version"), "source_plan.schema_version", minimum=2, maximum=2),
+    )
+
+    balanced = _mapping(document.get("balanced_required"), "balanced_required")
+    balanced_requirement = BalancedRequirement(
+        cell_id=_string(balanced.get("cell_id"), "balanced_required.cell_id"),
+        eye_bitrate_mbps=_integer(
+            balanced.get("eye_bitrate_mbps"),
+            "balanced_required.eye_bitrate_mbps",
+            minimum=1,
+            maximum=500,
+        ),
+        merge_quality=_integer(
+            balanced.get("merge_quality"),
+            "balanced_required.merge_quality",
+            minimum=0,
+            maximum=100,
+        ),
+    )
+    if balanced_requirement != BalancedRequirement("b020-m075", 20, 75):
+        raise QualificationFailure("balanced_required must identify production Balanced 20/75.")
+
+    candidate_policy = _mapping(document.get("candidate_policy"), "candidate_policy")
+    required_candidate_policy = {
+        "use_only_technically_eligible_cells": True,
+        "require_balanced_cell": True,
+        "boundary_quality_threshold": "pre_registered_thresholds.aggregate_quality_distinguishability",
+        "boundary_storage_threshold": "pre_registered_thresholds.storage_distinguishability_ratio",
+        "every_case_required": True,
+        "non_adjacent_boundaries_allowed": True,
+        "no_new_encodes": True,
+        "ladder_mapping_selected": False,
+    }
+    if dict(candidate_policy) != required_candidate_policy:
+        raise QualificationFailure("candidate_policy does not match the checked collapse contract.")
+
+    selection_policy = _mapping(document.get("selection_policy"), "selection_policy")
+    if selection_policy.get("primary") != "maximum_cardinality_ordered_subset":
+        raise QualificationFailure("selection_policy.primary is unsupported.")
+    tie_breaks = tuple(
+        _string(item, "selection_policy.tie_breaks value")
+        for item in _array(selection_policy.get("tie_breaks"), "selection_policy.tie_breaks")
+    )
+    if tie_breaks != EXPECTED_TIE_BREAKS:
+        raise QualificationFailure("selection_policy.tie_breaks do not match the checked order.")
+    target_named_step_count = _integer(
+        selection_policy.get("target_named_step_count"),
+        "selection_policy.target_named_step_count",
+        minimum=2,
+        maximum=20,
+    )
+    if target_named_step_count != 7:
+        raise QualificationFailure("selection_policy.target_named_step_count must remain 7.")
+    return CollapsePlan(
+        analysis_id=analysis_id,
+        source_receipt=receipt_binding,
+        source_plan=plan_binding,
+        balanced=balanced_requirement,
+        target_named_step_count=target_named_step_count,
+    )
+
+
+def load_analysis_plan(path: Path) -> tuple[CollapsePlan, str]:
+    resolved = path.resolve()
+    try:
+        relative_path = resolved.relative_to(REPOSITORY_ROOT).as_posix()
+    except ValueError as error:
+        raise QualificationFailure("Collapse analysis plan must be inside the repository.") from error
+    try:
+        data = resolved.read_bytes()
+    except OSError as error:
+        raise QualificationFailure(f"Could not read collapse analysis plan: {error}") from error
+    raw = _loads_json(data, "collapse analysis plan")
+    parsed = parse_analysis_plan(raw)
+    return CollapsePlan(
+        analysis_id=parsed.analysis_id,
+        source_receipt=parsed.source_receipt,
+        source_plan=parsed.source_plan,
+        balanced=parsed.balanced,
+        target_named_step_count=parsed.target_named_step_count,
+        relative_path=relative_path,
+    ), hashlib.sha256(data).hexdigest()
+
+
+def _load_source_plan(plan: CollapsePlan) -> Mapping[str, object]:
+    path = plan.source_plan.path
+    if not path.is_file():
+        raise QualificationFailure("The source refinement plan is unavailable.")
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        raise QualificationFailure("Could not read the source refinement plan.") from error
+    if hashlib.sha256(data).hexdigest() != plan.source_plan.sha256:
+        raise QualificationFailure("The source refinement plan does not match its pinned SHA-256 identity.")
+    document = _loads_json(data, "source refinement plan")
+    if document.get("schema_version") != plan.source_plan.schema_version:
+        raise QualificationFailure("The source refinement plan schema does not match the collapse plan.")
+    if document.get("experiment_id") != plan.source_receipt.experiment_id:
+        raise QualificationFailure("The source refinement plan experiment ID is inconsistent.")
+    if document.get("target_id") != "generated_mv_hevc":
+        raise QualificationFailure("The source refinement plan target is inconsistent.")
+    balanced = _mapping(document.get("balanced"), "source refinement plan balanced")
+    if (
+        balanced.get("eye_bitrate_mbps") != plan.balanced.eye_bitrate_mbps
+        or balanced.get("merge_quality") != plan.balanced.merge_quality
+    ):
+        raise QualificationFailure("The source refinement plan Balanced cell is inconsistent.")
+    decision_policy = _mapping(document.get("decision_policy"), "source refinement plan decision_policy")
+    if (
+        decision_policy.get("stage") != "merge_response_refinement_only"
+        or decision_policy.get("ladder_mapping_selected") is not False
+    ):
+        raise QualificationFailure("The source refinement plan decision policy is inconsistent.")
+    _mapping(document.get("pre_registered_thresholds"), "source refinement plan thresholds")
+    return document
+
+
+def _load_source_corpus_binding(source_plan: Mapping[str, object]) -> SourceCorpusBinding:
+    reference = _mapping(source_plan.get("corpus_binding"), "source refinement corpus_binding")
+    path = _repository_path(reference.get("path"), "source refinement corpus_binding.path")
+    expected_sha256 = _sha256_identity(
+        reference.get("sha256"),
+        "source refinement corpus_binding.sha256",
+    )
+    expected_binding_id = _string(
+        reference.get("binding_id"),
+        "source refinement corpus_binding.binding_id",
+    )
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        raise QualificationFailure("Could not read the source corpus binding.") from error
+    if hashlib.sha256(data).hexdigest() != expected_sha256:
+        raise QualificationFailure("The source corpus binding does not match its pinned SHA-256 identity.")
+    document = _loads_json(data, "source corpus binding")
+    if document.get("binding_id") != expected_binding_id:
+        raise QualificationFailure("The source corpus binding ID is inconsistent.")
+    selected_case_ids = tuple(
+        _string(value, "source corpus selected_case_ids value")
+        for value in _array(document.get("selected_case_ids"), "source corpus selected_case_ids")
+    )
+    if not selected_case_ids or len(set(selected_case_ids)) != len(selected_case_ids):
+        raise QualificationFailure("The source corpus selected case IDs are invalid.")
+    return SourceCorpusBinding(
+        path=path,
+        sha256=expected_sha256,
+        binding_id=expected_binding_id,
+        selected_case_ids=selected_case_ids,
+    )
+
+
+def _cell_id(eye_bitrate_mbps: int, merge_quality: int) -> str:
+    return f"b{eye_bitrate_mbps:03d}-m{merge_quality:03d}"
+
+
+def _validate_source_receipt(
+    plan: CollapsePlan,
+    receipt: Mapping[str, object],
+    source_plan: Mapping[str, object],
+    source_binding: SourceCorpusBinding,
+) -> tuple[list[dict[str, object]], list[str], list[Mapping[str, object]], Mapping[str, object]]:
+    if receipt.get("schema_version") != plan.source_receipt.schema_version:
+        raise QualificationFailure("The source refinement receipt schema is unsupported.")
+    if (
+        receipt.get("experiment_id") != plan.source_receipt.experiment_id
+        or receipt.get("source_git_sha") != plan.source_receipt.source_git_sha
+        or receipt.get("source_tree_dirty") is not False
+    ):
+        raise QualificationFailure("The source refinement receipt identity is inconsistent.")
+    experiment_plan = _mapping(receipt.get("experiment_plan"), "source receipt experiment_plan")
+    expected_plan_path = plan.source_plan.path.relative_to(REPOSITORY_ROOT).as_posix()
+    if experiment_plan != {"path": expected_plan_path, "sha256": plan.source_plan.sha256}:
+        raise QualificationFailure("The source receipt refinement plan identity is inconsistent.")
+    receipt_binding = _mapping(receipt.get("corpus_binding"), "source receipt corpus_binding")
+    expected_binding_path = source_binding.path.relative_to(REPOSITORY_ROOT).as_posix()
+    if receipt_binding != {
+        "path": expected_binding_path,
+        "binding_id": source_binding.binding_id,
+        "sha256": source_binding.sha256,
+    }:
+        raise QualificationFailure("The source receipt corpus binding identity is inconsistent.")
+
+    source_thresholds = _mapping(source_plan.get("pre_registered_thresholds"), "source plan thresholds")
+    receipt_thresholds = _mapping(receipt.get("pre_registered_thresholds"), "source receipt thresholds")
+    method = _mapping(receipt.get("method"), "source receipt method")
+    method_thresholds = _mapping(method.get("pre_registered_thresholds"), "source receipt method thresholds")
+    if receipt_thresholds != source_thresholds or method_thresholds != source_thresholds:
+        raise QualificationFailure("The source receipt thresholds differ from the checked refinement plan.")
+    if method.get("decision_stage") != "merge_response_refinement_only":
+        raise QualificationFailure("The source receipt decision stage is inconsistent.")
+    method_balanced = _mapping(method.get("balanced"), "source receipt method balanced")
+    if method_balanced != {
+        "eye_bitrate_mbps": plan.balanced.eye_bitrate_mbps,
+        "merge_quality": plan.balanced.merge_quality,
+    }:
+        raise QualificationFailure("The source receipt method Balanced cell is inconsistent.")
+
+    acceptance = _mapping(receipt.get("acceptance"), "source receipt acceptance")
+    for key in (
+        "complete",
+        "experiment_complete",
+        "execution_passed",
+        "objective_validation_passed",
+        "eye_order_passed",
+        "planned_stress_corpus",
+        "thresholds_pre_registered",
+        "thresholds_evaluated",
+        "refinement_evidence_ready",
+    ):
+        if acceptance.get(key) is not True:
+            raise QualificationFailure(f"The source receipt acceptance gate {key} did not pass.")
+    for key in ("refinement_decision_ready", "ladder_evidence_ready", "ladder_mapping_selected"):
+        if acceptance.get(key) is not False:
+            raise QualificationFailure(f"The source receipt acceptance gate {key} must remain false.")
+    if (
+        _integer(
+            acceptance.get("ambiguous_adjacent_count"), "acceptance.ambiguous_adjacent_count", minimum=1, maximum=100
+        )
+        < 1
+    ):
+        raise QualificationFailure("The source receipt does not require collapse analysis.")
+
+    source_axes = _mapping(source_plan.get("axes"), "source refinement plan axes")
+    eye_bitrates = _array(source_axes.get("eye_bitrate_mbps"), "source refinement eye bitrate axis")
+    merge_qualities = [
+        _integer(value, "merge quality", minimum=0, maximum=100)
+        for value in _array(source_axes.get("merge_quality"), "source refinement merge-quality axis")
+    ]
+    if eye_bitrates != [plan.balanced.eye_bitrate_mbps]:
+        raise QualificationFailure("The source refinement eye-bitrate axis is inconsistent.")
+    expected_cells = [
+        {
+            "id": _cell_id(plan.balanced.eye_bitrate_mbps, value),
+            "eye_bitrate_mbps": plan.balanced.eye_bitrate_mbps,
+            "merge_quality": value,
+        }
+        for value in merge_qualities
+    ]
+    cells = _array(receipt.get("cells"), "source receipt cells")
+    if cells != expected_cells:
+        raise QualificationFailure("The source receipt cell order differs from the checked refinement plan.")
+
+    raw_evaluations = _array(receipt.get("refinement_cell_evaluations"), "source receipt cell evaluations")
+    evaluations = [_mapping(value, "source receipt cell evaluation") for value in raw_evaluations]
+    if len(evaluations) != len(expected_cells):
+        raise QualificationFailure("The source receipt cell evaluation set is incomplete.")
+    evaluation_by_id: dict[str, Mapping[str, object]] = {}
+    for evaluation in evaluations:
+        cell_id = _string(evaluation.get("cell_id"), "cell evaluation cell_id")
+        if cell_id in evaluation_by_id or evaluation.get("complete") is not True:
+            raise QualificationFailure("The source receipt contains invalid cell evaluations.")
+        evaluation_by_id[cell_id] = evaluation
+    if set(evaluation_by_id) != {str(cell["id"]) for cell in expected_cells}:
+        raise QualificationFailure("The source receipt cell evaluations do not match the checked cells.")
+    eligible_ids = [
+        str(cell["id"])
+        for cell in expected_cells
+        if evaluation_by_id[str(cell["id"])].get("candidate_constraints_passed") is True
+    ]
+    if len(eligible_ids) != acceptance.get("technically_eligible_cell_count"):
+        raise QualificationFailure("The source receipt eligible-cell count is inconsistent.")
+    if plan.balanced.cell_id not in eligible_ids:
+        raise QualificationFailure("Production Balanced is not technically eligible in the source receipt.")
+
+    selected_case_ids = [
+        _string(value, "selected_case_ids value")
+        for value in _array(receipt.get("selected_case_ids"), "source receipt selected_case_ids")
+    ]
+    if tuple(selected_case_ids) != source_binding.selected_case_ids:
+        raise QualificationFailure("The source receipt case IDs differ from the checked corpus binding.")
+    cases = [_mapping(value, "source receipt case") for value in _array(receipt.get("cases"), "source receipt cases")]
+    if [case.get("id") for case in cases] != selected_case_ids:
+        raise QualificationFailure("The source receipt case order is inconsistent.")
+    for case in cases:
+        case_cells = _array(case.get("cells"), "source receipt case cells")
+        case_cell_ids = [
+            _string(_mapping(cell, "source receipt case cell").get("id"), "source receipt case cell id")
+            for cell in case_cells
+        ]
+        if case_cell_ids != [str(cell["id"]) for cell in expected_cells]:
+            raise QualificationFailure("A source receipt case has an inconsistent cell set.")
+        for raw_cell in case_cells:
+            summary = _mapping(_mapping(raw_cell, "source receipt case cell").get("summary"), "cell summary")
+            _number(summary.get("median_min_same_eye_ssim"), "median_min_same_eye_ssim")
+            median_final_bytes = _number(summary.get("median_final_bytes"), "median_final_bytes")
+            if median_final_bytes <= 0:
+                raise QualificationFailure("median_final_bytes must be positive.")
+    return expected_cells, eligible_ids, cases, source_thresholds
+
+
+def _load_source_receipt(
+    plan: CollapsePlan,
+    receipt_path: Path,
+    source_plan: Mapping[str, object],
+    source_binding: SourceCorpusBinding,
+) -> tuple[Mapping[str, object], list[dict[str, object]], list[str], list[Mapping[str, object]], Mapping[str, object]]:
+    resolved = receipt_path.resolve()
+    if receipt_path.is_symlink():
+        raise QualificationFailure("The source refinement receipt is unavailable or unsafe.")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(resolved, flags)
+    except OSError as error:
+        raise QualificationFailure("The source refinement receipt is unavailable or unsafe.") from error
+    with os.fdopen(descriptor, "rb") as receipt_file:
+        receipt_stat = os.fstat(receipt_file.fileno())
+        if not stat.S_ISREG(receipt_stat.st_mode):
+            raise QualificationFailure("The source refinement receipt is not a regular file.")
+        data = receipt_file.read()
+    if stat.S_IMODE(receipt_stat.st_mode) != plan.source_receipt.required_file_mode:
+        raise QualificationFailure("The source refinement receipt must be frozen read-only.")
+    if hashlib.sha256(data).hexdigest() != plan.source_receipt.sha256:
+        raise QualificationFailure("The source refinement receipt does not match its pinned SHA-256 identity.")
+    receipt = _loads_json(data, "source refinement receipt")
+    _assert_private_values_absent(receipt, ())
+    cells, eligible_ids, cases, thresholds = _validate_source_receipt(
+        plan,
+        receipt,
+        source_plan,
+        source_binding,
+    )
+    return receipt, cells, eligible_ids, cases, thresholds
+
+
+def _case_cell_summary(case: Mapping[str, object], cell_id: str) -> Mapping[str, object]:
+    for raw_cell in _array(case.get("cells"), "source receipt case cells"):
+        cell = _mapping(raw_cell, "source receipt case cell")
+        if cell.get("id") == cell_id:
+            return _mapping(cell.get("summary"), "source receipt cell summary")
+    raise QualificationFailure(f"Source receipt case is missing cell {cell_id}.")
+
+
+def evaluate_boundaries(
+    cells: Sequence[Mapping[str, object]],
+    eligible_ids: Sequence[str],
+    cases: Sequence[Mapping[str, object]],
+    thresholds: Mapping[str, object],
+) -> list[dict[str, object]]:
+    quality_threshold = _number(
+        thresholds.get("aggregate_quality_distinguishability"),
+        "aggregate quality distinguishability threshold",
+    )
+    storage_threshold = _number(
+        thresholds.get("storage_distinguishability_ratio"),
+        "storage distinguishability threshold",
+    )
+    cell_by_id = {str(cell["id"]): cell for cell in cells}
+    boundaries: list[dict[str, object]] = []
+    for lower_id, higher_id in combinations(eligible_ids, 2):
+        lower = cell_by_id[lower_id]
+        higher = cell_by_id[higher_id]
+        if int(lower["merge_quality"]) >= int(higher["merge_quality"]):
+            raise QualificationFailure("Eligible cells are not strictly ordered by merge quality.")
+        case_evaluations: list[dict[str, object]] = []
+        for case in cases:
+            lower_summary = _case_cell_summary(case, lower_id)
+            higher_summary = _case_cell_summary(case, higher_id)
+            quality_separation = _number(
+                higher_summary.get("median_min_same_eye_ssim"),
+                "higher median_min_same_eye_ssim",
+            ) - _number(lower_summary.get("median_min_same_eye_ssim"), "lower median_min_same_eye_ssim")
+            lower_bytes = _number(lower_summary.get("median_final_bytes"), "lower median_final_bytes")
+            higher_bytes = _number(higher_summary.get("median_final_bytes"), "higher median_final_bytes")
+            storage_growth_ratio = higher_bytes / lower_bytes - 1.0
+            case_evaluations.append(
+                {
+                    "case_id": case["id"],
+                    "quality_separation": quality_separation,
+                    "storage_growth_ratio": storage_growth_ratio,
+                    "quality_distinct": quality_separation >= quality_threshold,
+                    "storage_distinct": storage_growth_ratio >= storage_threshold,
+                }
+            )
+        minimum_quality_separation = min(float(item["quality_separation"]) for item in case_evaluations)
+        minimum_storage_growth_ratio = min(float(item["storage_growth_ratio"]) for item in case_evaluations)
+        quality_distinct = all(item["quality_distinct"] is True for item in case_evaluations)
+        storage_distinct = all(item["storage_distinct"] is True for item in case_evaluations)
+        boundaries.append(
+            {
+                "lower_cell_id": lower_id,
+                "higher_cell_id": higher_id,
+                "case_evaluations": case_evaluations,
+                "minimum_quality_separation": minimum_quality_separation,
+                "median_quality_separation": statistics.median(
+                    float(item["quality_separation"]) for item in case_evaluations
+                ),
+                "minimum_storage_growth_ratio": minimum_storage_growth_ratio,
+                "median_storage_growth_ratio": statistics.median(
+                    float(item["storage_growth_ratio"]) for item in case_evaluations
+                ),
+                "minimum_quality_margin": minimum_quality_separation - quality_threshold,
+                "minimum_storage_margin": minimum_storage_growth_ratio - storage_threshold,
+                "quality_distinct": quality_distinct,
+                "storage_distinct": storage_distinct,
+                "response_separable": quality_distinct and storage_distinct,
+            }
+        )
+    return boundaries
+
+
+def select_collapsed_subset(
+    cells: Sequence[Mapping[str, object]],
+    eligible_ids: Sequence[str],
+    boundaries: Sequence[Mapping[str, object]],
+    balanced_cell_id: str,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    if balanced_cell_id not in eligible_ids:
+        raise QualificationFailure("Balanced is absent from the eligible collapse candidates.")
+    cell_by_id = {str(cell["id"]): cell for cell in cells}
+    boundary_by_pair = {
+        (str(boundary["lower_cell_id"]), str(boundary["higher_cell_id"])): boundary for boundary in boundaries
+    }
+    valid_subsets: list[dict[str, object]] = []
+    for subset_size in range(1, len(eligible_ids) + 1):
+        for candidate_tuple in combinations(eligible_ids, subset_size):
+            if balanced_cell_id not in candidate_tuple:
+                continue
+            successive = [boundary_by_pair[pair] for pair in pairwise(candidate_tuple)]
+            if not all(boundary.get("response_separable") is True for boundary in successive):
+                continue
+            if len(candidate_tuple) > 1:
+                coverage_boundary = boundary_by_pair[(candidate_tuple[0], candidate_tuple[-1])]
+                storage_coverage = float(coverage_boundary["minimum_storage_growth_ratio"])
+                minimum_quality_margin = min(float(boundary["minimum_quality_margin"]) for boundary in successive)
+                minimum_storage_margin = min(float(boundary["minimum_storage_margin"]) for boundary in successive)
+            else:
+                storage_coverage = 0.0
+                minimum_quality_margin = 0.0
+                minimum_storage_margin = 0.0
+            valid_subsets.append(
+                {
+                    "cell_ids": list(candidate_tuple),
+                    "cardinality": len(candidate_tuple),
+                    "minimum_case_storage_coverage": storage_coverage,
+                    "minimum_boundary_quality_margin": minimum_quality_margin,
+                    "minimum_boundary_storage_margin": minimum_storage_margin,
+                    "first_merge_quality": int(cell_by_id[candidate_tuple[0]]["merge_quality"]),
+                }
+            )
+    if not valid_subsets:
+        raise QualificationFailure("No valid collapsed subset contains production Balanced.")
+    valid_subsets.sort(
+        key=lambda subset: (
+            -int(subset["cardinality"]),
+            -float(subset["minimum_case_storage_coverage"]),
+            -float(subset["minimum_boundary_quality_margin"]),
+            -float(subset["minimum_boundary_storage_margin"]),
+            int(subset["first_merge_quality"]),
+            tuple(str(cell_id) for cell_id in subset["cell_ids"]),
+        )
+    )
+    selected = dict(valid_subsets[0])
+    selected["contains_balanced"] = balanced_cell_id in selected["cell_ids"]
+    selected["selection_policy"] = {
+        "primary": "maximum_cardinality_ordered_subset",
+        "tie_breaks": list(EXPECTED_TIE_BREAKS),
+    }
+    return selected, valid_subsets
+
+
+def build_analysis_receipt(
+    plan: CollapsePlan,
+    plan_sha256: str,
+    analyzer_git_sha: str,
+    source_binding: SourceCorpusBinding,
+    cells: Sequence[Mapping[str, object]],
+    eligible_ids: Sequence[str],
+    thresholds: Mapping[str, object],
+    boundaries: Sequence[Mapping[str, object]],
+    selected: Mapping[str, object],
+    valid_subsets: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    if plan.relative_path is None:
+        raise QualificationFailure("Collapse analysis plan is not repository-bound.")
+    target_met = int(selected["cardinality"]) >= plan.target_named_step_count
+    cell_by_id = {str(cell["id"]): cell for cell in cells}
+    return {
+        "schema_version": OUTPUT_SCHEMA_VERSION,
+        "analysis_id": plan.analysis_id,
+        "created_at": datetime.now(UTC).isoformat(),
+        "analysis_source_git_sha": analyzer_git_sha,
+        "analysis_source_tree_dirty": False,
+        "analysis_plan": {"path": plan.relative_path, "sha256": plan_sha256},
+        "source_receipt": {
+            "schema_version": plan.source_receipt.schema_version,
+            "experiment_id": plan.source_receipt.experiment_id,
+            "sha256": plan.source_receipt.sha256,
+            "source_git_sha": plan.source_receipt.source_git_sha,
+            "file_mode": "0444",
+        },
+        "source_plan": {
+            "path": plan.source_plan.path.relative_to(REPOSITORY_ROOT).as_posix(),
+            "sha256": plan.source_plan.sha256,
+            "schema_version": plan.source_plan.schema_version,
+        },
+        "source_corpus_binding": {
+            "path": source_binding.path.relative_to(REPOSITORY_ROOT).as_posix(),
+            "sha256": source_binding.sha256,
+            "binding_id": source_binding.binding_id,
+            "selected_case_ids": list(source_binding.selected_case_ids),
+        },
+        "thresholds": dict(thresholds),
+        "eligible_cells": [dict(cell_by_id[cell_id]) for cell_id in eligible_ids],
+        "boundary_evaluations": [dict(boundary) for boundary in boundaries],
+        "valid_subsets": [dict(subset) for subset in valid_subsets],
+        "selected_subset": dict(selected),
+        "acceptance": {
+            "analysis_complete": True,
+            "source_receipt_verified": True,
+            "source_plan_verified": True,
+            "thresholds_unchanged": True,
+            "non_adjacent_pairwise_evaluation_used": True,
+            "balanced_included": selected.get("contains_balanced") is True,
+            "selected_chain_valid": True,
+            "target_named_step_count": plan.target_named_step_count,
+            "selected_step_count": selected["cardinality"],
+            "target_step_count_met": target_met,
+            "bitrate_search_ready": target_met,
+            "product_decision_required": not target_met,
+            "ladder_evidence_ready": False,
+            "ladder_mapping_selected": False,
+        },
+    }
+
+
+@contextmanager
+def collapse_lock(output_path: Path) -> Iterator[None]:
+    lock_path = Path(f"{output_path}{LOCK_SUFFIX}")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise QualificationFailure("Generated collapse analysis is already running for this output.") from error
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def run_analysis(analysis_plan_path: Path, source_receipt_path: Path, output_path: Path) -> dict[str, object]:
+    analyzer_git_sha = _git_head_from_clean_worktree()
+    plan, plan_sha256 = load_analysis_plan(analysis_plan_path)
+    if _require_head_tracked_file(analysis_plan_path, "Collapse analysis plan") != plan.relative_path:
+        raise QualificationFailure("Collapse analysis plan repository identity changed during validation.")
+    _require_head_tracked_file(plan.source_plan.path, "Source refinement plan")
+    source_plan = _load_source_plan(plan)
+    source_binding = _load_source_corpus_binding(source_plan)
+    _require_head_tracked_file(source_binding.path, "Source corpus binding")
+    _, cells, eligible_ids, cases, thresholds = _load_source_receipt(
+        plan,
+        source_receipt_path,
+        source_plan,
+        source_binding,
+    )
+    boundaries = evaluate_boundaries(cells, eligible_ids, cases, thresholds)
+    selected, valid_subsets = select_collapsed_subset(
+        cells,
+        eligible_ids,
+        boundaries,
+        plan.balanced.cell_id,
+    )
+    evidence = build_analysis_receipt(
+        plan,
+        plan_sha256,
+        analyzer_git_sha,
+        source_binding,
+        cells,
+        eligible_ids,
+        thresholds,
+        boundaries,
+        selected,
+        valid_subsets,
+    )
+    _assert_private_values_absent(evidence, ())
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with collapse_lock(output_path):
+        if output_path.exists() or output_path.is_symlink():
+            raise QualificationFailure("Collapse analysis output already exists; choose a new output path.")
+        _atomic_write(output_path, evidence, ())
+        _freeze_receipt(output_path)
+    return evidence
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Collapse generated MV-HEVC merge candidates using a checked immutable refinement receipt."
+    )
+    parser.add_argument("--analysis-plan", type=Path, default=DEFAULT_ANALYSIS_PLAN)
+    parser.add_argument("--source-receipt", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        evidence = run_analysis(
+            args.analysis_plan.resolve(),
+            args.source_receipt.absolute(),
+            args.output.absolute(),
+        )
+    except (
+        AssertionError,
+        KeyError,
+        OSError,
+        TypeError,
+        subprocess.SubprocessError,
+        QualificationFailure,
+        ValueError,
+    ) as error:
+        print(f"Generated MV-HEVC collapse analysis failed: {error}", file=sys.stderr)
+        return 2
+    acceptance = evidence.get("acceptance")
+    if not isinstance(acceptance, Mapping) or acceptance.get("analysis_complete") is not True:
+        print("Generated MV-HEVC collapse analysis failed: acceptance record is missing.", file=sys.stderr)
+        return 2
+    return 0 if acceptance.get("target_step_count_met") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generated_mv_hevc_collapse.py
+++ b/tests/test_generated_mv_hevc_collapse.py
@@ -1,0 +1,290 @@
+import copy
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.qualify_direct_mv_hevc import QualificationFailure
+from scripts.qualify_generated_mv_hevc_collapse import (
+    DEFAULT_ANALYSIS_PLAN,
+    _load_source_corpus_binding,
+    _load_source_plan,
+    _load_source_receipt,
+    _loads_json,
+    _validate_source_receipt,
+    build_analysis_receipt,
+    evaluate_boundaries,
+    load_analysis_plan,
+    main,
+    parse_analysis_plan,
+    select_collapsed_subset,
+)
+
+
+class GeneratedCollapsePlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.document = json.loads(DEFAULT_ANALYSIS_PLAN.read_text(encoding="utf-8"))
+
+    def test_committed_plan_is_valid_and_fail_closed(self) -> None:
+        plan, digest = load_analysis_plan(DEFAULT_ANALYSIS_PLAN)
+
+        self.assertEqual(plan.analysis_id, "generated-mv-hevc-collapse-analysis-v1")
+        self.assertEqual(plan.balanced.cell_id, "b020-m075")
+        self.assertEqual(plan.target_named_step_count, 7)
+        self.assertEqual(
+            plan.source_receipt.sha256,
+            "e6b4d5a8908352f1667c092e199853f3cfc25256f22d803e56f94b30783dcbdf",
+        )
+        self.assertEqual(len(digest), 64)
+
+    def test_rejects_changed_tie_break_order(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["selection_policy"]["tie_breaks"].reverse()
+
+        with self.assertRaisesRegex(QualificationFailure, "tie_breaks"):
+            parse_analysis_plan(document)
+
+    def test_rejects_lower_target_step_count(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["selection_policy"]["target_named_step_count"] = 2
+
+        with self.assertRaisesRegex(QualificationFailure, "must remain 7"):
+            parse_analysis_plan(document)
+
+    def test_strict_json_rejects_duplicate_keys(self) -> None:
+        with self.assertRaisesRegex(QualificationFailure, "duplicate key"):
+            _loads_json(b'{"schema_version": 1, "schema_version": 2}', "test document")
+
+
+class GeneratedCollapseAnalysisTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.plan, self.plan_sha256 = load_analysis_plan(DEFAULT_ANALYSIS_PLAN)
+        self.source_plan = _load_source_plan(self.plan)
+        self.source_binding = _load_source_corpus_binding(self.source_plan)
+        self.receipt = self._receipt()
+
+    def _receipt(self) -> dict[str, object]:
+        thresholds = copy.deepcopy(self.source_plan["pre_registered_thresholds"])
+        merges = list(self.source_plan["axes"]["merge_quality"])
+        cells = [{"id": f"b020-m{merge:03d}", "eye_bitrate_mbps": 20, "merge_quality": merge} for merge in merges]
+        eligible_ids = {"b020-m065", "b020-m068", "b020-m071", "b020-m075"}
+        evaluations = [
+            {
+                "cell_id": cell["id"],
+                "eye_bitrate_mbps": 20,
+                "merge_quality": cell["merge_quality"],
+                "complete": True,
+                "case_evaluations": [],
+                "candidate_constraints_passed": cell["id"] in eligible_ids,
+            }
+            for cell in cells
+        ]
+        quality_profiles = (
+            {65: 0.9000, 68: 0.9005, 71: 0.9008, 75: 0.9010, 79: 0.9012, 82: 0.9013, 85: 0.9014},
+            {65: 0.9000, 68: 0.9010, 71: 0.9017, 75: 0.9020, 79: 0.9022, 82: 0.9023, 85: 0.9024},
+        )
+        quality_by_case = {
+            case_id: quality_profiles[index % len(quality_profiles)]
+            for index, case_id in enumerate(self.source_binding.selected_case_ids)
+        }
+        bytes_by_merge = {65: 100, 68: 130, 71: 150, 75: 200, 79: 250, 82: 280, 85: 320}
+        cases = []
+        for case_id, quality_by_merge in quality_by_case.items():
+            cases.append(
+                {
+                    "id": case_id,
+                    "cells": [
+                        {
+                            **cell,
+                            "summary": {
+                                "median_min_same_eye_ssim": quality_by_merge[int(cell["merge_quality"])],
+                                "median_final_bytes": bytes_by_merge[int(cell["merge_quality"])],
+                            },
+                        }
+                        for cell in cells
+                    ],
+                }
+            )
+        return {
+            "schema_version": 1,
+            "experiment_id": self.plan.source_receipt.experiment_id,
+            "source_git_sha": self.plan.source_receipt.source_git_sha,
+            "source_tree_dirty": False,
+            "experiment_plan": {
+                "path": self.plan.source_plan.path.relative_to(DEFAULT_ANALYSIS_PLAN.parents[2]).as_posix(),
+                "sha256": self.plan.source_plan.sha256,
+            },
+            "corpus_binding": {
+                "path": self.source_binding.path.relative_to(DEFAULT_ANALYSIS_PLAN.parents[2]).as_posix(),
+                "binding_id": self.source_binding.binding_id,
+                "sha256": self.source_binding.sha256,
+            },
+            "method": {
+                "decision_stage": "merge_response_refinement_only",
+                "balanced": {"eye_bitrate_mbps": 20, "merge_quality": 75},
+                "pre_registered_thresholds": thresholds,
+            },
+            "pre_registered_thresholds": thresholds,
+            "acceptance": {
+                "complete": True,
+                "experiment_complete": True,
+                "execution_passed": True,
+                "objective_validation_passed": True,
+                "eye_order_passed": True,
+                "planned_stress_corpus": True,
+                "thresholds_pre_registered": True,
+                "thresholds_evaluated": True,
+                "refinement_evidence_ready": True,
+                "refinement_decision_ready": False,
+                "ladder_evidence_ready": False,
+                "ladder_mapping_selected": False,
+                "ambiguous_adjacent_count": 6,
+                "technically_eligible_cell_count": 4,
+            },
+            "cells": cells,
+            "refinement_cell_evaluations": evaluations,
+            "selected_case_ids": list(self.source_binding.selected_case_ids),
+            "cases": cases,
+        }
+
+    def _validated(self):
+        return _validate_source_receipt(
+            self.plan,
+            self.receipt,
+            self.source_plan,
+            self.source_binding,
+        )
+
+    def test_rejects_threshold_drift(self) -> None:
+        self.receipt["pre_registered_thresholds"]["aggregate_quality_distinguishability"] = 0.001
+
+        with self.assertRaisesRegex(QualificationFailure, "thresholds differ"):
+            self._validated()
+
+    def test_rejects_missing_eligible_balanced(self) -> None:
+        balanced = next(
+            evaluation
+            for evaluation in self.receipt["refinement_cell_evaluations"]
+            if evaluation["cell_id"] == "b020-m075"
+        )
+        balanced["candidate_constraints_passed"] = False
+        self.receipt["acceptance"]["technically_eligible_cell_count"] = 3
+
+        with self.assertRaisesRegex(QualificationFailure, "Balanced is not technically eligible"):
+            self._validated()
+
+    def test_rejects_source_receipt_that_selected_mapping(self) -> None:
+        self.receipt["acceptance"]["ladder_mapping_selected"] = True
+
+        with self.assertRaisesRegex(QualificationFailure, "ladder_mapping_selected must remain false"):
+            self._validated()
+
+    def test_rejects_case_set_that_differs_from_checked_binding(self) -> None:
+        self.receipt["selected_case_ids"][0] = "different-case"
+        self.receipt["cases"][0]["id"] = "different-case"
+
+        with self.assertRaisesRegex(QualificationFailure, "checked corpus binding"):
+            self._validated()
+
+    def test_selects_non_adjacent_65_to_75_collapse(self) -> None:
+        cells, eligible_ids, cases, thresholds = self._validated()
+
+        boundaries = evaluate_boundaries(cells, eligible_ids, cases, thresholds)
+        selected, valid_subsets = select_collapsed_subset(
+            cells,
+            eligible_ids,
+            boundaries,
+            self.plan.balanced.cell_id,
+        )
+
+        self.assertEqual(selected["cell_ids"], ["b020-m065", "b020-m075"])
+        self.assertEqual(selected["cardinality"], 2)
+        boundary_by_pair = {
+            (boundary["lower_cell_id"], boundary["higher_cell_id"]): boundary for boundary in boundaries
+        }
+        self.assertTrue(boundary_by_pair[("b020-m065", "b020-m075")]["response_separable"])
+        self.assertFalse(boundary_by_pair[("b020-m065", "b020-m068")]["response_separable"])
+        self.assertTrue(any(subset["cell_ids"] == ["b020-m075"] for subset in valid_subsets))
+
+    def test_evaluation_order_does_not_change_selected_subset(self) -> None:
+        self.receipt["refinement_cell_evaluations"].reverse()
+        cells, eligible_ids, cases, thresholds = self._validated()
+
+        boundaries = evaluate_boundaries(cells, eligible_ids, cases, thresholds)
+        selected, _ = select_collapsed_subset(cells, eligible_ids, boundaries, self.plan.balanced.cell_id)
+
+        self.assertEqual(eligible_ids, ["b020-m065", "b020-m068", "b020-m071", "b020-m075"])
+        self.assertEqual(selected["cell_ids"], ["b020-m065", "b020-m075"])
+
+    def test_receipt_requires_product_decision_below_target(self) -> None:
+        cells, eligible_ids, cases, thresholds = self._validated()
+        boundaries = evaluate_boundaries(cells, eligible_ids, cases, thresholds)
+        selected, valid_subsets = select_collapsed_subset(
+            cells,
+            eligible_ids,
+            boundaries,
+            self.plan.balanced.cell_id,
+        )
+
+        evidence = build_analysis_receipt(
+            self.plan,
+            self.plan_sha256,
+            "d" * 40,
+            self.source_binding,
+            cells,
+            eligible_ids,
+            thresholds,
+            boundaries,
+            selected,
+            valid_subsets,
+        )
+
+        self.assertTrue(evidence["acceptance"]["analysis_complete"])
+        self.assertFalse(evidence["acceptance"]["target_step_count_met"])
+        self.assertFalse(evidence["acceptance"]["bitrate_search_ready"])
+        self.assertTrue(evidence["acceptance"]["product_decision_required"])
+        self.assertFalse(evidence["acceptance"]["ladder_mapping_selected"])
+
+    def test_source_file_must_be_frozen_before_hash_check(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt = Path(temporary_directory) / "receipt.json"
+            receipt.write_text(json.dumps(self.receipt), encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationFailure, "frozen read-only"):
+                _load_source_receipt(
+                    self.plan,
+                    receipt,
+                    self.source_plan,
+                    self.source_binding,
+                )
+
+
+class GeneratedCollapseCliTests(unittest.TestCase):
+    @staticmethod
+    def _args() -> list[str]:
+        return ["--source-receipt", "source.json", "--output", "output.json"]
+
+    def test_complete_collapse_below_target_returns_one(self) -> None:
+        evidence = {"acceptance": {"analysis_complete": True, "target_step_count_met": False}}
+
+        with patch("scripts.qualify_generated_mv_hevc_collapse.run_analysis", return_value=evidence):
+            self.assertEqual(main(self._args()), 1)
+
+    def test_target_count_met_returns_zero(self) -> None:
+        evidence = {"acceptance": {"analysis_complete": True, "target_step_count_met": True}}
+
+        with patch("scripts.qualify_generated_mv_hevc_collapse.run_analysis", return_value=evidence):
+            self.assertEqual(main(self._args()), 0)
+
+    def test_invalid_source_returns_two(self) -> None:
+        with patch(
+            "scripts.qualify_generated_mv_hevc_collapse.run_analysis",
+            side_effect=QualificationFailure("invalid"),
+        ):
+            self.assertEqual(main(self._args()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #419
Parent: #418

## Summary

- add a checked, analysis-only generated MV-HEVC collapse contract
- bind the exact frozen refinement receipt, source plan, source corpus, source Git SHA, and unchanged thresholds
- reject duplicate JSON keys and hash/parse the exact bytes read from a single non-symlink file descriptor
- evaluate every ordered technically eligible pair, including wider non-adjacent boundaries, against the existing every-case quality and storage thresholds
- select the maximum-cardinality ordered subset containing production `Balanced = 20/75`
- apply deterministic storage/margin/merge/lexicographic tie-breaks
- never encode media, mutate the ladder, or expose private source paths

## Immutable Evidence

- analyzer source commit: `a89207857fe8016c938f60a28d30b9cd886e920f`
- source refinement receipt SHA-256: `e6b4d5a8908352f1667c092e199853f3cfc25256f22d803e56f94b30783dcbdf`
- collapse receipt SHA-256: `23d4564abf0f04b897e1c42b0c88d7af686b1b47ff892ee7c77d79e2c288b07f`
- technically eligible source cells: `20/65`, `20/68`, `20/71`, `20/75`
- evaluated ordered boundaries: 6
- valid ordered subsets containing Balanced: 2
- selected collapsed subset: `20/65 → 20/75`

The retained `65 → 75` boundary clears the unchanged threshold on every stress case:

- minimum quality separation: `0.0008150000000000102` (`+0.000215` above the registered threshold)
- minimum storage growth: `0.42024344676753955` (`+0.400243` above the registered threshold)

The selected count is `2` versus the target `7`, so the analyzer correctly returned exit `1` with a frozen receipt:

- `product_decision_required: true`
- `bitrate_search_ready: false`
- `ladder_evidence_ready: false`
- `ladder_mapping_selected: false`

No thresholds were changed and no new encodes were run. Non-adjacent comparison is used only to collapse existing measurements, not to assign public quality steps.

## Validation

- `uv run python -m unittest discover -s tests -t .` — 1,258 passed, 3 skipped
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- observability migration, import, and CLI smoke passed
- real frozen receipt verified and analyzed successfully
- JetBrains changed-files inspection: green, zero actionable findings
- final GPT fallback review: no blocker/high/medium findings after duplicate-key, single-descriptor, and corpus-binding fixes
- Antigravity/Gemini was prioritized and retried three times but returned no report; Claude was not used

## Product Decision

This evidence does not support seven generated-route quality steps. After this PR, #419 must choose explicitly between:

1. expose fewer generated-route named steps, using `65` and `75` as the only currently defensible anchors; or
2. commission at least three blinded independent human reviewers for carefully chosen wider boundaries before authorizing additional generated steps.

Per-tier bitrate minimization, full-corpus confirmation, UI exposure, beta signing, and physical Vision Pro qualification remain blocked until that decision is recorded.

## Reviewability

The change is isolated to one new analysis-only script, one checked manifest, one focused test module, and documentation. The script is intentionally strict because provenance, duplicate-key handling, exact-byte hashing, corpus membership, threshold identity, deterministic selection, and fail-closed output must land together for the receipt to be trustworthy.
