### PR TITLE
fix: continue when PGS subtitles are unreadable

### DIFF
--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -18,6 +18,7 @@ from bd_to_avp.modules.languages import (
 )
 from bd_to_avp.observability import ObservabilityContext
 from bd_to_avp.presentation import cli_message
+from bd_to_avp.process_runner import ProcessCancelled
 from bd_to_avp.runtime import RunContext
 
 
@@ -114,7 +115,25 @@ def extract_subtitle_to_srt(
                 report_subtitle_warning(message, warning_handler)
                 return None
 
-            pgsrip.rip(mkv_file, sub_options)
+            try:
+                ripped_track_count = pgsrip.rip(mkv_file, sub_options)
+            except ProcessCancelled:
+                raise
+            except Exception as error:
+                cleanup_existing_subtitle_files(output_path)
+                report_subtitle_warning(
+                    f"PGS subtitle extraction failed; continuing without subtitles. ({error})",
+                    warning_handler,
+                )
+                return None
+
+            if ripped_track_count == 0:
+                cleanup_existing_subtitle_files(output_path)
+                report_subtitle_warning(
+                    "PGS subtitle extraction did not produce usable subtitle files; continuing without subtitles.",
+                    warning_handler,
+                )
+                return None
 
             for srt_file in output_path.glob("*.srt"):
                 if srt_file.stat().st_size == 0:

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from bd_to_avp.modules import sub
+from bd_to_avp.process_runner import ProcessCancelled
 from bd_to_avp.vendor.pgsrip.media_path import MediaPath
 from bd_to_avp.vendor.pgsrip.mkv import MkvTrack
 from bd_to_avp.modules.sub import (
@@ -356,6 +357,51 @@ class SubtitleStreamDetectionTests(unittest.TestCase):
             self.assertFalse((output_folder / "movie.mkv").exists())
             rip.assert_called_once()
             mark_forced.assert_called_once_with([], None)
+
+    def test_unreadable_pgs_tracks_warn_and_remove_partial_subtitles(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.sub.get_languages_in_mkv", return_value=[{"index": 3, "language": "eng"}]),
+            patch.object(sub.config, "skip_subtitles", False),
+            patch("bd_to_avp.modules.sub.Mkv") as mkv_class,
+            patch("bd_to_avp.modules.sub.get_selected_subtitle_tracks", return_value=[]),
+        ):
+            output_path = Path(temp_dir)
+            source_mkv = output_path / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+            partial_srt = output_path / "movie.en.srt"
+            warnings: list[str] = []
+            mkv_class.side_effect = lambda path, **_kwargs: type("MkvStub", (), {"media_path": Path(path)})()
+
+            def produce_no_usable_subtitles(_mkv_file, _options):
+                partial_srt.write_text("partial", encoding="utf-8")
+                return 0
+
+            with patch("bd_to_avp.modules.sub.pgsrip.rip", side_effect=produce_no_usable_subtitles):
+                extract_subtitle_to_srt(source_mkv, output_path, warnings.append)
+
+            self.assertFalse(partial_srt.exists())
+            self.assertEqual(
+                warnings,
+                ["PGS subtitle extraction did not produce usable subtitle files; continuing without subtitles."],
+            )
+
+    def test_subtitle_extraction_preserves_cancellation(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("bd_to_avp.modules.sub.get_languages_in_mkv", return_value=[{"index": 3, "language": "eng"}]),
+            patch.object(sub.config, "skip_subtitles", False),
+            patch("bd_to_avp.modules.sub.Mkv") as mkv_class,
+            patch("bd_to_avp.modules.sub.get_selected_subtitle_tracks", return_value=[]),
+            patch("bd_to_avp.modules.sub.pgsrip.rip", side_effect=ProcessCancelled("cancelled")),
+        ):
+            output_path = Path(temp_dir)
+            source_mkv = output_path / "movie.mkv"
+            source_mkv.write_bytes(b"mkv")
+            mkv_class.side_effect = lambda path, **_kwargs: type("MkvStub", (), {"media_path": Path(path)})()
+
+            with self.assertRaisesRegex(ProcessCancelled, "cancelled"):
+                extract_subtitle_to_srt(source_mkv, output_path)
 
     def test_subtitle_source_alias_uses_absolute_target_for_relative_source(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- continue conversion when every selected PGS subtitle track is unreadable
- remove partial SRT files and surface a warning instead of failing the movie
- preserve cancellation and existing recoverable subtitle behavior

## Validation
- `uv run python -m unittest tests.test_subtitles`

Fixes #458