### PR TITLE
chore: prepare 0.3.0 RC 1 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Beta 4 (`0.3.0b4`, build `149`) through Beta 8 (`0.3.0b8`, build `153`) and Beta
 10 (`0.3.0b10`, build `155`) are published and immutable. Beta 9 (`0.3.0b9`,
 build `154`) failed after production signing but before DMG creation and is
 permanently burned without publication.
-Beta 11 (`0.3.0b11`, build `156`) is published and immutable. Beta 12 metadata
-(`0.3.0b12`, build `157`) is prepared for the guarded Prerelease workflow.
-There is no Beta 12 tag, DMG, release, or updater item until exact-SHA signing,
-publication, and public verification complete.
+Beta 11 (`0.3.0b11`, build `156`) is published and immutable. The first Release
+Candidate metadata (`0.3.0rc1`, build `158`) is prepared for the guarded
+Prerelease workflow. There is no RC 1 tag, DMG, release, or updater item until
+exact-SHA signing, publication, and public verification complete.
 
 See [Distribution Policy](docs/distribution-policy.md) for the current GUI
 release artifact and dependency policy.

--- a/docs/0.3.0-beta.12-cut-packet.md
+++ b/docs/0.3.0-beta.12-cut-packet.md
@@ -1,17 +1,14 @@
 # 0.3.0 Beta 12 Cut Packet
 
-> **Prepared metadata; publication pending.** Milestone #1 and issues #386,
-> #388, #392, #418, and #422 authorize preparation and review of one shared
-> signed-beta candidate. Dispatch remains a deliberate later decision after the
-> metadata PR and pre-registered qualification matrix merge green under a
-> temporary `main` merge hold. The `macos-signing` environment remains a
-> separate, run-bound authorization requiring explicit approval in the active
-> conversation.
+> **Abandoned metadata; never dispatched or published.** Beta 12 was superseded
+> by the explicit decision to cut RC 1 from a newer protected-`main` candidate.
+> Build `157` remains permanently unavailable for reuse. No tag, draft, release,
+> DMG, or appcast item was created.
 
 The normative identity and route contract remains in
-[release-routes.md](release-routes.md). Beta 12 advances from immutable
-published Beta 11 and packages the full-conversion cleanup correction from PR
-#452. It is not an RC nomination.
+[release-routes.md](release-routes.md). Beta 12 was a metadata-only candidate
+after immutable published Beta 11 and includes the full-conversion cleanup
+correction from PR #452. It is not an RC nomination and must not be dispatched.
 
 ## Exact Metadata
 
@@ -28,12 +25,12 @@ published Beta 11 and packages the full-conversion cleanup correction from PR
 | Publish to PyPI or Homebrew | `false` |
 | Product name | `3D Blu-ray to Vision Pro` |
 | Bundle identifier | `com.shinycomputers.bd-to-avp` |
-| Privacy contract | Privacy rules version `4` |
+| Privacy contract | Privacy rules version `5` |
 
 Build `157` is globally newer than immutable Beta 11 build `156`; failed Beta
-9 build `154` remains burned. Beta 12 has no tag, release, draft, appcast item,
-or freeze entry. The public cumulative appcast currently ends at Beta 11 build
-`156`.
+9 build `154` remains burned. Beta 12 has no tag, release, draft, DMG, appcast
+item, or freeze entry. The public cumulative appcast ends at Beta 11 build
+`156`; RC 1 replaces this abandoned candidate.
 
 ## Included Product Changes
 
@@ -45,10 +42,10 @@ or freeze entry. The public cumulative appcast currently ends at Beta 11 build
 - Dependency updates already merged to protected `main` remain included in the
   candidate.
 
-## Cumulative Update Contract
+## Abandoned Update Contract
 
-Publication must append Beta 12 above immutable public history while retaining
-burned build `154` as absent:
+No Beta 12 appcast item will be created. The proposed ordering is retained only
+as the original review record; RC 1 defines the active cumulative route contract.
 
 | Order | Internal version | Build | Channel |
 | ---: | --- | ---: | --- |
@@ -65,42 +62,30 @@ burned build `154` as absent:
 | 11 | `0.2.143rc5` | `145` | `rc` |
 | 12 | `0.2.143rc4` | `144` | `rc` |
 
-Stable and RC continue to exclude every Beta item. Beta and Alpha admit the
-published Betas plus Beta 12 if publication succeeds. An installed Beta 11 may
-update directly to build `157` without changing its saved route.
+Stable and RC continue to exclude every Beta item. Beta and Alpha continue to
+admit the published Betas. No installation can update to build `157`.
 
-## Reviewed Release-Note Seed
+## Unused Release-Note Seed
 
 > BD_to_AVP `v0.3.0-beta.12` fixes cleanup safety for cancelled conversions and
 > rejected overwrite attempts. Existing final files and resumable intermediates
 > stay intact when overwrite is disabled, while fresh cancelled workspaces are
 > removed safely. Beta 11 remains immutable published history.
 
-Do not describe Beta 12 as downloadable, signed, published, notarized, or
-Sparkle-discoverable until the guarded workflow verifies the immutable public
-state. Publishing the beta does not qualify AV1 on physical M5 Vision Pro and
-does not turn the candidate into an RC.
+This unpublished note must not be published or used for RC 1. Beta 12 never
+qualified AV1 on physical M5 Vision Pro and never became an RC.
 
-## Exact-Artifact Qualification
+## Qualification Disposition
 
 The last exact public artifact is immutable Beta 11. Beta 12 exact-artifact
-qualification must bind one protected-`main` SHA to the signed and notarized
-DMG, release/appcast identity, updater routes, the mounted-network overwrite
-and active-upscale cancellation row, source-safe cleanup, and the public-safe
-#386 closure. Existing Beta 11 quality, package, physical Vision Pro, and
-full-length receipts remain valid inputs and are not rerun merely to create the
-new candidate identity.
+qualification was not run. RC 1 owns a new pre-registered exact-artifact matrix;
+existing Beta 11 quality, package, physical Vision Pro, and full-length receipts
+remain inputs only.
 
-If any field row fails, Beta 12 remains immutable public history and the fix
-advances to a new beta version and global build; assets, notes, tags, and
-appcast items are never silently replaced.
+Build `157` must never be repurposed. Assets, notes, tags, and appcast items are
+never silently replaced.
 
 ## Authorization Boundary
 
-This packet authorizes metadata preparation and review, not an unattended
-release. Before dispatch, record the exact protected `main` SHA and establish a
-temporary merge hold. While the Prerelease workflow is nonterminal, `main` must
-remain fixed. Monitor only with
-`uv run python -m scripts.github_release_run watch`. If it exits `20`, obtain
-fresh explicit run-bound authorization in the active conversation and approve
-only through `scripts.github_release_run approve` with the emitted fingerprint.
+This packet is historical only and authorizes no dispatch. RC 1 controls all
+future release authorization and its protected-`main` merge hold.

--- a/docs/0.3.0-rc.1-cut-packet.md
+++ b/docs/0.3.0-rc.1-cut-packet.md
@@ -1,0 +1,75 @@
+# 0.3.0 RC 1 Cut Packet
+
+> **Prepared metadata; publication pending.** Issue #460 records the first
+> `0.3.0` Release Candidate. It may be dispatched only from the exact merged
+> protected-`main` SHA under a temporary merge hold. The `macos-signing`
+> environment requires fresh explicit run-bound authorization in the active
+> conversation.
+
+The normative identity and route contract remains in
+[release-routes.md](release-routes.md). RC 1 follows immutable Beta 11 and
+supersedes abandoned Beta 12 metadata without publishing it. It includes the
+full-conversion cleanup correction from PR #452 and malformed-PGS recovery from
+PR #459.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.0rc1` |
+| Public version | `0.3.0-rc.1` |
+| Bundle and Sparkle build | `158` |
+| GitHub tag and release title | `v0.3.0-rc.1` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.0-rc.1.dmg` |
+| Sparkle channel | `rc` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `158` is globally newer than published Beta 11 build `156`, abandoned
+Beta 12 build `157`, and burned builds `147` and `154`. RC 1 has no tag,
+release, draft, appcast item, or freeze entry until the guarded workflow
+finishes and public verification succeeds.
+
+RC 1 deliberately re-nominates the never-published `0.3.0rc1` version string
+from burned build `147` at a newer build. Publication supersedes only the Beta
+3 recovery receipt's historical absence assertion for that tag; it does not
+alter the immutable recovery evidence or make build `147` reusable.
+
+## Update and Qualification Contract
+
+The last exact public artifact is immutable Beta 11. RC 1 exact-artifact
+qualification must bind the final protected-`main` SHA to the signed and
+notarized DMG, release/appcast identity, updater routes, installed native notes,
+fresh-profile quality UI, capacity, cleanup, source safety, generated-network
+outputs, and the malformed-PGS recovery behavior from PR #459.
+
+The RC route must offer RC 1 only to eligible newer installations; Stable must
+not receive it. Beta and Alpha may receive the RC item under the existing
+cumulative route contract. Existing Beta 11 receipts are inputs only and do not
+substitute for fresh signed RC qualification.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.0-rc.1` improves conversion safety and subtitle recovery.
+> Cancelled conversions remove only fresh worker-owned temporary data, rejected
+> overwrite attempts preserve existing output and resumable work, and unreadable
+> PGS subtitles now warn and continue without subtitles instead of failing the
+> full conversion. RC 1 also includes the latest route-aware quality and direct
+> distribution improvements from the qualified beta line.
+
+Do not describe RC 1 as downloadable, signed, published, notarized, or
+Sparkle-discoverable until the guarded workflow verifies the immutable public
+state.
+
+## Authorization Boundary
+
+Before dispatch, record the exact protected `main` SHA and establish a temporary
+merge hold. Monitor only with `uv run python -m scripts.github_release_run
+watch`. If it exits `20`, obtain fresh explicit run-bound authorization in the
+active conversation and approve only through `scripts.github_release_run
+approve` using the emitted run, workflow, full `main` SHA, confirmation SHA,
+and approval fingerprint.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -100,8 +100,8 @@ document it as an external dependency with preflight behavior.
   `0.3.0b9`, build `154`) failed after production signing but before DMG
   creation and is permanently burned without publication. Beta 11
   (`v0.3.0-beta.11`, internal version `0.3.0b11`, build `156`) is published and
-  immutable. The next prepared production-identity field build is Beta 12
-  (`v0.3.0-beta.12`, internal version `0.3.0b12`, build `157`). It remains
+  immutable. The next prepared production-identity field build is RC 1
+  (`v0.3.0-rc.1`, internal version `0.3.0rc1`, build `158`). It remains
   unpublished until exact-SHA signing and public verification complete. Beta 3 build `148` remains the
   manual-download seed and immutable appcast history below the later Beta
   releases.

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -116,11 +116,12 @@ older Stable and RC installations cannot discover it, while an installed Beta
 (`0.3.0b8`, build `153`) are published and immutable. Beta 9 (`0.3.0b9`, build
 `154`) failed after production signing and is burned without a public appcast
   item. Beta 10 (`0.3.0b10`, build `155`) and Beta 11 (`0.3.0b11`, build `156`)
-  are published and immutable. Beta 12 (`0.3.0b12`, build `157`) is the next
-  prepared target for the guarded exact-SHA Prerelease workflow. Its future
-  cumulative item must sit above Beta 11, Beta 10, Beta 8
-through Beta 3, skip burned build `154`, and remain visible only to Beta and
-Alpha until a later newer Stable supersedes it.
+  are published and immutable. Abandoned Beta 12 metadata build `157` has no
+  public artifact. RC 1 (`0.3.0rc1`, build `158`) is the next prepared target
+  for the guarded exact-SHA Prerelease workflow. Its future cumulative item must
+  sit above Beta 11, Beta 10, Beta 8 through Beta 3, skip builds `147`, `154`,
+  and `157`, remain excluded from Stable, and be visible to RC, Beta, and Alpha
+  until a later newer Stable supersedes it.
 
 ## Release Workflow
 
@@ -180,19 +181,20 @@ fixed the missing AVKit link and added an installed-player presentation smoke.
 The exact Beta 10 artifact passed that release smoke and real preview
 presentation, but its GUI cancellation run left destination-backed preview
 residue. PR #416 fixed that cleanup behavior after Beta 10. The route-aware
-quality system also landed after Beta 10 and requires protocol v12. Beta 12
+quality system also landed after Beta 10 and requires protocol v12. RC 1
 exact-artifact qualification must prove that:
 
-- Beta 11 updates forward to Beta 12 on Beta and Alpha without changing the saved
-  route;
-- Stable and RC continue to exclude every Beta item;
+- Beta 11 updates forward to RC 1 on RC, Beta, and Alpha without changing the
+  saved route;
+- Stable excludes RC 1;
 - the downloaded notarized DMG passes signature, staple, Gatekeeper, startup,
   bundled-helper, and worker-capability checks; and
 - the installed app exposes the frozen route-relative quality behavior through
   protocol v12 without changing reversible Custom values; and
 - packaged GUI preview presentation, visible fallback, capacity, cleanup,
-  final output, overwrite, and cancellation satisfy the pre-registered shared
-  #392/#422 matrix without treating unsigned evidence as release proof; and
+  generated-network final output, overwrite, cancellation, and malformed-PGS
+  recovery satisfy the pre-registered RC 1 matrix for #460 without treating
+  unsigned evidence as release proof; and
 - the release package smoke executes the real installed player guard before
   publication. Physical M5 Vision Pro AV1 evidence remains separately tracked
   by #409 and is not inferred from publication.

--- a/docs/qualification/rc1-signed-qualification-v1.json
+++ b/docs/qualification/rc1-signed-qualification-v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "qualification_id": "rc1-signed-qualification-v1",
+  "status": "preregistered_pending_exact_candidate",
+  "issues": ["#460", "#457", "#458"],
+  "candidate": {
+    "package_version": "0.3.0rc1",
+    "public_version": "0.3.0-rc.1",
+    "build_version": "158",
+    "release_tag": "v0.3.0-rc.1",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.1.dmg",
+    "workflow": "Prerelease",
+    "worker_protocol_version": 12,
+    "route_table_id": "route-relative-video-quality-v2",
+    "mapping_version": 2,
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "source_git_sha": null,
+    "dmg_sha256": null,
+    "signed_app_tree_sha256": null,
+    "release_run_id": null,
+    "release_id": null,
+    "appcast_sha256": null
+  },
+  "prior_evidence": [
+    {
+      "id": "beta11-shared-signed-qualification-v1",
+      "scope": "immutable prior quality, media, and signed-package inputs only"
+    }
+  ],
+  "execution_policy": {
+    "main_must_remain_fixed_while_nonterminal": true,
+    "watch_command": "uv run python -m scripts.github_release_run watch",
+    "generic_run_waiter_is_sufficient": false,
+    "approval_required_exit_code": 20,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "release_stage": "rc",
+    "field_qualification_timing": "post_publication_exact_artifact"
+  },
+  "matrix": [
+    {"id": "release-workflow-identity", "phase": "workflow"},
+    {"id": "updater-route-beta11-to-rc1", "phase": "installed_candidate"},
+    {"id": "native-sparkle-notes-rc1", "phase": "installed_candidate"},
+    {"id": "fresh-profile-quality-ui", "phase": "installed_candidate"},
+    {"id": "signed-packaged-route-parity", "phase": "signed_artifact"},
+    {"id": "gui-preview-low-local-ample-destination", "phase": "signed_artifact"},
+    {"id": "gui-preview-cancel-cleanup", "phase": "signed_artifact"},
+    {"id": "gui-preview-failure-cleanup", "phase": "signed_artifact"},
+    {"id": "capacity-known-low", "phase": "signed_artifact"},
+    {"id": "capacity-unknown-and-conflicting", "phase": "signed_artifact"},
+    {"id": "network-generated-final-output", "phase": "signed_artifact"},
+    {"id": "overwrite-and-conversion-cancel", "phase": "signed_artifact"},
+    {"id": "malformed-pgs-recovery", "phase": "signed_artifact"},
+    {"id": "public-diagnostics-and-field-closure", "phase": "post_publication"}
+  ],
+  "acceptance": {
+    "required_case_ids": [
+      "release-workflow-identity",
+      "updater-route-beta11-to-rc1",
+      "native-sparkle-notes-rc1",
+      "fresh-profile-quality-ui",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-recovery",
+      "public-diagnostics-and-field-closure"
+    ],
+    "signed_rc_complete": false,
+    "passed": false
+  }
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,22 +6,23 @@ boundary, and publication policy are defined in
 
 The repository carries published, immutable Beta 3 through Beta 8, Beta 10, and
 Beta 11 history at builds `148` through `156` except burned build `154`. Failed,
-unpublished Beta 9 (`0.3.0b9`, build `154`) and the earlier `0.3.0rc1` build
-`147` attempt are permanently burned. The next prepared target is Beta 12 at
-`0.3.0b12`, build `157`. The
+unpublished Beta 9 (`0.3.0b9`, build `154`) and the earlier RC candidate build
+`147` are permanently burned. The first current RC candidate re-nominates
+`0.3.0rc1` at globally newer build `158`. The
 [Beta 8 cut packet](0.3.0-beta.8-cut-packet.md) records immutable publication
 history, [the Beta 9 cut packet](0.3.0-beta.9-cut-packet.md) records the failed
 unpublished attempt, [the Beta 10 cut packet](0.3.0-beta.10-cut-packet.md)
 records immutable publication history, [the Beta 11 cut packet](0.3.0-beta.11-cut-packet.md)
-records historical preparation, and [the Beta 12 cut packet](0.3.0-beta.12-cut-packet.md)
+records historical preparation, [the Beta 12 cut packet](0.3.0-beta.12-cut-packet.md)
+records abandoned Beta metadata, and [the RC 1 cut packet](0.3.0-rc.1-cut-packet.md)
 records current pending metadata.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
 entrypoints, Beta 3 bootstrap contract, and one-time metadata recovery are
-implemented and regression-covered. Issues #392 and #422 own the shared Beta 11
-qualification. They authorize metadata preparation and review; exact-SHA
-dispatch remains a deliberate later decision, and run-bound signing approval
+implemented and regression-covered. Issue #460 owns RC 1 qualification. It
+authorizes metadata preparation and review; exact-SHA dispatch remains a
+deliberate later decision, and run-bound signing approval
 remains a separate authorization boundary.
 
 ## Release Preparation
@@ -81,14 +82,12 @@ or from a stale main commit.
 
 ## Release Orchestration
 
-> **Beta 10 is published and immutable; Beta 11 is prepared but not yet
-> published.** Beta 10 was published on July 29, 2026 from protected-main SHA
-> `50b874a4ad681762f3aa94e02926b8a82f0aa221` by guarded Prerelease run
-> `30445073119`. It must not be rebuilt. Issues #392 and #422 authorize Beta 11
-> metadata preparation and review, not unattended dispatch. Dispatch Beta 11
+> **Beta 11 is published and immutable; RC 1 is prepared but not yet
+> published.** Beta 11 remains the last public artifact. Issue #460 authorizes
+> RC 1 metadata preparation and review, not unattended dispatch. Dispatch RC 1
 > only after its pre-registered matrix merges green and a temporary `main`
 > merge hold is active. Keep `main` fixed while the workflow is nonterminal,
-> and do not describe Beta 11 as public until signing, notarization, appcast
+> and do not describe RC 1 as public until signing, notarization, appcast
 > publication, and route verification complete.
 
 Dispatch `Stable` from `main` only for reviewed committed Stable metadata, or

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -8,10 +8,11 @@ The application preference model, release metadata/history parser, appcast
 tooling, reusable release engine, and guarded operator entrypoints implement
 this four-route contract. Beta 3 through Beta 8, Beta 10, and Beta 11 are
 published and immutable at builds `148` through `156`, excluding permanently
-burned builds `147` and `154`. Failed Beta 9 (`0.3.0b9`, build `154`) was never
-published. The next prepared target is Beta 12 at `0.3.0b12` build `157`.
-Issues #392 and #422 own the shared exact-signed-candidate qualification;
-run-bound signing approval remains a separate authorization boundary.
+burned builds `147`, `154`, and abandoned metadata build `157`. Failed Beta 9
+(`0.3.0b9`, build `154`) was never published. The next prepared target is RC 1
+at `0.3.0rc1` build `158`. Issue
+#460 owns its exact-signed-candidate qualification; run-bound signing approval
+remains a separate authorization boundary.
 
 ## Production Identity
 
@@ -241,33 +242,37 @@ burned Beta 9 build `154` absent. Stable and RC exclude all Beta items; Beta and
 Alpha admit them. Historical metadata and release evidence are in
 [the Beta 10 cut packet](0.3.0-beta.10-cut-packet.md).
 
-## Beta 12 Prepared Target
+## RC 1 Prepared Target
 
-The repository is prepared for review of the guarded `v0.3.0-beta.12`
+The repository is prepared for review of the guarded `v0.3.0-rc.1`
 Prerelease workflow:
 
-- internal version `0.3.0b12`;
-- public tag and title `v0.3.0-beta.12`;
-- global build `157`;
-- Sparkle channel `beta`;
+- internal version `0.3.0rc1`;
+- public tag and title `v0.3.0-rc.1`;
+- global build `158`;
+- Sparkle channel `rc`;
 - GitHub prerelease, never Latest, PyPI, or Homebrew; and
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta 11.
 
-Publication must place Beta 12 above immutable Beta 11 build `156`, Beta 10
-build `155`, Beta 8 build `153`, Beta 7 build `152`, Beta 6 build `151`, Beta 5
-build `150`, Beta 4 build `149`, Beta 3 build `148`, Stable build `146`, RC5
-build `145`, and RC4 build `144`, with burned build `154` absent. Stable and RC
-exclude all Beta items; Beta and Alpha admit them, allowing an installed Beta 11
-to update forward to Beta 12 without changing the saved route.
+RC 1 deliberately re-nominates the never-published `0.3.0rc1` version string
+from burned build `147` at a newer build. If RC 1 is published, the Beta 3
+recovery receipt's historical absence assertion for that tag is superseded; its
+immutable Beta 3 recovery evidence and build-`147` exclusion remain unchanged.
 
-Issues #392 and #422 authorize metadata preparation and review of this shared
-candidate. The repository has no freeze entry for this exact tag; that absence
-allows workflow preflight but does not assert that a tag, draft, DMG, release,
-or appcast item exists. Dispatch remains a deliberate later decision under a
-fixed-`main` merge hold. The reviewed metadata, release-note seed, and
-qualification boundary are in
-[the Beta 12 cut packet](0.3.0-beta.12-cut-packet.md).
+Publication must place RC 1 above immutable Beta 11 build `156`, Beta 10 build
+`155`, Beta 8 build `153`, Beta 7 build `152`, Beta 6 build `151`, Beta 5 build
+`150`, Beta 4 build `149`, Beta 3 build `148`, Stable build `146`, RC5 build
+`145`, and RC4 build `144`, with burned builds `147` and `154` absent. Stable
+continues to exclude the RC; RC, Beta, and Alpha admit it, allowing an installed
+RC-route client to update forward without changing its saved route.
+
+Issue #460 authorizes metadata preparation and review of this candidate. The
+repository has no freeze entry for this exact tag; that absence allows workflow
+preflight but does not assert that a tag, draft, DMG, release, or appcast item
+exists. Dispatch requires an explicit RC-creation decision under a fixed-`main`
+merge hold. The reviewed metadata, release-note seed, and qualification boundary
+are in [the RC 1 cut packet](0.3.0-rc.1-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-smoke.md
+++ b/docs/release-smoke.md
@@ -288,32 +288,32 @@ Beta without pretending the current Stable or RC client can discover it.
    apps remain separate and cannot Sparkle-update into the production app. Do
    not reopen them to edit the shared profile library after Beta 3 installation.
 
-### Beta 12 Preparation Smoke
+### RC 1 Preparation Smoke
 
-Run these checks after the Beta 12 metadata preparation lands and before
+Run these checks after the RC 1 metadata preparation lands and before
 workflow dispatch. They prove the committed target and authorization boundary,
 not a signed or published app.
 
 1. Run `uv run python -m scripts.release validate` and confirm internal
-   `0.3.0b12`, public `0.3.0-beta.12`, build `157`, Beta channel, prerelease,
+   `0.3.0rc1`, public `0.3.0-rc.1`, build `158`, RC channel, prerelease,
    non-Latest, and no PyPI publication.
 2. Run the Prerelease metadata policy with the committed target and confirm the
-   Beta 12 freeze is absent while all route, identity, and existing-release
+   RC 1 freeze is absent while all route, identity, and existing-release
    guards remain active before packaging or signing.
-3. Validate a cumulative appcast fixture ordered Beta 12 build `157`, Beta 11
+3. Validate a cumulative appcast fixture ordered RC 1 build `158`, Beta 11
    build `156`, Beta 10 build `155`, Beta 8 build `153`, Beta 7 build `152`, Beta 6 build `151`, Beta
    5 build `150`, Beta 4 build `149`, Beta 3 build `148`, then Stable build
-   `146`, RC5 build `145`, and RC4 build `144`; burned Beta 9 build `154` must
-   be absent, Stable and RC must exclude every Beta item, and Beta and Alpha
-   must admit them.
+   `146`, RC5 build `145`, and RC4 build `144`; burned builds `147` and `154`
+   must be absent, Stable must exclude the RC, and RC, Beta, and Alpha must
+   admit it.
 4. Confirm immutable Beta 11 targets its published release identity, then confirm
-   the live repository has no Beta 12 tag, release, draft, asset, or appcast item.
+   the live repository has no RC 1 tag, release, draft, asset, or appcast item.
 5. Continue only through the exact-SHA Prerelease workflow. Signed-app,
    update-route, installed quality UI, capacity, cleanup, and final-output
    qualification remain incomplete until the guarded workflow and exact-
    artifact checks in
-   `docs/qualification/beta11-shared-signed-qualification-v1.json` and the
-   Beta 12 field receipts finish.
+   `docs/qualification/rc1-signed-qualification-v1.json` and the
+   RC 1 field receipts finish.
    Physical M5 Vision Pro AV1 evidence stays in #409.
 
 ## Follow-Up Routing

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -70,8 +70,9 @@ Sparkle uses its adaptive native text view without loading GitHub page chrome or
 making a second release-note request. A full-release link remains available for
 downloads and extended context, and historical external-link items remain valid.
 The live feed carries cumulative production history through Beta 11 build `156`.
-Failed Beta 9 build `154` never entered the feed; prepared Beta 12 metadata does
-not alter it before guarded publication.
+Failed Beta 9 build `154` and abandoned Beta 12 metadata build `157` never
+entered the feed; prepared RC 1 metadata does not alter it before guarded
+publication.
 See [release-process.md](release-process.md) for the operator sequence.
 
 Stable `0.2.143` remains compatible with macOS 14. The production SwiftUI line
@@ -269,11 +270,12 @@ Sparkle-upgrade into Beta 3.
 
 Published `v0.3.0-beta.11` (`0.3.0b11`, build `156`) is the immutable head of
 the current cumulative feed above Beta 10, Beta 8 through Beta 3. Failed Beta 9
-build `154` is burned and omitted from public history. The next prepared item is
-`v0.3.0-beta.12` (`0.3.0b12`, build `157`). Publication must append Beta 12
-above the existing Betas, remain excluded from Stable and RC, and be eligible
-to Beta and Alpha. The exact-SHA Prerelease workflow, signing approval,
-notarization, and public verification remain separate fail-closed boundaries.
+build `154` and abandoned Beta 12 metadata build `157` are omitted from public
+history. The next prepared item is `v0.3.0-rc.1` (`0.3.0rc1`, build `158`).
+Publication must append RC 1 above the existing history, exclude it from Stable,
+and admit it on RC, Beta, and Alpha. The exact-SHA Prerelease workflow, signing
+approval, notarization, and public verification remain separate fail-closed
+boundaries.
 
 ## Runtime Integration and UX
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 157
+        CURRENT_PROJECT_VERSION: 158
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0b12
+        MARKETING_VERSION: 0.3.0rc1
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0b12"
+version = "0.3.0rc1"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -111,7 +111,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "157"
+CFBundleVersion = "158"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0b12")
-        self.assertEqual(NATIVE_BUILD_VERSION, "157")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0rc1")
+        self.assertEqual(NATIVE_BUILD_VERSION, "158")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -185,9 +185,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("fresh explicit run-bound authorization", cut_packet)
 
         qualification = json.loads(
-            (REPO_ROOT / "docs" / "qualification" / "rc1-signed-qualification-v1.json").read_text(
-                encoding="utf-8"
-            )
+            (REPO_ROOT / "docs" / "qualification" / "rc1-signed-qualification-v1.json").read_text(encoding="utf-8")
         )
         self.assertEqual(qualification["candidate"]["package_version"], "0.3.0rc1")
         self.assertEqual(qualification["candidate"]["build_version"], "158")

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -156,42 +156,41 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(apps["bd-to-avp"]["min_os_version"], "14.0")
 
-    def test_repository_is_prepared_for_beta12(self) -> None:
+    def test_repository_is_prepared_for_rc1(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0b12")
-        self.assertEqual(metadata.public_version, "0.3.0-beta.12")
-        self.assertEqual(metadata.build_version, "157")
-        self.assertEqual(metadata.release_tag, "v0.3.0-beta.12")
-        self.assertEqual(metadata.release_name, "v0.3.0-beta.12")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.12.dmg")
-        self.assertEqual(metadata.channel, "beta")
+        self.assertEqual(metadata.package_version, "0.3.0rc1")
+        self.assertEqual(metadata.public_version, "0.3.0-rc.1")
+        self.assertEqual(metadata.build_version, "158")
+        self.assertEqual(metadata.release_tag, "v0.3.0-rc.1")
+        self.assertEqual(metadata.release_name, "v0.3.0-rc.1")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.1.dmg")
+        self.assertEqual(metadata.channel, "rc")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0-beta.12", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.0-rc.1", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.12-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0b12`", cut_packet)
-        self.assertIn("Build `157`", cut_packet)
-        for pull_request in (452,):
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-rc.1-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.0rc1`", cut_packet)
+        self.assertIn("Build `158`", cut_packet)
+        for pull_request in (452, 459):
             self.assertIn(f"#{pull_request}", cut_packet)
-        self.assertIn("Privacy rules version `4`", cut_packet)
-        self.assertIn("#392", cut_packet)
-        self.assertIn("#422", cut_packet)
+        self.assertIn("Privacy rules version `5`", cut_packet)
+        self.assertIn("#460", cut_packet)
         self.assertIn("Prepared metadata; publication pending", cut_packet)
         self.assertIn("last exact public artifact is immutable Beta 11", cut_packet)
         self.assertIn("fresh explicit run-bound authorization", cut_packet)
 
         qualification = json.loads(
-            (REPO_ROOT / "docs" / "qualification" / "beta11-shared-signed-qualification-v1.json").read_text(
+            (REPO_ROOT / "docs" / "qualification" / "rc1-signed-qualification-v1.json").read_text(
                 encoding="utf-8"
             )
         )
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.0b11")
-        self.assertEqual(qualification["candidate"]["build_version"], "156")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.0rc1")
+        self.assertEqual(qualification["candidate"]["build_version"], "158")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
         self.assertEqual(
@@ -200,7 +199,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-beta10-to-beta11",
+            "updater-route-beta11-to-rc1",
+            "native-sparkle-notes-rc1",
             "fresh-profile-quality-ui",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",
@@ -210,6 +210,7 @@ class ReleaseMetadataTests(unittest.TestCase):
             "capacity-unknown-and-conflicting",
             "network-generated-final-output",
             "overwrite-and-conversion-cancel",
+            "malformed-pgs-recovery",
             "public-diagnostics-and-field-closure",
         }
         self.assertEqual({case["id"] for case in qualification["matrix"]}, expected_case_ids)
@@ -227,8 +228,35 @@ class ReleaseMetadataTests(unittest.TestCase):
             qualification["execution_policy"]["macos_signing_requires_fresh_explicit_run_bound_authorization"]
         )
         self.assertEqual(qualification["execution_policy"]["approval_required_exit_code"], 20)
+        self.assertFalse(qualification["acceptance"]["signed_rc_complete"])
+        self.assertFalse(qualification["acceptance"]["passed"])
+
+    def test_beta11_qualification_remains_historical_receipt(self) -> None:
+        qualification = json.loads(
+            (REPO_ROOT / "docs" / "qualification" / "beta11-shared-signed-qualification-v1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.0b11")
+        self.assertEqual(qualification["candidate"]["build_version"], "156")
+        self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
+        self.assertEqual(qualification["candidate"]["mapping_version"], 2)
+        self.assertEqual(
+            qualification["candidate"]["route_table_sha256"],
+            "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+        )
         self.assertFalse(qualification["acceptance"]["signed_beta_complete"])
         self.assertFalse(qualification["acceptance"]["passed"])
+
+    def test_beta12_cut_packet_records_abandoned_metadata(self) -> None:
+        cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.12-cut-packet.md").read_text(encoding="utf-8")
+
+        self.assertIn("Abandoned metadata; never dispatched or published", cut_packet)
+        self.assertIn("`0.3.0b12`", cut_packet)
+        self.assertIn("Build `157`", cut_packet)
+        self.assertIn("No tag, draft, release", cut_packet)
+        self.assertIn("DMG, or appcast item was created", cut_packet)
 
     def test_beta10_cut_packet_records_immutable_published_identity(self) -> None:
         cut_packet = (REPO_ROOT / "docs" / "0.3.0-beta.10-cut-packet.md").read_text(encoding="utf-8")

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "157")
+        self.assertEqual(info["CFBundleVersion"], "158")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0b12"
+version = "0.3.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- prepare `0.3.0rc1` / build `158` as the first RC candidate
- register a distinct exact-signed RC qualification matrix and retire Beta 12 metadata
- align RC route, packaging, Sparkle, and release documentation

## Validation
- `uv run python -m scripts.release validate`
- `uv run python -m unittest tests.test_release tests.test_sparkle_appcast tests.test_sparkle_workflows tests.test_native_app tests.test_sparkle_packaging`

## Review
- final Opus review approved the metadata, release history, RC route, and qualification boundary