### PR TITLE
Add checked generated bitrate minimization

### DIFF
--- a/docs/qualification/direct-4k-real-mvc-v1.json
+++ b/docs/qualification/direct-4k-real-mvc-v1.json
@@ -146,7 +146,7 @@
       "scripts/benchmark_mv_hevc_metalfx.py": "98e7afaa3881db4afafb67912113f9b6e4c2431e7d3bec5ecb2a73ec71c5c52b",
       "scripts/create_real_mvc_qualification_segment.py": "13b8fb6465af8c2e819b6007fbd9495d98f5ac132026bccaceae144c0274b778",
       "scripts/qualify_direct_mv_hevc.py": "1e2ee2234e612d4122996e7d11f2a2912d70eae15229be6cc35c6ba7de88109f",
-      "scripts/qualify_mv_hevc_corpus.py": "633c4adc9ac704427b08b940fcb98287be164f1d139b163f5bb9634ea2fbddb4",
+      "scripts/qualify_mv_hevc_corpus.py": "d2f9f8f775cf6cb64b7a26032f99a09054b8f5d89266327c415e0bebbd540df1",
       "scripts/qualify_mv_hevc_quality_match.py": "2df839f6974fd55bce9b3ec8655c092a8ee39daecb4d9c0d1759d3af291073cd",
       "scripts/qualify_real_mvc_4k_quality.py": "d457d18fb2e16f65b05fec00ada15d83ccfb269d1f18394c61b09fe1b3d8c247",
       "scripts/qualify_real_mvc_feature.py": "de7c5fdf7a68b661163de99995ae98e868f7b16417843274c7c98322f43af7bc",

--- a/docs/qualification/generated-mv-hevc-bitrate-search-v1.json
+++ b/docs/qualification/generated-mv-hevc-bitrate-search-v1.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": 3,
+  "experiment_id": "generated-mv-hevc-bitrate-search-v1",
+  "target_id": "generated_mv_hevc",
+  "purpose": "same_tier_bitrate_minimization_not_ladder_mapping",
+  "design": "full_integer_bitrate_sweep_1_to_20_v1",
+  "corpus_binding": {
+    "path": "docs/qualification/generated-mv-hevc-corpus-v1.json",
+    "binding_id": "generated-mv-hevc-stress-v1",
+    "sha256": "2d6d25d89258ec24f28375749f9fe833595eaed005bbcc8d6f798f3efd0d0049"
+  },
+  "balanced": {
+    "eye_bitrate_mbps": 20,
+    "eye_bitrate_source": "bd_to_avp.modules.video_quality_defaults.AUTOMATIC_GENERATED_EYE_BITRATE_MBPS",
+    "merge_quality": 75,
+    "merge_quality_source": "bd_to_avp.modules.video_quality_defaults.AUTOMATIC_GENERATED_MERGE_QUALITY"
+  },
+  "runs_per_cell": 3,
+  "execution_order": "latin_thirds",
+  "axes": {
+    "eye_bitrate_mbps": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20
+    ],
+    "merge_quality": [
+      65,
+      75
+    ]
+  },
+  "bitrate_search": {
+    "merge_refinement_receipt": {
+      "schema_version": 1,
+      "evidence_id": "generated-mv-hevc-merge-refinement-v1",
+      "sha256": "e6b4d5a8908352f1667c092e199853f3cfc25256f22d803e56f94b30783dcbdf",
+      "source_git_sha": "1a3b2c3b25351a9f981bf7bd65415bd8f5688f85",
+      "required_file_mode": "0444"
+    },
+    "collapse_receipt": {
+      "schema_version": 1,
+      "evidence_id": "generated-mv-hevc-collapse-analysis-v1",
+      "sha256": "23d4564abf0f04b897e1c42b0c88d7af686b1b47ff892ee7c77d79e2c288b07f",
+      "source_git_sha": "a89207857fe8016c938f60a28d30b9cd886e920f",
+      "required_file_mode": "0444"
+    },
+    "collapse_plan": {
+      "path": "docs/qualification/generated-mv-hevc-collapse-analysis-v1.json",
+      "sha256": "c662580160e23454581f9abc084aecf562486f328d4c7a84256900669dfe1ee2",
+      "schema_version": 1
+    },
+    "threshold_noise_evidence": {
+      "experiment_id": "generated-mv-hevc-interaction-v1",
+      "receipt_sha256": "fe3c81e96771f9d0f4dc1f6461556d5fdf22c95034776b044f268978d68bd07f",
+      "source_git_sha": "4c21ebb2cb42632a1aa0d37aa1ca47bd51b3500e",
+      "baseline_cell_id": "b020-m075",
+      "maximum_repeat_ssim_spread": 0.000274,
+      "maximum_repeat_size_ratio_spread": 0.008639211494662749,
+      "maximum_minimum_frame_ssim_spread": 0.00031399999999992545,
+      "maximum_p05_frame_ssim_spread": 0.0004979999999999984,
+      "maximum_frame_ssim_standard_deviation_spread": 0.00009296255193789321,
+      "maximum_adjacent_frame_ssim_drop_spread": 0.00037199999999992794
+    },
+    "accepted_merge_qualities": [
+      65,
+      75
+    ],
+    "guided_anchor_count": 2,
+    "custom_exact_retained": true,
+    "maximum_case_size_ratio_vs_tier_anchor": 1.02,
+    "minimum_aggregate_storage_reduction_ratio": 0.02
+  },
+  "pre_registered_thresholds": {
+    "noise_multiplier": 2,
+    "aggregate_quality_non_inferiority_margin": 0.0006,
+    "aggregate_quality_distinguishability": 0.0006,
+    "storage_distinguishability_ratio": 0.02,
+    "repeat_ssim_spread_limit": 0.0006,
+    "repeat_size_ratio_spread_limit": 0.02,
+    "minimum_frame_quality_non_inferiority_margin": 0.0007,
+    "p05_frame_quality_non_inferiority_margin": 0.001,
+    "frame_ssim_standard_deviation_increase_limit": 0.0002,
+    "adjacent_frame_ssim_drop_increase_limit": 0.0008,
+    "maximum_output_size_ratio": 3.0
+  },
+  "toolchain": {
+    "ffmpeg_manifest": {
+      "path": "vendor/ffmpeg-macos-arm64.toml",
+      "sha256": "a8afa883b2128ee925276953193aa179acdb1378873960286082debb20ae1fb5"
+    },
+    "generated_encoder_contract": "production_generated_mv_hevc_v1",
+    "metric_contract": "ffmpeg_ssim_aggregate_and_per_frame_v1"
+  },
+  "decision_policy": {
+    "stage": "same_tier_bitrate_minimization_only",
+    "same_tier_anchor_eye_bitrate_mbps": 20,
+    "frontier_order": "failed_then_passed",
+    "selection": "lowest_passing_integer_with_storage_benefit_else_anchor",
+    "full_corpus_confirmation_required": true,
+    "post_hoc_thresholds_forbidden": true,
+    "ladder_mapping_selected": false
+  }
+}

--- a/docs/video-quality-ladder-calibration.md
+++ b/docs/video-quality-ladder-calibration.md
@@ -170,6 +170,45 @@ only if seven technically defensible cells survive. It exits `1` with a frozen i
 setting `product_decision_required` and leaving bitrate search and ladder selection false. Fatal provenance, schema,
 privacy, threshold, Balanced, or evidence inconsistencies exit `2`.
 
+## Generated Bitrate Minimization
+
+`docs/qualification/generated-mv-hevc-bitrate-search-v1.json` records the post-collapse product decision: generated
+MV-HEVC has two guided anchors, merge `65` and `75`, plus exact reversible `Custom`. It binds the frozen merge
+refinement and collapse receipts, the checked collapse plan, unchanged noise-derived thresholds, the four-case stress
+corpus, and the production generated encoder/toolchain identities.
+
+The checked design measures every integer bitrate from `1` through `20` Mbps per eye at both accepted merge tiers,
+three times per cell. The exhaustive `40`-cell, `480`-encode stress sweep avoids interpolation and post-hoc refinement.
+A checked three-group Latin schedule places every cell, including both `20 Mbps/eye` anchors, exactly once in early,
+middle, and late execution windows across the three repeats. Every lower candidate is compared only with the anchor at
+the same merge quality.
+
+The technical frontier excludes storage benefit so an encoder cap that does not bind cannot create an artificial
+fail/pass inversion. Every candidate must pass aggregate, minimum-frame, fifth-percentile, temporal-stability,
+repeatability, eye-order, artifact-structure, and per-case size non-regression gates. The pass sequence must be a
+single fail-then-pass frontier. The lowest technical pass is adopted only when total median bytes across the complete
+stress subset improve by at least the checked `2%`; otherwise the same-tier `20 Mbps/eye` anchor remains selected.
+The receipt fails closed on incomplete cases, a failing anchor, a non-monotone frontier, changed source evidence, or
+changed thresholds.
+
+After committing the plan and runner in a clean worktree, run:
+
+```bash
+BD_TO_AVP_RELEASE_MVC_SOURCE=/private/source.mkv \
+uv run python scripts/qualify_generated_mv_hevc_calibration.py \
+  --experiment-plan docs/qualification/generated-mv-hevc-bitrate-search-v1.json \
+  --source-evidence-receipt /private/generated-mv-hevc-merge-refinement-receipt.json \
+  --collapse-receipt /private/generated-mv-hevc-collapse-analysis-receipt.json \
+  --output build/qualification/generated-mv-hevc-bitrate-search-v1.json \
+  --work-directory build/qualification/generated-mv-hevc-bitrate-search-v1-work
+```
+
+The command exits `0` only when both integer frontiers are decision-ready on the complete checked stress subset. It
+exits `1` with a frozen receipt for a subset run or an unresolved frontier, and `2` for fatal source, plan, tool,
+privacy, schema, or evidence errors. Even exit `0` keeps `ladder_mapping_selected=false`: the selected stress minima
+still require full eight-case confirmation, packaged-app validation, and physical Vision Pro playback before the
+generated route table can freeze.
+
 ## Validation
 
 Run the structural and production-anchor check with:

--- a/scripts/qualify_generated_mv_hevc_calibration.py
+++ b/scripts/qualify_generated_mv_hevc_calibration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import copy
 import fcntl
+import hashlib
 import json
 import math
 import os
@@ -56,6 +57,7 @@ from scripts.qualify_mv_hevc_quality_match import sha256_file
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EXPERIMENT_PLAN = REPOSITORY_ROOT / "docs/qualification/generated-mv-hevc-calibration-sweep-v1.json"
 DEFAULT_REFINEMENT_PLAN = REPOSITORY_ROOT / "docs/qualification/generated-mv-hevc-merge-refinement-v1.json"
+DEFAULT_BITRATE_SEARCH_PLAN = REPOSITORY_ROOT / "docs/qualification/generated-mv-hevc-bitrate-search-v1.json"
 EVIDENCE_SCHEMA_VERSION = 1
 MAX_RUNS = 10
 WORK_DIRECTORY_MARKER = ".bd-to-avp-generated-mv-hevc-calibration.json"
@@ -110,6 +112,35 @@ class RefinementThresholds:
 
 
 @dataclass(frozen=True)
+class FrozenEvidenceBinding:
+    schema_version: int
+    evidence_id: str
+    sha256: str
+    source_git_sha: str
+    required_file_mode: int
+
+
+@dataclass(frozen=True)
+class CheckedPlanBinding:
+    path: Path
+    sha256: str
+    schema_version: int
+
+
+@dataclass(frozen=True)
+class BitrateSearchPolicy:
+    merge_refinement_receipt: FrozenEvidenceBinding
+    collapse_receipt: FrozenEvidenceBinding
+    collapse_plan: CheckedPlanBinding
+    noise_evidence: RefinementSourceEvidence
+    accepted_merge_qualities: tuple[int, ...]
+    guided_anchor_count: int
+    custom_exact_retained: bool
+    maximum_case_size_ratio_vs_tier_anchor: float
+    minimum_aggregate_storage_reduction_ratio: float
+
+
+@dataclass(frozen=True)
 class ExperimentPlan:
     experiment_id: str
     binding_path: Path
@@ -133,6 +164,7 @@ class ExperimentPlan:
     decision_stage: str = "interaction_characterization_only"
     source_evidence: RefinementSourceEvidence | None = None
     thresholds: RefinementThresholds | None = None
+    bitrate_search: BitrateSearchPolicy | None = None
 
 
 def _mapping(value: object, label: str) -> Mapping[str, object]:
@@ -181,6 +213,23 @@ def _number(value: object, label: str, *, positive: bool = False) -> float:
         qualifier = "positive and finite" if positive else "finite"
         raise QualificationFailure(f"{label} must be {qualifier}.")
     return parsed
+
+
+def _strict_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise QualificationFailure(f"JSON object contains duplicate key: {key}")
+        document[key] = value
+    return document
+
+
+def _loads_json_bytes(data: bytes, label: str) -> Mapping[str, object]:
+    try:
+        document = json.loads(data.decode("utf-8"), object_pairs_hook=_strict_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationFailure(f"Could not parse {label} as strict UTF-8 JSON.") from error
+    return _mapping(document, label)
 
 
 def _integer_axis(
@@ -240,6 +289,88 @@ def _refinement_source_evidence(value: object) -> RefinementSourceEvidence:
             "source_evidence.maximum_adjacent_frame_ssim_drop_spread",
             positive=True,
         ),
+    )
+
+
+def _frozen_evidence_binding(value: object, label: str) -> FrozenEvidenceBinding:
+    document = _mapping(value, label)
+    required_mode = _string(document.get("required_file_mode"), f"{label}.required_file_mode")
+    if required_mode != "0444":
+        raise QualificationFailure(f"{label}.required_file_mode must be '0444'.")
+    return FrozenEvidenceBinding(
+        schema_version=_integer(document.get("schema_version"), f"{label}.schema_version", minimum=1, maximum=1),
+        evidence_id=_string(document.get("evidence_id"), f"{label}.evidence_id"),
+        sha256=_sha256_identity(document.get("sha256"), f"{label}.sha256"),
+        source_git_sha=_git_sha_identity(document.get("source_git_sha"), f"{label}.source_git_sha"),
+        required_file_mode=0o444,
+    )
+
+
+def _checked_plan_binding(value: object, label: str) -> CheckedPlanBinding:
+    document = _mapping(value, label)
+    return CheckedPlanBinding(
+        path=_repository_path(_string(document.get("path"), f"{label}.path"), f"{label} path"),
+        sha256=_sha256_identity(document.get("sha256"), f"{label}.sha256"),
+        schema_version=_integer(document.get("schema_version"), f"{label}.schema_version", minimum=1, maximum=1),
+    )
+
+
+def _bitrate_search_policy(value: object) -> BitrateSearchPolicy:
+    document = _mapping(value, "bitrate_search")
+    accepted_merge_qualities = tuple(
+        _integer(raw, f"bitrate_search.accepted_merge_qualities[{index}]", minimum=0, maximum=100)
+        for index, raw in enumerate(
+            _array(document.get("accepted_merge_qualities"), "bitrate_search.accepted_merge_qualities")
+        )
+    )
+    if accepted_merge_qualities != (65, 75):
+        raise QualificationFailure("bitrate_search.accepted_merge_qualities must be [65, 75].")
+    guided_anchor_count = _integer(
+        document.get("guided_anchor_count"),
+        "bitrate_search.guided_anchor_count",
+        minimum=1,
+        maximum=7,
+    )
+    if guided_anchor_count != len(accepted_merge_qualities):
+        raise QualificationFailure("bitrate_search.guided_anchor_count must match the accepted merge tiers.")
+    if document.get("custom_exact_retained") is not True:
+        raise QualificationFailure("bitrate_search.custom_exact_retained must be true.")
+    maximum_case_size_ratio = _number(
+        document.get("maximum_case_size_ratio_vs_tier_anchor"),
+        "bitrate_search.maximum_case_size_ratio_vs_tier_anchor",
+        positive=True,
+    )
+    minimum_storage_reduction = _number(
+        document.get("minimum_aggregate_storage_reduction_ratio"),
+        "bitrate_search.minimum_aggregate_storage_reduction_ratio",
+        positive=True,
+    )
+    if not math.isclose(maximum_case_size_ratio, 1.02, rel_tol=0.0, abs_tol=1e-12):
+        raise QualificationFailure("bitrate_search maximum case size ratio must preserve the checked 2% tolerance.")
+    if not math.isclose(minimum_storage_reduction, 0.02, rel_tol=0.0, abs_tol=1e-12):
+        raise QualificationFailure("bitrate_search minimum aggregate storage reduction must be 2%.")
+    merge_refinement_receipt = _frozen_evidence_binding(
+        document.get("merge_refinement_receipt"),
+        "bitrate_search.merge_refinement_receipt",
+    )
+    collapse_receipt = _frozen_evidence_binding(
+        document.get("collapse_receipt"),
+        "bitrate_search.collapse_receipt",
+    )
+    if merge_refinement_receipt.evidence_id != "generated-mv-hevc-merge-refinement-v1":
+        raise QualificationFailure("bitrate_search merge refinement evidence ID is unsupported.")
+    if collapse_receipt.evidence_id != "generated-mv-hevc-collapse-analysis-v1":
+        raise QualificationFailure("bitrate_search collapse evidence ID is unsupported.")
+    return BitrateSearchPolicy(
+        merge_refinement_receipt=merge_refinement_receipt,
+        collapse_receipt=collapse_receipt,
+        collapse_plan=_checked_plan_binding(document.get("collapse_plan"), "bitrate_search.collapse_plan"),
+        noise_evidence=_refinement_source_evidence(document.get("threshold_noise_evidence")),
+        accepted_merge_qualities=accepted_merge_qualities,
+        guided_anchor_count=guided_anchor_count,
+        custom_exact_retained=True,
+        maximum_case_size_ratio_vs_tier_anchor=maximum_case_size_ratio,
+        minimum_aggregate_storage_reduction_ratio=minimum_storage_reduction,
     )
 
 
@@ -408,8 +539,8 @@ def load_corpus_binding(path: Path) -> tuple[CorpusBinding, str]:
     resolved_path = path.resolve()
     relative_path = _relative_repository_path(resolved_path, "Generated calibration corpus binding")
     try:
-        raw = json.loads(resolved_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
+        raw = _loads_json_bytes(resolved_path.read_bytes(), "generated calibration corpus binding")
+    except OSError as error:
         raise QualificationFailure(
             f"Could not read generated calibration corpus binding {path.name}: {error}"
         ) from error
@@ -450,19 +581,23 @@ def _cell_id(eye_bitrate_mbps: int, merge_quality: int) -> str:
 def parse_experiment_plan(raw: object) -> ExperimentPlan:
     document = _mapping(raw, "experiment plan")
     schema_version = document.get("schema_version")
-    if schema_version not in {1, 2}:
-        raise QualificationFailure("experiment plan schema_version must be 1 or 2.")
+    if schema_version not in {1, 2, 3}:
+        raise QualificationFailure("experiment plan schema_version must be 1, 2, or 3.")
     experiment_id = _string(document.get("experiment_id"), "experiment_id")
     if document.get("target_id") != "generated_mv_hevc":
         raise QualificationFailure("experiment plan target_id must be 'generated_mv_hevc'.")
     purpose = _string(document.get("purpose"), "purpose")
     design = _string(document.get("design"), "design")
-    expected_purpose = (
-        "joint_interaction_characterization_not_ladder_mappings"
-        if schema_version == 1
-        else "merge_response_refinement_not_ladder_mappings"
-    )
-    expected_design = "full_factorial_3x3" if schema_version == 1 else "fixed_bitrate_merge_sweep_v1"
+    expected_purpose = {
+        1: "joint_interaction_characterization_not_ladder_mappings",
+        2: "merge_response_refinement_not_ladder_mappings",
+        3: "same_tier_bitrate_minimization_not_ladder_mapping",
+    }[schema_version]
+    expected_design = {
+        1: "full_factorial_3x3",
+        2: "fixed_bitrate_merge_sweep_v1",
+        3: "full_integer_bitrate_sweep_1_to_20_v1",
+    }[schema_version]
     if purpose != expected_purpose or design != expected_design:
         raise QualificationFailure("experiment plan purpose and design do not match its schema version.")
 
@@ -506,7 +641,11 @@ def parse_experiment_plan(raw: object) -> ExperimentPlan:
     if runs_per_cell != 3:
         raise QualificationFailure("runs_per_cell must be 3 for the checked cyclic ordering design.")
     execution_order = _string(document.get("execution_order"), "execution_order")
-    expected_execution_order = "cyclic_thirds" if schema_version == 1 else "cyclic_balanced"
+    expected_execution_order = {
+        1: "cyclic_thirds",
+        2: "cyclic_balanced",
+        3: "latin_thirds",
+    }[schema_version]
     if execution_order != expected_execution_order:
         raise QualificationFailure(f"execution_order must be '{expected_execution_order}'.")
     axes = _mapping(document.get("axes"), "axes")
@@ -515,27 +654,32 @@ def parse_experiment_plan(raw: object) -> ExperimentPlan:
         "axes.eye_bitrate_mbps",
         minimum=1,
         maximum=500,
-        expected_length=3 if schema_version == 1 else 1,
+        expected_length={1: 3, 2: 1, 3: 20}[schema_version],
     )
     merge_qualities = _integer_axis(
         axes.get("merge_quality"),
         "axes.merge_quality",
         minimum=0,
         maximum=100,
-        expected_length=3 if schema_version == 1 else 7,
+        expected_length={1: 3, 2: 7, 3: 2}[schema_version],
     )
     if schema_version == 1:
         if eye_bitrates_mbps[1] != balanced_eye_bitrate_mbps:
             raise QualificationFailure("Balanced eye bitrate must be the center level of the checked design.")
         if merge_qualities[1] != balanced_merge_quality:
             raise QualificationFailure("Balanced merge quality must be the center level of the checked design.")
-    else:
+    elif schema_version == 2:
         if eye_bitrates_mbps != (balanced_eye_bitrate_mbps,):
             raise QualificationFailure("Merge refinement must hold eye bitrate at the production default.")
         if merge_qualities != (65, 68, 71, 75, 79, 82, 85):
             raise QualificationFailure("Merge refinement levels must match the checked seven-level response design.")
         if merge_qualities[len(merge_qualities) // 2] != balanced_merge_quality:
             raise QualificationFailure("Balanced merge quality must remain the center refinement level.")
+    else:
+        if eye_bitrates_mbps != tuple(range(1, balanced_eye_bitrate_mbps + 1)):
+            raise QualificationFailure("Bitrate search must cover every integer Mbps/eye value from 1 through 20.")
+        if merge_qualities != (65, balanced_merge_quality):
+            raise QualificationFailure("Bitrate search merge tiers must be exactly [65, 75].")
 
     toolchain = _mapping(document.get("toolchain"), "toolchain")
     ffmpeg_manifest = _mapping(toolchain.get("ffmpeg_manifest"), "toolchain.ffmpeg_manifest")
@@ -559,15 +703,29 @@ def parse_experiment_plan(raw: object) -> ExperimentPlan:
 
     decision_policy = _mapping(document.get("decision_policy"), "decision_policy")
     decision_stage = _string(decision_policy.get("stage"), "decision_policy.stage")
-    expected_stage = "interaction_characterization_only" if schema_version == 1 else "merge_response_refinement_only"
+    expected_stage = {
+        1: "interaction_characterization_only",
+        2: "merge_response_refinement_only",
+        3: "same_tier_bitrate_minimization_only",
+    }[schema_version]
     if decision_stage != expected_stage:
         raise QualificationFailure(f"decision_policy.stage must be '{expected_stage}'.")
     if decision_policy.get("post_hoc_thresholds_forbidden") is not True:
         raise QualificationFailure("decision policy must forbid post-hoc thresholds.")
     if decision_policy.get("ladder_mapping_selected") is not False:
         raise QualificationFailure("generated calibration experiments must not select a ladder mapping.")
+    if schema_version == 3:
+        if decision_policy.get("same_tier_anchor_eye_bitrate_mbps") != balanced_eye_bitrate_mbps:
+            raise QualificationFailure("Bitrate search must compare against the same-tier 20 Mbps/eye anchor.")
+        if decision_policy.get("frontier_order") != "failed_then_passed":
+            raise QualificationFailure("Bitrate search frontier order must be fail-then-pass.")
+        if decision_policy.get("selection") != "lowest_passing_integer_with_storage_benefit_else_anchor":
+            raise QualificationFailure("Bitrate search selection policy is unsupported.")
+        if decision_policy.get("full_corpus_confirmation_required") is not True:
+            raise QualificationFailure("Bitrate search must require later full-corpus confirmation.")
     source_evidence = None
     thresholds = None
+    bitrate_search = None
     if schema_version == 2:
         source_evidence = _refinement_source_evidence(document.get("source_evidence"))
         thresholds = _refinement_thresholds(document.get("pre_registered_thresholds"), source_evidence)
@@ -576,6 +734,17 @@ def parse_experiment_plan(raw: object) -> ExperimentPlan:
             balanced_merge_quality,
         ):
             raise QualificationFailure("source_evidence baseline cell must match the production Balanced cell.")
+    elif schema_version == 3:
+        bitrate_search = _bitrate_search_policy(document.get("bitrate_search"))
+        thresholds = _refinement_thresholds(
+            document.get("pre_registered_thresholds"),
+            bitrate_search.noise_evidence,
+        )
+        if bitrate_search.noise_evidence.baseline_cell_id != _cell_id(
+            balanced_eye_bitrate_mbps,
+            balanced_merge_quality,
+        ):
+            raise QualificationFailure("Bitrate search noise baseline must match the production Balanced cell.")
 
     cells = tuple(
         ExperimentCell(_cell_id(eye_bitrate, merge_quality), eye_bitrate, merge_quality)
@@ -603,6 +772,7 @@ def parse_experiment_plan(raw: object) -> ExperimentPlan:
         decision_stage=decision_stage,
         source_evidence=source_evidence,
         thresholds=thresholds,
+        bitrate_search=bitrate_search,
     )
 
 
@@ -610,8 +780,8 @@ def load_experiment_plan(path: Path) -> tuple[ExperimentPlan, CorpusBinding, str
     resolved_path = path.resolve()
     relative_path = _relative_repository_path(resolved_path, "Generated calibration experiment plan")
     try:
-        raw = json.loads(resolved_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
+        raw = _loads_json_bytes(resolved_path.read_bytes(), "generated calibration experiment plan")
+    except OSError as error:
         raise QualificationFailure(
             f"Could not read generated calibration experiment plan {path.name}: {error}"
         ) from error
@@ -627,6 +797,19 @@ def load_experiment_plan(path: Path) -> tuple[ExperimentPlan, CorpusBinding, str
         raise QualificationFailure("The pinned FFmpeg vendor manifest is unavailable.")
     if sha256_file(parsed.ffmpeg_manifest_path) != parsed.ffmpeg_manifest_sha256:
         raise QualificationFailure("The FFmpeg vendor manifest does not match its pinned SHA-256 identity.")
+    if parsed.bitrate_search is not None:
+        collapse_plan_binding = parsed.bitrate_search.collapse_plan
+        if not collapse_plan_binding.path.is_file():
+            raise QualificationFailure("The checked collapse analysis plan is unavailable.")
+        collapse_plan_bytes = collapse_plan_binding.path.read_bytes()
+        if hashlib.sha256(collapse_plan_bytes).hexdigest() != collapse_plan_binding.sha256:
+            raise QualificationFailure("The collapse analysis plan does not match its pinned SHA-256 identity.")
+        collapse_plan = _loads_json_bytes(collapse_plan_bytes, "collapse analysis plan")
+        if (
+            collapse_plan.get("schema_version") != collapse_plan_binding.schema_version
+            or collapse_plan.get("analysis_id") != parsed.bitrate_search.collapse_receipt.evidence_id
+        ):
+            raise QualificationFailure("The collapse analysis plan identity does not match the bitrate search plan.")
     plan = ExperimentPlan(
         experiment_id=parsed.experiment_id,
         binding_path=parsed.binding_path,
@@ -650,6 +833,7 @@ def load_experiment_plan(path: Path) -> tuple[ExperimentPlan, CorpusBinding, str
         decision_stage=parsed.decision_stage,
         source_evidence=parsed.source_evidence,
         thresholds=parsed.thresholds,
+        bitrate_search=parsed.bitrate_search,
     )
     return plan, binding, sha256_file(resolved_path), binding_sha256
 
@@ -786,6 +970,38 @@ def _source_evidence_record(source: RefinementSourceEvidence) -> dict[str, objec
     }
 
 
+def _frozen_evidence_record(binding: FrozenEvidenceBinding) -> dict[str, object]:
+    return {
+        "schema_version": binding.schema_version,
+        "evidence_id": binding.evidence_id,
+        "sha256": binding.sha256,
+        "source_git_sha": binding.source_git_sha,
+        "required_file_mode": f"{binding.required_file_mode:04o}",
+    }
+
+
+def _checked_plan_record(binding: CheckedPlanBinding) -> dict[str, object]:
+    return {
+        "path": _relative_repository_path(binding.path, "Checked plan"),
+        "sha256": binding.sha256,
+        "schema_version": binding.schema_version,
+    }
+
+
+def _bitrate_search_record(policy: BitrateSearchPolicy) -> dict[str, object]:
+    return {
+        "merge_refinement_receipt": _frozen_evidence_record(policy.merge_refinement_receipt),
+        "collapse_receipt": _frozen_evidence_record(policy.collapse_receipt),
+        "collapse_plan": _checked_plan_record(policy.collapse_plan),
+        "threshold_noise_evidence": _source_evidence_record(policy.noise_evidence),
+        "accepted_merge_qualities": list(policy.accepted_merge_qualities),
+        "guided_anchor_count": policy.guided_anchor_count,
+        "custom_exact_retained": policy.custom_exact_retained,
+        "maximum_case_size_ratio_vs_tier_anchor": policy.maximum_case_size_ratio_vs_tier_anchor,
+        "minimum_aggregate_storage_reduction_ratio": policy.minimum_aggregate_storage_reduction_ratio,
+    }
+
+
 def _threshold_record(thresholds: RefinementThresholds) -> dict[str, object]:
     return {
         "noise_multiplier": 2,
@@ -812,16 +1028,19 @@ def _method_record(plan: ExperimentPlan) -> dict[str, object]:
         },
         "cell_order": plan.execution_order,
         "quality_metric": "aggregate and per-frame decoded same-eye SSIM",
-        "interaction_metric": (
-            "adjacent 2x2 difference of merge-quality effects"
-            if plan.schema_version == 1
-            else "pre-registered adjacent merge-quality response thresholds"
-        ),
+        "interaction_metric": {
+            1: "adjacent 2x2 difference of merge-quality effects",
+            2: "pre-registered adjacent merge-quality response thresholds",
+            3: "same-tier integer bitrate non-inferiority frontier",
+        }[plan.schema_version],
         "post_hoc_thresholds_forbidden": True,
         "decision_stage": plan.decision_stage,
     }
     if plan.source_evidence is not None and plan.thresholds is not None:
         method["source_evidence"] = _source_evidence_record(plan.source_evidence)
+        method["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
+    if plan.bitrate_search is not None and plan.thresholds is not None:
+        method["bitrate_search"] = _bitrate_search_record(plan.bitrate_search)
         method["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
     return method
 
@@ -1123,6 +1342,18 @@ def _cell_order(plan: ExperimentPlan, run_index: int) -> tuple[ExperimentCell, .
         shift = (run_index % 3) * (len(plan.cells) // 3)
     elif plan.execution_order == "cyclic_balanced":
         shift = (run_index * len(plan.cells)) // plan.runs_per_cell
+    elif plan.execution_order == "latin_thirds":
+        if len(plan.cells) != 40 or plan.runs_per_cell != 3:
+            raise QualificationFailure("Latin-thirds ordering requires the checked 40-cell, three-run design.")
+        early_group = plan.cells[:14]
+        middle_group = plan.cells[14:27]
+        late_group = plan.cells[27:]
+        orders = (
+            early_group + middle_group + late_group,
+            middle_group + late_group + early_group,
+            late_group + early_group + middle_group,
+        )
+        return orders[run_index % plan.runs_per_cell]
     else:
         raise QualificationFailure(f"Unsupported calibration execution order: {plan.execution_order}")
     return plan.cells[shift:] + plan.cells[:shift]
@@ -1423,6 +1654,178 @@ def _refinement_evaluations(
     return cell_evaluations, adjacent_evaluations
 
 
+def _bitrate_search_evaluations(
+    cases: Sequence[Mapping[str, object]],
+    plan: ExperimentPlan,
+    case_definitions: Mapping[str, CorpusCase],
+) -> list[dict[str, object]]:
+    policy = plan.bitrate_search
+    thresholds = plan.thresholds
+    if policy is None or thresholds is None:
+        return []
+    tier_evaluations: list[dict[str, object]] = []
+    for merge_quality in policy.accepted_merge_qualities:
+        tier_cells = tuple(cell for cell in plan.cells if cell.merge_quality == merge_quality)
+        anchor = next(cell for cell in tier_cells if cell.eye_bitrate_mbps == plan.balanced_eye_bitrate_mbps)
+        cell_evaluations: list[dict[str, object]] = []
+        for cell in tier_cells:
+            case_evaluations: list[dict[str, object]] = []
+            candidate_total_bytes = 0.0
+            anchor_total_bytes = 0.0
+            for case in cases:
+                case_id = str(case["id"])
+                candidate_record = _cell_record(case, cell.cell_id)
+                anchor_record = _cell_record(case, anchor.cell_id)
+                candidate = candidate_record.get("summary") if candidate_record is not None else None
+                baseline = anchor_record.get("summary") if anchor_record is not None else None
+                if not isinstance(candidate, Mapping) or not isinstance(baseline, Mapping):
+                    continue
+                quality_delta = float(candidate["median_min_same_eye_ssim"]) - float(
+                    baseline["median_min_same_eye_ssim"]
+                )
+                minimum_frame_delta = float(candidate["minimum_frame_same_eye_ssim"]) - float(
+                    baseline["minimum_frame_same_eye_ssim"]
+                )
+                p05_frame_delta = float(candidate["median_p05_frame_same_eye_ssim"]) - float(
+                    baseline["median_p05_frame_same_eye_ssim"]
+                )
+                standard_deviation_increase = float(candidate["maximum_frame_ssim_standard_deviation"]) - float(
+                    baseline["maximum_frame_ssim_standard_deviation"]
+                )
+                adjacent_drop_increase = float(candidate["maximum_adjacent_frame_ssim_drop"]) - float(
+                    baseline["maximum_adjacent_frame_ssim_drop"]
+                )
+                candidate_bytes = float(candidate["median_final_bytes"])
+                baseline_bytes = float(baseline["median_final_bytes"])
+                output_size_ratio = candidate_bytes / baseline_bytes
+                candidate_total_bytes += candidate_bytes
+                anchor_total_bytes += baseline_bytes
+                result = {
+                    "case_id": case_id,
+                    "quality_delta": quality_delta,
+                    "minimum_frame_quality_delta": minimum_frame_delta,
+                    "p05_frame_quality_delta": p05_frame_delta,
+                    "frame_ssim_standard_deviation_increase": standard_deviation_increase,
+                    "adjacent_frame_ssim_drop_increase": adjacent_drop_increase,
+                    "output_size_ratio_vs_tier_anchor": output_size_ratio,
+                    "quality_non_inferiority_passed": (
+                        quality_delta >= -thresholds.aggregate_quality_non_inferiority_margin
+                    ),
+                    "minimum_frame_non_inferiority_passed": (
+                        minimum_frame_delta >= -thresholds.minimum_frame_quality_non_inferiority_margin
+                    ),
+                    "p05_frame_non_inferiority_passed": (
+                        p05_frame_delta >= -thresholds.p05_frame_quality_non_inferiority_margin
+                    ),
+                    "temporal_stability_passed": (
+                        standard_deviation_increase <= thresholds.frame_ssim_standard_deviation_increase_limit
+                        and adjacent_drop_increase <= thresholds.adjacent_frame_ssim_drop_increase_limit
+                    ),
+                    "repeatability_passed": (
+                        float(candidate["repeat_ssim_spread"]) <= thresholds.repeat_ssim_spread_limit
+                        and float(candidate["repeat_size_ratio_spread"]) <= thresholds.repeat_size_ratio_spread_limit
+                    ),
+                    "eye_order_passed": (
+                        float(candidate["minimum_eye_order_margin"])
+                        >= case_definitions[case_id].minimum_eye_order_margin
+                    ),
+                    "case_size_non_regression_passed": (
+                        output_size_ratio <= policy.maximum_case_size_ratio_vs_tier_anchor
+                    ),
+                    "artifact_structure_passed": True,
+                }
+                constraint_keys = (
+                    "quality_non_inferiority_passed",
+                    "minimum_frame_non_inferiority_passed",
+                    "p05_frame_non_inferiority_passed",
+                    "temporal_stability_passed",
+                    "repeatability_passed",
+                    "eye_order_passed",
+                    "case_size_non_regression_passed",
+                    "artifact_structure_passed",
+                )
+                result["candidate_constraints_passed"] = all(bool(result[key]) for key in constraint_keys)
+                case_evaluations.append(result)
+            complete = len(case_evaluations) == len(case_definitions)
+            aggregate_size_ratio = (
+                candidate_total_bytes / anchor_total_bytes if complete and anchor_total_bytes > 0 else None
+            )
+            aggregate_storage_reduction = 1.0 - aggregate_size_ratio if aggregate_size_ratio is not None else None
+            core_passed = complete and all(bool(item["candidate_constraints_passed"]) for item in case_evaluations)
+            storage_benefit_passed = (
+                aggregate_storage_reduction is not None
+                and aggregate_storage_reduction >= policy.minimum_aggregate_storage_reduction_ratio
+            )
+            cell_evaluations.append(
+                {
+                    "cell_id": cell.cell_id,
+                    "eye_bitrate_mbps": cell.eye_bitrate_mbps,
+                    "merge_quality": cell.merge_quality,
+                    "complete": complete,
+                    "case_evaluations": case_evaluations,
+                    "aggregate_size_ratio_vs_tier_anchor": aggregate_size_ratio,
+                    "aggregate_storage_reduction_ratio": aggregate_storage_reduction,
+                    "candidate_constraints_passed": core_passed,
+                    "storage_benefit_passed": storage_benefit_passed,
+                }
+            )
+
+        passing_flags = [bool(item["candidate_constraints_passed"]) for item in cell_evaluations]
+        first_passing_index = next((index for index, passed in enumerate(passing_flags) if passed), None)
+        frontier_monotone = first_passing_index is not None and all(passing_flags[first_passing_index:])
+        anchor_evaluation = next(item for item in cell_evaluations if item["cell_id"] == anchor.cell_id)
+        anchor_passed = anchor_evaluation["candidate_constraints_passed"] is True
+        core_minimum = cell_evaluations[first_passing_index] if first_passing_index is not None else None
+        minimum_bracketed = core_minimum is not None and (
+            int(core_minimum["eye_bitrate_mbps"]) == 1
+            or (
+                first_passing_index is not None
+                and first_passing_index > 0
+                and int(cell_evaluations[first_passing_index - 1]["eye_bitrate_mbps"])
+                == int(core_minimum["eye_bitrate_mbps"]) - 1
+                and cell_evaluations[first_passing_index - 1]["candidate_constraints_passed"] is False
+            )
+        )
+        decision_ready = (
+            len(cell_evaluations) == len(tier_cells)
+            and all(item["complete"] is True for item in cell_evaluations)
+            and anchor_passed
+            and frontier_monotone
+            and minimum_bracketed
+        )
+        selected = anchor_evaluation
+        minimization_adopted = False
+        if (
+            decision_ready
+            and core_minimum is not None
+            and int(core_minimum["eye_bitrate_mbps"]) < plan.balanced_eye_bitrate_mbps
+            and core_minimum["storage_benefit_passed"] is True
+        ):
+            selected = core_minimum
+            minimization_adopted = True
+        tier_evaluations.append(
+            {
+                "merge_quality": merge_quality,
+                "anchor_cell_id": anchor.cell_id,
+                "cell_evaluations": cell_evaluations,
+                "complete": len(cell_evaluations) == len(tier_cells)
+                and all(item["complete"] is True for item in cell_evaluations),
+                "anchor_passed": anchor_passed,
+                "frontier_monotone": frontier_monotone,
+                "minimum_bracketed": minimum_bracketed,
+                "core_minimum_cell_id": core_minimum["cell_id"] if core_minimum is not None else None,
+                "selected_cell_id": selected["cell_id"] if decision_ready else None,
+                "selected_eye_bitrate_mbps": selected["eye_bitrate_mbps"] if decision_ready else None,
+                "selected_aggregate_storage_reduction_ratio": (
+                    selected["aggregate_storage_reduction_ratio"] if decision_ready else None
+                ),
+                "minimization_adopted": minimization_adopted,
+                "decision_ready": decision_ready,
+            }
+        )
+    return tier_evaluations
+
+
 def _refresh_summaries(
     evidence: dict[str, object],
     plan: ExperimentPlan,
@@ -1553,22 +1956,33 @@ def _refresh_summaries(
             default=None,
         ),
     }
-    evidence["axis_findings"] = [
-        finding for case in cases if isinstance(case, Mapping) for finding in _axis_findings(case, plan)
-    ]
-    evidence["interaction_observations"] = [
-        observation
-        for case in cases
-        if isinstance(case, Mapping)
-        for observation in _interaction_observations(case, plan)
-    ]
-    refinement_cell_evaluations, refinement_adjacent_evaluations = _refinement_evaluations(
-        [case for case in cases if isinstance(case, Mapping)],
-        plan,
-        case_definitions,
+    typed_cases = [case for case in cases if isinstance(case, Mapping)]
+    evidence["axis_findings"] = (
+        [] if plan.schema_version == 3 else [finding for case in typed_cases for finding in _axis_findings(case, plan)]
+    )
+    evidence["interaction_observations"] = (
+        []
+        if plan.schema_version == 3
+        else [observation for case in typed_cases for observation in _interaction_observations(case, plan)]
+    )
+    refinement_cell_evaluations, refinement_adjacent_evaluations = (
+        ([], []) if plan.schema_version == 3 else _refinement_evaluations(typed_cases, plan, case_definitions)
     )
     evidence["refinement_cell_evaluations"] = refinement_cell_evaluations
     evidence["refinement_adjacent_evaluations"] = refinement_adjacent_evaluations
+    bitrate_tier_evaluations = _bitrate_search_evaluations(typed_cases, plan, case_definitions)
+    evidence["bitrate_tier_evaluations"] = bitrate_tier_evaluations
+    evidence["selected_bitrate_cells"] = [
+        {
+            "merge_quality": evaluation["merge_quality"],
+            "cell_id": evaluation["selected_cell_id"],
+            "eye_bitrate_mbps": evaluation["selected_eye_bitrate_mbps"],
+            "aggregate_storage_reduction_ratio": evaluation["selected_aggregate_storage_reduction_ratio"],
+            "minimization_adopted": evaluation["minimization_adopted"],
+        }
+        for evaluation in bitrate_tier_evaluations
+        if evaluation["decision_ready"] is True
+    ]
 
     cells_complete = len(cell_summaries) == len(plan.cells) and all(
         summary["complete"] is True for summary in cell_summaries
@@ -1585,6 +1999,45 @@ def _refresh_summaries(
             if isinstance(cell, Mapping) and isinstance(cell.get("summary"), Mapping)
         ]
     )
+    if plan.schema_version == 3:
+        planned_tier_count = len(plan.bitrate_search.accepted_merge_qualities) if plan.bitrate_search else 0
+        tier_evaluations_complete = (
+            cells_complete
+            and len(bitrate_tier_evaluations) == planned_tier_count
+            and all(evaluation["complete"] is True for evaluation in bitrate_tier_evaluations)
+        )
+        tier_decisions_ready = tier_evaluations_complete and all(
+            evaluation["decision_ready"] is True for evaluation in bitrate_tier_evaluations
+        )
+        planned_stress_corpus = set(case_definitions) == set(binding.selected_case_ids)
+        bitrate_search_ready = (
+            tier_decisions_ready and planned_stress_corpus and eye_order_passed and plan.thresholds is not None
+        )
+        evidence["acceptance"] = {
+            "complete": cells_complete,
+            "planned_stress_corpus": planned_stress_corpus,
+            "objective_validation_passed": cells_complete,
+            "eye_order_passed": eye_order_passed,
+            "baseline_repeatability_ready": len(baseline_cases) == len(case_definitions),
+            "execution_passed": cells_complete and eye_order_passed,
+            "thresholds_selected": True,
+            "thresholds_pre_registered": True,
+            "thresholds_evaluated": tier_evaluations_complete,
+            "source_evidence_verified": True,
+            "accepted_merge_tier_count": planned_tier_count,
+            "tier_evaluations_complete": tier_evaluations_complete,
+            "tier_decisions_ready": tier_decisions_ready,
+            "selected_tier_count": len(evidence["selected_bitrate_cells"]),
+            "bitrate_search_ready": bitrate_search_ready,
+            "stress_subset_evidence_ready": bitrate_search_ready,
+            "full_corpus_confirmation_required": True,
+            "package_validation_required": True,
+            "physical_vision_pro_validation_required": True,
+            "ladder_evidence_ready": False,
+            "ladder_mapping_selected": False,
+            "experiment_complete": bitrate_search_ready,
+        }
+        return
     expected_interactions = len(case_definitions) * (len(plan.eye_bitrates_mbps) - 1) * (len(plan.merge_qualities) - 1)
     interaction_observations_complete = (
         cells_complete and len(evidence["interaction_observations"]) == expected_interactions
@@ -1708,6 +2161,35 @@ def _new_evidence(
     if plan.source_evidence is not None and plan.thresholds is not None:
         evidence["source_evidence"] = _source_evidence_record(plan.source_evidence)
         evidence["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
+    if plan.bitrate_search is not None and plan.thresholds is not None:
+        evidence["bitrate_search"] = _bitrate_search_record(plan.bitrate_search)
+        evidence["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
+        evidence["bitrate_tier_evaluations"] = []
+        evidence["selected_bitrate_cells"] = []
+        evidence["acceptance"] = {
+            "complete": False,
+            "planned_stress_corpus": False,
+            "objective_validation_passed": False,
+            "eye_order_passed": False,
+            "baseline_repeatability_ready": False,
+            "execution_passed": False,
+            "thresholds_selected": True,
+            "thresholds_pre_registered": True,
+            "thresholds_evaluated": False,
+            "source_evidence_verified": True,
+            "accepted_merge_tier_count": len(plan.bitrate_search.accepted_merge_qualities),
+            "tier_evaluations_complete": False,
+            "tier_decisions_ready": False,
+            "selected_tier_count": 0,
+            "bitrate_search_ready": False,
+            "stress_subset_evidence_ready": False,
+            "full_corpus_confirmation_required": True,
+            "package_validation_required": True,
+            "physical_vision_pro_validation_required": True,
+            "ladder_evidence_ready": False,
+            "ladder_mapping_selected": False,
+            "experiment_complete": False,
+        }
     return evidence
 
 
@@ -1788,9 +2270,10 @@ def _load_resume_evidence(
     if output_path.is_symlink():
         raise QualificationFailure("Resume evidence must not be a symlink.")
     try:
-        raw_evidence = output_path.read_text(encoding="utf-8")
-        evidence = json.loads(raw_evidence)
-    except (OSError, json.JSONDecodeError) as error:
+        raw_evidence_bytes = output_path.read_bytes()
+        raw_evidence = raw_evidence_bytes.decode("utf-8")
+        evidence = dict(_loads_json_bytes(raw_evidence_bytes, "resume evidence"))
+    except (OSError, UnicodeDecodeError) as error:
         raise QualificationFailure(f"Could not read resume evidence: {error}") from error
     if not isinstance(evidence, dict) or evidence.get("schema_version") != EVIDENCE_SCHEMA_VERSION:
         raise QualificationFailure("Resume evidence has an unsupported schema.")
@@ -1823,6 +2306,9 @@ def _load_resume_evidence(
     }
     if plan.source_evidence is not None and plan.thresholds is not None:
         expected_identity["source_evidence"] = _source_evidence_record(plan.source_evidence)
+        expected_identity["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
+    if plan.bitrate_search is not None and plan.thresholds is not None:
+        expected_identity["bitrate_search"] = _bitrate_search_record(plan.bitrate_search)
         expected_identity["pre_registered_thresholds"] = _threshold_record(plan.thresholds)
     for key, expected in expected_identity.items():
         if evidence.get(key) != expected:
@@ -1876,6 +2362,8 @@ def _completed_resume_is_consistent(
     ]
     if plan.schema_version == 2:
         summary_keys.extend(("refinement_cell_evaluations", "refinement_adjacent_evaluations"))
+    elif plan.schema_version == 3:
+        summary_keys.extend(("bitrate_tier_evaluations", "selected_bitrate_cells"))
     for key in summary_keys:
         if refreshed.get(key) != evidence.get(key):
             raise QualificationFailure("Completed resume evidence summaries contradict the recorded runs.")
@@ -1953,6 +2441,38 @@ def _inspect_generated_output(ffprobe: str, prepared, output_path: Path) -> dict
     }
 
 
+def _read_frozen_evidence(
+    path: Path | None,
+    binding: FrozenEvidenceBinding,
+    label: str,
+) -> Mapping[str, object]:
+    if path is None:
+        raise QualificationFailure(f"{label} is required.")
+    absolute = path.absolute()
+    if absolute.is_symlink():
+        raise QualificationFailure(f"{label} must not be a symlink.")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(absolute, flags)
+    except OSError as error:
+        raise QualificationFailure(f"Could not open {label} safely.") from error
+    try:
+        file_status = os.fstat(descriptor)
+        if not stat.S_ISREG(file_status.st_mode):
+            raise QualificationFailure(f"{label} must be a regular file.")
+        if stat.S_IMODE(file_status.st_mode) != binding.required_file_mode:
+            raise QualificationFailure(f"{label} must be frozen read-only.")
+        chunks: list[bytes] = []
+        while chunk := os.read(descriptor, 1024 * 1024):
+            chunks.append(chunk)
+        data = b"".join(chunks)
+    finally:
+        os.close(descriptor)
+    if hashlib.sha256(data).hexdigest() != binding.sha256:
+        raise QualificationFailure(f"{label} does not match its pinned SHA-256 identity.")
+    return _loads_json_bytes(data, label)
+
+
 def _verify_refinement_source_receipt(plan: ExperimentPlan, receipt_path: Path | None) -> None:
     source = plan.source_evidence
     if source is None:
@@ -1961,17 +2481,17 @@ def _verify_refinement_source_receipt(plan: ExperimentPlan, receipt_path: Path |
         return
     if receipt_path is None:
         raise QualificationFailure("Merge refinement requires --source-evidence-receipt.")
-    resolved = receipt_path.resolve()
-    if receipt_path.is_symlink() or not resolved.is_file():
-        raise QualificationFailure("The source evidence receipt is unavailable or unsafe.")
-    if stat.S_IMODE(resolved.stat().st_mode) != 0o444:
-        raise QualificationFailure("The source evidence receipt must be frozen read-only.")
-    if sha256_file(resolved) != source.receipt_sha256:
-        raise QualificationFailure("The source evidence receipt does not match its pinned SHA-256 identity.")
-    try:
-        receipt = _mapping(json.loads(resolved.read_text(encoding="utf-8")), "source evidence receipt")
-    except (OSError, json.JSONDecodeError) as error:
-        raise QualificationFailure("Could not read the source evidence receipt.") from error
+    receipt = _read_frozen_evidence(
+        receipt_path,
+        FrozenEvidenceBinding(
+            schema_version=1,
+            evidence_id=source.experiment_id,
+            sha256=source.receipt_sha256,
+            source_git_sha=source.source_git_sha,
+            required_file_mode=0o444,
+        ),
+        "Source evidence receipt",
+    )
     if (
         receipt.get("experiment_id") != source.experiment_id
         or receipt.get("source_git_sha") != source.source_git_sha
@@ -2022,6 +2542,127 @@ def _verify_refinement_source_receipt(plan: ExperimentPlan, receipt_path: Path |
             raise QualificationFailure("The source evidence receipt per-frame noise floor does not match the plan.")
 
 
+def _verify_bitrate_search_source_receipts(
+    plan: ExperimentPlan,
+    binding: CorpusBinding,
+    refinement_receipt_path: Path | None,
+    collapse_receipt_path: Path | None,
+) -> None:
+    policy = plan.bitrate_search
+    if policy is None:
+        if collapse_receipt_path is not None:
+            raise QualificationFailure("A collapse receipt is not valid for this experiment plan.")
+        _verify_refinement_source_receipt(plan, refinement_receipt_path)
+        return
+
+    refinement = _read_frozen_evidence(
+        refinement_receipt_path,
+        policy.merge_refinement_receipt,
+        "Merge refinement receipt",
+    )
+    if (
+        refinement.get("schema_version") != policy.merge_refinement_receipt.schema_version
+        or refinement.get("experiment_id") != policy.merge_refinement_receipt.evidence_id
+        or refinement.get("source_git_sha") != policy.merge_refinement_receipt.source_git_sha
+        or refinement.get("source_tree_dirty") is not False
+    ):
+        raise QualificationFailure("The merge refinement receipt identity is inconsistent with the checked plan.")
+    refinement_acceptance = _mapping(refinement.get("acceptance"), "merge refinement acceptance")
+    if (
+        refinement_acceptance.get("experiment_complete") is not True
+        or refinement_acceptance.get("refinement_evidence_ready") is not True
+        or refinement_acceptance.get("thresholds_pre_registered") is not True
+        or refinement_acceptance.get("ladder_mapping_selected") is not False
+    ):
+        raise QualificationFailure("The merge refinement receipt is not completed checked source evidence.")
+    if refinement.get("pre_registered_thresholds") != _threshold_record(plan.thresholds):
+        raise QualificationFailure("The merge refinement receipt thresholds changed before bitrate search.")
+    refinement_binding = _mapping(refinement.get("corpus_binding"), "merge refinement corpus binding")
+    expected_binding = {
+        "path": binding.relative_path,
+        "binding_id": binding.binding_id,
+        "sha256": plan.binding_sha256,
+    }
+    if refinement_binding != expected_binding:
+        raise QualificationFailure("The merge refinement receipt corpus binding changed before bitrate search.")
+    refinement_cells = {
+        _string(_mapping(cell, "merge refinement cell").get("id"), "merge refinement cell id")
+        for cell in _array(refinement.get("cells"), "merge refinement cells")
+    }
+    required_anchor_cells = {
+        _cell_id(plan.balanced_eye_bitrate_mbps, merge) for merge in policy.accepted_merge_qualities
+    }
+    if not required_anchor_cells.issubset(refinement_cells):
+        raise QualificationFailure("The merge refinement receipt is missing an accepted same-tier anchor.")
+
+    collapse = _read_frozen_evidence(
+        collapse_receipt_path,
+        policy.collapse_receipt,
+        "Collapse analysis receipt",
+    )
+    if (
+        collapse.get("schema_version") != policy.collapse_receipt.schema_version
+        or collapse.get("analysis_id") != policy.collapse_receipt.evidence_id
+        or collapse.get("analysis_source_git_sha") != policy.collapse_receipt.source_git_sha
+        or collapse.get("analysis_source_tree_dirty") is not False
+    ):
+        raise QualificationFailure("The collapse analysis receipt identity is inconsistent with the checked plan.")
+    expected_analysis_plan = _checked_plan_record(policy.collapse_plan)
+    if collapse.get("analysis_plan") != {
+        "path": expected_analysis_plan["path"],
+        "sha256": expected_analysis_plan["sha256"],
+    }:
+        raise QualificationFailure("The collapse analysis receipt does not match its checked plan.")
+    collapse_source_receipt = _mapping(collapse.get("source_receipt"), "collapse source receipt")
+    if (
+        collapse_source_receipt.get("schema_version") != policy.merge_refinement_receipt.schema_version
+        or collapse_source_receipt.get("experiment_id") != policy.merge_refinement_receipt.evidence_id
+        or collapse_source_receipt.get("sha256") != policy.merge_refinement_receipt.sha256
+        or collapse_source_receipt.get("source_git_sha") != policy.merge_refinement_receipt.source_git_sha
+        or collapse_source_receipt.get("file_mode") != "0444"
+    ):
+        raise QualificationFailure("The collapse receipt does not bind the checked merge refinement evidence.")
+    refinement_plan_record = _mapping(refinement.get("experiment_plan"), "merge refinement plan record")
+    collapse_source_plan = _mapping(collapse.get("source_plan"), "collapse source plan")
+    if (
+        collapse_source_plan.get("path") != refinement_plan_record.get("path")
+        or collapse_source_plan.get("sha256") != refinement_plan_record.get("sha256")
+        or collapse_source_plan.get("schema_version") != 2
+    ):
+        raise QualificationFailure("The collapse receipt source plan changed before bitrate search.")
+    expected_corpus_binding = {
+        "path": binding.relative_path,
+        "binding_id": binding.binding_id,
+        "sha256": plan.binding_sha256,
+        "selected_case_ids": list(binding.selected_case_ids),
+    }
+    if collapse.get("source_corpus_binding") != expected_corpus_binding:
+        raise QualificationFailure("The collapse receipt corpus binding changed before bitrate search.")
+    if collapse.get("thresholds") != _threshold_record(plan.thresholds):
+        raise QualificationFailure("The collapse receipt thresholds changed before bitrate search.")
+    selected_subset = _mapping(collapse.get("selected_subset"), "collapse selected subset")
+    expected_cell_ids = [_cell_id(plan.balanced_eye_bitrate_mbps, merge) for merge in policy.accepted_merge_qualities]
+    if (
+        selected_subset.get("cell_ids") != expected_cell_ids
+        or selected_subset.get("cardinality") != policy.guided_anchor_count
+        or selected_subset.get("contains_balanced") is not True
+    ):
+        raise QualificationFailure("The collapse receipt does not select the accepted generated anchors.")
+    collapse_acceptance = _mapping(collapse.get("acceptance"), "collapse acceptance")
+    required_acceptance = {
+        "analysis_complete": True,
+        "balanced_included": True,
+        "selected_chain_valid": True,
+        "source_plan_verified": True,
+        "source_receipt_verified": True,
+        "thresholds_unchanged": True,
+        "selected_step_count": policy.guided_anchor_count,
+        "ladder_mapping_selected": False,
+    }
+    if any(collapse_acceptance.get(key) != expected for key, expected in required_acceptance.items()):
+        raise QualificationFailure("The collapse receipt acceptance is inconsistent with the product decision.")
+
+
 def _validate_prepared_source(binding: CorpusBinding, prepared) -> None:
     expected = binding.expected_case_sources[prepared.definition.case_id]
     if dict(prepared.source_evidence) != dict(expected):
@@ -2038,6 +2679,7 @@ def _run_calibration_unlocked(
     resume: bool,
     case_ids: Sequence[str] = (),
     source_evidence_receipt: Path | None = None,
+    collapse_receipt: Path | None = None,
 ) -> dict[str, object]:
     if platform.system() != "Darwin" or platform.machine() != "arm64":
         raise QualificationFailure("Generated MV-HEVC calibration requires macOS arm64.")
@@ -2046,13 +2688,20 @@ def _run_calibration_unlocked(
             raise QualificationFailure(f"Required bundled tool is unavailable: {tool.name}")
     source_git_sha = _git_head_from_clean_worktree()
     plan, binding, plan_sha256, binding_sha256 = load_experiment_plan(experiment_plan_path)
-    _verify_refinement_source_receipt(plan, source_evidence_receipt)
+    _verify_bitrate_search_source_receipts(
+        plan,
+        binding,
+        source_evidence_receipt,
+        collapse_receipt,
+    )
     if _require_head_tracked_file(experiment_plan_path, "Experiment plan") != plan.relative_path:
         raise QualificationFailure("Experiment plan repository identity changed during validation.")
     if _require_head_tracked_file(plan.binding_path, "Corpus binding") != binding.relative_path:
         raise QualificationFailure("Corpus binding repository identity changed during validation.")
     _require_head_tracked_file(binding.source_manifest_path, "Bound corpus manifest")
     _require_head_tracked_file(plan.ffmpeg_manifest_path, "FFmpeg vendor manifest")
+    if plan.bitrate_search is not None:
+        _require_head_tracked_file(plan.bitrate_search.collapse_plan.path, "Collapse analysis plan")
     manifest = load_manifest(binding.source_manifest_path)
     gated_by_id = {case.case_id: case for case in manifest.cases if case.quality_gate}
     planned_cases = tuple(gated_by_id[case_id] for case_id in binding.selected_case_ids)
@@ -2179,6 +2828,7 @@ def _run_calibration_unlocked(
                         case_work / f"{cell.cell_id}-run-{run_index + 1}-split",
                         target_bitrate_mbps=cell.eye_bitrate_mbps * 2,
                         include_frame_metrics=True,
+                        delete_output=False,
                     )
                 except QualificationFailure as error:
                     raise QualificationFailure(redact_private_source_paths(str(error), private_paths)) from None
@@ -2205,6 +2855,7 @@ def _run_calibration_unlocked(
                 runs.sort(key=lambda run: int(run["run_index"]))
                 evidence["updated_at"] = datetime.now(UTC).isoformat()
                 _atomic_write(output_path, evidence, private_paths)
+                output.unlink(missing_ok=True)
         _refresh_summaries(evidence, plan, binding, case_definitions)
         evidence["updated_at"] = datetime.now(UTC).isoformat()
         _atomic_write(output_path, evidence, private_paths)
@@ -2226,6 +2877,7 @@ def run_calibration(
     resume: bool,
     case_ids: Sequence[str] = (),
     source_evidence_receipt: Path | None = None,
+    collapse_receipt: Path | None = None,
 ) -> dict[str, object]:
     with calibration_lock(output_path, work_directory):
         return _run_calibration_unlocked(
@@ -2235,17 +2887,19 @@ def run_calibration(
             resume=resume,
             case_ids=case_ids,
             source_evidence_receipt=source_evidence_receipt,
+            collapse_receipt=collapse_receipt,
         )
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Measure a checked generated MV-HEVC interaction or merge-refinement plan."
+        description="Measure a checked generated MV-HEVC interaction, merge-refinement, or bitrate-search plan."
     )
     parser.add_argument("--experiment-plan", type=Path, default=DEFAULT_EXPERIMENT_PLAN)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--work-directory", type=Path, required=True)
     parser.add_argument("--source-evidence-receipt", type=Path)
+    parser.add_argument("--collapse-receipt", type=Path)
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--case-id", action="append", default=[])
     return parser
@@ -2263,6 +2917,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_evidence_receipt=(
                 args.source_evidence_receipt.absolute() if args.source_evidence_receipt is not None else None
             ),
+            collapse_receipt=(args.collapse_receipt.absolute() if args.collapse_receipt is not None else None),
         )
     except (
         AssertionError,
@@ -2282,6 +2937,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     method = evidence.get("method")
     if isinstance(method, Mapping) and method.get("decision_stage") == "merge_response_refinement_only":
         return 0 if acceptance.get("refinement_decision_ready") is True else 1
+    if isinstance(method, Mapping) and method.get("decision_stage") == "same_tier_bitrate_minimization_only":
+        return 0 if acceptance.get("bitrate_search_ready") is True else 1
     return 0 if acceptance.get("execution_passed") is True else 1
 
 

--- a/scripts/qualify_mv_hevc_corpus.py
+++ b/scripts/qualify_mv_hevc_corpus.py
@@ -911,6 +911,7 @@ def _measure_output(
     *,
     target_bitrate_mbps: float | None,
     include_frame_metrics: bool = False,
+    delete_output: bool = True,
 ) -> dict[str, object]:
     left, right = split_mv_hevc(output_path, split_directory)
     if include_frame_metrics:
@@ -940,7 +941,8 @@ def _measure_output(
     if include_frame_metrics:
         record.update(summarize_frame_quality(left_frame_scores, right_frame_scores))
     shutil.rmtree(split_directory, ignore_errors=True)
-    output_path.unlink(missing_ok=True)
+    if delete_output:
+        output_path.unlink(missing_ok=True)
     return record
 
 

--- a/tests/test_generated_mv_hevc_calibration.py
+++ b/tests/test_generated_mv_hevc_calibration.py
@@ -1,9 +1,11 @@
 import copy
+import hashlib
 import json
 import stat
 import tempfile
 import unittest
 
+from dataclasses import replace
 from itertools import product
 from pathlib import Path
 from unittest.mock import patch
@@ -11,6 +13,7 @@ from unittest.mock import patch
 from scripts.qualify_direct_mv_hevc import CURRENT_REQUIRED_BOX_TYPES, QualificationFailure
 from scripts.qualify_generated_mv_hevc_calibration import (
     DEFAULT_EXPERIMENT_PLAN,
+    DEFAULT_BITRATE_SEARCH_PLAN,
     DEFAULT_REFINEMENT_PLAN,
     CorpusBinding,
     ExperimentCell,
@@ -26,7 +29,9 @@ from scripts.qualify_generated_mv_hevc_calibration import (
     _refresh_summaries,
     _reset_case_directory,
     _summarize_measurement_runs,
+    _threshold_record,
     _validate_run_record,
+    _verify_bitrate_search_source_receipts,
     _verify_refinement_source_receipt,
     calibration_lock,
     load_experiment_plan,
@@ -38,6 +43,7 @@ from scripts.qualify_mv_hevc_corpus import (
     CorpusCase,
     PreparedCase,
     _encode_generated,
+    _measure_output,
     summarize_frame_quality,
 )
 
@@ -46,6 +52,7 @@ class GeneratedCalibrationPlanTests(unittest.TestCase):
     def setUp(self) -> None:
         self.document = json.loads(DEFAULT_EXPERIMENT_PLAN.read_text(encoding="utf-8"))
         self.refinement_document = json.loads(DEFAULT_REFINEMENT_PLAN.read_text(encoding="utf-8"))
+        self.bitrate_search_document = json.loads(DEFAULT_BITRATE_SEARCH_PLAN.read_text(encoding="utf-8"))
         self.binding_document = json.loads(
             DEFAULT_EXPERIMENT_PLAN.with_name("generated-mv-hevc-corpus-v1.json").read_text(encoding="utf-8")
         )
@@ -141,6 +148,83 @@ class GeneratedCalibrationPlanTests(unittest.TestCase):
 
         with self.assertRaisesRegex(QualificationFailure, "checked rounded 2x noise derivation"):
             parse_experiment_plan(document)
+
+    def test_committed_bitrate_search_plan_covers_exact_integer_frontiers(self) -> None:
+        plan, binding, plan_digest, binding_digest = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+
+        self.assertEqual(plan.schema_version, 3)
+        self.assertEqual(plan.eye_bitrates_mbps, tuple(range(1, 21)))
+        self.assertEqual(plan.merge_qualities, (65, 75))
+        self.assertEqual(len(plan.cells), 40)
+        self.assertEqual(plan.decision_stage, "same_tier_bitrate_minimization_only")
+        self.assertIsNotNone(plan.bitrate_search)
+        self.assertIsNotNone(plan.thresholds)
+        assert plan.bitrate_search is not None
+        self.assertEqual(plan.bitrate_search.accepted_merge_qualities, (65, 75))
+        self.assertEqual(plan.bitrate_search.guided_anchor_count, 2)
+        self.assertTrue(plan.bitrate_search.custom_exact_retained)
+        self.assertEqual(binding.binding_id, "generated-mv-hevc-stress-v1")
+        self.assertEqual(len(plan_digest), 64)
+        self.assertEqual(len(binding_digest), 64)
+
+    def test_bitrate_search_rejects_incomplete_integer_grid(self) -> None:
+        document = copy.deepcopy(self.bitrate_search_document)
+        document["axes"]["eye_bitrate_mbps"].remove(11)
+
+        with self.assertRaisesRegex(QualificationFailure, "exactly 20 levels"):
+            parse_experiment_plan(document)
+
+    def test_bitrate_search_rejects_changed_product_decision(self) -> None:
+        document = copy.deepcopy(self.bitrate_search_document)
+        document["bitrate_search"]["accepted_merge_qualities"] = [65, 71, 75]
+
+        with self.assertRaisesRegex(QualificationFailure, r"must be \[65, 75\]"):
+            parse_experiment_plan(document)
+
+    def test_bitrate_search_rejects_post_hoc_storage_threshold(self) -> None:
+        document = copy.deepcopy(self.bitrate_search_document)
+        document["bitrate_search"]["minimum_aggregate_storage_reduction_ratio"] = 0.01
+
+        with self.assertRaisesRegex(QualificationFailure, "must be 2%"):
+            parse_experiment_plan(document)
+
+    def test_bitrate_search_latin_order_balances_every_cell_across_execution_windows(self) -> None:
+        plan, _, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        orders = [_cell_order(plan, run_index) for run_index in range(plan.runs_per_cell)]
+        window_bounds = ((14, 27), (13, 26), (13, 27))
+
+        for cell in plan.cells:
+            windows: list[str] = []
+            for order, (early_end, middle_end) in zip(orders, window_bounds, strict=True):
+                position = order.index(cell)
+                windows.append("early" if position < early_end else "middle" if position < middle_end else "late")
+            self.assertEqual(set(windows), {"early", "middle", "late"})
+
+        for anchor_id in ("b020-m065", "b020-m075"):
+            anchor = next(cell for cell in plan.cells if cell.cell_id == anchor_id)
+            self.assertEqual(
+                [order.index(anchor) for order in orders],
+                [
+                    38 if anchor_id.endswith("065") else 39,
+                    24 if anchor_id.endswith("065") else 25,
+                    11 if anchor_id.endswith("065") else 12,
+                ],
+            )
+
+    def test_plan_and_binding_loaders_reject_duplicate_json_keys(self) -> None:
+        build_directory = DEFAULT_EXPERIMENT_PLAN.parents[2] / "build"
+        build_directory.mkdir(exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=build_directory) as temporary_directory:
+            root = Path(temporary_directory)
+            plan_path = root / "plan.json"
+            binding_path = root / "binding.json"
+            plan_path.write_text('{"schema_version":1,"schema_version":1}\n', encoding="utf-8")
+            binding_path.write_text('{"schema_version":1,"schema_version":1}\n', encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationFailure, "duplicate key"):
+                load_experiment_plan(plan_path)
+            with self.assertRaisesRegex(QualificationFailure, "duplicate key"):
+                load_corpus_binding(binding_path)
 
     def test_rejects_duplicate_binding_cases(self) -> None:
         document = copy.deepcopy(self.binding_document)
@@ -265,6 +349,45 @@ class GeneratedCalibrationSummaryTests(unittest.TestCase):
                         "summary": None,
                     }
                 )
+        return {"id": case_id, "cells": cells}
+
+    @classmethod
+    def _bitrate_case_record(
+        cls,
+        plan: ExperimentPlan,
+        case_id: str = "case-a",
+        *,
+        frontiers: dict[int, int] | None = None,
+        storage_benefit: bool = True,
+    ) -> dict[str, object]:
+        frontier_by_merge = frontiers or {65: 5, 75: 8}
+        cells: list[dict[str, object]] = []
+        for cell in plan.cells:
+            anchor_quality = 0.95 if cell.merge_quality == 65 else 0.96
+            if cell.eye_bitrate_mbps == 20:
+                quality = anchor_quality
+            elif cell.eye_bitrate_mbps >= frontier_by_merge[cell.merge_quality]:
+                quality = anchor_quality - 0.0002
+            else:
+                quality = anchor_quality - 0.002
+            anchor_size = 10_000 if cell.merge_quality == 65 else 20_000
+            if storage_benefit:
+                size = int(anchor_size * (0.5 + 0.5 * cell.eye_bitrate_mbps / 20))
+            else:
+                size = anchor_size
+            runs = [
+                cls._run(cell, run_index, quality + run_index * 0.00005, size + run_index, 2 + run_index)
+                for run_index in range(plan.runs_per_cell)
+            ]
+            cells.append(
+                {
+                    "id": cell.cell_id,
+                    "eye_bitrate_mbps": cell.eye_bitrate_mbps,
+                    "merge_quality": cell.merge_quality,
+                    "runs": runs,
+                    "summary": None,
+                }
+            )
         return {"id": case_id, "cells": cells}
 
     @staticmethod
@@ -485,6 +608,88 @@ class GeneratedCalibrationSummaryTests(unittest.TestCase):
         self.assertFalse(evaluation["candidate_constraints_passed"])
         self.assertFalse(evidence["acceptance"]["eye_order_passed"])
 
+    def test_bitrate_search_selects_exact_same_tier_integer_frontiers(self) -> None:
+        plan, _, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        binding = self._binding("case-a")
+        evidence: dict[str, object] = {"cases": [self._bitrate_case_record(plan)]}
+
+        _refresh_summaries(evidence, plan, binding, {"case-a": self._definition()})
+
+        evaluations = {item["merge_quality"]: item for item in evidence["bitrate_tier_evaluations"]}
+        self.assertEqual(evaluations[65]["core_minimum_cell_id"], "b005-m065")
+        self.assertEqual(evaluations[65]["selected_cell_id"], "b005-m065")
+        self.assertEqual(evaluations[75]["core_minimum_cell_id"], "b008-m075")
+        self.assertEqual(evaluations[75]["selected_cell_id"], "b008-m075")
+        self.assertTrue(evaluations[65]["frontier_monotone"])
+        self.assertTrue(evaluations[75]["minimization_adopted"])
+        self.assertTrue(evidence["acceptance"]["bitrate_search_ready"])
+        self.assertFalse(evidence["acceptance"]["ladder_mapping_selected"])
+
+    def test_bitrate_search_fails_closed_on_non_monotone_frontier(self) -> None:
+        plan, _, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        binding = self._binding("case-a")
+        case = self._bitrate_case_record(plan)
+        failed_cell = next(cell for cell in case["cells"] if cell["id"] == "b006-m065")
+        for run in failed_cell["runs"]:
+            quality = 0.948
+            run["left_match_ssim"] = quality
+            run["right_match_ssim"] = quality + 0.0001
+            run["left_cross_ssim"] = quality - 0.2
+            run["right_cross_ssim"] = quality - 0.1999
+            run["min_same_eye_ssim"] = quality
+            run["minimum_frame_same_eye_ssim"] = quality - 0.01
+            run["p05_frame_same_eye_ssim"] = quality - 0.005
+            run["median_frame_same_eye_ssim"] = quality
+        evidence: dict[str, object] = {"cases": [case]}
+
+        _refresh_summaries(evidence, plan, binding, {"case-a": self._definition()})
+
+        evaluation = next(item for item in evidence["bitrate_tier_evaluations"] if item["merge_quality"] == 65)
+        self.assertFalse(evaluation["frontier_monotone"])
+        self.assertFalse(evaluation["decision_ready"])
+        self.assertFalse(evidence["acceptance"]["bitrate_search_ready"])
+
+    def test_bitrate_search_keeps_storage_benefit_out_of_quality_frontier(self) -> None:
+        plan, _, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        binding = self._binding("case-a")
+        evidence: dict[str, object] = {"cases": [self._bitrate_case_record(plan, storage_benefit=False)]}
+
+        _refresh_summaries(evidence, plan, binding, {"case-a": self._definition()})
+
+        evaluations = {item["merge_quality"]: item for item in evidence["bitrate_tier_evaluations"]}
+        self.assertTrue(evaluations[65]["frontier_monotone"])
+        self.assertTrue(evaluations[65]["decision_ready"])
+        self.assertFalse(evaluations[65]["minimization_adopted"])
+        self.assertEqual(evaluations[65]["selected_cell_id"], "b020-m065")
+        self.assertTrue(evidence["acceptance"]["bitrate_search_ready"])
+
+    def test_bitrate_search_storage_benefit_uses_total_case_bytes(self) -> None:
+        plan, _, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        binding = self._binding("case-a", "case-b")
+        first = self._bitrate_case_record(plan, "case-a", storage_benefit=False)
+        second = self._bitrate_case_record(plan, "case-b", storage_benefit=False)
+
+        def set_sizes(case: dict[str, object], cell_id: str, size: int) -> None:
+            cell = next(item for item in case["cells"] if item["id"] == cell_id)
+            for run_index, run in enumerate(cell["runs"]):
+                run["final_bytes"] = size + run_index
+
+        for bitrate in plan.eye_bitrates_mbps:
+            set_sizes(first, f"b{bitrate:03d}-m065", 1_000)
+            set_sizes(second, f"b{bitrate:03d}-m065", 100_000)
+        set_sizes(first, "b005-m065", 500)
+        set_sizes(second, "b005-m065", 99_000)
+        definitions = {case_id: self._definition(case_id) for case_id in binding.selected_case_ids}
+        evidence: dict[str, object] = {"cases": [first, second]}
+
+        _refresh_summaries(evidence, plan, binding, definitions)
+
+        tier = next(item for item in evidence["bitrate_tier_evaluations"] if item["merge_quality"] == 65)
+        candidate = next(item for item in tier["cell_evaluations"] if item["cell_id"] == "b005-m065")
+        self.assertAlmostEqual(candidate["aggregate_size_ratio_vs_tier_anchor"], 99_502 / 101_002)
+        self.assertFalse(candidate["storage_benefit_passed"])
+        self.assertEqual(tier["selected_cell_id"], "b020-m065")
+
     def test_run_validation_rejects_contradictory_eye_metrics(self) -> None:
         plan = self._plan()
         cell = plan.cells[0]
@@ -518,8 +723,33 @@ class GeneratedCalibrationCliTests(unittest.TestCase):
         with patch("scripts.qualify_generated_mv_hevc_calibration.run_calibration", return_value=evidence):
             self.assertEqual(main(self._args()), 0)
 
+    def test_bitrate_search_returns_one_when_frontier_is_not_ready(self) -> None:
+        evidence = {
+            "method": {"decision_stage": "same_tier_bitrate_minimization_only"},
+            "acceptance": {"execution_passed": True, "bitrate_search_ready": False},
+        }
+
+        with patch("scripts.qualify_generated_mv_hevc_calibration.run_calibration", return_value=evidence):
+            self.assertEqual(main(self._args()), 1)
+
+    def test_bitrate_search_returns_zero_only_when_frontiers_are_ready(self) -> None:
+        evidence = {
+            "method": {"decision_stage": "same_tier_bitrate_minimization_only"},
+            "acceptance": {"execution_passed": True, "bitrate_search_ready": True},
+        }
+
+        with patch("scripts.qualify_generated_mv_hevc_calibration.run_calibration", return_value=evidence):
+            self.assertEqual(main(self._args()), 0)
+
 
 class GeneratedCalibrationReceiptTests(unittest.TestCase):
+    @staticmethod
+    def _write_frozen_document(path: Path, document: object) -> str:
+        data = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode()
+        path.write_bytes(data)
+        path.chmod(0o444)
+        return hashlib.sha256(data).hexdigest()
+
     def test_refinement_requires_pinned_source_receipt(self) -> None:
         plan, _, _, _ = load_experiment_plan(DEFAULT_REFINEMENT_PLAN)
 
@@ -535,6 +765,124 @@ class GeneratedCalibrationReceiptTests(unittest.TestCase):
 
             with self.assertRaisesRegex(QualificationFailure, "pinned SHA-256"):
                 _verify_refinement_source_receipt(plan, receipt)
+
+    def test_bitrate_search_verifies_both_frozen_source_receipts(self) -> None:
+        plan, binding, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        assert plan.bitrate_search is not None
+        assert plan.thresholds is not None
+        refinement_plan_record = {
+            "path": "docs/qualification/generated-mv-hevc-merge-refinement-v1.json",
+            "sha256": "a2dabc8afc72356e67f40ef9416a087103db3674cb12359fd8632959f5bee5d4",
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            refinement_path = root / "refinement.json"
+            refinement_document = {
+                "schema_version": 1,
+                "experiment_id": plan.bitrate_search.merge_refinement_receipt.evidence_id,
+                "source_git_sha": plan.bitrate_search.merge_refinement_receipt.source_git_sha,
+                "source_tree_dirty": False,
+                "experiment_plan": refinement_plan_record,
+                "corpus_binding": {
+                    "path": binding.relative_path,
+                    "binding_id": binding.binding_id,
+                    "sha256": plan.binding_sha256,
+                },
+                "pre_registered_thresholds": _threshold_record(plan.thresholds),
+                "cells": [{"id": "b020-m065"}, {"id": "b020-m075"}],
+                "acceptance": {
+                    "experiment_complete": True,
+                    "refinement_evidence_ready": True,
+                    "thresholds_pre_registered": True,
+                    "ladder_mapping_selected": False,
+                },
+            }
+            refinement_sha = self._write_frozen_document(refinement_path, refinement_document)
+            policy = replace(
+                plan.bitrate_search,
+                merge_refinement_receipt=replace(
+                    plan.bitrate_search.merge_refinement_receipt,
+                    sha256=refinement_sha,
+                ),
+            )
+
+            collapse_path = root / "collapse.json"
+            collapse_document = {
+                "schema_version": 1,
+                "analysis_id": policy.collapse_receipt.evidence_id,
+                "analysis_source_git_sha": policy.collapse_receipt.source_git_sha,
+                "analysis_source_tree_dirty": False,
+                "analysis_plan": {
+                    "path": policy.collapse_plan.path.relative_to(DEFAULT_BITRATE_SEARCH_PLAN.parents[2]).as_posix(),
+                    "sha256": policy.collapse_plan.sha256,
+                },
+                "source_receipt": {
+                    "schema_version": 1,
+                    "experiment_id": policy.merge_refinement_receipt.evidence_id,
+                    "sha256": refinement_sha,
+                    "source_git_sha": policy.merge_refinement_receipt.source_git_sha,
+                    "file_mode": "0444",
+                },
+                "source_plan": {**refinement_plan_record, "schema_version": 2},
+                "source_corpus_binding": {
+                    "path": binding.relative_path,
+                    "binding_id": binding.binding_id,
+                    "sha256": plan.binding_sha256,
+                    "selected_case_ids": list(binding.selected_case_ids),
+                },
+                "thresholds": _threshold_record(plan.thresholds),
+                "selected_subset": {
+                    "cell_ids": ["b020-m065", "b020-m075"],
+                    "cardinality": 2,
+                    "contains_balanced": True,
+                },
+                "acceptance": {
+                    "analysis_complete": True,
+                    "balanced_included": True,
+                    "selected_chain_valid": True,
+                    "source_plan_verified": True,
+                    "source_receipt_verified": True,
+                    "thresholds_unchanged": True,
+                    "selected_step_count": 2,
+                    "ladder_mapping_selected": False,
+                },
+            }
+            collapse_sha = self._write_frozen_document(collapse_path, collapse_document)
+            policy = replace(
+                policy,
+                collapse_receipt=replace(policy.collapse_receipt, sha256=collapse_sha),
+            )
+
+            _verify_bitrate_search_source_receipts(
+                replace(plan, bitrate_search=policy),
+                binding,
+                refinement_path,
+                collapse_path,
+            )
+
+    def test_bitrate_search_rejects_duplicate_keys_in_frozen_receipt(self) -> None:
+        plan, binding, _, _ = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        assert plan.bitrate_search is not None
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt = Path(temporary_directory) / "receipt.json"
+            data = b'{"schema_version":1,"schema_version":1}\n'
+            receipt.write_bytes(data)
+            receipt.chmod(0o444)
+            policy = replace(
+                plan.bitrate_search,
+                merge_refinement_receipt=replace(
+                    plan.bitrate_search.merge_refinement_receipt,
+                    sha256=hashlib.sha256(data).hexdigest(),
+                ),
+            )
+
+            with self.assertRaisesRegex(QualificationFailure, "duplicate key"):
+                _verify_bitrate_search_source_receipts(
+                    replace(plan, bitrate_search=policy),
+                    binding,
+                    receipt,
+                    None,
+                )
 
     def test_binding_rejects_changed_source_manifest_identity(self) -> None:
         document = json.loads(
@@ -642,6 +990,33 @@ class GeneratedCalibrationReceiptTests(unittest.TestCase):
                     private_paths=(),
                 )
 
+    def test_resume_rejects_duplicate_json_keys(self) -> None:
+        plan, binding, plan_sha256, binding_sha256 = load_experiment_plan(DEFAULT_BITRATE_SEARCH_PLAN)
+        environment = {"git_head": "d" * 40, "ffmpeg_sha256": "e" * 64}
+        case = CorpusCase(
+            case_id="case-a",
+            tags=("animation",),
+            source={"kind": "synthetic"},
+            eye_width=2,
+            eye_height=2,
+            frame_rate="24",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "receipt.json"
+            output.write_text('{"schema_version":1,"schema_version":1}\n', encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationFailure, "duplicate key"):
+                _load_resume_evidence(
+                    output,
+                    plan=plan,
+                    binding=binding,
+                    plan_sha256=plan_sha256,
+                    binding_sha256=binding_sha256,
+                    environment=environment,
+                    selected_cases=[case],
+                    private_paths=(),
+                )
+
     def test_refinement_resume_rejects_top_level_threshold_tampering(self) -> None:
         plan, binding, plan_sha256, binding_sha256 = load_experiment_plan(DEFAULT_REFINEMENT_PLAN)
         environment = {"git_head": "d" * 40, "ffmpeg_sha256": "e" * 64}
@@ -731,6 +1106,51 @@ class GeneratedCalibrationReceiptTests(unittest.TestCase):
 
 
 class GeneratedCalibrationProductionParityTests(unittest.TestCase):
+    def test_measurement_can_preserve_output_until_evidence_is_persisted(self) -> None:
+        definition = CorpusCase(
+            case_id="case-a",
+            tags=("animation",),
+            source={"kind": "synthetic"},
+            eye_width=2,
+            eye_height=2,
+            frame_rate="24",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            output = root / "output.mov"
+            output.write_bytes(b"encoded")
+            left = root / "left.mov"
+            right = root / "right.mov"
+            left.write_bytes(b"left")
+            right.write_bytes(b"right")
+            split_directory = root / "split"
+            split_directory.mkdir()
+            prepared = PreparedCase(
+                definition=definition,
+                source_path=root / "source.mkv",
+                reference_left=root / "reference-left.mkv",
+                reference_right=root / "reference-right.mkv",
+                duration_seconds=4.0,
+                frame_count=96,
+                source_evidence={"kind": "synthetic"},
+            )
+
+            with (
+                patch("scripts.qualify_mv_hevc_corpus.split_mv_hevc", return_value=(left, right)),
+                patch("scripts.qualify_mv_hevc_corpus.ssim", side_effect=(0.95, 0.96, 0.75, 0.76)),
+            ):
+                _measure_output(
+                    "ffmpeg",
+                    prepared,
+                    output,
+                    split_directory,
+                    target_bitrate_mbps=20,
+                    delete_output=False,
+                )
+
+            self.assertTrue(output.is_file())
+            self.assertFalse(split_directory.exists())
+
     def test_generated_encode_matches_production_rate_control_and_merge_contract(self) -> None:
         definition = CorpusCase(
             case_id="synthetic-animation",


### PR DESCRIPTION
## Summary

- add a checked schema-v3 generated MV-HEVC bitrate-minimization stage
- sweep every integer `1..20 Mbps/eye` at accepted merge tiers `65` and `75`, three times over the frozen four-case stress corpus
- compare each candidate only with its same-tier `20 Mbps/eye` anchor using unchanged quality, tail, temporal, repeatability, stereo, structure, and size gates
- use a checked Latin execution schedule so every cell and both anchors appear once in early, middle, and late windows
- bind and strictly verify the frozen refinement and collapse receipts, reject duplicate-key JSON, preserve resumability, and freeze completed evidence read-only
- document the checked workflow and retain `ladder_mapping_selected=false`

## Completed Evidence

The clean source commit `98d8808595911dc95c7fdbdb7bc43b8343f5a90d` completed all `480` planned encodes and produced immutable receipt SHA-256 `ca975aa92853614fbad696c1cadf52f26e726b06e2ffbad02f6bdcba9ed06325`.

- merge `65`: monotone bracketed frontier selects `12 Mbps/eye`; aggregate stress storage reduction `2.3879%`
- merge `75`: monotone bracketed frontier selects `13 Mbps/eye`; aggregate stress storage reduction `2.0139%`
- `11/65` and `12/75` each fail the pre-registered aggregate-quality margin on `production-grain-rain`
- both selected cells pass every aggregate, per-frame, temporal, repeatability, eye-order, structure, and case-size gate
- full eight-case, packaged-app, and physical Vision Pro confirmation remain required before mapping exposure

## Validation

- `uv run python -m unittest discover -s tests -t .` — 1,274 passed, 3 skipped
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- import and CLI smoke checks
- independent implementation and receipt reviews found no blocker/high issue; the narrow `13/75` storage margin is explicitly deferred to full-corpus confirmation

Closes no issue; advances #419 and #418.
