### PR TITLE
Add falsifiable subtitle evidence to Vision Pro playback checks

### DIFF
--- a/docs/av1-stereo-feasibility.md
+++ b/docs/av1-stereo-feasibility.md
@@ -349,6 +349,18 @@ remains M5-targeted and experimental until an M5 wearer provides decode,
 stereoscopic presentation, eye-order, seek, sustained-playback, and thermal
 evidence.
 
+The M5 run must use BD to AVP Playback Check 0.2.0 build 10 or later. Report
+schema 5 separates subtitle evidence into discovered options, the initial
+automatic option, the explicitly requested non-forced option, the final selected
+option, selection confirmation, decoded cue event timing, and wearer-visible
+text. For the immutable candidate above, the expected prompts appear near the
+beginning, middle, and end. Launch the run with
+`BD_TO_AVP_PROBE_EXPECTED_SUBTITLE_CUE_TIMES=0.5,27,55` so the validator visits
+those exact windows instead of inferring failure from arbitrary playback
+sections. This distinguishes a missing track, forced-only automatic selection,
+failed selection, cue-decoding failure, and decoded cues that RealityKit does
+not visibly render.
+
 ## Result Matrix
 
 | Representation | Tool result | Apple-framework result | Product meaning |

--- a/docs/visionos-playback-validator.md
+++ b/docs/visionos-playback-validator.md
@@ -8,7 +8,7 @@ The validator asks the person wearing Apple Vision Pro to do four things:
 
 1. Choose one finished movie.
 2. Select **Run Playback Check**.
-3. Watch sustained playback plus three short seek sections and answer three plain-language questions.
+3. Watch sustained playback plus three short seek sections and answer the plain-language questions, including subtitle visibility when the movie exposes subtitle choices.
 4. Share the generated report when evidence is needed.
 
 Nothing in the app publishes a build, approves a GitHub deployment, merges code, or authorizes a release. A passing report is playback evidence for the named movie and device; it is not a release approval by itself.
@@ -23,13 +23,14 @@ Movies selected through Files are copied into the app's cache so playback can co
 - Actual stereoscopic playback and whether the presentation matches the selected validation expectation.
 - Up to 30 seconds of continuous playback with ready rendering, stereoscopic presentation, and before/after thermal state preserved.
 - Beginning, middle, and end seeks, including preservation of stereoscopic playback and required spatial treatment.
-- Available audio and subtitle choices for manual review under **Technical details**.
+- Available audio and subtitle choices, the initial and requested selections, whether selection succeeded, and decoded subtitle cue events. When subtitles are present, the guided check prefers a non-forced option and otherwise uses the first selectable option.
 
 After the automatic sequence, the validator asks only:
 
 - Did the picture stay visible and free of obvious freezes or corruption?
 - Did the scene look three-dimensional rather than flat?
 - Did the depth direction look correct and comfortable rather than inside-out?
+- When subtitles are present, did the selected subtitle text appear over the video?
 
 **Not sure** is a valid answer and produces **One result needs review** rather than a false pass.
 
@@ -50,11 +51,11 @@ Apple requires spatial metadata to describe the true, constant properties of the
 
 ## Result Meanings
 
-- **Playback check passed**: every automatic check passed and all three visible observations were **Yes**.
+- **Playback check passed**: every automatic check passed and every required visible observation was **Yes**.
 - **One result needs review**: the automatic checks did not fail, but at least one observation was **Not sure** or a check did not reach a final pass state.
 - **Playback check found a problem**: an automatic check failed or any visible observation was **No**.
 
-The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The schema-4 report contains the expected presentation, validator version and build, visionOS version, hardware model, filename, full-file SHA-256 fingerprint, file size, duration, media-option counts, selected video codec and sample-entry tag, AV1 and MV-HEVC capability results, independent first-frame decode result, selected decode route, sustained-playback duration, before/after thermal state, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
+The app automatically writes a named JSON report plus `Latest-Playback-Report.json` under its Documents directory. **Share JSON Report** sends that file as a `.json` attachment instead of untyped text. The schema-5 report contains the expected presentation, validator version and build, visionOS version, hardware model, filename, full-file SHA-256 fingerprint, file size, duration, media-option details and per-run identifiers, initial/requested/final selections, subtitle cue expectations and decoded cue timing, selected video codec and sample-entry tag, AV1 and MV-HEVC capability results, independent first-frame decode result, selected decode route, sustained-playback duration, before/after thermal state, actual viewing/spatial/immersive modes, automatic check details, observations, and result. It intentionally omits the source file path and subtitle text. The fingerprint binds release evidence to the exact movie even when an automated device transfer names it `Probe.mov`.
 
 ## Build
 
@@ -158,7 +159,17 @@ xcrun devicectl device process launch \
   com.shinycomputers.bd-to-avp.spatial-playback-probe
 ```
 
-Autorun starts the automatic sequence only after the player is ready and the full-file SHA-256 fingerprint is complete. Large movies can remain in the preparing state for several minutes while the cooperative background fingerprint pass runs. It stops at the three human observations; automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
+For issue #409's immutable 60-second AV1 candidate, require the three known subtitle windows explicitly:
+
+```bash
+xcrun devicectl device process launch \
+  --device <device-id> \
+  --terminate-existing \
+  --environment-variables '{"BD_TO_AVP_PROBE_ASSET":"Probe.mov","BD_TO_AVP_PROBE_AUTORUN":"1","BD_TO_AVP_PROBE_EXPECTED_SUBTITLE_CUE_TIMES":"0.5,27,55"}' \
+  com.shinycomputers.bd-to-avp.spatial-playback-probe
+```
+
+Autorun starts the automatic sequence only after the player is ready and the full-file SHA-256 fingerprint is complete. Large movies can remain in the preparing state for several minutes while the cooperative background fingerprint pass runs. It stops at the required human observations: three for video/depth, plus subtitle visibility when subtitles are discovered or expected. Automation does not fabricate visible playback answers. The physical UI test uses the spatial calibration expectation, requires all automatic checks to pass, and verifies that the observation screen is presented.
 
 After the operator selects **Finish Check**, retrieve the report directly without asking them to save share-sheet text manually:
 
@@ -194,7 +205,9 @@ run must record:
 - wearer confirmation for visible video without corruption, visible depth, and
   correct non-inverted eye order;
 - before/after thermal state plus usable audio and subtitle choices where
-  present.
+  present. Subtitle evidence must record the initial automatic option, the
+  explicitly requested non-forced option, the final selected option, selection
+  confirmation, decoded cue event count, and wearer-visible text.
 
 Until that report exists, AV1 remains an experimental M5-targeted export. M2
 Vision Pro is explicitly unsupported, and MV-HEVC remains the default.
@@ -212,10 +225,11 @@ uv run python scripts/create_spatial_audio_validation_fixtures.py \
 The generator exercises production audio preparation and final muxing. It produces Automatic AAC copy, Automatic AAC fallback, Convert AAC, and PCM cases with English 5.1 audio, French stereo audio, English subtitles, synchronized flashes, and a machine-readable `manifest.json`.
 
 Run **Playback Check** for each fixture. After the guided result, expand **Technical details** to switch audio and subtitle choices using the generated `CHECKLIST.md`.
+Those post-result switches are manual follow-up only; the saved report preserves the selections and cue evidence from the completed guided run.
 
 ## Structured Evidence
 
-Structured events use the `BD_TO_AVP_PLAYBACK_PROBE` prefix. `automated_probe_complete` records the automatic result after sustained playback and all three seeks. `guided_validation_complete` records the final result and the three human observations.
+Structured events use the `BD_TO_AVP_PLAYBACK_PROBE` prefix. `automated_probe_complete` records the automatic result after sustained playback and all three seeks. `subtitle_selected` records requested, selected, and confirmed option state; `subtitle_cue_decoded` records cue timing without copying subtitle text. `guided_validation_complete` records the final result and human observations.
 
 Physical acceptance requires:
 
@@ -223,6 +237,17 @@ Physical acceptance requires:
 - `expected_presentation=stereo` for normal finalized Blu-ray movies, or `expected_presentation=spatial` for the generated calibration fixture.
 - Visible video throughout beginning, middle, and end playback.
 - Comfortable, non-inverted depth.
+- For movies with subtitles, a confirmed non-forced selection, decoded cue
+  events, and wearer confirmation that text appeared.
 - A shared report whose result matches the operator's observations.
+
+For an M5 AV1 run, interpret subtitle evidence in layers:
+
+- no discovered subtitle options means the device did not expose the muxed text track;
+- an unconfirmed requested selection means media selection failed;
+- when `BD_TO_AVP_PROBE_EXPECTED_SUBTITLE_CUE_TIMES` is set, insufficient decoded cue events means the selected track did not deliver legible content across the explicit cue windows;
+- without an expected cue schedule, a zero cue count is diagnostic only and must not be treated as proof of subtitle failure;
+- decoded cue events with a **No** visibility answer isolate the failure to presentation rather than muxing or cue decoding;
+- decoded cue events with a **Yes** visibility answer disprove the claim that the exact asset and validator build cannot show subtitles.
 
 Live playback while the conversion pipeline is still writing a movie remains out of scope. The validator consumes immutable finalized artifacts only.

--- a/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeModel.swift
@@ -96,6 +96,23 @@ private final class ProbeSeekCompletion: @unchecked Sendable {
     }
 }
 
+private final class ProbeSubtitleCueObserver: NSObject, AVPlayerItemLegibleOutputPushDelegate {
+    let onCues: (CMTime, [NSAttributedString]) -> Void
+
+    init(onCues: @escaping (CMTime, [NSAttributedString]) -> Void) {
+        self.onCues = onCues
+    }
+
+    func legibleOutput(
+        _ output: AVPlayerItemLegibleOutput,
+        didOutputAttributedStrings strings: [NSAttributedString],
+        nativeSampleBuffers: [Any],
+        forItemTime itemTime: CMTime
+    ) {
+        onCues(itemTime, strings)
+    }
+}
+
 @MainActor
 final class PlaybackProbeModel: ObservableObject {
     private struct PendingImportedAsset {
@@ -127,6 +144,9 @@ final class PlaybackProbeModel: ObservableObject {
     @Published private(set) var failure: ProbeFailure?
     @Published private(set) var audioOptions: [ProbeMediaOption] = []
     @Published private(set) var subtitleOptions: [ProbeMediaOption] = []
+    @Published private(set) var subtitleCueEventCount = 0
+    @Published private(set) var firstSubtitleCueTimeSeconds: Double?
+    @Published private(set) var lastSubtitleCueTimeSeconds: Double?
     @Published var selectedAudioID = ""
     @Published var selectedSubtitleID = "off"
     @Published private(set) var validationPhase: PlaybackValidationPhase = .selectMovie
@@ -144,6 +164,9 @@ final class PlaybackProbeModel: ObservableObject {
     let presentationExpectation = PlaybackPresentationExpectation.resolve(
         environment: ProcessInfo.processInfo.environment
     )
+    let subtitleExpectation = PlaybackSubtitleExpectation.resolve(
+        environment: ProcessInfo.processInfo.environment
+    )
 
     private var itemStatusObservation: NSKeyValueObservation?
     private var timeObserver: Any?
@@ -156,6 +179,14 @@ final class PlaybackProbeModel: ObservableObject {
     private var subtitleGroup: AVMediaSelectionGroup?
     private var audioSelectionByID: [String: AVMediaSelectionOption] = [:]
     private var subtitleSelectionByID: [String: AVMediaSelectionOption] = [:]
+    private var subtitleCueOutput: AVPlayerItemLegibleOutput?
+    private var subtitleCueObserver: ProbeSubtitleCueObserver?
+    private var subtitleCueTimes = Set<Int64>()
+    private var subtitleCueTimeByKey: [Int64: Double] = [:]
+    private var subtitleCueWindows: [PlaybackSubtitleCueWindowSummary] = []
+    private var automaticSubtitleEvidenceResult: PlaybackSubtitleEvidenceResult = .notRequired
+    private var initialAudioOptionID: String?
+    private var initialSubtitleOptionID: String?
     private var automatedValidationStarted = false
     private var loadGeneration = 0
     private var validationGeneration = 0
@@ -238,7 +269,48 @@ final class PlaybackProbeModel: ObservableObject {
     }
 
     var canFinishObservations: Bool {
-        !isLoading && validationPhase == .observations && observations.isComplete
+        !isLoading
+            && validationPhase == .observations
+            && observations.isComplete(requiresSubtitleObservation: requiresSubtitleObservation)
+    }
+
+    var canChangeMediaSelection: Bool {
+        validationPhase == .ready || validationPhase == .complete
+    }
+
+    var requiresSubtitleObservation: Bool {
+        subtitleExpectation.isRequired || subtitleOptions.contains(where: { $0.id != "off" })
+    }
+
+    var subtitleExpectationIsRequired: Bool {
+        subtitleExpectation.isRequired
+    }
+
+    var requiredObservationCount: Int {
+        requiresSubtitleObservation ? 4 : 3
+    }
+
+    var subtitleOptionUnderTestName: String? {
+        preferredSubtitleIDForValidation().flatMap { subtitleSelectionByID[$0]?.displayName }
+    }
+
+    var selectedSubtitleOptionName: String {
+        guard
+            let currentItem = player.currentItem,
+            let subtitleGroup,
+            let option = currentItem.currentMediaSelection.selectedMediaOption(in: subtitleGroup)
+        else {
+            return "Off"
+        }
+        return option.displayName
+    }
+
+    var subtitleEvidenceText: String {
+        guard requiresSubtitleObservation else {
+            return "No subtitle choices"
+        }
+        let cueLabel = subtitleCueEventCount == 1 ? "cue event" : "cue events"
+        return "\(selectedSubtitleOptionName) selected · \(subtitleCueEventCount) decoded \(cueLabel)"
     }
 
     var timeSummary: String {
@@ -279,6 +351,9 @@ final class PlaybackProbeModel: ObservableObject {
         loadTask?.cancel()
         fingerprintTask?.cancel()
         validationTask?.cancel()
+        if let subtitleCueOutput, let currentItem = player.currentItem {
+            currentItem.remove(subtitleCueOutput)
+        }
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
         }
@@ -507,7 +582,13 @@ final class PlaybackProbeModel: ObservableObject {
         sustainedPlaybackSeconds = 0
         thermalStateBefore = "not_measured"
         thermalStateAfter = "not_measured"
+        player.pause()
+        removeSubtitleCueObservation()
+        resetSubtitleCueEvidence()
         validationPhase = .running
+        if let currentItem = player.currentItem {
+            configureSubtitleCueObservation(for: currentItem, validationGeneration: generation)
+        }
         currentValidationStepText = "Preparing the playback check…"
         requestSpatialPresentation(true)
 
@@ -530,7 +611,8 @@ final class PlaybackProbeModel: ObservableObject {
 
         let result = PlaybackValidationRules.result(
             checks: validationChecks,
-            observations: observations
+            observations: observations,
+            requiresSubtitleObservation: requiresSubtitleObservation
         )
         validationResult = result
         validationPhase = .complete
@@ -538,8 +620,13 @@ final class PlaybackProbeModel: ObservableObject {
 
         let generatedAt = Date()
         let assessment = decodeAssessment
+        let mediaSelection = mediaSelectionSummary()
+        let subtitleEvidenceResult = PlaybackValidationRules.subtitleEvidenceResult(
+            automaticResult: automaticSubtitleEvidenceResult,
+            visibility: observations.subtitlesAppeared
+        )
         let report = PlaybackValidationReport(
-            schemaVersion: 4,
+            schemaVersion: 5,
             validatorVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "development",
             validatorBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "development",
             generatedAt: ISO8601DateFormatter().string(from: generatedAt),
@@ -551,6 +638,13 @@ final class PlaybackProbeModel: ObservableObject {
                 durationSeconds: durationSeconds,
                 audioOptionCount: audioOptions.count,
                 subtitleOptionCount: max(0, subtitleOptions.count - 1)
+            ),
+            mediaSelection: mediaSelection,
+            subtitleEvidence: PlaybackSubtitleEvidenceSummary(
+                required: subtitleExpectation.isRequired,
+                expectedCueTimesSeconds: subtitleExpectation.cueTimesSeconds,
+                cueWindows: subtitleCueWindows,
+                result: subtitleEvidenceResult
             ),
             decode: PlaybackDecodeSummary(
                 videoCodec: sourceVideoFormat.codec,
@@ -626,6 +720,11 @@ final class PlaybackProbeModel: ObservableObject {
                 "video_remained_visible": observations.videoRemainedVisible.rawValue,
                 "appeared_three_dimensional": observations.appearedThreeDimensional.rawValue,
                 "eye_order_appeared_correct": observations.eyeOrderAppearedCorrect.rawValue,
+                "subtitles_appeared": requiresSubtitleObservation
+                    ? observations.subtitlesAppeared.rawValue
+                    : "not_applicable",
+                "subtitle_evidence_result": subtitleEvidenceResult.rawValue,
+                "subtitle_cue_event_count": String(subtitleCueEventCount),
             ]
         )
     }
@@ -679,8 +778,17 @@ final class PlaybackProbeModel: ObservableObject {
             return
         }
 
+        selectedAudioID = identifier
         currentItem.select(option, in: audioGroup)
-        emit("audio_selected", values: ["name": option.displayName])
+        let selectedOption = currentItem.currentMediaSelection.selectedMediaOption(in: audioGroup)
+        emit(
+            "audio_selected",
+            values: [
+                "requested": option.displayName,
+                "selected": selectedOption?.displayName ?? "none",
+                "confirmed": String(Self.selectionsMatch(selectedOption, option)),
+            ]
+        )
     }
 
     func selectSubtitle(_ identifier: String) {
@@ -689,8 +797,218 @@ final class PlaybackProbeModel: ObservableObject {
         }
 
         let option = subtitleSelectionByID[identifier]
+        selectedSubtitleID = identifier
         currentItem.select(option, in: subtitleGroup)
-        emit("subtitle_selected", values: ["name": option?.displayName ?? "Off"])
+        let selectedOption = currentItem.currentMediaSelection.selectedMediaOption(in: subtitleGroup)
+        emit(
+            "subtitle_selected",
+            values: [
+                "requested": option?.displayName ?? "Off",
+                "selected": selectedOption?.displayName ?? "Off",
+                "confirmed": String(Self.selectionsMatch(selectedOption, option)),
+            ]
+        )
+    }
+
+    private func preferredSubtitleIDForValidation() -> String? {
+        let subtitleIDs = subtitleOptions.lazy.map(\.id).filter { $0 != "off" }
+        return subtitleIDs.first(where: { identifier in
+            guard let option = subtitleSelectionByID[identifier] else {
+                return false
+            }
+            return !option.hasMediaCharacteristic(.containsOnlyForcedSubtitles)
+        }) ?? subtitleIDs.first
+    }
+
+    private func selectPreferredSubtitleForValidation() {
+        guard let identifier = preferredSubtitleIDForValidation() else {
+            return
+        }
+        player.appliesMediaSelectionCriteriaAutomatically = false
+        selectSubtitle(identifier)
+    }
+
+    private func configureSubtitleCueObservation(for item: AVPlayerItem, validationGeneration: Int) {
+        let output = AVPlayerItemLegibleOutput()
+        output.suppressesPlayerRendering = false
+        let observer = ProbeSubtitleCueObserver { [weak self] itemTime, strings in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                self.recordSubtitleCues(
+                    strings,
+                    at: itemTime,
+                    validationGeneration: validationGeneration
+                )
+            }
+        }
+        output.setDelegate(observer, queue: .main)
+        item.add(output)
+        subtitleCueOutput = output
+        subtitleCueObserver = observer
+    }
+
+    private func removeSubtitleCueObservation() {
+        if let subtitleCueOutput, let currentItem = player.currentItem {
+            currentItem.remove(subtitleCueOutput)
+        }
+        subtitleCueOutput = nil
+        subtitleCueObserver = nil
+    }
+
+    private func recordSubtitleCues(
+        _ strings: [NSAttributedString],
+        at itemTime: CMTime,
+        validationGeneration: Int
+    ) {
+        guard self.validationGeneration == validationGeneration, validationPhase == .running else {
+            return
+        }
+        guard strings.contains(where: { !$0.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            return
+        }
+        let seconds = itemTime.seconds.isFinite ? max(0, itemTime.seconds) : max(0, player.currentTime().seconds)
+        let timeKey = Int64((seconds * 1_000).rounded())
+        guard subtitleCueTimes.insert(timeKey).inserted else {
+            return
+        }
+
+        subtitleCueTimeByKey[timeKey] = seconds
+        subtitleCueEventCount = subtitleCueTimes.count
+        firstSubtitleCueTimeSeconds = firstSubtitleCueTimeSeconds.map { min($0, seconds) } ?? seconds
+        lastSubtitleCueTimeSeconds = lastSubtitleCueTimeSeconds.map { max($0, seconds) } ?? seconds
+        emit(
+            "subtitle_cue_decoded",
+            values: [
+                "item_time_seconds": formatNumber(seconds),
+                "event_count": String(subtitleCueEventCount),
+            ]
+        )
+    }
+
+    private func resetSubtitleCueEvidence() {
+        subtitleCueTimes.removeAll()
+        subtitleCueTimeByKey.removeAll()
+        subtitleCueWindows = []
+        automaticSubtitleEvidenceResult = .notRequired
+        subtitleCueEventCount = 0
+        firstSubtitleCueTimeSeconds = nil
+        lastSubtitleCueTimeSeconds = nil
+    }
+
+    private func mediaSelectionSummary() -> PlaybackMediaSelectionSummary {
+        let currentItem = player.currentItem
+        let requestedAudioOption = audioSelectionByID[selectedAudioID]
+        let requestedSubtitleOption = subtitleSelectionByID[selectedSubtitleID]
+        let selectedAudioOption = audioGroup.flatMap {
+            currentItem?.currentMediaSelection.selectedMediaOption(in: $0)
+        }
+        let selectedSubtitleOption = subtitleGroup.flatMap {
+            currentItem?.currentMediaSelection.selectedMediaOption(in: $0)
+        }
+        let selectedAudioOptionID = selectionID(for: selectedAudioOption, in: audioSelectionByID)
+        let selectedSubtitleOptionID = selectionID(for: selectedSubtitleOption, in: subtitleSelectionByID)
+
+        return PlaybackMediaSelectionSummary(
+            audioOptions: audioOptions.compactMap { option in
+                guard let selection = audioSelectionByID[option.id] else {
+                    return nil
+                }
+                return PlaybackMediaOptionSummary(
+                    id: option.id,
+                    name: selection.displayName,
+                    localeIdentifier: selection.locale?.identifier
+                )
+            },
+            subtitleOptions: subtitleOptions.compactMap { option in
+                guard let selection = subtitleSelectionByID[option.id] else {
+                    return nil
+                }
+                return PlaybackSubtitleOptionSummary(
+                    id: option.id,
+                    name: selection.displayName,
+                    localeIdentifier: selection.locale?.identifier,
+                    containsOnlyForcedSubtitles: selection.hasMediaCharacteristic(.containsOnlyForcedSubtitles)
+                )
+            },
+            initialAudioOption: audioSelectionReference(for: initialAudioOptionID),
+            initialSubtitleOption: subtitleSelectionReference(for: initialSubtitleOptionID),
+            requestedAudioOption: audioSelectionReference(for: selectedAudioID),
+            requestedSubtitleOption: subtitleSelectionReference(for: selectedSubtitleID)
+                ?? PlaybackMediaSelectionReference(
+                    id: "off",
+                    name: "Off",
+                    localeIdentifier: nil,
+                    containsOnlyForcedSubtitles: nil
+                ),
+            selectedAudioOption: audioSelectionReference(for: selectedAudioOptionID),
+            selectedSubtitleOption: subtitleSelectionReference(for: selectedSubtitleOptionID),
+            audioSelectionConfirmed: Self.selectionsMatch(selectedAudioOption, requestedAudioOption),
+            subtitleSelectionConfirmed: Self.selectionsMatch(selectedSubtitleOption, requestedSubtitleOption),
+            subtitleCueEventCount: subtitleCueEventCount,
+            firstSubtitleCueTimeSeconds: firstSubtitleCueTimeSeconds,
+            lastSubtitleCueTimeSeconds: lastSubtitleCueTimeSeconds
+        )
+    }
+
+    private func audioSelectionReference(for identifier: String?) -> PlaybackMediaSelectionReference? {
+        guard let identifier, let option = audioSelectionByID[identifier] else {
+            return nil
+        }
+        return PlaybackMediaSelectionReference(
+            id: identifier,
+            name: option.displayName,
+            localeIdentifier: option.locale?.identifier,
+            containsOnlyForcedSubtitles: nil
+        )
+    }
+
+    private func subtitleSelectionReference(for identifier: String?) -> PlaybackMediaSelectionReference? {
+        guard let identifier else {
+            return nil
+        }
+        if identifier == "off" {
+            return PlaybackMediaSelectionReference(
+                id: identifier,
+                name: "Off",
+                localeIdentifier: nil,
+                containsOnlyForcedSubtitles: nil
+            )
+        }
+        guard let option = subtitleSelectionByID[identifier] else {
+            return nil
+        }
+        return PlaybackMediaSelectionReference(
+            id: identifier,
+            name: option.displayName,
+            localeIdentifier: option.locale?.identifier,
+            containsOnlyForcedSubtitles: option.hasMediaCharacteristic(.containsOnlyForcedSubtitles)
+        )
+    }
+
+    private func selectionID(
+        for selection: AVMediaSelectionOption?,
+        in selectionsByID: [String: AVMediaSelectionOption]
+    ) -> String? {
+        guard let selection else {
+            return nil
+        }
+        return selectionsByID.first(where: { $0.value === selection })?.key
+    }
+
+    private static func selectionsMatch(
+        _ selected: AVMediaSelectionOption?,
+        _ requested: AVMediaSelectionOption?
+    ) -> Bool {
+        switch (selected, requested) {
+        case (nil, nil):
+            return true
+        case let (selected?, requested?):
+            return selected === requested
+        default:
+            return false
+        }
     }
 
     private func loadAsset(
@@ -711,6 +1029,7 @@ final class PlaybackProbeModel: ObservableObject {
         }
 
         isLoading = true
+        player.appliesMediaSelectionCriteriaAutomatically = true
         let asset = AVURLAsset(url: url)
         let item = AVPlayerItem(asset: asset)
 
@@ -775,6 +1094,18 @@ final class PlaybackProbeModel: ObservableObject {
             selectedSubtitleID = preparedMediaSelections.selectedSubtitleID
             audioSelectionByID = preparedMediaSelections.audioSelectionByID
             subtitleSelectionByID = preparedMediaSelections.subtitleSelectionByID
+            initialAudioOptionID = preparedMediaSelections.audioGroup.flatMap {
+                selectionID(
+                    for: item.currentMediaSelection.selectedMediaOption(in: $0),
+                    in: preparedMediaSelections.audioSelectionByID
+                )
+            }
+            initialSubtitleOptionID = preparedMediaSelections.subtitleGroup.flatMap {
+                selectionID(
+                    for: item.currentMediaSelection.selectedMediaOption(in: $0),
+                    in: preparedMediaSelections.subtitleSelectionByID
+                )
+            } ?? "off"
             automatedValidationStarted = false
             resetValidationState(phase: .preparing)
 
@@ -1126,6 +1457,15 @@ final class PlaybackProbeModel: ObservableObject {
             detail: presentationModeDetail(matchesExpectation: presentationMatchesExpectation)
         )
 
+        await runSubtitleEvidenceCheck(generation: generation, item: validationItem)
+        guard isValidationCurrent(generation, item: validationItem) else {
+            return
+        }
+        _ = await seek(to: 0)
+        guard isValidationCurrent(generation, item: validationItem) else {
+            return
+        }
+
         await runSustainedPlaybackCheck(
             generation: generation,
             item: validationItem,
@@ -1221,6 +1561,7 @@ final class PlaybackProbeModel: ObservableObject {
         }
 
         player.pause()
+        removeSubtitleCueObservation()
         isPlaying = false
         currentValidationStepText = "Automatic checks finished."
 
@@ -1240,6 +1581,9 @@ final class PlaybackProbeModel: ObservableObject {
                 "checks_passed": String(automaticChecksPassed),
                 "audio_options": String(audioOptions.count),
                 "subtitle_options": String(max(0, subtitleOptions.count - 1)),
+                "selected_subtitle": selectedSubtitleOptionName,
+                "expected_subtitle_cue_count": String(subtitleExpectation.cueTimesSeconds.count),
+                "subtitle_cue_event_count": String(subtitleCueEventCount),
             ]
         )
 
@@ -1257,6 +1601,154 @@ final class PlaybackProbeModel: ObservableObject {
             return
         }
         validationPhase = .observations
+    }
+
+    private func runSubtitleEvidenceCheck(generation: Int, item: AVPlayerItem) async {
+        player.pause()
+        _ = await seek(to: 0)
+        guard isValidationCurrent(generation, item: item) else {
+            return
+        }
+        resetSubtitleCueEvidence()
+        selectPreferredSubtitleForValidation()
+
+        let discoveredOptionCount = max(0, subtitleOptions.count - 1)
+        let requestedOption = subtitleSelectionByID[selectedSubtitleID]
+        let selectedOption = subtitleGroup.flatMap {
+            item.currentMediaSelection.selectedMediaOption(in: $0)
+        }
+        let selectionConfirmed = Self.selectionsMatch(selectedOption, requestedOption)
+
+        guard subtitleExpectation.isRequired else {
+            automaticSubtitleEvidenceResult = PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: subtitleExpectation,
+                discoveredOptionCount: discoveredOptionCount,
+                selectionConfirmed: selectionConfirmed,
+                cueWindows: []
+            )
+            let passed = automaticSubtitleEvidenceResult != .selectionFailed
+            updateCheck(
+                .subtitleEvidence,
+                status: passed ? .passed : .failed,
+                detail: passed
+                    ? "No expected subtitle cue schedule was configured; media selection and decoded cues remain diagnostic."
+                    : "The requested subtitle option did not become the selected AVFoundation option."
+            )
+            return
+        }
+
+        currentValidationStepText = "Checking expected subtitle cues…"
+        updateCheck(
+            .subtitleEvidence,
+            status: .running,
+            detail: "Selecting subtitles and visiting each expected cue window."
+        )
+
+        guard discoveredOptionCount > 0, requestedOption != nil else {
+            automaticSubtitleEvidenceResult = .missingOptions
+            updateCheck(
+                .subtitleEvidence,
+                status: .failed,
+                detail: "The movie was expected to contain subtitles, but AVFoundation exposed no selectable subtitle option."
+            )
+            return
+        }
+
+        guard selectionConfirmed else {
+            automaticSubtitleEvidenceResult = .selectionFailed
+            updateCheck(
+                .subtitleEvidence,
+                status: .failed,
+                detail: "The requested subtitle option did not become the selected AVFoundation option."
+            )
+            return
+        }
+
+        for cueTime in subtitleExpectation.cueTimesSeconds {
+            guard isValidationCurrent(generation, item: item) else {
+                return
+            }
+            let allowedTimeError = 0.75
+            let cueKeysBeforeWindow = subtitleCueTimes
+            let seekFinished: Bool
+            let observedCueTime: Double?
+
+            if cueTime <= durationSeconds {
+                let target = max(0, cueTime - min(0.25, cueTime))
+                seekFinished = await seek(to: target)
+                guard isValidationCurrent(generation, item: item) else {
+                    return
+                }
+                if seekFinished {
+                    player.play()
+                    _ = await waitForCondition(maxAttempts: 12) { [weak self] in
+                        self?.matchingSubtitleCueTime(
+                            after: cueKeysBeforeWindow,
+                            expectedTime: cueTime,
+                            allowedTimeError: allowedTimeError
+                        ) != nil
+                    }
+                    player.pause()
+                }
+                observedCueTime = matchingSubtitleCueTime(
+                    after: cueKeysBeforeWindow,
+                    expectedTime: cueTime,
+                    allowedTimeError: allowedTimeError
+                )
+            } else {
+                seekFinished = false
+                observedCueTime = nil
+            }
+
+            let windowPassed = seekFinished && observedCueTime != nil
+            subtitleCueWindows.append(
+                PlaybackSubtitleCueWindowSummary(
+                    expectedTimeSeconds: cueTime,
+                    seekSucceeded: seekFinished,
+                    observedCueTimeSeconds: observedCueTime,
+                    allowedTimeErrorSeconds: allowedTimeError,
+                    passed: windowPassed
+                )
+            )
+            emit(
+                "subtitle_cue_window",
+                values: [
+                    "expected_time_seconds": formatNumber(cueTime),
+                    "seek_finished": String(seekFinished),
+                    "observed_time_seconds": observedCueTime.map(formatNumber) ?? "none",
+                    "passed": String(windowPassed),
+                    "event_count": String(subtitleCueEventCount),
+                ]
+            )
+        }
+
+        automaticSubtitleEvidenceResult = PlaybackValidationRules.automaticSubtitleEvidenceResult(
+            expectation: subtitleExpectation,
+            discoveredOptionCount: discoveredOptionCount,
+            selectionConfirmed: selectionConfirmed,
+            cueWindows: subtitleCueWindows
+        )
+        let expectedCueCount = subtitleExpectation.cueTimesSeconds.count
+        let passed = automaticSubtitleEvidenceResult == .decoded
+        updateCheck(
+            .subtitleEvidence,
+            status: passed ? .passed : .failed,
+            detail: passed
+                ? "AVFoundation delivered an on-time decoded cue in each of \(expectedCueCount) expected subtitle windows."
+                : "One or more of the \(expectedCueCount) expected subtitle windows did not seek successfully or deliver an on-time decoded cue."
+        )
+    }
+
+    private func matchingSubtitleCueTime(
+        after previousKeys: Set<Int64>,
+        expectedTime: Double,
+        allowedTimeError: Double
+    ) -> Double? {
+        subtitleCueTimes
+            .subtracting(previousKeys)
+            .compactMap { subtitleCueTimeByKey[$0] }
+            .filter { abs($0 - expectedTime) <= allowedTimeError }
+            .min(by: { abs($0 - expectedTime) < abs($1 - expectedTime) })
     }
 
     private func runSustainedPlaybackCheck(
@@ -1475,6 +1967,8 @@ final class PlaybackProbeModel: ObservableObject {
     private func resetValidationState(phase: PlaybackValidationPhase) {
         validationGeneration += 1
         validationTask?.cancel()
+        removeSubtitleCueObservation()
+        resetSubtitleCueEvidence()
         validationChecks = PlaybackCheckID.allCases.map { PlaybackCheck(id: $0) }
         observations = PlaybackObservations()
         validationResult = nil
@@ -1678,6 +2172,7 @@ final class PlaybackProbeModel: ObservableObject {
         isLoading = false
         hasLoadedAsset = false
         player.pause()
+        removeSubtitleCueObservation()
         player.replaceCurrentItem(with: nil)
         playerItemStatusText = "Failed"
         renderingStatusText = "Not loaded"
@@ -1704,6 +2199,9 @@ final class PlaybackProbeModel: ObservableObject {
         subtitleGroup = nil
         audioSelectionByID.removeAll()
         subtitleSelectionByID.removeAll()
+        initialAudioOptionID = nil
+        initialSubtitleOptionID = nil
+        resetSubtitleCueEvidence()
         if let currentImportedURL, currentImportedURL != preservedImportedURL {
             removeImportedAsset(currentImportedURL, reason: "failed_movie")
             self.currentImportedURL = nil

--- a/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackProbeView.swift
@@ -266,7 +266,32 @@ struct PlaybackProbeView: View {
             VStack(alignment: .leading, spacing: 12) {
                 instructionRow(number: 1, text: "Start the guided check")
                 instructionRow(number: 2, text: "Watch sustained playback and three short seeks")
-                instructionRow(number: 3, text: "Answer three plain-language questions")
+                instructionRow(
+                    number: 3,
+                    text: "Answer \(model.requiredObservationCount) plain-language questions"
+                )
+            }
+
+            if let subtitleName = model.subtitleOptionUnderTestName {
+                Label {
+                    Text("The check will select \(subtitleName), monitor decoded subtitle cues, and ask whether the text appeared.")
+                } icon: {
+                    Image(systemName: "captions.bubble.fill")
+                        .foregroundStyle(.blue)
+                }
+                .font(.callout)
+                .padding(14)
+                .background(.blue.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))
+            } else if model.subtitleExpectationIsRequired {
+                Label {
+                    Text("This run expects subtitle cues, but the movie currently exposes no selectable subtitle option.")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+                .font(.callout)
+                .padding(14)
+                .background(.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))
             }
 
             Button {
@@ -311,7 +336,7 @@ struct PlaybackProbeView: View {
             .accessibilityIdentifier("automatic-check-status")
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Three things only you can confirm")
+                Text("\(model.requiredObservationCount) things only you can confirm")
                     .font(.title2.bold())
                 Text("These answers record what you saw. They do not approve a release or publish anything.")
                     .foregroundStyle(.secondary)
@@ -334,6 +359,14 @@ struct PlaybackProbeView: View {
                 detail: "Answer No if foreground and background appeared reversed or the 3D view felt strongly inverted.",
                 keyPath: \.eyeOrderAppearedCorrect
             )
+
+            if model.requiresSubtitleObservation {
+                observationCard(
+                    title: "Did the selected subtitles appear over the video?",
+                    detail: "The app recorded \(model.subtitleEvidenceText). Answer No if subtitle text never appeared during the beginning, middle, or end sections.",
+                    keyPath: \.subtitlesAppeared
+                )
+            }
 
             Button {
                 model.finishGuidedValidation()
@@ -456,6 +489,9 @@ struct PlaybackProbeView: View {
                     title: "Movie fingerprint",
                     value: model.sourceSHA256.isEmpty ? "Not available" : String(model.sourceSHA256.prefix(16))
                 )
+                if model.requiresSubtitleObservation {
+                    statusRow(title: "Subtitle evidence", value: model.subtitleEvidenceText)
+                }
 
                 if !model.audioOptions.isEmpty {
                     Picker("Audio", selection: $model.selectedAudioID) {
@@ -463,6 +499,7 @@ struct PlaybackProbeView: View {
                             Text(option.name).tag(option.id)
                         }
                     }
+                    .disabled(!model.canChangeMediaSelection)
                 }
 
                 if !model.subtitleOptions.isEmpty {
@@ -471,6 +508,7 @@ struct PlaybackProbeView: View {
                             Text(option.name).tag(option.id)
                         }
                     }
+                    .disabled(!model.canChangeMediaSelection)
                 }
             }
             .padding(.top, 12)

--- a/macos/SpatialPlaybackProbe/PlaybackValidation.swift
+++ b/macos/SpatialPlaybackProbe/PlaybackValidation.swift
@@ -54,6 +54,24 @@ enum PlaybackPresentationExpectation: String, Codable, Equatable {
     }
 }
 
+struct PlaybackSubtitleExpectation: Codable, Equatable {
+    static let environmentKey = "BD_TO_AVP_PROBE_EXPECTED_SUBTITLE_CUE_TIMES"
+
+    let cueTimesSeconds: [Double]
+
+    static func resolve(environment: [String: String]) -> Self {
+        let cueTimes = environment[environmentKey]?
+            .split(separator: ",")
+            .compactMap { Double($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            .filter { $0.isFinite && $0 >= 0 } ?? []
+        return Self(cueTimesSeconds: Array(Set(cueTimes)).sorted())
+    }
+
+    var isRequired: Bool {
+        !cueTimesSeconds.isEmpty
+    }
+}
+
 enum PlaybackVideoCodec: String, Codable, Equatable {
     case av1
     case hevc
@@ -188,6 +206,7 @@ enum PlaybackCheckID: String, Codable, CaseIterable {
     case renderingReady
     case stereoPresentation
     case presentationMode
+    case subtitleEvidence
     case sustainedPlayback
     case beginningSeek
     case middleSeek
@@ -205,6 +224,8 @@ enum PlaybackCheckID: String, Codable, CaseIterable {
             return "Stereoscopic playback is active"
         case .presentationMode:
             return "3D presentation matches the movie type"
+        case .subtitleEvidence:
+            return "Expected subtitle cues decode"
         case .sustainedPlayback:
             return "Sustained playback remains stable"
         case .beginningSeek:
@@ -260,11 +281,13 @@ struct PlaybackObservations: Codable, Equatable {
     var videoRemainedVisible: PlaybackObservationAnswer = .unanswered
     var appearedThreeDimensional: PlaybackObservationAnswer = .unanswered
     var eyeOrderAppearedCorrect: PlaybackObservationAnswer = .unanswered
+    var subtitlesAppeared: PlaybackObservationAnswer = .unanswered
 
-    var isComplete: Bool {
+    func isComplete(requiresSubtitleObservation: Bool) -> Bool {
         videoRemainedVisible != .unanswered
             && appearedThreeDimensional != .unanswered
             && eyeOrderAppearedCorrect != .unanswered
+            && (!requiresSubtitleObservation || subtitlesAppeared != .unanswered)
     }
 }
 
@@ -316,6 +339,68 @@ struct PlaybackSourceSummary: Codable, Equatable {
     let subtitleOptionCount: Int
 }
 
+struct PlaybackMediaOptionSummary: Codable, Equatable {
+    let id: String
+    let name: String
+    let localeIdentifier: String?
+}
+
+struct PlaybackSubtitleOptionSummary: Codable, Equatable {
+    let id: String
+    let name: String
+    let localeIdentifier: String?
+    let containsOnlyForcedSubtitles: Bool
+}
+
+struct PlaybackMediaSelectionReference: Codable, Equatable {
+    let id: String
+    let name: String
+    let localeIdentifier: String?
+    let containsOnlyForcedSubtitles: Bool?
+}
+
+struct PlaybackMediaSelectionSummary: Codable, Equatable {
+    let audioOptions: [PlaybackMediaOptionSummary]
+    let subtitleOptions: [PlaybackSubtitleOptionSummary]
+    let initialAudioOption: PlaybackMediaSelectionReference?
+    let initialSubtitleOption: PlaybackMediaSelectionReference?
+    let requestedAudioOption: PlaybackMediaSelectionReference?
+    let requestedSubtitleOption: PlaybackMediaSelectionReference
+    let selectedAudioOption: PlaybackMediaSelectionReference?
+    let selectedSubtitleOption: PlaybackMediaSelectionReference?
+    let audioSelectionConfirmed: Bool
+    let subtitleSelectionConfirmed: Bool
+    let subtitleCueEventCount: Int
+    let firstSubtitleCueTimeSeconds: Double?
+    let lastSubtitleCueTimeSeconds: Double?
+}
+
+enum PlaybackSubtitleEvidenceResult: String, Codable, Equatable {
+    case notRequired
+    case missingOptions
+    case selectionFailed
+    case insufficientDecodedCues
+    case decoded
+    case notVisible
+    case needsReview
+    case passed
+}
+
+struct PlaybackSubtitleCueWindowSummary: Codable, Equatable {
+    let expectedTimeSeconds: Double
+    let seekSucceeded: Bool
+    let observedCueTimeSeconds: Double?
+    let allowedTimeErrorSeconds: Double
+    let passed: Bool
+}
+
+struct PlaybackSubtitleEvidenceSummary: Codable, Equatable {
+    let required: Bool
+    let expectedCueTimesSeconds: [Double]
+    let cueWindows: [PlaybackSubtitleCueWindowSummary]
+    let result: PlaybackSubtitleEvidenceResult
+}
+
 struct PlaybackDecodeSummary: Codable, Equatable {
     let videoCodec: PlaybackVideoCodec
     let codecTag: String
@@ -347,6 +432,8 @@ struct PlaybackValidationReport: Codable, Equatable {
     let generatedAt: String
     let operatingSystem: String
     let source: PlaybackSourceSummary
+    let mediaSelection: PlaybackMediaSelectionSummary
+    let subtitleEvidence: PlaybackSubtitleEvidenceSummary
     let decode: PlaybackDecodeSummary
     let runtime: PlaybackRuntimeSummary
     let presentation: PlaybackPresentationSummary
@@ -382,12 +469,14 @@ enum PlaybackValidationRules {
 
     static func result(
         checks: [PlaybackCheck],
-        observations: PlaybackObservations
+        observations: PlaybackObservations,
+        requiresSubtitleObservation: Bool = false
     ) -> PlaybackValidationResult {
         if checks.contains(where: { $0.status == .failed })
             || observations.videoRemainedVisible == .no
             || observations.appearedThreeDimensional == .no
             || observations.eyeOrderAppearedCorrect == .no
+            || (requiresSubtitleObservation && observations.subtitlesAppeared == .no)
         {
             return .failed
         }
@@ -396,6 +485,7 @@ enum PlaybackValidationRules {
             || observations.videoRemainedVisible != .yes
             || observations.appearedThreeDimensional != .yes
             || observations.eyeOrderAppearedCorrect != .yes
+            || (requiresSubtitleObservation && observations.subtitlesAppeared != .yes)
         {
             return .needsReview
         }
@@ -417,6 +507,47 @@ enum PlaybackValidationRules {
             && evidence.renderingStayedReady
             && evidence.stereoPresentationStayedActive
             && evidence.expectedPresentationStayedActive
+    }
+
+    static func automaticSubtitleEvidenceResult(
+        expectation: PlaybackSubtitleExpectation,
+        discoveredOptionCount: Int,
+        selectionConfirmed: Bool,
+        cueWindows: [PlaybackSubtitleCueWindowSummary]
+    ) -> PlaybackSubtitleEvidenceResult {
+        if !expectation.isRequired {
+            return discoveredOptionCount > 0 && !selectionConfirmed ? .selectionFailed : .notRequired
+        }
+        guard discoveredOptionCount > 0 else {
+            return .missingOptions
+        }
+        guard selectionConfirmed else {
+            return .selectionFailed
+        }
+        guard
+            cueWindows.count == expectation.cueTimesSeconds.count,
+            cueWindows.allSatisfy(\.passed)
+        else {
+            return .insufficientDecodedCues
+        }
+        return .decoded
+    }
+
+    static func subtitleEvidenceResult(
+        automaticResult: PlaybackSubtitleEvidenceResult,
+        visibility: PlaybackObservationAnswer
+    ) -> PlaybackSubtitleEvidenceResult {
+        guard automaticResult == .decoded else {
+            return automaticResult
+        }
+        switch visibility {
+        case .yes:
+            return .passed
+        case .no:
+            return .notVisible
+        case .unanswered, .unsure:
+            return .needsReview
+        }
     }
 }
 

--- a/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
+++ b/macos/SpatialPlaybackProbeTests/PlaybackValidationTests.swift
@@ -54,6 +54,19 @@ final class PlaybackValidationTests: XCTestCase {
         XCTAssertTrue(PlaybackPresentationExpectation.spatial.matches(isStereo: true, isSpatial: true))
     }
 
+    func testSubtitleExpectationParsesSortedUniqueCueTimes() {
+        XCTAssertFalse(PlaybackSubtitleExpectation.resolve(environment: [:]).isRequired)
+
+        let expectation = PlaybackSubtitleExpectation.resolve(
+            environment: [
+                PlaybackSubtitleExpectation.environmentKey: "55, 0.5,invalid,27,27,-1",
+            ]
+        )
+
+        XCTAssertTrue(expectation.isRequired)
+        XCTAssertEqual(expectation.cueTimesSeconds, [0.5, 27, 55])
+    }
+
     func testPassingChecksAndObservationsProducePass() {
         let checks = PlaybackCheckID.allCases.map {
             PlaybackCheck(id: $0, status: .passed, detail: "Passed")
@@ -119,9 +132,126 @@ final class PlaybackValidationTests: XCTestCase {
         )
     }
 
+    func testRequiredSubtitleObservationParticipatesInCompletionAndResult() {
+        let checks = PlaybackCheckID.allCases.map {
+            PlaybackCheck(id: $0, status: .passed, detail: "Passed")
+        }
+        var observations = PlaybackObservations(
+            videoRemainedVisible: .yes,
+            appearedThreeDimensional: .yes,
+            eyeOrderAppearedCorrect: .yes
+        )
+
+        XCTAssertFalse(observations.isComplete(requiresSubtitleObservation: true))
+        XCTAssertTrue(observations.isComplete(requiresSubtitleObservation: false))
+        XCTAssertEqual(
+            PlaybackValidationRules.result(
+                checks: checks,
+                observations: observations,
+                requiresSubtitleObservation: true
+            ),
+            .needsReview
+        )
+
+        observations.subtitlesAppeared = .no
+        XCTAssertTrue(observations.isComplete(requiresSubtitleObservation: true))
+        XCTAssertEqual(
+            PlaybackValidationRules.result(
+                checks: checks,
+                observations: observations,
+                requiresSubtitleObservation: true
+            ),
+            .failed
+        )
+
+        observations.subtitlesAppeared = .yes
+        XCTAssertEqual(
+            PlaybackValidationRules.result(
+                checks: checks,
+                observations: observations,
+                requiresSubtitleObservation: true
+            ),
+            .passed
+        )
+    }
+
+    func testSubtitleEvidenceResultSeparatesPipelineFailures() {
+        let expectation = PlaybackSubtitleExpectation(cueTimesSeconds: [0.5, 27, 55])
+        let optionalExpectation = PlaybackSubtitleExpectation(cueTimesSeconds: [])
+        let passingWindows = expectation.cueTimesSeconds.map { cueTime in
+            PlaybackSubtitleCueWindowSummary(
+                expectedTimeSeconds: cueTime,
+                seekSucceeded: true,
+                observedCueTimeSeconds: cueTime,
+                allowedTimeErrorSeconds: 0.75,
+                passed: true
+            )
+        }
+
+        XCTAssertEqual(
+            PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: optionalExpectation,
+                discoveredOptionCount: 2,
+                selectionConfirmed: false,
+                cueWindows: []
+            ),
+            .selectionFailed
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: expectation,
+                discoveredOptionCount: 0,
+                selectionConfirmed: false,
+                cueWindows: []
+            ),
+            .missingOptions
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: expectation,
+                discoveredOptionCount: 2,
+                selectionConfirmed: false,
+                cueWindows: []
+            ),
+            .selectionFailed
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: expectation,
+                discoveredOptionCount: 2,
+                selectionConfirmed: true,
+                cueWindows: Array(passingWindows.dropLast())
+            ),
+            .insufficientDecodedCues
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.automaticSubtitleEvidenceResult(
+                expectation: expectation,
+                discoveredOptionCount: 2,
+                selectionConfirmed: true,
+                cueWindows: passingWindows
+            ),
+            .decoded
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.subtitleEvidenceResult(
+                automaticResult: .decoded,
+                visibility: .no
+            ),
+            .notVisible
+        )
+        XCTAssertEqual(
+            PlaybackValidationRules.subtitleEvidenceResult(
+                automaticResult: .decoded,
+                visibility: .yes
+            ),
+            .passed
+        )
+    }
+
     func testReportContainsFilenameWithoutSourcePath() throws {
         let report = PlaybackValidationReport(
-            schemaVersion: 4,
+            schemaVersion: 5,
             validatorVersion: "0.1.0",
             validatorBuild: "42",
             generatedAt: "2026-07-17T20:00:00Z",
@@ -133,6 +263,95 @@ final class PlaybackValidationTests: XCTestCase {
                 durationSeconds: 24,
                 audioOptionCount: 2,
                 subtitleOptionCount: 1
+            ),
+            mediaSelection: PlaybackMediaSelectionSummary(
+                audioOptions: [
+                    PlaybackMediaOptionSummary(id: "audio-0", name: "English 5.1", localeIdentifier: "en"),
+                    PlaybackMediaOptionSummary(id: "audio-1", name: "French stereo", localeIdentifier: "fr"),
+                ],
+                subtitleOptions: [
+                    PlaybackSubtitleOptionSummary(
+                        id: "subtitle-0",
+                        name: "English",
+                        localeIdentifier: "en",
+                        containsOnlyForcedSubtitles: false
+                    ),
+                    PlaybackSubtitleOptionSummary(
+                        id: "subtitle-1",
+                        name: "English Forced",
+                        localeIdentifier: "en",
+                        containsOnlyForcedSubtitles: true
+                    ),
+                ],
+                initialAudioOption: PlaybackMediaSelectionReference(
+                    id: "audio-0",
+                    name: "English 5.1",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: nil
+                ),
+                initialSubtitleOption: PlaybackMediaSelectionReference(
+                    id: "subtitle-1",
+                    name: "English Forced",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: true
+                ),
+                requestedAudioOption: PlaybackMediaSelectionReference(
+                    id: "audio-0",
+                    name: "English 5.1",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: nil
+                ),
+                requestedSubtitleOption: PlaybackMediaSelectionReference(
+                    id: "subtitle-0",
+                    name: "English",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: false
+                ),
+                selectedAudioOption: PlaybackMediaSelectionReference(
+                    id: "audio-0",
+                    name: "English 5.1",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: nil
+                ),
+                selectedSubtitleOption: PlaybackMediaSelectionReference(
+                    id: "subtitle-0",
+                    name: "English",
+                    localeIdentifier: "en",
+                    containsOnlyForcedSubtitles: false
+                ),
+                audioSelectionConfirmed: true,
+                subtitleSelectionConfirmed: true,
+                subtitleCueEventCount: 3,
+                firstSubtitleCueTimeSeconds: 0.5,
+                lastSubtitleCueTimeSeconds: 55
+            ),
+            subtitleEvidence: PlaybackSubtitleEvidenceSummary(
+                required: true,
+                expectedCueTimesSeconds: [0.5, 27, 55],
+                cueWindows: [
+                    PlaybackSubtitleCueWindowSummary(
+                        expectedTimeSeconds: 0.5,
+                        seekSucceeded: true,
+                        observedCueTimeSeconds: 0.5,
+                        allowedTimeErrorSeconds: 0.75,
+                        passed: true
+                    ),
+                    PlaybackSubtitleCueWindowSummary(
+                        expectedTimeSeconds: 27,
+                        seekSucceeded: true,
+                        observedCueTimeSeconds: 27,
+                        allowedTimeErrorSeconds: 0.75,
+                        passed: true
+                    ),
+                    PlaybackSubtitleCueWindowSummary(
+                        expectedTimeSeconds: 55,
+                        seekSucceeded: true,
+                        observedCueTimeSeconds: 55,
+                        allowedTimeErrorSeconds: 0.75,
+                        passed: true
+                    ),
+                ],
+                result: .passed
             ),
             decode: PlaybackDecodeSummary(
                 videoCodec: .av1,
@@ -159,7 +378,8 @@ final class PlaybackValidationTests: XCTestCase {
             observations: PlaybackObservations(
                 videoRemainedVisible: .yes,
                 appearedThreeDimensional: .yes,
-                eyeOrderAppearedCorrect: .yes
+                eyeOrderAppearedCorrect: .yes,
+                subtitlesAppeared: .yes
             ),
             result: .passed
         )
@@ -171,12 +391,19 @@ final class PlaybackValidationTests: XCTestCase {
         XCTAssertTrue(reportText.contains(String(repeating: "a", count: 64)))
         XCTAssertTrue(reportText.contains("audioOptionCount"))
         XCTAssertTrue(reportText.contains("subtitleOptionCount"))
+        XCTAssertTrue(reportText.contains("initialSubtitleOption"))
+        XCTAssertTrue(reportText.contains("English Forced"))
+        XCTAssertTrue(reportText.contains("subtitleSelectionConfirmed"))
+        XCTAssertTrue(reportText.contains("subtitleCueEventCount"))
+        XCTAssertTrue(reportText.contains("expectedCueTimesSeconds"))
+        XCTAssertTrue(reportText.contains("subtitle-0"))
         XCTAssertTrue(reportText.contains("spatialVideoMode"))
         XCTAssertTrue(reportText.contains("expectation"))
         XCTAssertTrue(reportText.contains("av01"))
         XCTAssertTrue(reportText.contains("fallback"))
         XCTAssertTrue(reportText.contains("RealityDevice14,1"))
         XCTAssertTrue(reportText.contains("eyeOrderAppearedCorrect"))
+        XCTAssertTrue(reportText.contains("subtitlesAppeared"))
         XCTAssertFalse(reportText.contains("/Users/"))
         XCTAssertFalse(reportText.contains("sourcePath"))
     }
@@ -270,7 +497,7 @@ final class PlaybackValidationTests: XCTestCase {
             videoRemainedVisible: .yes,
             appearedThreeDimensional: .yes
         )
-        XCTAssertFalse(incompleteObservations.isComplete)
+        XCTAssertFalse(incompleteObservations.isComplete(requiresSubtitleObservation: false))
     }
 
     func testSeekRequiresPlaybackAdvanceAndFreshSpatialRendering() {

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -88,7 +88,7 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 9
+        CURRENT_PROJECT_VERSION: 10
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: SpatialPlaybackProbe/Info.plist
         MARKETING_VERSION: 0.2.0


### PR DESCRIPTION
## Summary

- upgrade Playback Check reports to schema 5 with per-run audio/subtitle option identities, initial/requested/final selections, forced-only state, and selection confirmation
- capture AVFoundation legible cue events only during the active validation generation and validate explicit cue windows with successful seeks plus timestamp tolerance
- require a wearer subtitle-visibility observation when subtitles are discovered or expected, while preserving an immutable automatic subtitle verdict
- document the exact issue #409 M5 launch contract with `BD_TO_AVP_PROBE_EXPECTED_SUBTITLE_CUE_TIMES=0.5,27,55`

## Why

The existing validator could prove AV1 decode and stereo presentation, but only counted subtitle choices. It could not distinguish a missing text track, automatic forced-only selection, failed explicit selection, decoded-but-not-rendered cues, or visible subtitles. This change makes Ship's M5 report falsifiable without inferring headset behavior from macOS.

## Validation

- `xcodebuild ... -scheme SpatialPlaybackProbe ... test`: 19 passed, 1 physical-device test skipped on the visionOS 27.0 simulator
- generic physical visionOS build: succeeded
- `uv run python scripts/native_app.py test`: 338 passed after two unrelated timing/process failures passed targeted reruns and the full retry
- JetBrains changed-files inspection: GREEN, 0 actionable findings
- `git diff --check`: clean

## Physical M5 decision rule

- no subtitle options: device discovery failure
- requested option not selected: media-selection failure
- expected cue window lacks a successful seek and on-time decoded cue: decode/delivery failure
- all cue windows pass but wearer answers No: RealityKit presentation failure
- all cue windows pass and wearer answers Yes: disproves that the exact asset/build cannot show subtitles

Refs #409