### PR TITLE
Automate immutable release receipts and evidence PRs

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -70,6 +70,7 @@
     "requiredEvent": "workflow_dispatch",
     "approvalEnvironment": "macos-signing",
     "engineWorkflowPath": ".github/workflows/release-engine.yml",
+    "evidenceWorkflowPath": ".github/workflows/release-evidence.yml",
     "workflows": {
       "Stable": {
         "path": ".github/workflows/briefcase.yml",
@@ -92,6 +93,7 @@
       ".github/workflows/briefcase.yml",
       ".github/workflows/prerelease.yml",
       ".github/workflows/release-engine.yml",
+      ".github/workflows/release-evidence.yml",
       ".github/workflows/sparkle-pages.yml",
       ".github/workflows/manage-sparkle-pages.yml"
     ]
@@ -115,6 +117,7 @@
       "unitSmoke": "uv run python -m unittest discover -s tests -t .",
       "releaseQualificationPolicy": "uv run python -m scripts.qualify_release_scope --validate-policy",
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
+      "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "macosApp": "uv run python scripts/native_app.py test",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"
@@ -146,6 +149,7 @@
     "CodeQL",
     "Stable",
     "Prerelease",
+    "Release Evidence",
     "Manage Sparkle Pages",
     "Update FFmpeg Vendor Pins"
   ],

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -119,6 +119,12 @@ name: Signed release engine
       release_sha:
         description: Validated protected-main release commit
         value: ${{ jobs.policy.outputs.release_sha }}
+      release_receipt_asset_id:
+        description: Immutable GitHub Release asset ID for the public-safe release receipt
+        value: ${{ jobs.build-receipt.outputs.receipt_asset_id }}
+      release_receipt_sha256:
+        description: SHA-256 of the exact uploaded release receipt file
+        value: ${{ jobs.build-receipt.outputs.receipt_file_sha256 }}
 
 permissions:
   actions: read
@@ -542,6 +548,7 @@ jobs:
       dmg_name: ${{ steps.package_artifact.outputs.dmg_name }}
       dmg_sha256: ${{ steps.package_artifact.outputs.dmg_sha256 }}
       dmg_size: ${{ steps.package_artifact.outputs.dmg_size }}
+      signed_app_tree_sha256: ${{ steps.package_artifact.outputs.signed_app_tree_sha256 }}
     steps:
       - name: Checkout validated main commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -960,11 +967,14 @@ jobs:
           fi
           DMG_SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
           DMG_SIZE=$(stat -f %z "$DMG_PATH")
+          SIGNED_APP_TREE_SHA256=$(uv run python -c \
+            'from pathlib import Path; from scripts.artifact_identity import app_tree_sha256; print(app_tree_sha256(Path("macos/build/package/3D Blu-ray to Vision Pro.app")))')
           printf '%s  %s\n' "$DMG_SHA256" "$DMG_NAME" > dist/SHA256SUMS
           {
             echo "dmg_name=$DMG_NAME"
             echo "dmg_sha256=$DMG_SHA256"
             echo "dmg_size=$DMG_SIZE"
+            echo "signed_app_tree_sha256=$SIGNED_APP_TREE_SHA256"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload log on failure
@@ -1654,6 +1664,12 @@ jobs:
     permissions:
       attestations: read
       contents: write
+    outputs:
+      appcast_asset_id: ${{ steps.verify_assets.outputs.appcast_asset_id }}
+      checksum_asset_id: ${{ steps.verify_assets.outputs.checksum_asset_id }}
+      checksum_sha256: ${{ steps.verify_assets.outputs.checksum_sha256 }}
+      checksum_size: ${{ steps.verify_assets.outputs.checksum_size }}
+      dmg_asset_id: ${{ steps.verify_assets.outputs.dmg_asset_id }}
     steps:
       - name: Checkout protected verification tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -1729,6 +1745,7 @@ jobs:
           esac
 
       - name: Re-download and verify every release boundary
+        id: verify_assets
         env:
           BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
           EXPECTED_APPCAST_SHA256: ${{ needs.publish-appcast.outputs.appcast_sha256 }}
@@ -1863,6 +1880,171 @@ jobs:
             --length "$ASSET_SIZE" \
             --release-notes-file verified-assets/release-notes.md \
             --full-release-notes-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+          {
+            echo "dmg_asset_id=$DMG_ASSET_ID"
+            echo "checksum_asset_id=$CHECKSUM_ASSET_ID"
+            echo "checksum_sha256=$(shasum -a 256 verified-assets/SHA256SUMS | awk '{print $1}')"
+            echo "checksum_size=$(stat -f %z verified-assets/SHA256SUMS)"
+            echo "appcast_asset_id=$APPCAST_ASSET_ID"
+          } >> "$GITHUB_OUTPUT"
+
+  build-receipt:
+    name: Build and verify immutable release receipt
+    needs:
+      - policy
+      - prepare
+      - package
+      - create-draft
+      - publish-appcast
+      - verify-draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    outputs:
+      receipt_asset_id: ${{ steps.receipt.outputs.receipt_asset_id }}
+      receipt_file_sha256: ${{ steps.receipt.outputs.receipt_file_sha256 }}
+      receipt_sha256: ${{ steps.receipt.outputs.receipt_sha256 }}
+    steps:
+      - name: Checkout protected receipt tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build, upload, and re-download receipt
+        id: receipt
+        env:
+          APPCAST_ASSET_ID: ${{ needs.verify-draft.outputs.appcast_asset_id }}
+          APPCAST_SHA256: ${{ needs.publish-appcast.outputs.appcast_sha256 }}
+          APPCAST_SIZE: ${{ needs.publish-appcast.outputs.appcast_size }}
+          BUILD_VERSION: ${{ needs.prepare.outputs.build_version }}
+          CHECKSUM_ASSET_ID: ${{ needs.verify-draft.outputs.checksum_asset_id }}
+          CHECKSUM_SHA256: ${{ needs.verify-draft.outputs.checksum_sha256 }}
+          CHECKSUM_SIZE: ${{ needs.verify-draft.outputs.checksum_size }}
+          DMG_ASSET_ID: ${{ needs.verify-draft.outputs.dmg_asset_id }}
+          DMG_NAME: ${{ needs.package.outputs.dmg_name }}
+          DMG_SHA256: ${{ needs.package.outputs.dmg_sha256 }}
+          DMG_SIZE: ${{ needs.package.outputs.dmg_size }}
+          GH_TOKEN: ${{ github.token }}
+          MAKE_LATEST: ${{ needs.prepare.outputs.make_latest }}
+          PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+          PUBLIC_VERSION: ${{ needs.prepare.outputs.public_version }}
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_CREATED_AT: ${{ needs.create-draft.outputs.release_created_at }}
+          RELEASE_ID: ${{ needs.create-draft.outputs.release_id }}
+          RELEASE_NAME: ${{ needs.prepare.outputs.release_name }}
+          RELEASE_ROUTE: ${{ needs.policy.outputs.release_route }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          SIGNED_APP_TREE_SHA256: ${{ needs.package.outputs.signed_app_tree_sha256 }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg release_route "$RELEASE_ROUTE" \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg workflow_actor "$RELEASE_ACTOR" \
+            --argjson workflow_run_id "$GITHUB_RUN_ID" \
+            --argjson workflow_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg package_version "$PACKAGE_VERSION" \
+            --arg public_version "$PUBLIC_VERSION" \
+            --arg build_version "$BUILD_VERSION" \
+            --arg release_tag "$RELEASE_TAG" \
+            --arg release_name "$RELEASE_NAME" \
+            --argjson release_id "$RELEASE_ID" \
+            --arg release_created_at "$RELEASE_CREATED_AT" \
+            --argjson prerelease "$PRERELEASE" \
+            --argjson make_latest "$MAKE_LATEST" \
+            --arg signed_app_tree_sha256 "$SIGNED_APP_TREE_SHA256" \
+            --arg dmg_name "$DMG_NAME" \
+            --arg dmg_sha256 "$DMG_SHA256" \
+            --argjson dmg_size "$DMG_SIZE" \
+            --argjson dmg_asset_id "$DMG_ASSET_ID" \
+            --arg checksum_sha256 "$CHECKSUM_SHA256" \
+            --argjson checksum_size "$CHECKSUM_SIZE" \
+            --argjson checksum_asset_id "$CHECKSUM_ASSET_ID" \
+            --arg appcast_sha256 "$APPCAST_SHA256" \
+            --argjson appcast_size "$APPCAST_SIZE" \
+            --argjson appcast_asset_id "$APPCAST_ASSET_ID" \
+            '{
+              release_route: $release_route,
+              source_sha: $source_sha,
+              workflow_actor: $workflow_actor,
+              workflow_run_id: $workflow_run_id,
+              workflow_run_attempt: $workflow_run_attempt,
+              package_version: $package_version,
+              public_version: $public_version,
+              build_version: $build_version,
+              release_tag: $release_tag,
+              release_name: $release_name,
+              release_id: $release_id,
+              release_created_at: $release_created_at,
+              prerelease: $prerelease,
+              make_latest: $make_latest,
+              signed_app_tree_sha256: $signed_app_tree_sha256,
+              artifacts: [
+                {kind: "dmg", name: $dmg_name, sha256: $dmg_sha256, size_bytes: $dmg_size, asset_id: $dmg_asset_id},
+                {kind: "checksum", name: "SHA256SUMS", sha256: $checksum_sha256, size_bytes: $checksum_size, asset_id: $checksum_asset_id},
+                {kind: "appcast", name: "appcast.xml", sha256: $appcast_sha256, size_bytes: $appcast_size, asset_id: $appcast_asset_id}
+              ]
+            }' > release-receipt-facts.json
+          python -m scripts.release_receipt build \
+            --facts release-receipt-facts.json \
+            --output release-receipt.json
+          RECEIPT_FILE_SHA256=$(sha256sum release-receipt.json | awk '{print $1}')
+          RECEIPT_SHA256=$(jq -r .receipt_sha256 release-receipt.json)
+
+          RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
+          if [ "$(jq -r .draft <<< "$RELEASE_JSON")" != "true" ]; then
+            echo "Release must remain a draft while the receipt is attached." >&2
+            exit 1
+          fi
+          RECEIPT_COUNT=$(jq '[.assets[] | select(.name == "release-receipt.json")] | length' <<< "$RELEASE_JSON")
+          case "$RECEIPT_COUNT" in
+            0)
+              UPLOADED_RECEIPT=$(gh api --method POST \
+                "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=release-receipt.json" \
+                -H "Content-Type: application/json" \
+                --input release-receipt.json)
+              RECEIPT_ASSET_ID=$(jq -r .id <<< "$UPLOADED_RECEIPT")
+              ;;
+            1)
+              RECEIPT_ASSET_ID=$(jq -r '.assets[] | select(.name == "release-receipt.json") | .id' <<< "$RELEASE_JSON")
+              gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID" \
+                -H "Accept: application/octet-stream" > existing-release-receipt.json
+              if ! cmp --silent release-receipt.json existing-release-receipt.json; then
+                echo "Existing immutable release receipt differs from the verified receipt." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Draft release contains duplicate release receipts." >&2
+              exit 1
+              ;;
+          esac
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID" \
+            -H "Accept: application/octet-stream" > downloaded-release-receipt.json
+          if ! cmp --silent release-receipt.json downloaded-release-receipt.json; then
+            echo "Re-downloaded release receipt differs from the verified local receipt." >&2
+            exit 1
+          fi
+          python -m scripts.release_receipt validate --receipt downloaded-release-receipt.json
+          RECEIPT_ASSET_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID")
+          if [ "$(jq -r .digest <<< "$RECEIPT_ASSET_JSON")" != "sha256:$RECEIPT_FILE_SHA256" ]; then
+            echo "GitHub receipt asset digest differs from the verified local receipt." >&2
+            exit 1
+          fi
+          {
+            echo "receipt_asset_id=$RECEIPT_ASSET_ID"
+            echo "receipt_file_sha256=$RECEIPT_FILE_SHA256"
+            echo "receipt_sha256=$RECEIPT_SHA256"
+          } >> "$GITHUB_OUTPUT"
 
   publish-release:
     name: Publish verified GitHub Release
@@ -1872,12 +2054,14 @@ jobs:
       - prepare
       - package
       - verify-draft
+      - build-receipt
     if: >-
       !cancelled() &&
       needs.create-draft.result == 'success' &&
       needs.prepare.result == 'success' &&
       needs.package.result == 'success' &&
       needs.verify-draft.result == 'success' &&
+      needs.build-receipt.result == 'success' &&
       (
         needs.prepare.outputs.publish_pypi != 'true' ||
         needs.build-python.result == 'success'
@@ -1897,6 +2081,8 @@ jobs:
           RELEASE_ID: ${{ needs.create-draft.outputs.release_id }}
           RELEASE_NAME: ${{ needs.prepare.outputs.release_name }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          EXPECTED_RECEIPT_ASSET_ID: ${{ needs.build-receipt.outputs.receipt_asset_id }}
+          EXPECTED_RECEIPT_FILE_SHA256: ${{ needs.build-receipt.outputs.receipt_file_sha256 }}
         run: |
           set -euo pipefail
           case "$PRERELEASE:$MAKE_LATEST" in
@@ -1922,6 +2108,23 @@ jobs:
           }
           RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
           verify_release_notes_body "$RELEASE_JSON"
+          RECEIPT_COUNT=$(jq '[.assets[] | select(.name == "release-receipt.json")] | length' <<< "$RELEASE_JSON")
+          TOTAL_ASSET_COUNT=$(jq '.assets | length' <<< "$RELEASE_JSON")
+          if [ "$RECEIPT_COUNT" != "1" ] || [ "$TOTAL_ASSET_COUNT" != "4" ]; then
+            echo "Verified release must contain exactly the DMG, checksum, appcast, and receipt assets." >&2
+            exit 1
+          fi
+          RECEIPT_ASSET_ID=$(jq -r '.assets[] | select(.name == "release-receipt.json") | .id' <<< "$RELEASE_JSON")
+          if [ "$RECEIPT_ASSET_ID" != "$EXPECTED_RECEIPT_ASSET_ID" ]; then
+            echo "Release receipt asset identity changed before publication." >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID" \
+            -H "Accept: application/octet-stream" > release-receipt.json
+          if [ "$(sha256sum release-receipt.json | awk '{print $1}')" != "$EXPECTED_RECEIPT_FILE_SHA256" ]; then
+            echo "Release receipt digest changed before publication." >&2
+            exit 1
+          fi
           if [ "$(jq -r .target_commitish <<< "$RELEASE_JSON")" != "$GITHUB_SHA" ]; then
             echo "Release target no longer matches github.sha." >&2
             exit 1
@@ -1949,10 +2152,19 @@ jobs:
             verify_release_notes_body "$RELEASE_JSON"
           fi
 
-          if [ "$(jq -r .draft <<< "$RELEASE_JSON")" != "false" ]; then
-            echo "Release publication did not complete." >&2
-            exit 1
-          fi
+          for attempt in {1..12}; do
+            RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
+            if [ "$(jq -r .draft <<< "$RELEASE_JSON")" = "false" ] \
+              && [ "$(jq -r .immutable <<< "$RELEASE_JSON")" = "true" ]; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "Published release did not become immutable." >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          verify_release_notes_body "$RELEASE_JSON"
           if [ "$(jq -r .prerelease <<< "$RELEASE_JSON")" != "$PRERELEASE" ]; then
             echo "Published release channel does not match the committed version." >&2
             exit 1

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,0 +1,229 @@
+---
+name: Release Evidence
+
+"on":
+  workflow_run:
+    workflows:
+      - Stable
+      - Prerelease
+    types:
+      - completed
+
+concurrency:
+  group: release-evidence-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  validate-and-prepare:
+    name: Validate publication and prepare checked evidence
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      base_main_sha: ${{ steps.base.outputs.sha }}
+      has_changes: ${{ steps.stage.outputs.has_changes }}
+      receipt_file_sha256: ${{ steps.reconcile.outputs.receipt_file_sha256 }}
+      release_tag: ${{ steps.reconcile.outputs.release_tag }}
+      source_sha: ${{ steps.reconcile.outputs.source_sha }}
+    steps:
+      - name: Checkout current protected main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: main
+
+      - name: Record protected-main evidence base
+        id: base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Resolve the immutable release and receipt
+        env:
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$EXPECTED_RUN_ID" > workflow-run.json
+          if [ "$(jq -r .head_sha workflow-run.json)" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "Workflow-run API source SHA differs from the completion event." >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --paginate --slurp > releases-pages.json
+          jq -c \
+            --arg source_sha "$EXPECTED_SOURCE_SHA" \
+            '[.[][] | select(
+              .target_commitish == $source_sha
+              and .draft == false
+              and .immutable == true
+              and any(.assets[]?; .name == "release-receipt.json")
+            )]' releases-pages.json > release-matches.json
+          rm -f release.json release-receipt.json
+          MATCH_COUNT=0
+          while IFS= read -r candidate; do
+            RECEIPT_ASSET_ID=$(jq -r '.assets[] | select(.name == "release-receipt.json") | .id' <<< "$candidate")
+            gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID" \
+              -H "Accept: application/octet-stream" > candidate-release-receipt.json
+            if [ "$(jq -r .workflow.run_id candidate-release-receipt.json)" = "$EXPECTED_RUN_ID" ] \
+              && [ "$(jq -r .workflow.run_attempt candidate-release-receipt.json)" \
+                = "$(jq -r .run_attempt workflow-run.json)" ]; then
+              MATCH_COUNT=$((MATCH_COUNT + 1))
+              printf '%s\n' "$candidate" > release.json
+              cp candidate-release-receipt.json release-receipt.json
+            fi
+          done < <(jq -c '.[]' release-matches.json)
+          if [ "$MATCH_COUNT" != "1" ]; then
+            echo "Expected exactly one immutable published release receipt for the completed run and attempt." >&2
+            exit 1
+          fi
+          curl --fail --location --silent --show-error \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            --connect-timeout 10 --max-time 60 \
+            "https://cbusillo.github.io/BD_to_AVP/appcast.xml" \
+            --output live-appcast.xml
+
+      - name: Preserve an existing idempotent evidence branch
+        run: |
+          set -euo pipefail
+          RECEIPT_FILE_SHA256=$(sha256sum release-receipt.json | awk '{print $1}')
+          RELEASE_TAG=$(jq -r .release.tag release-receipt.json)
+          BRANCH_NAME="automation/release-evidence-$RELEASE_TAG"
+          if ! git ls-remote --exit-code --heads origin "refs/heads/$BRANCH_NAME" >/dev/null 2>&1; then
+            exit 0
+          fi
+          git fetch --no-tags origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/release-evidence-existing"
+          if git diff --name-only main...refs/remotes/origin/release-evidence-existing \
+            | grep -Ev '^docs/' | grep -q .; then
+            echo "Existing evidence branch contains changes outside docs/." >&2
+            exit 1
+          fi
+          RECEIPT_PATH="docs/release-evidence/$RELEASE_TAG/release-receipt.json"
+          if git cat-file -e "refs/remotes/origin/release-evidence-existing:$RECEIPT_PATH" 2>/dev/null; then
+            git show "refs/remotes/origin/release-evidence-existing:$RECEIPT_PATH" > existing-release-receipt.json
+            if [ "$(sha256sum existing-release-receipt.json | awk '{print $1}')" != "$RECEIPT_FILE_SHA256" ]; then
+              echo "Existing evidence branch contains a conflicting receipt for the immutable release." >&2
+              exit 1
+            fi
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout --detach refs/remotes/origin/release-evidence-existing
+          git merge --no-edit main
+
+      - name: Reconcile checked evidence
+        id: reconcile
+        run: |
+          set -euo pipefail
+          python -m scripts.release_evidence \
+            --workflow-run workflow-run.json \
+            --release release.json \
+            --receipt release-receipt.json \
+            --live-appcast live-appcast.xml \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Stage only generated evidence files
+        id: stage
+        run: |
+          set -euo pipefail
+          mkdir -p prepared-evidence
+          {
+            git diff --name-only main...HEAD -- docs
+            git diff --name-only -- docs
+            git ls-files --others --exclude-standard -- docs
+          } | LC_ALL=C sort -u > evidence-files.txt
+          if [ ! -s evidence-files.txt ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          while IFS= read -r path; do
+            rsync -R "$path" prepared-evidence/
+          done < evidence-files.txt
+
+      - name: Upload prepared evidence
+        if: steps.stage.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-evidence-${{ github.event.workflow_run.id }}
+          path: prepared-evidence
+          if-no-files-found: error
+          retention-days: 7
+
+  create-pr:
+    name: Open or update release evidence pull request
+    needs: validate-and-prepare
+    if: needs.validate-and-prepare.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout current protected main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: main
+
+      - name: Reject protected-main movement during evidence transfer
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-and-prepare.outputs.base_main_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_MAIN_SHA" ]; then
+            echo "Protected main moved after evidence preparation; rerun against the new base." >&2
+            exit 1
+          fi
+
+      - name: Reject conflicting evidence on the idempotent branch
+        env:
+          BRANCH_NAME: automation/release-evidence-${{ needs.validate-and-prepare.outputs.release_tag }}
+          EXPECTED_RECEIPT_FILE_SHA256: ${{ needs.validate-and-prepare.outputs.receipt_file_sha256 }}
+          RELEASE_TAG: ${{ needs.validate-and-prepare.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH_NAME" >/dev/null 2>&1; then
+            git fetch --no-tags origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/release-evidence-existing"
+            RECEIPT_PATH="docs/release-evidence/$RELEASE_TAG/release-receipt.json"
+            if git cat-file -e "refs/remotes/origin/release-evidence-existing:$RECEIPT_PATH" 2>/dev/null; then
+              git show "refs/remotes/origin/release-evidence-existing:$RECEIPT_PATH" > existing-release-receipt.json
+              if [ "$(sha256sum existing-release-receipt.json | awk '{print $1}')" \
+                != "$EXPECTED_RECEIPT_FILE_SHA256" ]; then
+                echo "Existing evidence branch contains a conflicting receipt for the immutable release." >&2
+                exit 1
+              fi
+            fi
+          fi
+
+      - name: Download prepared evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-evidence-${{ github.event.workflow_run.id }}
+          path: .
+
+      - name: Create or update evidence pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          add-paths: docs
+          branch: automation/release-evidence-${{ needs.validate-and-prepare.outputs.release_tag }}
+          commit-message: Record immutable evidence for ${{ needs.validate-and-prepare.outputs.release_tag }}
+          delete-branch: true
+          title: Record immutable evidence for ${{ needs.validate-and-prepare.outputs.release_tag }}
+          body: |
+            Records the deterministic public-safe receipt and publication evidence for `${{ needs.validate-and-prepare.outputs.release_tag }}`.
+
+            - Release run: `${{ github.event.workflow_run.id }}`
+            - Source SHA: `${{ needs.validate-and-prepare.outputs.source_sha }}`
+            - Receipt file SHA-256: `${{ needs.validate-and-prepare.outputs.receipt_file_sha256 }}`
+
+            The release workflow, immutable asset identities, live Pages appcast, qualification record, release ledger, and cut packet were revalidated before this branch was prepared. Signing and deployment secrets are not available to this workflow.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -220,7 +220,14 @@ The workflow performs these ordered boundaries:
    and repeat the exact digest, size, notarization, Gatekeeper, bundle-version,
    embedded-release-note, appcast-item, and exact-main-commit GitHub provenance
    checks.
-8. Publish the verified draft only if it still targets the current `main` HEAD.
+8. Build a deterministic public-safe `release-receipt.json` from those verified
+   outputs. The receipt binds the route, workflow run and attempt, protected
+   source SHA, versions, release ID, release asset IDs/sizes/digests, signed app
+   tree, appcast, verification outcomes, and Tier 1 case references. Upload it
+   to the draft, re-download it by asset ID, and verify its content and file
+   digests before publication. The receipt deliberately excludes credentials,
+   approval context, private paths, and diagnostic identifiers.
+9. Publish the verified draft only if it still targets the current `main` HEAD.
    The release body is hashed again immediately before and after publication so
    edits cannot silently diverge from the updater notes. The reusable engine
    returns Stable Python distributions only as an immutable workflow artifact
@@ -228,15 +235,23 @@ The workflow performs these ordered boundaries:
    and other prerelease routes return no Python artifact. Stable releases then
    publish that verified artifact through PyPI Trusted Publishing with PEP 740
    attestations; Alpha, Beta, and RC releases never publish to PyPI.
-9. Deploy the durable `appcast.xml` release asset to GitHub Pages. A deployment
+10. Deploy the durable `appcast.xml` release asset to GitHub Pages. A deployment
    failure can be retried without rebuilding, retagging, or re-signing.
-10. After the complete reusable engine succeeds, the Stable operator
+11. After the complete reusable engine succeeds, the Stable operator
     revalidates the current protected-main SHA, operator/engine policy evidence,
     GitHub artifact digest, and every distribution checksum, then publishes
     through the pinned PyPI Trusted Publisher with PEP 740 attestations. The publisher remains in
     `briefcase.yml` and the `pypi` environment so its existing OIDC identity does
     not change.
-11. The separate `cbusillo/homebrew-tap` repository checks the latest stable
+12. After either operator workflow completes successfully, the secret-free
+   `Release Evidence` workflow revalidates the completed workflow identity,
+   immutable release, receipt asset, and live Pages appcast. It copies the exact
+   receipt into `docs/release-evidence/<tag>/`, writes the publication record and
+   release ledger, updates the matching qualification and cut packet, and opens
+   or updates `automation/release-evidence-<tag>`. Branch protection, CI, review,
+   and normal merge policy remain in force. A reconciliation failure does not
+   rebuild, replace, or invalidate the correctly published release.
+13. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,
    source installation, command tests, and linkage checks before merge.

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -57,3 +57,26 @@ direct invalidation patterns or referenced contracts. RC3 migration overrides
 keep its Sparkle, accessibility, PGS, and subtitle-diagnostic checks fresh.
 Tier 1 invalidation mappings document release-engine ownership only; Tier 1
 always requires a new exact-candidate receipt and never carries.
+
+## Release Engine Receipts
+
+Every successful guarded Stable or Prerelease publication includes a
+`release-receipt.json` GitHub Release asset. The engine builds it only after the
+DMG, checksum, appcast, signatures, notarization, Gatekeeper checks, package
+smokes, attestation, and draft assets have been verified. It is uploaded while
+the release is still a draft, re-downloaded by asset ID, and digest-verified
+before publication.
+
+The receipt's `receipt_sha256` is the SHA-256 of canonical compact JSON with the
+`receipt_sha256` field omitted. The checked evidence index separately records
+the SHA-256 of the exact formatted receipt file downloaded from GitHub. This
+avoids a self-referential file hash while preserving deterministic semantic and
+byte-for-byte identities.
+
+After the operator workflow completes, `.github/workflows/release-evidence.yml`
+validates the successful `workflow_dispatch` run, approved actor, protected
+source SHA, immutable release fields, asset IDs and sizes, receipt digest, and
+live Pages appcast. It then opens or updates one task-branch PR containing the
+receipt, publication record, release ledger, qualification fields, and cut
+packet status. The workflow has no signing, notarization, Sparkle private-key,
+PyPI, or deployment secrets.

--- a/scripts/release_evidence.py
+++ b/scripts/release_evidence.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.release_receipt import (
+    EXPECTED_BRANCH,
+    EXPECTED_REPOSITORY,
+    RECEIPT_ASSET_NAME,
+    ROUTES,
+    ReleaseReceiptError,
+    file_sha256,
+    validate_receipt,
+)
+
+
+EVIDENCE_INDEX_PATH = Path("docs/qualification/release-evidence-v1.json")
+RELEASE_LEDGER_PATH = Path("docs/release-evidence/index-v1.json")
+
+
+class ReleaseEvidenceError(RuntimeError):
+    pass
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReleaseEvidenceError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ReleaseEvidenceError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReleaseEvidenceError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ReleaseEvidenceError(f"{description} must be a positive integer.")
+    return value
+
+
+def _load_json(path: Path, description: str) -> Mapping[str, Any]:
+    try:
+        return _mapping(json.loads(path.read_text(encoding="utf-8")), description)
+    except OSError as error:
+        raise ReleaseEvidenceError(f"Unable to read {description} at {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ReleaseEvidenceError(f"Invalid JSON in {description} at {path}: {error}") from error
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _parse_timestamp(value: object, description: str) -> str:
+    text = _string(value, description)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReleaseEvidenceError(f"{description} must be an ISO-8601 timestamp.") from error
+    if parsed.tzinfo is None:
+        raise ReleaseEvidenceError(f"{description} must include a timezone.")
+    return text
+
+
+def _artifact(receipt: Mapping[str, Any], kind: str) -> Mapping[str, Any]:
+    matches = [
+        _mapping(item, "release receipt artifact")
+        for item in _sequence(receipt.get("artifacts"), "release receipt artifacts")
+        if _mapping(item, "release receipt artifact").get("kind") == kind
+    ]
+    if len(matches) != 1:
+        raise ReleaseEvidenceError(f"Release receipt must contain one {kind} artifact.")
+    return matches[0]
+
+
+def validate_publication(
+    workflow_run: Mapping[str, Any],
+    release: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    receipt_path: Path,
+    live_appcast_path: Path,
+) -> dict[str, Any]:
+    try:
+        validate_receipt(receipt)
+    except ReleaseReceiptError as error:
+        raise ReleaseEvidenceError(str(error)) from error
+
+    route = _string(receipt.get("release_route"), "release route")
+    expected_workflow_name, expected_workflow_path = ROUTES[route]
+    workflow = _mapping(receipt.get("workflow"), "receipt workflow")
+    source_sha = _string(receipt.get("source_sha"), "receipt source_sha")
+    if workflow_run.get("name") != expected_workflow_name or workflow_run.get("path") != expected_workflow_path:
+        raise ReleaseEvidenceError("Completed workflow identity does not match the release route.")
+    if workflow_run.get("event") != "workflow_dispatch":
+        raise ReleaseEvidenceError("Evidence reconciliation requires a workflow_dispatch release run.")
+    if workflow_run.get("status") != "completed" or workflow_run.get("conclusion") != "success":
+        raise ReleaseEvidenceError("Evidence reconciliation requires a successful completed release run.")
+    if workflow_run.get("head_branch") != EXPECTED_BRANCH or workflow_run.get("head_sha") != source_sha:
+        raise ReleaseEvidenceError("Completed release run is not bound to the receipt's protected-main SHA.")
+    if workflow_run.get("id") != workflow.get("run_id") or workflow_run.get("run_attempt") != workflow.get(
+        "run_attempt"
+    ):
+        raise ReleaseEvidenceError("Completed release run ID or attempt does not match the receipt.")
+    for actor_field in ("actor", "triggering_actor"):
+        actor = _mapping(workflow_run.get(actor_field), f"workflow run {actor_field}")
+        if actor.get("login") != "shiny-code-bot":
+            raise ReleaseEvidenceError(f"Workflow run {actor_field} is not the approved release actor.")
+    repository = _mapping(workflow_run.get("repository"), "workflow run repository")
+    if repository.get("full_name") != EXPECTED_REPOSITORY:
+        raise ReleaseEvidenceError("Workflow run repository is not canonical.")
+
+    receipt_release = _mapping(receipt.get("release"), "receipt release")
+    release_id = _integer(receipt_release.get("id"), "receipt release id")
+    if release.get("id") != release_id:
+        raise ReleaseEvidenceError("Published release ID does not match the receipt.")
+    if release.get("tag_name") != receipt_release.get("tag") or release.get("name") != receipt_release.get("name"):
+        raise ReleaseEvidenceError("Published release tag or name does not match the receipt.")
+    if release.get("target_commitish") != source_sha:
+        raise ReleaseEvidenceError("Published release target does not match the receipt source SHA.")
+    if release.get("immutable") is not True:
+        raise ReleaseEvidenceError("Published release is not protected by GitHub release immutability.")
+    if release.get("draft") is not False or release.get("prerelease") is not receipt_release.get("prerelease"):
+        raise ReleaseEvidenceError("Release is mutable or its prerelease state conflicts with the receipt.")
+    published_at = _parse_timestamp(release.get("published_at"), "release published_at")
+
+    release_assets = _sequence(release.get("assets"), "release assets")
+    expected_names = {
+        _string(_artifact(receipt, "dmg").get("name"), "DMG name"),
+        _string(_artifact(receipt, "checksum").get("name"), "checksum name"),
+        _string(_artifact(receipt, "appcast").get("name"), "appcast name"),
+        RECEIPT_ASSET_NAME,
+    }
+    names = [_string(_mapping(asset, "release asset").get("name"), "release asset name") for asset in release_assets]
+    if len(names) != len(expected_names) or set(names) != expected_names:
+        raise ReleaseEvidenceError("Published release asset set is incomplete or conflicting.")
+    for kind in ("dmg", "checksum", "appcast"):
+        recorded = _artifact(receipt, kind)
+        matches = [
+            _mapping(asset, "release asset")
+            for asset in release_assets
+            if _mapping(asset, "release asset").get("name") == recorded.get("name")
+        ]
+        if len(matches) != 1:
+            raise ReleaseEvidenceError(f"Published release does not contain exactly one {kind} asset.")
+        actual = matches[0]
+        if actual.get("id") != recorded.get("asset_id") or actual.get("size") != recorded.get("size_bytes"):
+            raise ReleaseEvidenceError(f"Published {kind} asset identity differs from the receipt.")
+        if actual.get("digest") != f"sha256:{recorded.get('sha256')}":
+            raise ReleaseEvidenceError(f"Published {kind} asset digest differs from the receipt.")
+
+    receipt_assets = [
+        _mapping(asset, "release receipt asset")
+        for asset in release_assets
+        if _mapping(asset, "release asset").get("name") == RECEIPT_ASSET_NAME
+    ]
+    receipt_file_digest = file_sha256(receipt_path)
+    if len(receipt_assets) != 1 or receipt_assets[0].get("size") != receipt_path.stat().st_size:
+        raise ReleaseEvidenceError("Published receipt asset size does not match the downloaded receipt.")
+    if receipt_assets[0].get("digest") != f"sha256:{receipt_file_digest}":
+        raise ReleaseEvidenceError("Published receipt asset digest does not match the downloaded receipt.")
+    live_appcast_sha256 = hashlib.sha256(live_appcast_path.read_bytes()).hexdigest()
+    appcast = _mapping(receipt.get("appcast"), "receipt appcast")
+    if live_appcast_sha256 != appcast.get("live_pages_sha256"):
+        raise ReleaseEvidenceError("Live Pages appcast does not match the verified release appcast.")
+
+    return {
+        "published_at": published_at,
+        "receipt_asset_id": _integer(receipt_assets[0].get("id"), "receipt asset id"),
+        "receipt_file_sha256": receipt_file_digest,
+        "live_appcast_sha256": live_appcast_sha256,
+    }
+
+
+def _merge_unique_record(records: list[dict[str, Any]], record: dict[str, Any], key: str) -> None:
+    matches = [existing for existing in records if existing.get(key) == record[key]]
+    if not matches:
+        records.append(record)
+        return
+    if len(matches) != 1 or matches[0] != record:
+        raise ReleaseEvidenceError(f"Existing immutable record {record[key]!r} conflicts with this publication.")
+
+
+def _update_qualification(repo_root: Path, receipt: Mapping[str, Any]) -> Path:
+    release = _mapping(receipt.get("release"), "receipt release")
+    tag = _string(release.get("tag"), "release tag")
+    candidates: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted((repo_root / "docs" / "qualification").glob("*-signed-qualification-v1.json")):
+        document = dict(_load_json(path, "signed qualification"))
+        candidate = document.get("candidate")
+        if isinstance(candidate, Mapping) and candidate.get("release_tag") == tag:
+            candidates.append((path, document))
+    if len(candidates) != 1:
+        raise ReleaseEvidenceError(
+            f"Expected exactly one signed qualification record for {tag}; found {len(candidates)}."
+        )
+    path, document = candidates[0]
+    candidate = dict(_mapping(document.get("candidate"), "qualification candidate"))
+    updates = {
+        "appcast_sha256": _artifact(receipt, "appcast")["sha256"],
+        "dmg_sha256": _artifact(receipt, "dmg")["sha256"],
+        "release_id": release["id"],
+        "release_run_id": _mapping(receipt.get("workflow"), "receipt workflow")["run_id"],
+        "signed_app_tree_sha256": receipt["signed_app_tree_sha256"],
+        "source_git_sha": receipt["source_sha"],
+    }
+    for field, value in updates.items():
+        if field not in candidate:
+            continue
+        if candidate[field] not in (None, value):
+            raise ReleaseEvidenceError(f"Qualification field candidate.{field} conflicts with immutable receipt data.")
+        candidate[field] = value
+    document["candidate"] = candidate
+    _write_json(path, document)
+    return path
+
+
+def _update_cut_packet(repo_root: Path, receipt: Mapping[str, Any], publication: Mapping[str, Any]) -> Path:
+    versions = _mapping(receipt.get("versions"), "receipt versions")
+    path = repo_root / "docs" / f"{_string(versions.get('public'), 'public version')}-cut-packet.md"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ReleaseEvidenceError(f"Unable to read release cut packet at {path}: {error}") from error
+    pending = "**Prepared metadata; publication pending.**"
+    published = "**Published and immutable.**"
+    if pending in text:
+        text = text.replace(pending, published, 1)
+    elif published not in text:
+        raise ReleaseEvidenceError("Release cut packet has no recognized publication state.")
+    marker = "<!-- release-evidence-receipt-v1 -->"
+    release = _mapping(receipt.get("release"), "receipt release")
+    workflow = _mapping(receipt.get("workflow"), "receipt workflow")
+    block = (
+        f"\n\n{marker}\n"
+        "## Immutable Publication Receipt\n\n"
+        f"- Source SHA: `{receipt['source_sha']}`\n"
+        f"- Release workflow run: `{workflow['run_id']}` attempt `{workflow['run_attempt']}`\n"
+        f"- GitHub release ID: `{release['id']}`\n"
+        f"- Published at: `{publication['published_at']}`\n"
+        f"- DMG SHA-256: `{_artifact(receipt, 'dmg')['sha256']}`\n"
+        f"- Signed app-tree SHA-256: `{receipt['signed_app_tree_sha256']}`\n"
+        f"- Appcast SHA-256: `{_artifact(receipt, 'appcast')['sha256']}`\n"
+        f"- Receipt file SHA-256: `{publication['receipt_file_sha256']}`\n"
+    )
+    if marker in text:
+        prefix = text.split(marker, 1)[0].rstrip()
+        text = prefix + block
+    else:
+        text = text.rstrip() + block
+    path.write_text(text.rstrip() + "\n", encoding="utf-8")
+    return path
+
+
+def reconcile(
+    repo_root: Path,
+    workflow_run: Mapping[str, Any],
+    release: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    receipt_path: Path,
+    live_appcast_path: Path,
+) -> dict[str, Any]:
+    publication = validate_publication(workflow_run, release, receipt, receipt_path, live_appcast_path)
+    release_data = _mapping(receipt.get("release"), "receipt release")
+    workflow = _mapping(receipt.get("workflow"), "receipt workflow")
+    tag = _string(release_data.get("tag"), "release tag")
+    evidence_directory = repo_root / "docs" / "release-evidence" / tag
+    checked_receipt = evidence_directory / RECEIPT_ASSET_NAME
+    if checked_receipt.exists() and checked_receipt.read_bytes() != receipt_path.read_bytes():
+        raise ReleaseEvidenceError(f"Checked receipt for immutable release {tag} conflicts with the published asset.")
+    checked_receipt.parent.mkdir(parents=True, exist_ok=True)
+    checked_receipt.write_bytes(receipt_path.read_bytes())
+
+    publication_record = {
+        "live_pages": {
+            "sha256": publication["live_appcast_sha256"],
+            "state": "verified",
+            "url": _mapping(receipt.get("appcast"), "receipt appcast")["live_pages_url"],
+        },
+        "published_at": publication["published_at"],
+        "receipt_asset_id": publication["receipt_asset_id"],
+        "receipt_file_sha256": publication["receipt_file_sha256"],
+        "release_id": release_data["id"],
+        "release_tag": tag,
+        "schema_version": 1,
+        "source_sha": receipt["source_sha"],
+        "workflow_conclusion": "success",
+        "workflow_run_id": workflow["run_id"],
+    }
+    publication_path = evidence_directory / "publication-record.json"
+    if publication_path.exists() and _load_json(publication_path, "publication record") != publication_record:
+        raise ReleaseEvidenceError(f"Checked publication record for immutable release {tag} conflicts.")
+    _write_json(publication_path, publication_record)
+
+    ledger_path = repo_root / RELEASE_LEDGER_PATH
+    ledger = (
+        dict(_load_json(ledger_path, "release evidence ledger"))
+        if ledger_path.exists()
+        else {"schema_version": 1, "releases": []}
+    )
+    if ledger.get("schema_version") != 1:
+        raise ReleaseEvidenceError("Release evidence ledger schema_version must be 1.")
+    releases = [
+        dict(_mapping(item, "release ledger record"))
+        for item in _sequence(ledger.get("releases"), "release ledger releases")
+    ]
+    ledger_record = {
+        "publication_record": publication_path.relative_to(repo_root).as_posix(),
+        "published_at": publication["published_at"],
+        "receipt": checked_receipt.relative_to(repo_root).as_posix(),
+        "receipt_file_sha256": publication["receipt_file_sha256"],
+        "release_id": release_data["id"],
+        "source_sha": receipt["source_sha"],
+        "tag": tag,
+        "workflow_run_id": workflow["run_id"],
+    }
+    _merge_unique_record(releases, ledger_record, "tag")
+    ledger["releases"] = sorted(releases, key=lambda item: cast(str, item["tag"]))
+    _write_json(ledger_path, ledger)
+
+    evidence_path = repo_root / EVIDENCE_INDEX_PATH
+    evidence = (
+        dict(_load_json(evidence_path, "release qualification evidence"))
+        if evidence_path.exists()
+        else {"schema_version": 1, "receipts": []}
+    )
+    if evidence.get("schema_version") != 1:
+        raise ReleaseEvidenceError("Release qualification evidence schema_version must be 1.")
+    receipts = [
+        dict(_mapping(item, "qualification evidence receipt"))
+        for item in _sequence(evidence.get("receipts"), "qualification evidence receipts")
+    ]
+    reference = checked_receipt.relative_to(repo_root).as_posix()
+    for case_id in _sequence(receipt.get("tier1_case_references"), "Tier 1 case references"):
+        case = _string(case_id, "Tier 1 case ID")
+        evidence_record = {
+            "accepted_at": publication["published_at"],
+            "case_id": case,
+            "receipt_id": f"{tag}:{case}",
+            "reference": reference,
+            "release_run_id": workflow["run_id"],
+            "sha256": publication["receipt_file_sha256"],
+            "source": "release_run_receipt",
+            "source_sha": receipt["source_sha"],
+            "status": "accepted",
+            "workflow_conclusion": "success",
+        }
+        _merge_unique_record(receipts, evidence_record, "receipt_id")
+    evidence["receipts"] = sorted(receipts, key=lambda item: cast(str, item["receipt_id"]))
+    _write_json(evidence_path, evidence)
+
+    qualification_path = _update_qualification(repo_root, receipt)
+    cut_packet_path = _update_cut_packet(repo_root, receipt, publication)
+    return {
+        "cut_packet": cut_packet_path.relative_to(repo_root).as_posix(),
+        "evidence_index": EVIDENCE_INDEX_PATH.as_posix(),
+        "publication_record": publication_path.relative_to(repo_root).as_posix(),
+        "qualification": qualification_path.relative_to(repo_root).as_posix(),
+        "receipt": reference,
+        "receipt_file_sha256": publication["receipt_file_sha256"],
+        "release_ledger": RELEASE_LEDGER_PATH.as_posix(),
+        "release_tag": tag,
+        "source_sha": receipt["source_sha"],
+    }
+
+
+def _write_github_output(path: Path, outputs: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a published release receipt and prepare checked evidence.")
+    parser.add_argument("--workflow-run", type=Path, required=True)
+    parser.add_argument("--release", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--live-appcast", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        outputs = reconcile(
+            args.repo_root.resolve(),
+            _load_json(args.workflow_run, "workflow run"),
+            _load_json(args.release, "published release"),
+            _load_json(args.receipt, "release receipt"),
+            args.receipt,
+            args.live_appcast,
+        )
+        if args.github_output is not None:
+            _write_github_output(args.github_output, outputs)
+        else:
+            print(json.dumps(outputs, sort_keys=True))
+    except ReleaseEvidenceError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_receipt.py
+++ b/scripts/release_receipt.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_PATH = REPO_ROOT / "docs" / "qualification" / "release-qualification-policy-v1.json"
+RECEIPT_ASSET_NAME = "release-receipt.json"
+RECEIPT_TYPE = "bd-to-avp-release-engine"
+SCHEMA_VERSION = 1
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+TAG_PATTERN = re.compile(r"^v[0-9A-Za-z][0-9A-Za-z.-]*$")
+EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
+EXPECTED_BRANCH = "main"
+ENGINE_WORKFLOW_PATH = ".github/workflows/release-engine.yml"
+ROUTES = {
+    "stable": ("Stable", ".github/workflows/briefcase.yml"),
+    "prerelease": ("Prerelease", ".github/workflows/prerelease.yml"),
+}
+VERIFICATION_FIELDS = (
+    "app_notarization",
+    "app_staple",
+    "dmg_notarization",
+    "dmg_staple",
+    "gatekeeper",
+    "package_smoke",
+    "asset_redownload",
+    "attestation",
+    "appcast",
+)
+
+
+class ReleaseReceiptError(RuntimeError):
+    pass
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReleaseReceiptError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ReleaseReceiptError(f"{description} must be a JSON array.")
+    return value
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ReleaseReceiptError(f"{description} keys changed; missing={missing}, extra={extra}.")
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReleaseReceiptError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ReleaseReceiptError(f"{description} must be a positive integer.")
+    return value
+
+
+def _boolean(value: object, description: str) -> bool:
+    if not isinstance(value, bool):
+        raise ReleaseReceiptError(f"{description} must be a boolean.")
+    return value
+
+
+def _sha(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA_PATTERN.fullmatch(text) is None:
+        raise ReleaseReceiptError(f"{description} must be a full lowercase Git SHA.")
+    return text
+
+
+def _sha256(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA256_PATTERN.fullmatch(text) is None:
+        raise ReleaseReceiptError(f"{description} must be a lowercase SHA-256 digest.")
+    return text
+
+
+def _load_json(path: Path, description: str) -> Mapping[str, Any]:
+    try:
+        return _mapping(json.loads(path.read_text(encoding="utf-8")), description)
+    except OSError as error:
+        raise ReleaseReceiptError(f"Unable to read {description} at {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ReleaseReceiptError(f"Invalid JSON in {description} at {path}: {error}") from error
+
+
+def canonical_payload_bytes(receipt: Mapping[str, Any]) -> bytes:
+    payload = dict(receipt)
+    payload.pop("receipt_sha256", None)
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def receipt_sha256(receipt: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_payload_bytes(receipt)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tier1_case_ids(policy_path: Path) -> list[str]:
+    policy = _load_json(policy_path, "release qualification policy")
+    if policy.get("schema_version") != 1:
+        raise ReleaseReceiptError("Release qualification policy schema_version must be 1.")
+    case_ids: list[str] = []
+    for index, raw_case in enumerate(_sequence(policy.get("cases"), "release qualification cases")):
+        case = _mapping(raw_case, f"release qualification case {index}")
+        if case.get("tier") == 1:
+            case_ids.append(_string(case.get("id"), f"release qualification case {index} id"))
+    if not case_ids or len(case_ids) != len(set(case_ids)):
+        raise ReleaseReceiptError("Release qualification policy must define unique Tier 1 case IDs.")
+    return sorted(case_ids)
+
+
+def build_receipt(facts: Mapping[str, Any], policy_path: Path = DEFAULT_POLICY_PATH) -> dict[str, Any]:
+    route = _string(facts.get("release_route"), "release_route")
+    if route not in ROUTES:
+        raise ReleaseReceiptError(f"release_route must be one of {sorted(ROUTES)}.")
+    workflow_name, workflow_path = ROUTES[route]
+    source_sha = _sha(facts.get("source_sha"), "source_sha")
+
+    artifacts: list[dict[str, Any]] = []
+    raw_artifacts = _sequence(facts.get("artifacts"), "artifacts")
+    expected_artifacts = {"dmg", "checksum", "appcast"}
+    seen_artifacts: set[str] = set()
+    for index, raw_artifact in enumerate(raw_artifacts):
+        artifact = _mapping(raw_artifact, f"artifact {index}")
+        kind = _string(artifact.get("kind"), f"artifact {index} kind")
+        if kind not in expected_artifacts or kind in seen_artifacts:
+            raise ReleaseReceiptError("Artifacts must contain exactly one DMG, checksum, and appcast.")
+        seen_artifacts.add(kind)
+        artifacts.append(
+            {
+                "asset_id": _integer(artifact.get("asset_id"), f"artifact {kind} asset_id"),
+                "kind": kind,
+                "name": _string(artifact.get("name"), f"artifact {kind} name"),
+                "sha256": _sha256(artifact.get("sha256"), f"artifact {kind} sha256"),
+                "size_bytes": _integer(artifact.get("size_bytes"), f"artifact {kind} size_bytes"),
+            }
+        )
+    if seen_artifacts != expected_artifacts:
+        raise ReleaseReceiptError("Artifacts must contain exactly one DMG, checksum, and appcast.")
+    artifacts.sort(key=lambda item: cast(str, item["kind"]))
+    appcast = next(item for item in artifacts if item["kind"] == "appcast")
+
+    receipt: dict[str, Any] = {
+        "appcast": {
+            "live_pages_sha256": cast(str, appcast["sha256"]),
+            "live_pages_state": "pending_release_deploy",
+            "live_pages_url": "https://cbusillo.github.io/BD_to_AVP/appcast.xml",
+        },
+        "artifacts": artifacts,
+        "protected_branch": EXPECTED_BRANCH,
+        "receipt_type": RECEIPT_TYPE,
+        "release": {
+            "created_at": _string(facts.get("release_created_at"), "release_created_at"),
+            "id": _integer(facts.get("release_id"), "release_id"),
+            "make_latest": _boolean(facts.get("make_latest"), "make_latest"),
+            "name": _string(facts.get("release_name"), "release_name"),
+            "prerelease": _boolean(facts.get("prerelease"), "prerelease"),
+            "tag": _string(facts.get("release_tag"), "release_tag"),
+            "target_sha": source_sha,
+        },
+        "release_route": route,
+        "repository": EXPECTED_REPOSITORY,
+        "schema_version": SCHEMA_VERSION,
+        "signed_app_tree_sha256": _sha256(facts.get("signed_app_tree_sha256"), "signed_app_tree_sha256"),
+        "source_sha": source_sha,
+        "tier1_case_references": _tier1_case_ids(policy_path),
+        "verification": {field: "passed" for field in VERIFICATION_FIELDS},
+        "versions": {
+            "build": _string(facts.get("build_version"), "build_version"),
+            "package": _string(facts.get("package_version"), "package_version"),
+            "public": _string(facts.get("public_version"), "public_version"),
+        },
+        "workflow": {
+            "actor": _string(facts.get("workflow_actor"), "workflow_actor"),
+            "engine_path": ENGINE_WORKFLOW_PATH,
+            "name": workflow_name,
+            "path": workflow_path,
+            "run_attempt": _integer(facts.get("workflow_run_attempt"), "workflow_run_attempt"),
+            "run_id": _integer(facts.get("workflow_run_id"), "workflow_run_id"),
+        },
+    }
+    receipt["receipt_sha256"] = receipt_sha256(receipt)
+    validate_receipt(receipt)
+    return receipt
+
+
+def validate_receipt(receipt: Mapping[str, Any]) -> None:
+    _exact_keys(
+        receipt,
+        {
+            "appcast",
+            "artifacts",
+            "protected_branch",
+            "receipt_sha256",
+            "receipt_type",
+            "release",
+            "release_route",
+            "repository",
+            "schema_version",
+            "signed_app_tree_sha256",
+            "source_sha",
+            "tier1_case_references",
+            "verification",
+            "versions",
+            "workflow",
+        },
+        "release receipt",
+    )
+    if receipt.get("schema_version") != SCHEMA_VERSION or receipt.get("receipt_type") != RECEIPT_TYPE:
+        raise ReleaseReceiptError("Unsupported release receipt schema or type.")
+    if receipt.get("repository") != EXPECTED_REPOSITORY or receipt.get("protected_branch") != EXPECTED_BRANCH:
+        raise ReleaseReceiptError("Release receipt repository or protected branch is not canonical.")
+    source_sha = _sha(receipt.get("source_sha"), "source_sha")
+    _sha256(receipt.get("signed_app_tree_sha256"), "signed_app_tree_sha256")
+
+    route = _string(receipt.get("release_route"), "release_route")
+    if route not in ROUTES:
+        raise ReleaseReceiptError(f"release_route must be one of {sorted(ROUTES)}.")
+    workflow_name, workflow_path = ROUTES[route]
+    workflow = _mapping(receipt.get("workflow"), "workflow")
+    _exact_keys(workflow, {"actor", "engine_path", "name", "path", "run_attempt", "run_id"}, "workflow")
+    if workflow.get("name") != workflow_name or workflow.get("path") != workflow_path:
+        raise ReleaseReceiptError("Release receipt workflow does not match its route.")
+    if workflow.get("engine_path") != ENGINE_WORKFLOW_PATH:
+        raise ReleaseReceiptError("Release receipt engine workflow path is not canonical.")
+    if workflow.get("actor") != "shiny-code-bot":
+        raise ReleaseReceiptError("Release receipt actor is not the approved release actor.")
+    _integer(workflow.get("run_id"), "workflow run_id")
+    _integer(workflow.get("run_attempt"), "workflow run_attempt")
+
+    versions = _mapping(receipt.get("versions"), "versions")
+    _exact_keys(versions, {"build", "package", "public"}, "versions")
+    for key in versions:
+        _string(versions[key], f"versions.{key}")
+
+    release = _mapping(receipt.get("release"), "release")
+    _exact_keys(release, {"created_at", "id", "make_latest", "name", "prerelease", "tag", "target_sha"}, "release")
+    tag = _string(release.get("tag"), "release tag")
+    if TAG_PATTERN.fullmatch(tag) is None:
+        raise ReleaseReceiptError("Release receipt tag is not canonical.")
+    _integer(release.get("id"), "release id")
+    prerelease = _boolean(release.get("prerelease"), "release prerelease")
+    make_latest = _boolean(release.get("make_latest"), "release make_latest")
+    if (route, prerelease, make_latest) not in {
+        ("stable", False, True),
+        ("prerelease", True, False),
+    }:
+        raise ReleaseReceiptError("Release prerelease and Latest state do not match the guarded route.")
+    if release.get("target_sha") != source_sha:
+        raise ReleaseReceiptError("Release target SHA does not match source_sha.")
+    _string(release.get("created_at"), "release created_at")
+    _string(release.get("name"), "release name")
+
+    artifacts = _sequence(receipt.get("artifacts"), "artifacts")
+    seen: set[str] = set()
+    for index, raw_artifact in enumerate(artifacts):
+        artifact = _mapping(raw_artifact, f"artifact {index}")
+        _exact_keys(artifact, {"asset_id", "kind", "name", "sha256", "size_bytes"}, f"artifact {index}")
+        kind = _string(artifact.get("kind"), f"artifact {index} kind")
+        if kind not in {"dmg", "checksum", "appcast"} or kind in seen:
+            raise ReleaseReceiptError("Release receipt artifacts are incomplete or duplicated.")
+        seen.add(kind)
+        _integer(artifact.get("asset_id"), f"artifact {kind} asset_id")
+        _integer(artifact.get("size_bytes"), f"artifact {kind} size_bytes")
+        _string(artifact.get("name"), f"artifact {kind} name")
+        _sha256(artifact.get("sha256"), f"artifact {kind} sha256")
+    if seen != {"dmg", "checksum", "appcast"}:
+        raise ReleaseReceiptError("Release receipt artifacts are incomplete or duplicated.")
+
+    appcast = _mapping(receipt.get("appcast"), "appcast")
+    _exact_keys(appcast, {"live_pages_sha256", "live_pages_state", "live_pages_url"}, "appcast")
+    if appcast.get("live_pages_state") != "pending_release_deploy":
+        raise ReleaseReceiptError("Engine receipt appcast state must be pending_release_deploy.")
+    if appcast.get("live_pages_url") != "https://cbusillo.github.io/BD_to_AVP/appcast.xml":
+        raise ReleaseReceiptError("Release receipt live Pages URL is not canonical.")
+    appcast_sha = _sha256(appcast.get("live_pages_sha256"), "appcast live_pages_sha256")
+    recorded_appcast = next(
+        _mapping(item, "appcast artifact") for item in artifacts if _mapping(item, "artifact").get("kind") == "appcast"
+    )
+    if recorded_appcast.get("sha256") != appcast_sha:
+        raise ReleaseReceiptError("Release receipt appcast digests disagree.")
+
+    verification = _mapping(receipt.get("verification"), "verification")
+    _exact_keys(verification, set(VERIFICATION_FIELDS), "verification")
+    if any(verification.get(field) != "passed" for field in VERIFICATION_FIELDS):
+        raise ReleaseReceiptError("Every engine verification outcome must be passed.")
+    case_ids = _sequence(receipt.get("tier1_case_references"), "tier1_case_references")
+    if not case_ids or not all(isinstance(case_id, str) and case_id for case_id in case_ids):
+        raise ReleaseReceiptError("Tier 1 case references must contain non-empty strings.")
+    if list(case_ids) != sorted(set(cast(list[str], case_ids))):
+        raise ReleaseReceiptError("Tier 1 case references must be sorted and unique.")
+
+    recorded_digest = _sha256(receipt.get("receipt_sha256"), "receipt_sha256")
+    if recorded_digest != receipt_sha256(receipt):
+        raise ReleaseReceiptError("Release receipt self-digest mismatch.")
+
+
+def write_receipt(receipt: Mapping[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build and validate deterministic public-safe release receipts.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser("build", help="Build a release receipt from verified workflow facts.")
+    build_parser.add_argument("--facts", type=Path, required=True)
+    build_parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    build_parser.add_argument("--output", type=Path, required=True)
+
+    validate_parser = subparsers.add_parser("validate", help="Validate an existing release receipt.")
+    validate_parser.add_argument("--receipt", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "build":
+            receipt = build_receipt(_load_json(args.facts, "release receipt facts"), args.policy)
+            write_receipt(receipt, args.output)
+        else:
+            validate_receipt(_load_json(args.receipt, "release receipt"))
+    except ReleaseReceiptError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_receipt.py
+++ b/tests/test_release_receipt.py
@@ -1,0 +1,231 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+
+from scripts.release_evidence import ReleaseEvidenceError, reconcile
+from scripts.release_receipt import (
+    ReleaseReceiptError,
+    build_receipt,
+    file_sha256,
+    receipt_sha256,
+    validate_receipt,
+    write_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_SHA = "a" * 40
+DMG_SHA256 = "b" * 64
+CHECKSUM_SHA256 = "c" * 64
+APPCAST_SHA256 = "d" * 64
+APP_TREE_SHA256 = "e" * 64
+
+
+def receipt_facts() -> dict[str, object]:
+    return {
+        "release_route": "prerelease",
+        "source_sha": SOURCE_SHA,
+        "workflow_actor": "shiny-code-bot",
+        "workflow_run_id": 12345,
+        "workflow_run_attempt": 2,
+        "package_version": "0.3.0rc3",
+        "public_version": "0.3.0-rc.3",
+        "build_version": "160",
+        "release_tag": "v0.3.0-rc.3",
+        "release_name": "v0.3.0-rc.3",
+        "release_id": 67890,
+        "release_created_at": "2026-08-05T12:00:00Z",
+        "prerelease": True,
+        "make_latest": False,
+        "signed_app_tree_sha256": APP_TREE_SHA256,
+        "artifacts": [
+            {
+                "kind": "dmg",
+                "name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+                "sha256": DMG_SHA256,
+                "size_bytes": 1000,
+                "asset_id": 1,
+            },
+            {
+                "kind": "checksum",
+                "name": "SHA256SUMS",
+                "sha256": CHECKSUM_SHA256,
+                "size_bytes": 100,
+                "asset_id": 2,
+            },
+            {
+                "kind": "appcast",
+                "name": "appcast.xml",
+                "sha256": APPCAST_SHA256,
+                "size_bytes": 500,
+                "asset_id": 3,
+            },
+        ],
+    }
+
+
+def workflow_run() -> dict[str, object]:
+    return {
+        "actor": {"login": "shiny-code-bot"},
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": SOURCE_SHA,
+        "id": 12345,
+        "name": "Prerelease",
+        "path": ".github/workflows/prerelease.yml",
+        "repository": {"full_name": "cbusillo/BD_to_AVP"},
+        "run_attempt": 2,
+        "status": "completed",
+        "triggering_actor": {"login": "shiny-code-bot"},
+    }
+
+
+class ReleaseReceiptTests(unittest.TestCase):
+    def test_build_is_deterministic_and_public_safe(self) -> None:
+        first = build_receipt(receipt_facts())
+        second = build_receipt(receipt_facts())
+
+        self.assertEqual(first, second)
+        validate_receipt(first)
+        serialized = json.dumps(first, sort_keys=True)
+        for forbidden in ("token", "certificate", "keychain", "private_path", "approval_comment"):
+            self.assertNotIn(forbidden, serialized.lower())
+        self.assertEqual(
+            first["tier1_case_references"],
+            ["release-workflow-identity", "signed-packaged-route-parity"],
+        )
+
+    def test_validation_rejects_unknown_or_mutated_fields(self) -> None:
+        receipt = build_receipt(receipt_facts())
+        receipt["private_path"] = "/tmp/private"
+        with self.assertRaisesRegex(ReleaseReceiptError, "keys changed"):
+            validate_receipt(receipt)
+
+        receipt = build_receipt(receipt_facts())
+        receipt["release"]["name"] = "changed"
+        with self.assertRaisesRegex(ReleaseReceiptError, "self-digest mismatch"):
+            validate_receipt(receipt)
+
+    def test_reconcile_writes_idempotent_checked_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            qualification_directory = root / "docs" / "qualification"
+            qualification_directory.mkdir(parents=True)
+            qualification = {
+                "schema_version": 1,
+                "candidate": {
+                    "release_tag": "v0.3.0-rc.3",
+                    "source_git_sha": None,
+                    "dmg_sha256": None,
+                    "signed_app_tree_sha256": None,
+                    "release_run_id": None,
+                    "release_id": None,
+                    "appcast_sha256": None,
+                },
+            }
+            qualification_path = qualification_directory / "rc3-signed-qualification-v1.json"
+            qualification_path.write_text(json.dumps(qualification), encoding="utf-8")
+            cut_packet = root / "docs" / "0.3.0-rc.3-cut-packet.md"
+            cut_packet.write_text("# RC3\n\n> **Prepared metadata; publication pending.**\n", encoding="utf-8")
+
+            receipt = build_receipt(receipt_facts())
+            receipt_path = root / "published-release-receipt.json"
+            write_receipt(receipt, receipt_path)
+            live_appcast = root / "live-appcast.xml"
+            live_appcast.write_bytes(b"appcast")
+            appcast = next(artifact for artifact in receipt["artifacts"] if artifact["kind"] == "appcast")
+            appcast["sha256"] = file_sha256(live_appcast)
+            receipt["appcast"]["live_pages_sha256"] = file_sha256(live_appcast)
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            write_receipt(receipt, receipt_path)
+
+            release = {
+                "id": 67890,
+                "tag_name": "v0.3.0-rc.3",
+                "name": "v0.3.0-rc.3",
+                "target_commitish": SOURCE_SHA,
+                "draft": False,
+                "immutable": True,
+                "prerelease": True,
+                "published_at": "2026-08-05T13:00:00Z",
+                "assets": [
+                    {
+                        "digest": f"sha256:{artifact['sha256']}",
+                        "id": artifact["asset_id"],
+                        "name": artifact["name"],
+                        "size": artifact["size_bytes"],
+                    }
+                    for artifact in receipt["artifacts"]
+                ]
+                + [
+                    {
+                        "digest": f"sha256:{file_sha256(receipt_path)}",
+                        "id": 4,
+                        "name": "release-receipt.json",
+                        "size": receipt_path.stat().st_size,
+                    }
+                ],
+            }
+
+            first = reconcile(root, workflow_run(), release, receipt, receipt_path, live_appcast)
+            second = reconcile(root, workflow_run(), release, receipt, receipt_path, live_appcast)
+
+            self.assertEqual(first, second)
+            checked_receipt = root / first["receipt"]
+            self.assertEqual(checked_receipt.read_bytes(), receipt_path.read_bytes())
+            evidence = json.loads((root / first["evidence_index"]).read_text(encoding="utf-8"))
+            self.assertEqual(len(evidence["receipts"]), 2)
+            self.assertTrue(all(item["workflow_conclusion"] == "success" for item in evidence["receipts"]))
+            updated_qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            self.assertEqual(updated_qualification["candidate"]["source_git_sha"], SOURCE_SHA)
+            self.assertIn("Published and immutable", cut_packet.read_text(encoding="utf-8"))
+
+    def test_reconcile_fails_closed_for_wrong_actor_or_live_appcast(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt = build_receipt(receipt_facts())
+            receipt_path = root / "release-receipt.json"
+            write_receipt(receipt, receipt_path)
+            live_appcast = root / "appcast.xml"
+            live_appcast.write_bytes(b"wrong")
+            release = {
+                "id": 67890,
+                "tag_name": "v0.3.0-rc.3",
+                "name": "v0.3.0-rc.3",
+                "target_commitish": SOURCE_SHA,
+                "draft": False,
+                "immutable": True,
+                "prerelease": True,
+                "published_at": "2026-08-05T13:00:00Z",
+                "assets": [
+                    {
+                        "digest": f"sha256:{artifact['sha256']}",
+                        "id": artifact["asset_id"],
+                        "name": artifact["name"],
+                        "size": artifact["size_bytes"],
+                    }
+                    for artifact in receipt["artifacts"]
+                ]
+                + [
+                    {
+                        "digest": f"sha256:{file_sha256(receipt_path)}",
+                        "id": 4,
+                        "name": "release-receipt.json",
+                        "size": receipt_path.stat().st_size,
+                    }
+                ],
+            }
+            bad_run = workflow_run()
+            bad_run["actor"] = {"login": "not-approved"}
+
+            with self.assertRaisesRegex(ReleaseEvidenceError, "approved release actor"):
+                reconcile(root, bad_run, release, receipt, receipt_path, live_appcast)
+            with self.assertRaisesRegex(ReleaseEvidenceError, "Live Pages appcast"):
+                reconcile(root, workflow_run(), release, receipt, receipt_path, live_appcast)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -739,7 +739,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("--verify-distribution", str(jobs["verify-draft"]))
         self.assertEqual(
             set(jobs["publish-release"]["needs"]),
-            {"build-python", "create-draft", "prepare", "package", "verify-draft"},
+            {"build-python", "create-draft", "prepare", "package", "verify-draft", "build-receipt"},
         )
         self.assertIn("needs.create-draft.result == 'success'", jobs["publish-release"]["if"])
         self.assertIn("needs.build-python.result == 'success'", jobs["publish-release"]["if"])
@@ -751,6 +751,8 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("make_latest: $make_latest", str(jobs["publish-release"]))
         self.assertIn("prerelease: $prerelease", str(jobs["publish-release"]))
         self.assertIn("Published release title does not match", str(jobs["publish-release"]))
+        self.assertIn("release-receipt.json", str(jobs["build-receipt"]))
+        self.assertIn("needs.build-receipt.result == 'success'", jobs["publish-release"]["if"])
         publish_script = jobs["publish-release"]["steps"][0]["run"]
         payload_index = publish_script.index("}' > publish-release.json")
         freshness_index = publish_script.index(
@@ -770,6 +772,45 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertNotIn('gh release edit "$RELEASE_TAG"', str(workflow))
         self.assertIn("Draft release did not become visible through the API", str(workflow))
         self.assertIn('[ "$TOTAL_ASSET_COUNT" = "3" ]', str(jobs["verify-draft"]))
+        self.assertIn('[ "$TOTAL_ASSET_COUNT" != "4" ]', str(jobs["publish-release"]))
+
+    def test_release_receipt_is_verified_before_publication(self) -> None:
+        workflow = load_release_engine()
+        jobs = workflow["jobs"]
+        receipt = jobs["build-receipt"]
+
+        self.assertEqual(
+            set(receipt["needs"]),
+            {"policy", "prepare", "package", "create-draft", "publish-appcast", "verify-draft"},
+        )
+        self.assertEqual(receipt["permissions"], {"contents": "write"})
+        self.assertNotIn("environment", receipt)
+        self.assertNotIn("secrets.", str(receipt))
+        self.assertIn("python -m scripts.release_receipt build", str(receipt))
+        self.assertIn("python -m scripts.release_receipt validate", str(receipt))
+        self.assertIn("Existing immutable release receipt differs", str(receipt))
+        self.assertIn("GitHub receipt asset digest differs", str(receipt))
+        self.assertIn("receipt_file_sha256", receipt["outputs"])
+        self.assertIn("signed_app_tree_sha256", jobs["package"]["outputs"])
+
+    def test_post_release_evidence_workflow_is_secret_free_and_idempotent(self) -> None:
+        workflow = load_workflow("release-evidence.yml")
+        jobs = workflow["jobs"]
+        prepare = jobs["validate-and-prepare"]
+        create_pr = jobs["create-pr"]
+
+        self.assertEqual(set(workflow["on"]["workflow_run"]["workflows"]), {"Stable", "Prerelease"})
+        self.assertEqual(prepare["permissions"], {"actions": "read", "contents": "read"})
+        self.assertEqual(create_pr["permissions"], {"contents": "write", "pull-requests": "write"})
+        self.assertNotIn("environment", prepare)
+        self.assertNotIn("environment", create_pr)
+        self.assertNotIn("secrets.", str(workflow))
+        self.assertIn("python -m scripts.release_evidence", str(prepare))
+        self.assertIn("release-receipt.json", str(prepare))
+        self.assertIn(".immutable == true", str(prepare))
+        self.assertIn("Preserve an existing idempotent evidence branch", str(prepare))
+        self.assertIn("automation/release-evidence-", str(create_pr))
+        self.assertIn("peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", str(create_pr))
 
     def test_release_notes_are_frozen_embedded_and_reverified(self) -> None:
         workflow = load_release_engine()


### PR DESCRIPTION
## Summary
- build a deterministic public-safe `release-receipt.json` from verified release-engine outputs and attach/re-download it before publication
- require GitHub release immutability and bind every release asset to GitHub-computed SHA-256 digests
- add a secret-free post-release workflow that validates the completed run, immutable release, receipt, and live appcast before opening one idempotent evidence PR
- generate checked Tier 1 evidence, publication records, the release ledger, qualification fields, and cut-packet publication status

## Safety
- signing, notarization, Sparkle, PyPI, and deployment secrets remain isolated from the evidence workflow
- conflicting immutable receipts, asset identities, actors, SHAs, tags, workflow attempts, and existing evidence branches fail closed
- release publication is not rebuilt or rolled back when evidence reconciliation fails

## Validation
- `actionlint .github/workflows/release-engine.yml .github/workflows/release-evidence.yml`
- `uv run ruff format --check scripts/release_receipt.py scripts/release_evidence.py tests/test_release_receipt.py`
- `uv run ruff check scripts/release_receipt.py scripts/release_evidence.py tests/test_release_receipt.py`
- `uv run mypy scripts/release_receipt.py scripts/release_evidence.py`
- `uv run python -m unittest tests.test_release`
- `uv run python -m unittest tests.test_sparkle_workflows`
- `uv run python -m unittest tests.test_github_release_run`
- `uv run python -m unittest tests.test_release_receipt tests.test_qualify_release_scope`
- `uv run python -m unittest discover -s tests -t .` (1501 tests, 3 skipped)
- JetBrains changed-files inspection: GREEN, 0 findings

Closes #474