### PR TITLE
Add risk-tiered release qualification policy

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -87,6 +87,7 @@
     "lockfile": "uv.lock",
     "releaseRoutes": "docs/release-routes.md",
     "releaseProcess": "docs/release-process.md",
+    "releaseQualificationPolicy": "docs/release-qualification-policy.md",
     "releaseWorkflows": [
       ".github/workflows/briefcase.yml",
       ".github/workflows/prerelease.yml",
@@ -112,6 +113,8 @@
     "test": {
       "observabilityMigration": "uv run python scripts/validate_observability_migration.py",
       "unitSmoke": "uv run python -m unittest discover -s tests -t .",
+      "releaseQualificationPolicy": "uv run python -m scripts.qualify_release_scope --validate-policy",
+      "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
       "macosApp": "uv run python scripts/native_app.py test",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"

--- a/docs/qualification/rc3-signed-qualification-v1.json
+++ b/docs/qualification/rc3-signed-qualification-v1.json
@@ -3,6 +3,11 @@
   "qualification_id": "rc3-signed-qualification-v1",
   "status": "preregistered_pending_exact_candidate",
   "issues": ["#458"],
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/rc3-signed-qualification-v1.json --candidate-sha <full-sha> --evidence <checked-evidence.json> --release-stage rc --require-evidence"
+  },
   "candidate": {
     "package_version": "0.3.0rc3",
     "public_version": "0.3.0-rc.3",
@@ -58,24 +63,40 @@
     "field_qualification_timing": "post_publication_exact_artifact"
   },
   "matrix": [
-    {"id": "release-workflow-identity", "phase": "workflow"},
-    {"id": "updater-route-rc2-to-rc3", "phase": "installed_candidate"},
-    {"id": "native-sparkle-notes-rc3", "phase": "installed_candidate"},
-    {"id": "profile-save-action-accessibility", "phase": "installed_candidate"},
-    {"id": "signed-packaged-route-parity", "phase": "signed_artifact"},
-    {"id": "gui-preview-low-local-ample-destination", "phase": "signed_artifact"},
-    {"id": "gui-preview-cancel-cleanup", "phase": "signed_artifact"},
-    {"id": "gui-preview-failure-cleanup", "phase": "signed_artifact"},
-    {"id": "capacity-known-low", "phase": "signed_artifact"},
-    {"id": "capacity-unknown-and-conflicting", "phase": "signed_artifact"},
-    {"id": "network-generated-final-output", "phase": "signed_artifact"},
-    {"id": "overwrite-and-conversion-cancel", "phase": "signed_artifact"},
-    {"id": "malformed-pgs-parser-recovery", "phase": "signed_artifact"},
-    {"id": "subtitle-partial-output-diagnostics", "phase": "signed_artifact"},
-    {"id": "public-diagnostics-and-field-closure", "phase": "post_publication"}
+    {"id": "release-workflow-identity", "policy_case_id": "release-workflow-identity", "phase": "workflow", "migration": "release_run_receipt"},
+    {"id": "updater-route-rc2-to-rc3", "policy_case_id": "sparkle-update-route", "phase": "installed_candidate", "migration": "fresh_retest"},
+    {"id": "native-sparkle-notes-rc3", "policy_case_id": "native-sparkle-release-notes", "phase": "installed_candidate", "migration": "fresh_retest"},
+    {"id": "profile-save-action-accessibility", "policy_case_id": "profile-save-action-accessibility", "phase": "installed_candidate", "migration": "fresh_retest"},
+    {"id": "signed-packaged-route-parity", "policy_case_id": "signed-packaged-route-parity", "phase": "signed_artifact", "migration": "release_run_receipt"},
+    {"id": "gui-preview-low-local-ample-destination", "policy_case_id": "gui-preview-low-local-ample-destination", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "gui-preview-cancel-cleanup", "policy_case_id": "gui-preview-cancel-cleanup", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "gui-preview-failure-cleanup", "policy_case_id": "gui-preview-failure-cleanup", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "capacity-known-low", "policy_case_id": "capacity-known-low", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "capacity-unknown-and-conflicting", "policy_case_id": "capacity-unknown-and-conflicting", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "network-generated-final-output", "policy_case_id": "network-generated-final-output", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "overwrite-and-conversion-cancel", "policy_case_id": "overwrite-and-conversion-cancel", "phase": "signed_artifact", "migration": "scope_evaluated"},
+    {"id": "malformed-pgs-parser-recovery", "policy_case_id": "malformed-pgs-parser-recovery", "phase": "signed_artifact", "migration": "fresh_retest"},
+    {"id": "subtitle-partial-output-diagnostics", "policy_case_id": "subtitle-partial-output-diagnostics", "phase": "signed_artifact", "migration": "fresh_retest"},
+    {"id": "public-diagnostics-and-field-closure", "policy_case_id": "public-diagnostics-and-field-closure", "phase": "post_publication", "migration": "external_nonblocking"}
   ],
   "acceptance": {
     "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "native-sparkle-release-notes",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics"
+    ],
+    "preregistered_matrix_case_ids": [
       "release-workflow-identity",
       "updater-route-rc2-to-rc3",
       "native-sparkle-notes-rc3",
@@ -92,6 +113,7 @@
       "subtitle-partial-output-diagnostics",
       "public-diagnostics-and-field-closure"
     ],
+    "nonblocking_case_ids": ["public-diagnostics-and-field-closure"],
     "signed_rc_complete": false,
     "passed": false
   }

--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -1,0 +1,236 @@
+{
+  "schema_version": 1,
+  "policy_id": "release-qualification-policy-v1",
+  "result_states": ["covered", "carry", "retest", "external"],
+  "tiers": {
+    "0": {
+      "name": "per_commit",
+      "owner": "ci",
+      "blocking_phase": "commit"
+    },
+    "1": {
+      "name": "per_published_artifact",
+      "owner": "guarded_release_engine",
+      "blocking_phase": "publication"
+    },
+    "2": {
+      "name": "change_scoped",
+      "owner": "qualification",
+      "blocking_phase": "release_candidate"
+    },
+    "3": {
+      "name": "periodic_or_hardware",
+      "owner": "qualification",
+      "blocking_phase": "milestone",
+      "default_cadence": {
+        "first_rc_or_stable_candidate": true,
+        "max_age_days": 90
+      },
+      "hardware_receipt_required": true
+    },
+    "4": {
+      "name": "post_publication_observation",
+      "owner": "field_observation",
+      "blocking_phase": "none"
+    }
+  },
+  "contracts": {
+    "release-engine": [
+      ".github/workflows/briefcase.yml",
+      ".github/workflows/prerelease.yml",
+      ".github/workflows/release-engine.yml",
+      ".github/workflows/sparkle-pages.yml",
+      "scripts/artifact_identity.py",
+      "scripts/briefcase_macos_signing.py",
+      "scripts/github_release_run.py",
+      "scripts/macos_release.py",
+      "scripts/release.py",
+      "scripts/release_workflow_policy.py",
+      "scripts/smoke_release_app.py",
+      "scripts/sparkle_appcast.py",
+      "scripts/sparkle_bundle.py"
+    ],
+    "sparkle-update": [
+      ".github/workflows/manage-sparkle-pages.yml",
+      ".github/workflows/sparkle-pages.yml",
+      "macos/BluRayToVisionPro/Feature/SparkleUpdateBackend.swift",
+      "macos/BluRayToVisionPro/Feature/UpdateController.swift",
+      "scripts/sparkle_appcast.py",
+      "scripts/sparkle_bundle.py",
+      "scripts/sparkle_macos.py"
+    ],
+    "packaged-worker": [
+      "bd_to_avp/worker/**",
+      "macos/BluRayToVisionPro/Worker/**",
+      "scripts/briefcase_app.py",
+      "scripts/native_app.py",
+      "scripts/smoke_release_app.py",
+      "scripts/verify_app_tools.py"
+    ],
+    "profile-storage": [
+      "macos/BluRayToVisionPro/Feature/ProfileStore.swift",
+      "macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift",
+      "macos/BluRayToVisionProTests/ProfileStoreTests.swift"
+    ],
+    "preview-lifecycle": [
+      "bd_to_avp/modules/preview.py",
+      "bd_to_avp/modules/preview_range.py",
+      "bd_to_avp/worker/ownership.py",
+      "macos/BluRayToVisionPro/Feature/PreviewViewModel.swift",
+      "macos/BluRayToVisionPro/Models/PreviewWorkflow.swift",
+      "macos/BluRayToVisionPro/Views/PreviewSheet.swift"
+    ],
+    "storage-capacity": [
+      "bd_to_avp/modules/storage_capacity.py",
+      "bd_to_avp/preflight.py",
+      "macos/BluRayToVisionPro/Models/StorageCapacity.swift",
+      "macos/BluRayToVisionPro/Views/DestinationPicker.swift"
+    ],
+    "conversion-ownership": [
+      "bd_to_avp/modules/file.py",
+      "bd_to_avp/modules/process.py",
+      "bd_to_avp/process_runner.py",
+      "bd_to_avp/worker/operations.py",
+      "bd_to_avp/worker/ownership.py",
+      "macos/BluRayToVisionPro/Feature/ConversionViewModel.swift",
+      "macos/BluRayToVisionPro/Models/ConversionWorkflow.swift",
+      "macos/BluRayToVisionPro/Worker/WorkerProcessClient.swift"
+    ],
+    "subtitle-recovery": [
+      "bd_to_avp/modules/sub.py",
+      "bd_to_avp/vendor/pgsrip/**",
+      "bd_to_avp/worker/diagnostics.py",
+      "bd_to_avp/worker/operations.py"
+    ],
+    "support-diagnostics": [
+      "bd_to_avp/observability.py",
+      "bd_to_avp/presentation.py",
+      "bd_to_avp/worker/diagnostics.py",
+      "macos/BluRayToVisionPro/Diagnostics/**",
+      "macos/BluRayToVisionPro/Models/ObservabilityEvent.swift",
+      "scripts/support_diagnostics.py"
+    ]
+  },
+  "cases": [
+    {
+      "id": "release-workflow-identity",
+      "tier": 1,
+      "blocking_phase": "publication",
+      "invalidates_on": {"paths": [], "contracts": ["release-engine"]},
+      "allowed_evidence_sources": ["release_run_receipt"],
+      "carry_forward": {"allowed": false, "requires_prior_accepted_receipt": false, "requires_clean_invalidation": false}
+    },
+    {
+      "id": "sparkle-update-route",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": ["docs/release-routes.md", "pyproject.toml"], "contracts": ["sparkle-update"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "native-sparkle-release-notes",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": ["docs/release-notes/**", "docs/*-cut-packet.md"], "contracts": ["sparkle-update"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": ["macos/BluRayToVisionPro/Views/**"], "contracts": ["profile-storage"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "tier": 1,
+      "blocking_phase": "publication",
+      "invalidates_on": {"paths": ["bd_to_avp/modules/video*.py", "docs/qualification/video-quality-*.json"], "contracts": ["release-engine", "packaged-worker"]},
+      "allowed_evidence_sources": ["release_run_receipt"],
+      "carry_forward": {"allowed": false, "requires_prior_accepted_receipt": false, "requires_clean_invalidation": false}
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["preview-lifecycle", "storage-capacity"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["preview-lifecycle", "conversion-ownership"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["preview-lifecycle", "conversion-ownership"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "capacity-known-low",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["storage-capacity", "support-diagnostics"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["storage-capacity", "support-diagnostics"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "network-generated-final-output",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": ["bd_to_avp/modules/container.py", "bd_to_avp/modules/video*.py"], "contracts": ["conversion-ownership", "storage-capacity"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["conversion-ownership"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["subtitle-recovery"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "tier": 2,
+      "blocking_phase": "release_candidate",
+      "invalidates_on": {"paths": [], "contracts": ["subtitle-recovery", "support-diagnostics"]},
+      "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "tier": 4,
+      "blocking_phase": "none",
+      "invalidates_on": {"paths": [], "contracts": ["support-diagnostics"]},
+      "allowed_evidence_sources": ["field_observation"],
+      "carry_forward": {"allowed": false, "requires_prior_accepted_receipt": false, "requires_clean_invalidation": false}
+    }
+  ]
+}

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -1,0 +1,59 @@
+# Release Qualification Policy
+
+The versioned policy at
+[`docs/qualification/release-qualification-policy-v1.json`](qualification/release-qualification-policy-v1.json)
+separates release evidence by risk and ownership:
+
+- Tier 0 is automatic per-commit CI coverage.
+- Tier 1 is exact published-artifact evidence from the guarded release engine.
+- Tier 2 is functional evidence invalidated by mapped repository paths or shared contracts.
+- Tier 3 is periodic or hardware evidence with explicit milestone and expiry rules.
+- Tier 4 is post-publication observation and never blocks dispatch or publication.
+
+The classifier never performs signing, notarization, publication, or remote
+GitHub reads. It validates checked receipt references and compares their source
+SHAs with the candidate using the local Git repository.
+
+## Validate The Policy
+
+```sh
+uv run python -m scripts.qualify_release_scope --validate-policy
+```
+
+## Classify A Candidate
+
+```sh
+uv run python -m scripts.qualify_release_scope \
+  --candidate-sha "$CANDIDATE_SHA" \
+  --qualification docs/qualification/rc3-signed-qualification-v1.json \
+  --evidence path/to/checked-evidence.json \
+  --release-stage rc
+```
+
+Evidence uses schema version 1 and a `receipts` array. Each accepted receipt
+names a stable policy case, evidence source, source SHA, acceptance timestamp,
+repository-relative reference, and SHA-256 digest. The referenced receipt must
+be committed in the current repository `HEAD`, so an untracked local file can
+never satisfy release preparation. Tier 1 receipts additionally record a
+successful workflow conclusion and positive release-run ID. Tier 3 receipts
+must name every hardware/environment requirement declared by the case.
+
+Use `--require-evidence` during release preparation. It exits with status `2`
+when any blocking case remains `retest`; Tier 4 `external` cases never affect
+that exit status.
+
+```sh
+uv run python -m scripts.qualify_release_scope \
+  --candidate-sha "$CANDIDATE_SHA" \
+  --qualification docs/qualification/rc3-signed-qualification-v1.json \
+  --evidence path/to/checked-evidence.json \
+  --release-stage rc \
+  --require-evidence
+```
+
+Carry-forward is allowed only when an accepted named receipt exists and the
+diff from that receipt's source SHA contains no path covered by the case's
+direct invalidation patterns or referenced contracts. RC3 migration overrides
+keep its Sparkle, accessibility, PGS, and subtitle-diagnostic checks fresh.
+Tier 1 invalidation mappings document release-engine ownership only; Tier 1
+always requires a new exact-candidate receipt and never carries.

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import subprocess
+import sys
+
+from collections import Counter, defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_PATH = REPO_ROOT / "docs" / "qualification" / "release-qualification-policy-v1.json"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+RESULT_STATES = ("covered", "carry", "retest", "external")
+
+
+class QualificationScopeError(RuntimeError):
+    pass
+
+
+ChangedPaths = Callable[[str, str], set[str]]
+ReferenceContent = Callable[[str], bytes]
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise QualificationScopeError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise QualificationScopeError(f"{description} must be a JSON array.")
+    return value
+
+
+def _strings(value: object, description: str) -> tuple[str, ...]:
+    items = _sequence(value, description)
+    if not all(isinstance(item, str) and item for item in items):
+        raise QualificationScopeError(f"{description} must contain non-empty strings.")
+    return tuple(cast(str, item) for item in items)
+
+
+def _path_patterns(value: object, description: str) -> tuple[str, ...]:
+    patterns = _strings(value, description)
+    for pattern in patterns:
+        path = Path(pattern)
+        if path.is_absolute() or ".." in path.parts or pattern.startswith("./"):
+            raise QualificationScopeError(f"{description} must be repository-relative patterns: {pattern!r}.")
+    return patterns
+
+
+def _load_json(path: Path, description: str) -> Mapping[str, Any]:
+    try:
+        return _mapping(json.loads(path.read_text(encoding="utf-8")), description)
+    except OSError as error:
+        raise QualificationScopeError(f"Unable to read {description} at {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise QualificationScopeError(f"Invalid JSON in {description} at {path}: {error}") from error
+
+
+def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
+    policy = _load_json(path, "release qualification policy")
+    if policy.get("schema_version") != 1:
+        raise QualificationScopeError("Release qualification policy schema_version must be 1.")
+    if not isinstance(policy.get("policy_id"), str) or not policy["policy_id"]:
+        raise QualificationScopeError("Release qualification policy requires policy_id.")
+    if tuple(policy.get("result_states", ())) != RESULT_STATES:
+        raise QualificationScopeError(f"Release qualification result_states must be {RESULT_STATES!r}.")
+
+    tiers = _mapping(policy.get("tiers"), "release qualification tiers")
+    if set(tiers) != {"0", "1", "2", "3", "4"}:
+        raise QualificationScopeError("Release qualification policy must define tiers 0 through 4 exactly once.")
+    contracts = _mapping(policy.get("contracts"), "release qualification contracts")
+    for contract_id, patterns in contracts.items():
+        if not isinstance(contract_id, str) or not contract_id:
+            raise QualificationScopeError("Qualification contract IDs must be non-empty strings.")
+        _path_patterns(patterns, f"qualification contract {contract_id!r}")
+
+    cases = _sequence(policy.get("cases"), "release qualification cases")
+    seen: set[str] = set()
+    for index, raw_case in enumerate(cases):
+        case = _mapping(raw_case, f"release qualification case {index}")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            raise QualificationScopeError(f"Release qualification case {index} requires a stable id.")
+        if case_id in seen:
+            raise QualificationScopeError(f"Duplicate release qualification case ID: {case_id}")
+        seen.add(case_id)
+        tier = case.get("tier")
+        if not isinstance(tier, int) or isinstance(tier, bool) or tier not in range(5):
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} must have exactly one tier from 0 through 4."
+            )
+        blocking_phase = case.get("blocking_phase")
+        expected_blocking_phase = _mapping(tiers[str(tier)], f"qualification tier {tier}").get("blocking_phase")
+        if blocking_phase != expected_blocking_phase:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} blocking_phase must match tier {tier}: {expected_blocking_phase!r}."
+            )
+        invalidates_on = _mapping(case.get("invalidates_on"), f"qualification case {case_id!r} invalidates_on")
+        direct_paths = _path_patterns(
+            invalidates_on.get("paths"),
+            f"qualification case {case_id!r} invalidating paths",
+        )
+        contract_ids = _strings(
+            invalidates_on.get("contracts"),
+            f"qualification case {case_id!r} invalidating contracts",
+        )
+        unknown_contracts = sorted(set(contract_ids) - set(contracts))
+        if unknown_contracts:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} references unknown contracts: {unknown_contracts!r}."
+            )
+        if tier in {2, 3} and not direct_paths and not contract_ids:
+            raise QualificationScopeError(f"Qualification case {case_id!r} requires an invalidating path or contract.")
+        evidence_sources = _strings(
+            case.get("allowed_evidence_sources"),
+            f"qualification case {case_id!r} allowed evidence sources",
+        )
+        if len(evidence_sources) != 1:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} must have exactly one allowed evidence source."
+            )
+        carry = _mapping(case.get("carry_forward"), f"qualification case {case_id!r} carry_forward")
+        for field in ("allowed", "requires_prior_accepted_receipt", "requires_clean_invalidation"):
+            if not isinstance(carry.get(field), bool):
+                raise QualificationScopeError(f"Qualification case {case_id!r} carry_forward.{field} must be boolean.")
+        carry_allowed = cast(bool, carry["allowed"])
+        if tier in {0, 1, 4} and carry_allowed:
+            raise QualificationScopeError(f"Qualification case {case_id!r} cannot allow carry-forward at tier {tier}.")
+        if tier in {2, 3} and (
+            not carry_allowed
+            or not carry["requires_prior_accepted_receipt"]
+            or not carry["requires_clean_invalidation"]
+        ):
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} must require accepted prior evidence and clean invalidation to carry."
+            )
+        if tier == 3:
+            cadence = _mapping(case.get("cadence"), f"qualification case {case_id!r} cadence")
+            max_age_days = cadence.get("max_age_days")
+            if not isinstance(max_age_days, int) or isinstance(max_age_days, bool) or max_age_days <= 0:
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires positive max_age_days.")
+            if not isinstance(cadence.get("first_rc_or_stable_candidate"), bool):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} requires boolean first_rc_or_stable_candidate."
+                )
+            if not _strings(cadence.get("hardware"), f"Tier 3 qualification case {case_id!r} hardware"):
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires hardware metadata.")
+    return policy
+
+
+def load_evidence(path: Path | None) -> Mapping[str, Any]:
+    if path is None:
+        return {"schema_version": 1, "receipts": []}
+    evidence = _load_json(path, "release qualification evidence")
+    if evidence.get("schema_version") != 1:
+        raise QualificationScopeError("Release qualification evidence schema_version must be 1.")
+    _sequence(evidence.get("receipts"), "release qualification receipts")
+    return evidence
+
+
+def load_qualification_overrides(
+    path: Path | None,
+    policy: Mapping[str, Any],
+) -> tuple[str | None, dict[str, bool]]:
+    if path is None:
+        return None, {}
+    qualification = _load_json(path, "release qualification migration")
+    policy_id = policy.get("policy_id")
+    migration_policy = _mapping(qualification.get("qualification_policy"), "qualification_policy")
+    if migration_policy.get("id") != policy_id:
+        raise QualificationScopeError(
+            f"Qualification migration expects policy {migration_policy.get('id')!r}, not {policy_id!r}."
+        )
+    policy_cases = {
+        cast(str, case["id"]): case
+        for case in (_mapping(raw_case, "release qualification case") for raw_case in policy["cases"])
+    }
+    overrides: dict[str, bool] = {}
+    matrix_case_ids: set[str] = set()
+    for raw_case in _sequence(qualification.get("matrix"), "qualification matrix"):
+        case = _mapping(raw_case, "qualification matrix case")
+        matrix_case_id = case.get("id")
+        if not isinstance(matrix_case_id, str) or not matrix_case_id:
+            raise QualificationScopeError("Every qualification matrix case requires id.")
+        if matrix_case_id in matrix_case_ids:
+            raise QualificationScopeError(f"Qualification matrix case {matrix_case_id!r} is duplicated.")
+        matrix_case_ids.add(matrix_case_id)
+        policy_case_id = case.get("policy_case_id")
+        if not isinstance(policy_case_id, str) or not policy_case_id:
+            raise QualificationScopeError("Every qualification matrix case requires policy_case_id.")
+        if policy_case_id in overrides:
+            raise QualificationScopeError(
+                f"Qualification migration maps policy case {policy_case_id!r} more than once."
+            )
+        if policy_case_id not in policy_cases:
+            raise QualificationScopeError(f"Qualification migration references unknown policy case {policy_case_id!r}.")
+        migration = case.get("migration")
+        tier = cast(int, policy_cases[policy_case_id]["tier"])
+        allowed_migrations = {
+            0: {"covered"},
+            1: {"release_run_receipt"},
+            2: {"fresh_retest", "scope_evaluated"},
+            3: {"fresh_retest", "scope_evaluated"},
+            4: {"external_nonblocking"},
+        }[tier]
+        if migration not in allowed_migrations:
+            raise QualificationScopeError(
+                f"Qualification migration {migration!r} is invalid for tier {tier} case {policy_case_id!r}."
+            )
+        overrides[policy_case_id] = migration == "fresh_retest"
+    acceptance = _mapping(qualification.get("acceptance"), "qualification acceptance")
+    required_case_ids = set(_strings(acceptance.get("required_case_ids"), "qualification required case IDs"))
+    nonblocking_case_ids = set(_strings(acceptance.get("nonblocking_case_ids"), "qualification nonblocking case IDs"))
+    preregistered_case_ids = set(
+        _strings(
+            acceptance.get("preregistered_matrix_case_ids"),
+            "qualification preregistered matrix case IDs",
+        )
+    )
+    expected_required = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) in {0, 1, 2, 3}}
+    expected_nonblocking = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) == 4}
+    if required_case_ids != expected_required:
+        raise QualificationScopeError(
+            "Qualification acceptance required_case_ids must use the mapped blocking policy case IDs."
+        )
+    if nonblocking_case_ids != expected_nonblocking:
+        raise QualificationScopeError(
+            "Qualification acceptance nonblocking_case_ids must use the mapped Tier 4 policy case IDs."
+        )
+    if preregistered_case_ids != matrix_case_ids:
+        raise QualificationScopeError(
+            "Qualification acceptance preregistered_matrix_case_ids must preserve every original matrix case ID."
+        )
+    qualification_id = qualification.get("qualification_id")
+    if not isinstance(qualification_id, str) or not qualification_id:
+        raise QualificationScopeError("Qualification migration requires qualification_id.")
+    return qualification_id, overrides
+
+
+def git_changed_paths(repo: Path) -> ChangedPaths:
+    cache: dict[tuple[str, str], set[str]] = {}
+
+    def changed(base_sha: str, candidate_sha: str) -> set[str]:
+        key = (base_sha, candidate_sha)
+        if key not in cache:
+            result = subprocess.run(
+                ["git", "diff", "--name-only", "-z", f"{base_sha}..{candidate_sha}"],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                detail = result.stderr.decode("utf-8", errors="replace").strip() or "git diff failed"
+                raise QualificationScopeError(
+                    f"Unable to compare prior evidence SHA {base_sha} with candidate {candidate_sha}: {detail}"
+                )
+            cache[key] = {item.decode("utf-8", errors="surrogateescape") for item in result.stdout.split(b"\0") if item}
+        return cache[key]
+
+    return changed
+
+
+def git_checked_reference_content(repo: Path) -> ReferenceContent:
+    def read(reference: str) -> bytes:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{reference}"],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            raise QualificationScopeError(
+                f"Evidence reference {reference!r} must be committed in the current repository HEAD."
+            )
+        return result.stdout
+
+    return read
+
+
+def _parse_accepted_at(value: object, case_id: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise QualificationScopeError(f"Evidence for {case_id!r} requires accepted_at.")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise QualificationScopeError(f"Evidence for {case_id!r} has invalid accepted_at {value!r}.") from error
+    if parsed.tzinfo is None:
+        raise QualificationScopeError(f"Evidence for {case_id!r} accepted_at must include a timezone.")
+    return parsed.astimezone(timezone.utc)
+
+
+def _validated_receipts(
+    evidence: Mapping[str, Any],
+    cases_by_id: Mapping[str, Mapping[str, Any]],
+    reference_content: ReferenceContent,
+    as_of: date,
+) -> dict[str, list[Mapping[str, Any]]]:
+    receipts: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    receipt_ids: set[str] = set()
+    for index, raw_receipt in enumerate(_sequence(evidence.get("receipts"), "release qualification receipts")):
+        receipt = _mapping(raw_receipt, f"release qualification receipt {index}")
+        case_id = receipt.get("case_id")
+        if not isinstance(case_id, str) or case_id not in cases_by_id:
+            raise QualificationScopeError(f"Evidence receipt {index} references unknown case {case_id!r}.")
+        if receipt.get("status") != "accepted":
+            continue
+        case = cases_by_id[case_id]
+        evidence_source = _strings(
+            case["allowed_evidence_sources"],
+            f"case {case_id!r} evidence sources",
+        )[0]
+        source = receipt.get("source")
+        if source != evidence_source:
+            raise QualificationScopeError(
+                f"Evidence for {case_id!r} must use source {evidence_source!r}, not {source!r}."
+            )
+        source_sha = receipt.get("source_sha")
+        if not isinstance(source_sha, str) or SHA_PATTERN.fullmatch(source_sha) is None:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a full lowercase source_sha.")
+        receipt_id = receipt.get("receipt_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires receipt_id.")
+        if receipt_id in receipt_ids:
+            raise QualificationScopeError(f"Duplicate release qualification receipt ID: {receipt_id}")
+        receipt_ids.add(receipt_id)
+        accepted_at = _parse_accepted_at(receipt.get("accepted_at"), case_id)
+        if accepted_at.date() > as_of:
+            raise QualificationScopeError(f"Evidence for {case_id!r} cannot be accepted after {as_of.isoformat()}.")
+        tier = cast(int, case["tier"])
+        if tier == 1:
+            if receipt.get("workflow_conclusion") != "success":
+                raise QualificationScopeError(f"Tier 1 case {case_id!r} requires a successful workflow conclusion.")
+            run_id = receipt.get("release_run_id")
+            if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
+                raise QualificationScopeError(f"Tier 1 case {case_id!r} requires a positive release_run_id.")
+        if tier == 3:
+            cadence = _mapping(case["cadence"], f"case {case_id!r} cadence")
+            required_hardware = set(_strings(cadence["hardware"], f"case {case_id!r} hardware"))
+            receipt_hardware = set(_strings(receipt.get("hardware"), f"evidence for {case_id!r} hardware"))
+            if not required_hardware.issubset(receipt_hardware):
+                raise QualificationScopeError(
+                    f"Evidence for {case_id!r} does not cover required hardware: "
+                    f"{sorted(required_hardware - receipt_hardware)!r}."
+                )
+        reference = receipt.get("reference")
+        digest = receipt.get("sha256")
+        if (
+            not isinstance(reference, str)
+            or not reference
+            or Path(reference).is_absolute()
+            or ".." in Path(reference).parts
+        ):
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a repository-relative reference.")
+        if not isinstance(digest, str) or SHA256_PATTERN.fullmatch(digest) is None:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a lowercase SHA-256 digest.")
+        try:
+            actual_digest = hashlib.sha256(reference_content(reference)).hexdigest()
+        except OSError as error:
+            raise QualificationScopeError(f"Unable to read evidence reference {reference!r}: {error}") from error
+        if actual_digest != digest:
+            raise QualificationScopeError(
+                f"Evidence reference {reference!r} does not match its recorded SHA-256 digest."
+            )
+        receipts[case_id].append(receipt)
+    for case_receipts in receipts.values():
+        case_receipts.sort(
+            key=lambda receipt: (
+                _parse_accepted_at(receipt["accepted_at"], str(receipt["case_id"])),
+                str(receipt["receipt_id"]),
+            )
+        )
+    return receipts
+
+
+def _case_patterns(case: Mapping[str, Any], contracts: Mapping[str, Any]) -> tuple[str, ...]:
+    invalidates_on = _mapping(case["invalidates_on"], "case invalidates_on")
+    patterns = list(_path_patterns(invalidates_on["paths"], "case invalidating paths"))
+    for contract_id in _strings(invalidates_on["contracts"], "case invalidating contracts"):
+        patterns.extend(_path_patterns(contracts[contract_id], f"contract {contract_id!r}"))
+    return tuple(dict.fromkeys(patterns))
+
+
+def _matching_paths(changed_paths: set[str], patterns: Sequence[str]) -> list[str]:
+    return sorted(path for path in changed_paths if any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns))
+
+
+def _receipt_summary(receipt: Mapping[str, Any] | None) -> dict[str, Any]:
+    if receipt is None:
+        return {"receipt_id": None, "reference": None, "source_sha": None}
+    return {
+        "receipt_id": receipt["receipt_id"],
+        "reference": receipt["reference"],
+        "source_sha": receipt["source_sha"],
+    }
+
+
+def classify_release_scope(
+    policy: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    *,
+    candidate_sha: str,
+    changed_paths: ChangedPaths,
+    repo: Path = REPO_ROOT,
+    reference_content: ReferenceContent | None = None,
+    qualification_id: str | None = None,
+    fresh_retest: Mapping[str, bool] | None = None,
+    release_stage: str = "rc",
+    first_candidate_of_cycle: bool = False,
+    as_of: date | None = None,
+) -> dict[str, Any]:
+    if SHA_PATTERN.fullmatch(candidate_sha) is None:
+        raise QualificationScopeError("Candidate SHA must be a full lowercase Git SHA.")
+    if release_stage not in {"alpha", "beta", "rc", "stable"}:
+        raise QualificationScopeError("Release stage must be alpha, beta, rc, or stable.")
+    as_of = as_of or datetime.now(timezone.utc).date()
+    contracts = _mapping(policy["contracts"], "release qualification contracts")
+    cases = [_mapping(case, "release qualification case") for case in _sequence(policy["cases"], "cases")]
+    case_ids = {cast(str, case["id"]) for case in cases}
+    cases_by_id = {cast(str, case["id"]): case for case in cases}
+    receipt_map = _validated_receipts(
+        evidence,
+        cases_by_id,
+        reference_content or git_checked_reference_content(repo),
+        as_of,
+    )
+    fresh_retest = fresh_retest or {}
+    unknown_overrides = sorted(set(fresh_retest) - case_ids)
+    if unknown_overrides:
+        raise QualificationScopeError(
+            f"Qualification migration references unknown policy cases: {unknown_overrides!r}."
+        )
+
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        case_id = cast(str, case["id"])
+        tier = cast(int, case["tier"])
+        accepted = receipt_map.get(case_id, [])
+        exact = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] == candidate_sha), None)
+        prior = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] != candidate_sha), None)
+        status: str
+        reason: str
+        invalidating_paths: list[str] = []
+        selected_receipt: Mapping[str, Any] | None = exact or prior
+
+        if tier == 0:
+            status, reason = "covered", "Owned by the automatic per-commit quality gate."
+        elif tier == 4:
+            status, reason = "external", "Post-publication field evidence cannot block publication."
+        elif exact is not None:
+            status, reason = "covered", "Accepted evidence is bound to the exact candidate SHA."
+        elif tier == 1:
+            status, reason = "retest", "The guarded release engine has no accepted receipt for the exact candidate SHA."
+            selected_receipt = None
+        elif fresh_retest.get(case_id, False):
+            status, reason = "retest", "The candidate migration explicitly requires fresh targeted evidence."
+            selected_receipt = None
+        elif prior is None:
+            status, reason = "retest", "No accepted prior evidence receipt is available for carry-forward."
+        else:
+            carry = _mapping(case["carry_forward"], f"case {case_id!r} carry_forward")
+            if not carry["allowed"]:
+                status, reason = "retest", "The policy does not allow this evidence to carry forward."
+                selected_receipt = None
+            else:
+                patterns = _case_patterns(case, contracts)
+                invalidating_paths = _matching_paths(
+                    changed_paths(cast(str, prior["source_sha"]), candidate_sha),
+                    patterns,
+                )
+                if invalidating_paths:
+                    status, reason = "retest", "Candidate changes invalidate the accepted prior evidence."
+                elif tier == 3:
+                    cadence = _mapping(case["cadence"], f"case {case_id!r} cadence")
+                    accepted_date = _parse_accepted_at(prior["accepted_at"], case_id).date()
+                    age_days = (as_of - accepted_date).days
+                    due_for_milestone = bool(cadence.get("first_rc_or_stable_candidate")) and (
+                        release_stage == "stable" or (release_stage == "rc" and first_candidate_of_cycle)
+                    )
+                    if due_for_milestone:
+                        status, reason = "retest", "Tier 3 evidence is due for this release milestone."
+                    elif age_days > cast(int, cadence["max_age_days"]):
+                        status, reason = "retest", "Tier 3 evidence exceeded its maximum age."
+                    else:
+                        status, reason = (
+                            "carry",
+                            "Tier 3 evidence remains within cadence and no invalidating paths changed.",
+                        )
+                else:
+                    status, reason = "carry", "Accepted prior evidence remains valid because no mapped paths changed."
+
+        blocking_phase = cast(str, case["blocking_phase"])
+        result = {
+            "case_id": case_id,
+            "tier": tier,
+            "status": status,
+            "blocking_phase": blocking_phase,
+            "blocking": blocking_phase != "none",
+            "reason": reason,
+            "invalidating_paths": invalidating_paths,
+            "evidence": _receipt_summary(selected_receipt),
+        }
+        results.append(result)
+
+    counts = Counter(result["status"] for result in results)
+    blocking_retests = [
+        cast(str, result["case_id"]) for result in results if result["status"] == "retest" and result["blocking"]
+    ]
+    return {
+        "schema_version": 1,
+        "policy_id": policy["policy_id"],
+        "qualification_id": qualification_id,
+        "candidate_sha": candidate_sha,
+        "release_stage": release_stage,
+        "first_candidate_of_cycle": first_candidate_of_cycle,
+        "as_of": as_of.isoformat(),
+        "cases": results,
+        "summary": {state: counts[state] for state in RESULT_STATES},
+        "blocking_retests": blocking_retests,
+        "passed": not blocking_retests,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify release qualification scope from policy and checked evidence."
+    )
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    parser.add_argument("--validate-policy", action="store_true")
+    parser.add_argument("--evidence", type=Path)
+    parser.add_argument("--qualification", type=Path)
+    parser.add_argument("--candidate-sha")
+    parser.add_argument("--release-stage", choices=("alpha", "beta", "rc", "stable"), default="rc")
+    parser.add_argument("--first-candidate-of-cycle", action="store_true")
+    parser.add_argument("--as-of", type=date.fromisoformat)
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--require-evidence", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        policy = load_policy(args.policy)
+        if args.validate_policy:
+            payload = {
+                "policy_id": policy["policy_id"],
+                "case_count": len(cast(Sequence[Any], policy["cases"])),
+                "valid": True,
+            }
+        else:
+            if args.candidate_sha is None:
+                raise QualificationScopeError("--candidate-sha is required unless --validate-policy is used.")
+            evidence = load_evidence(args.evidence)
+            qualification_id, fresh_retest = load_qualification_overrides(args.qualification, policy)
+            payload = classify_release_scope(
+                policy,
+                evidence,
+                candidate_sha=args.candidate_sha,
+                changed_paths=git_changed_paths(args.repo),
+                repo=args.repo,
+                qualification_id=qualification_id,
+                fresh_retest=fresh_retest,
+                release_stage=args.release_stage,
+                first_candidate_of_cycle=args.first_candidate_of_cycle,
+                as_of=args.as_of,
+            )
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.output is not None:
+            args.output.write_text(rendered, encoding="utf-8")
+        print(rendered, end="")
+        if args.require_evidence and not cast(bool, payload.get("passed", True)):
+            return 2
+        return 0
+    except QualificationScopeError as error:
+        print(f"Release qualification scope failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -1,0 +1,473 @@
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+
+from contextlib import redirect_stdout
+from datetime import date
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from scripts.qualify_release_scope import (
+    DEFAULT_POLICY_PATH,
+    QualificationScopeError,
+    classify_release_scope,
+    load_policy,
+    load_qualification_overrides,
+    main,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RC3_QUALIFICATION_PATH = REPO_ROOT / "docs" / "qualification" / "rc3-signed-qualification-v1.json"
+CANDIDATE_SHA = "b" * 40
+PRIOR_SHA = "a" * 40
+
+
+class ReleaseQualificationScopeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy(DEFAULT_POLICY_PATH)
+
+    def evidence(
+        self,
+        root: Path,
+        case_id: str,
+        *,
+        source_sha: str = PRIOR_SHA,
+        source: str = "signed_artifact_receipt",
+        accepted_at: str = "2026-08-01T00:00:00Z",
+        tier1: bool = False,
+    ) -> dict[str, Any]:
+        reference = Path("docs") / "qualification" / f"{case_id}-receipt.json"
+        receipt_path = root / reference
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps({"case_id": case_id, "passed": True}), encoding="utf-8")
+        receipt: dict[str, Any] = {
+            "case_id": case_id,
+            "receipt_id": f"{case_id}-receipt-v1",
+            "source": source,
+            "status": "accepted",
+            "source_sha": source_sha,
+            "accepted_at": accepted_at,
+            "reference": reference.as_posix(),
+            "sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+        }
+        if tier1:
+            receipt["workflow_conclusion"] = "success"
+            receipt["release_run_id"] = 12345
+        return {"schema_version": 1, "receipts": [receipt]}
+
+    def classify(
+        self,
+        evidence: dict[str, Any],
+        root: Path,
+        *,
+        changed: set[str] | None = None,
+        fresh: dict[str, bool] | None = None,
+    ) -> dict[str, Any]:
+        return classify_release_scope(
+            self.policy,
+            evidence,
+            candidate_sha=CANDIDATE_SHA,
+            changed_paths=lambda _base, _candidate: changed or set(),
+            repo=root,
+            reference_content=lambda reference: (root / reference).read_bytes(),
+            fresh_retest=fresh,
+            as_of=date(2026, 8, 5),
+        )
+
+    def result_for(self, report: dict[str, Any], case_id: str) -> dict[str, Any]:
+        return next(case for case in report["cases"] if case["case_id"] == case_id)
+
+    def test_policy_and_rc3_migration_cover_every_preregistered_case(self) -> None:
+        qualification_id, overrides = load_qualification_overrides(
+            RC3_QUALIFICATION_PATH,
+            self.policy,
+        )
+        qualification = json.loads(RC3_QUALIFICATION_PATH.read_text(encoding="utf-8"))
+        policy_case_ids = {case["id"] for case in self.policy["cases"]}
+        mapped_case_ids = {case["policy_case_id"] for case in qualification["matrix"]}
+
+        self.assertEqual(qualification_id, "rc3-signed-qualification-v1")
+        self.assertEqual(mapped_case_ids, policy_case_ids)
+        self.assertTrue(overrides["sparkle-update-route"])
+        self.assertTrue(overrides["profile-save-action-accessibility"])
+        self.assertFalse(overrides["gui-preview-cancel-cleanup"])
+        self.assertNotIn(
+            "public-diagnostics-and-field-closure",
+            qualification["acceptance"]["required_case_ids"],
+        )
+
+    def test_contract_change_forces_retest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "gui-preview-cancel-cleanup")
+            report = self.classify(
+                evidence,
+                root,
+                changed={"bd_to_avp/modules/preview.py"},
+            )
+
+        result = self.result_for(report, "gui-preview-cancel-cleanup")
+        self.assertEqual(result["status"], "retest")
+        self.assertEqual(result["invalidating_paths"], ["bd_to_avp/modules/preview.py"])
+
+    def test_direct_path_pattern_forces_retest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "network-generated-final-output")
+            report = self.classify(
+                evidence,
+                root,
+                changed={"bd_to_avp/modules/container.py"},
+            )
+
+        result = self.result_for(report, "network-generated-final-output")
+        self.assertEqual(result["status"], "retest")
+        self.assertEqual(result["invalidating_paths"], ["bd_to_avp/modules/container.py"])
+
+    def test_unchanged_case_carries_named_prior_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "overwrite-and-conversion-cancel")
+            report = self.classify(evidence, root)
+
+        result = self.result_for(report, "overwrite-and-conversion-cancel")
+        self.assertEqual(result["status"], "carry")
+        self.assertEqual(result["evidence"]["receipt_id"], "overwrite-and-conversion-cancel-receipt-v1")
+
+    def test_missing_evidence_is_a_blocking_retest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            report = self.classify({"schema_version": 1, "receipts": []}, Path(temporary_directory))
+
+        self.assertIn("gui-preview-failure-cleanup", report["blocking_retests"])
+        self.assertFalse(report["passed"])
+
+    def test_fresh_rc3_override_prevents_carry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "malformed-pgs-parser-recovery")
+            report = self.classify(
+                evidence,
+                root,
+                fresh={"malformed-pgs-parser-recovery": True},
+            )
+
+        result = self.result_for(report, "malformed-pgs-parser-recovery")
+        self.assertEqual(result["status"], "retest")
+        self.assertIn("fresh targeted evidence", result["reason"])
+        self.assertIsNone(result["evidence"]["receipt_id"])
+
+    def test_tier1_requires_exact_successful_release_run_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            prior = self.evidence(
+                root,
+                "release-workflow-identity",
+                source="release_run_receipt",
+                tier1=True,
+            )
+            prior_report = self.classify(prior, root)
+            exact = self.evidence(
+                root,
+                "release-workflow-identity",
+                source_sha=CANDIDATE_SHA,
+                source="release_run_receipt",
+                tier1=True,
+            )
+            exact_report = self.classify(exact, root)
+
+        self.assertEqual(self.result_for(prior_report, "release-workflow-identity")["status"], "retest")
+        self.assertEqual(self.result_for(exact_report, "release-workflow-identity")["status"], "covered")
+
+    def test_tier1_rejects_unsuccessful_or_unbound_release_run_receipt(self) -> None:
+        for field, value in (("workflow_conclusion", "failure"), ("release_run_id", 0)):
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                evidence = self.evidence(
+                    root,
+                    "release-workflow-identity",
+                    source_sha=CANDIDATE_SHA,
+                    source="release_run_receipt",
+                    tier1=True,
+                )
+                evidence["receipts"][0][field] = value
+
+                with self.assertRaises(QualificationScopeError):
+                    self.classify(evidence, root)
+
+    def test_periodic_evidence_expires_and_first_rc_forces_retest(self) -> None:
+        policy = json.loads(json.dumps(self.policy))
+        policy["cases"].append(
+            {
+                "id": "real-drive-qualification",
+                "tier": 3,
+                "blocking_phase": "milestone",
+                "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
+                "allowed_evidence_sources": ["hardware_qualification_receipt"],
+                "carry_forward": {
+                    "allowed": True,
+                    "requires_prior_accepted_receipt": True,
+                    "requires_clean_invalidation": True,
+                },
+                "cadence": {
+                    "first_rc_or_stable_candidate": True,
+                    "max_age_days": 30,
+                    "hardware": ["usb_bluray_drive"],
+                },
+            }
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "real-drive-qualification",
+                source="hardware_qualification_receipt",
+                accepted_at="2026-06-01T00:00:00Z",
+            )
+            evidence["receipts"][0]["hardware"] = ["usb_bluray_drive"]
+            report = classify_release_scope(
+                policy,
+                evidence,
+                candidate_sha=CANDIDATE_SHA,
+                changed_paths=lambda _base, _candidate: set(),
+                repo=root,
+                reference_content=lambda reference: (root / reference).read_bytes(),
+                release_stage="rc",
+                first_candidate_of_cycle=True,
+                as_of=date(2026, 8, 5),
+            )
+
+        result = self.result_for(report, "real-drive-qualification")
+        self.assertEqual(result["status"], "retest")
+        self.assertIn("release milestone", result["reason"])
+
+    def test_periodic_evidence_expires_outside_milestone(self) -> None:
+        policy = json.loads(json.dumps(self.policy))
+        policy["cases"].append(
+            {
+                "id": "clean-machine-installation",
+                "tier": 3,
+                "blocking_phase": "milestone",
+                "invalidates_on": {"paths": ["scripts/macos_release.py"], "contracts": []},
+                "allowed_evidence_sources": ["hardware_qualification_receipt"],
+                "carry_forward": {
+                    "allowed": True,
+                    "requires_prior_accepted_receipt": True,
+                    "requires_clean_invalidation": True,
+                },
+                "cadence": {
+                    "first_rc_or_stable_candidate": True,
+                    "max_age_days": 30,
+                    "hardware": ["disposable_macos_vm"],
+                },
+            }
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "clean-machine-installation",
+                source="hardware_qualification_receipt",
+                accepted_at="2026-06-01T00:00:00Z",
+            )
+            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
+            report = classify_release_scope(
+                policy,
+                evidence,
+                candidate_sha=CANDIDATE_SHA,
+                changed_paths=lambda _base, _candidate: set(),
+                repo=root,
+                reference_content=lambda reference: (root / reference).read_bytes(),
+                release_stage="beta",
+                first_candidate_of_cycle=False,
+                as_of=date(2026, 8, 5),
+            )
+
+        result = self.result_for(report, "clean-machine-installation")
+        self.assertEqual(result["status"], "retest")
+        self.assertIn("maximum age", result["reason"])
+
+    def test_periodic_evidence_carries_with_matching_hardware_inside_cadence(self) -> None:
+        policy = json.loads(json.dumps(self.policy))
+        policy["cases"].append(
+            {
+                "id": "clean-machine-installation",
+                "tier": 3,
+                "blocking_phase": "milestone",
+                "invalidates_on": {"paths": ["scripts/macos_release.py"], "contracts": []},
+                "allowed_evidence_sources": ["hardware_qualification_receipt"],
+                "carry_forward": {
+                    "allowed": True,
+                    "requires_prior_accepted_receipt": True,
+                    "requires_clean_invalidation": True,
+                },
+                "cadence": {
+                    "first_rc_or_stable_candidate": True,
+                    "max_age_days": 30,
+                    "hardware": ["disposable_macos_vm"],
+                },
+            }
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "clean-machine-installation",
+                source="hardware_qualification_receipt",
+                accepted_at="2026-08-01T00:00:00Z",
+            )
+            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
+            report = classify_release_scope(
+                policy,
+                evidence,
+                candidate_sha=CANDIDATE_SHA,
+                changed_paths=lambda _base, _candidate: set(),
+                repo=root,
+                reference_content=lambda reference: (root / reference).read_bytes(),
+                release_stage="beta",
+                first_candidate_of_cycle=False,
+                as_of=date(2026, 8, 5),
+            )
+
+        self.assertEqual(self.result_for(report, "clean-machine-installation")["status"], "carry")
+
+    def test_periodic_evidence_requires_matching_hardware(self) -> None:
+        policy = json.loads(json.dumps(self.policy))
+        policy["cases"].append(
+            {
+                "id": "real-drive-qualification",
+                "tier": 3,
+                "blocking_phase": "milestone",
+                "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
+                "allowed_evidence_sources": ["hardware_qualification_receipt"],
+                "carry_forward": {
+                    "allowed": True,
+                    "requires_prior_accepted_receipt": True,
+                    "requires_clean_invalidation": True,
+                },
+                "cadence": {
+                    "first_rc_or_stable_candidate": True,
+                    "max_age_days": 30,
+                    "hardware": ["usb_bluray_drive"],
+                },
+            }
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "real-drive-qualification",
+                source="hardware_qualification_receipt",
+            )
+            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
+
+            with self.assertRaises(QualificationScopeError):
+                classify_release_scope(
+                    policy,
+                    evidence,
+                    candidate_sha=CANDIDATE_SHA,
+                    changed_paths=lambda _base, _candidate: set(),
+                    repo=root,
+                    reference_content=lambda reference: (root / reference).read_bytes(),
+                    as_of=date(2026, 8, 5),
+                )
+
+    def test_periodic_policy_rejects_noncanonical_cadence_types(self) -> None:
+        for field, value in (("max_age_days", True), ("first_rc_or_stable_candidate", "false")):
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as temporary_directory:
+                policy = json.loads(json.dumps(self.policy))
+                cadence = {
+                    "first_rc_or_stable_candidate": True,
+                    "max_age_days": 30,
+                    "hardware": ["usb_bluray_drive"],
+                }
+                cadence[field] = value
+                policy["cases"].append(
+                    {
+                        "id": "real-drive-qualification",
+                        "tier": 3,
+                        "blocking_phase": "milestone",
+                        "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
+                        "allowed_evidence_sources": ["hardware_qualification_receipt"],
+                        "carry_forward": {
+                            "allowed": True,
+                            "requires_prior_accepted_receipt": True,
+                            "requires_clean_invalidation": True,
+                        },
+                        "cadence": cadence,
+                    }
+                )
+                policy_path = Path(temporary_directory) / "policy.json"
+                policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+                with self.assertRaises(QualificationScopeError):
+                    load_policy(policy_path)
+
+    def test_future_dated_receipt_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "overwrite-and-conversion-cancel",
+                accepted_at="2026-08-06T00:00:00Z",
+            )
+
+            with self.assertRaises(QualificationScopeError):
+                self.classify(evidence, root)
+
+    def test_untracked_evidence_reference_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+            (root / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "initial"], cwd=root, check=True)
+            evidence = self.evidence(
+                root,
+                "release-workflow-identity",
+                source_sha=CANDIDATE_SHA,
+                source="release_run_receipt",
+                tier1=True,
+            )
+
+            with self.assertRaises(QualificationScopeError):
+                classify_release_scope(
+                    self.policy,
+                    evidence,
+                    candidate_sha=CANDIDATE_SHA,
+                    changed_paths=lambda _base, _candidate: set(),
+                    repo=root,
+                    as_of=date(2026, 8, 5),
+                )
+
+    def test_tier4_is_external_and_nonblocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            report = self.classify({"schema_version": 1, "receipts": []}, Path(temporary_directory))
+
+        result = self.result_for(report, "public-diagnostics-and-field-closure")
+        self.assertEqual(result["status"], "external")
+        self.assertFalse(result["blocking"])
+        self.assertNotIn("public-diagnostics-and-field-closure", report["blocking_retests"])
+
+    def test_require_evidence_returns_nonzero_for_blocking_retests(self) -> None:
+        with redirect_stdout(StringIO()):
+            exit_code = main(
+                [
+                    "--candidate-sha",
+                    CANDIDATE_SHA,
+                    "--require-evidence",
+                    "--repo",
+                    str(REPO_ROOT),
+                ]
+            )
+
+        self.assertEqual(exit_code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -213,7 +213,35 @@ class ReleaseMetadataTests(unittest.TestCase):
             "public-diagnostics-and-field-closure",
         }
         self.assertEqual({case["id"] for case in qualification["matrix"]}, expected_case_ids)
-        self.assertEqual(set(qualification["acceptance"]["required_case_ids"]), expected_case_ids)
+        self.assertEqual(
+            set(qualification["acceptance"]["required_case_ids"]),
+            {
+                "release-workflow-identity",
+                "sparkle-update-route",
+                "native-sparkle-release-notes",
+                "profile-save-action-accessibility",
+                "signed-packaged-route-parity",
+                "gui-preview-low-local-ample-destination",
+                "gui-preview-cancel-cleanup",
+                "gui-preview-failure-cleanup",
+                "capacity-known-low",
+                "capacity-unknown-and-conflicting",
+                "network-generated-final-output",
+                "overwrite-and-conversion-cancel",
+                "malformed-pgs-parser-recovery",
+                "subtitle-partial-output-diagnostics",
+            },
+        )
+        self.assertEqual(set(qualification["acceptance"]["preregistered_matrix_case_ids"]), expected_case_ids)
+        self.assertEqual(
+            qualification["acceptance"]["nonblocking_case_ids"],
+            ["public-diagnostics-and-field-closure"],
+        )
+        self.assertEqual(qualification["qualification_policy"]["id"], "release-qualification-policy-v1")
+        self.assertEqual(
+            {case["migration"] for case in qualification["matrix"]},
+            {"release_run_receipt", "fresh_retest", "scope_evaluated", "external_nonblocking"},
+        )
         for field in (
             "source_git_sha",
             "dmg_sha256",


### PR DESCRIPTION
## Summary
- add versioned Tier 0–4 release qualification policy and contract/path invalidation maps
- add deterministic offline scope classifier with checked receipt validation and blocking `--require-evidence` mode
- migrate the preregistered RC3 matrix to stable policy case IDs while keeping Sparkle, accessibility, PGS, and subtitle diagnostics fresh and field closure nonblocking
- document the workflow and register durable repository quality gates

## Validation
- `uv run python -m unittest discover -s tests -t .` (1495 tests, 3 skipped)
- `uv run python scripts/native_app.py test` (355 tests)
- `uv run python -m unittest tests.test_release tests.test_sparkle_workflows`
- `uv run python -m scripts.release validate`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run mypy scripts/qualify_release_scope.py tests/test_qualify_release_scope.py`
- `uv build`
- JetBrains changed-file inspection: GREEN, zero actionable findings

Closes #472
Refs #471