### PR TITLE
Integrate qualification classifier into guarded releases

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -71,6 +71,13 @@
     "approvalEnvironment": "macos-signing",
     "engineWorkflowPath": ".github/workflows/release-engine.yml",
     "evidenceWorkflowPath": ".github/workflows/release-evidence.yml",
+    "qualificationPolicyPath": "docs/qualification/release-qualification-policy-v1.json",
+    "qualificationEvidencePath": "docs/qualification/release-evidence-v1.json",
+    "qualificationRecordPath": "docs/qualification/rc3-signed-qualification-v1.json",
+    "qualificationReportArtifacts": [
+      "release-qualification-preparation-<run-attempt>",
+      "release-qualification-final-<run-attempt>"
+    ],
     "workflows": {
       "Stable": {
         "path": ".github/workflows/briefcase.yml",

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -132,6 +132,9 @@ permissions:
 
 env:
   GH_REPO: ${{ github.repository }}
+  RELEASE_QUALIFICATION_EVIDENCE: docs/qualification/release-evidence-v1.json
+  RELEASE_QUALIFICATION_POLICY: docs/qualification/release-qualification-policy-v1.json
+  RELEASE_QUALIFICATION_RECORD: docs/qualification/rc3-signed-qualification-v1.json
   XCODEGEN_VERSION: 2.45.4
   XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
   XCODE_VERSION: "26.5"
@@ -241,6 +244,7 @@ jobs:
       dmg_name: ${{ steps.metadata.outputs.dmg_name }}
       channel: ${{ steps.metadata.outputs.channel }}
       prerelease: ${{ steps.metadata.outputs.prerelease }}
+      first_candidate_of_cycle: ${{ steps.metadata.outputs.first_candidate_of_cycle }}
       make_latest: ${{ steps.metadata.outputs.make_latest }}
       publish_pypi: ${{ steps.metadata.outputs.publish_pypi }}
       previous_release_tag: ${{ steps.release_history.outputs.previous_release_tag }}
@@ -534,11 +538,79 @@ jobs:
               ;;
           esac
 
+  qualify-preparation:
+    name: Qualify release preparation
+    needs:
+      - prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact candidate and qualification evidence
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Classify preparation evidence
+        id: qualification
+        env:
+          FIRST_CANDIDATE_OF_CYCLE: ${{ needs.prepare.outputs.first_candidate_of_cycle }}
+          RELEASE_STAGE: ${{ needs.prepare.outputs.channel }}
+        run: |
+          set -euo pipefail
+          FIRST_CANDIDATE_ARGS=()
+          if [ "$FIRST_CANDIDATE_OF_CYCLE" = "true" ]; then
+            FIRST_CANDIDATE_ARGS+=(--first-candidate-of-cycle)
+          fi
+          set +e
+          python -m scripts.qualify_release_scope \
+            --policy "$RELEASE_QUALIFICATION_POLICY" \
+            --qualification "$RELEASE_QUALIFICATION_RECORD" \
+            --evidence "$RELEASE_QUALIFICATION_EVIDENCE" \
+            --candidate-sha "$GITHUB_SHA" \
+            --release-stage "$RELEASE_STAGE" \
+            --workflow-phase preparation \
+            "${FIRST_CANDIDATE_ARGS[@]}" \
+            --output release-qualification-preparation.json \
+            --require-evidence
+          EXIT_CODE=$?
+          set -e
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Retain preparation qualification report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-qualification-preparation-${{ github.run_attempt }}
+          path: release-qualification-preparation.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Enforce preparation qualification
+        if: always()
+        env:
+          QUALIFICATION_EXIT_CODE: ${{ steps.qualification.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "$QUALIFICATION_EXIT_CODE" != "0" ]; then
+            echo "Release preparation qualification failed with exit code $QUALIFICATION_EXIT_CODE." >&2
+            exit "$QUALIFICATION_EXIT_CODE"
+          fi
+
   package:
     name: Build, sign, notarize, and validate DMG
     needs:
       - policy
       - prepare
+      - qualify-preparation
     runs-on: macos-26
     timeout-minutes: 180
     environment: macos-signing
@@ -1139,7 +1211,9 @@ jobs:
 
   build-python:
     name: Build stable Python distributions
-    needs: prepare
+    needs:
+      - prepare
+      - qualify-preparation
     if: needs.prepare.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -2046,6 +2120,126 @@ jobs:
             echo "receipt_sha256=$RECEIPT_SHA256"
           } >> "$GITHUB_OUTPUT"
 
+  qualify-artifact:
+    name: Qualify exact release artifact
+    needs:
+      - policy
+      - prepare
+      - package
+      - create-draft
+      - publish-appcast
+      - verify-draft
+      - build-receipt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact candidate and qualification evidence
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download and verify release receipt
+        env:
+          EXPECTED_RECEIPT_ASSET_ID: ${{ needs.build-receipt.outputs.receipt_asset_id }}
+          EXPECTED_RECEIPT_FILE_SHA256: ${{ needs.build-receipt.outputs.receipt_file_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/releases/assets/$EXPECTED_RECEIPT_ASSET_ID" \
+            -H "Accept: application/octet-stream" > release-receipt.json
+          if [ "$(sha256sum release-receipt.json | awk '{print $1}')" != "$EXPECTED_RECEIPT_FILE_SHA256" ]; then
+            echo "Release receipt digest mismatch before artifact qualification." >&2
+            exit 1
+          fi
+
+      - name: Classify exact artifact evidence
+        id: qualification
+        env:
+          APPCAST_ASSET_ID: ${{ needs.verify-draft.outputs.appcast_asset_id }}
+          APPCAST_SHA256: ${{ needs.publish-appcast.outputs.appcast_sha256 }}
+          CHECKSUM_ASSET_ID: ${{ needs.verify-draft.outputs.checksum_asset_id }}
+          CHECKSUM_SHA256: ${{ needs.verify-draft.outputs.checksum_sha256 }}
+          BUILD_VERSION: ${{ needs.prepare.outputs.build_version }}
+          DMG_ASSET_ID: ${{ needs.verify-draft.outputs.dmg_asset_id }}
+          DMG_NAME: ${{ needs.prepare.outputs.dmg_name }}
+          DMG_SHA256: ${{ needs.package.outputs.dmg_sha256 }}
+          FIRST_CANDIDATE_OF_CYCLE: ${{ needs.prepare.outputs.first_candidate_of_cycle }}
+          PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+          PUBLIC_VERSION: ${{ needs.prepare.outputs.public_version }}
+          RECEIPT_FILE_SHA256: ${{ needs.build-receipt.outputs.receipt_file_sha256 }}
+          RELEASE_ID: ${{ needs.create-draft.outputs.release_id }}
+          RELEASE_ROUTE: ${{ needs.policy.outputs.release_route }}
+          RELEASE_STAGE: ${{ needs.prepare.outputs.channel }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          SIGNED_APP_TREE_SHA256: ${{ needs.package.outputs.signed_app_tree_sha256 }}
+        run: |
+          set -euo pipefail
+          FIRST_CANDIDATE_ARGS=()
+          if [ "$FIRST_CANDIDATE_OF_CYCLE" = "true" ]; then
+            FIRST_CANDIDATE_ARGS+=(--first-candidate-of-cycle)
+          fi
+          set +e
+          python -m scripts.qualify_release_scope \
+            --policy "$RELEASE_QUALIFICATION_POLICY" \
+            --qualification "$RELEASE_QUALIFICATION_RECORD" \
+            --evidence "$RELEASE_QUALIFICATION_EVIDENCE" \
+            --candidate-sha "$GITHUB_SHA" \
+            --release-stage "$RELEASE_STAGE" \
+            --workflow-phase artifact \
+            "${FIRST_CANDIDATE_ARGS[@]}" \
+            --release-receipt release-receipt.json \
+            --release-route "$RELEASE_ROUTE" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --release-id "$RELEASE_ID" \
+            --package-version "$PACKAGE_VERSION" \
+            --public-version "$PUBLIC_VERSION" \
+            --build-version "$BUILD_VERSION" \
+            --release-tag "$RELEASE_TAG" \
+            --dmg-name "$DMG_NAME" \
+            --release-receipt-sha256 "$RECEIPT_FILE_SHA256" \
+            --signed-app-tree-sha256 "$SIGNED_APP_TREE_SHA256" \
+            --dmg-asset-id "$DMG_ASSET_ID" \
+            --dmg-sha256 "$DMG_SHA256" \
+            --checksum-asset-id "$CHECKSUM_ASSET_ID" \
+            --checksum-sha256 "$CHECKSUM_SHA256" \
+            --appcast-asset-id "$APPCAST_ASSET_ID" \
+            --appcast-sha256 "$APPCAST_SHA256" \
+            --output release-qualification-final.json \
+            --require-evidence
+          EXIT_CODE=$?
+          set -e
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Retain final qualification report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-qualification-final-${{ github.run_attempt }}
+          path: release-qualification-final.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Enforce exact artifact qualification
+        if: always()
+        env:
+          QUALIFICATION_EXIT_CODE: ${{ steps.qualification.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "$QUALIFICATION_EXIT_CODE" != "0" ]; then
+            echo "Exact artifact qualification failed with exit code $QUALIFICATION_EXIT_CODE." >&2
+            exit "$QUALIFICATION_EXIT_CODE"
+          fi
+
   publish-release:
     name: Publish verified GitHub Release
     needs:
@@ -2055,6 +2249,7 @@ jobs:
       - package
       - verify-draft
       - build-receipt
+      - qualify-artifact
     if: >-
       !cancelled() &&
       needs.create-draft.result == 'success' &&
@@ -2062,6 +2257,7 @@ jobs:
       needs.package.result == 'success' &&
       needs.verify-draft.result == 'success' &&
       needs.build-receipt.result == 'success' &&
+      needs.qualify-artifact.result == 'success' &&
       (
         needs.prepare.outputs.publish_pypi != 'true' ||
         needs.build-python.result == 'success'

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -199,38 +199,52 @@ The workflow performs these ordered boundaries:
 2. Reject a conflicting tag, release, Sparkle version/build, or Stable PyPI
    version while allowing a matching draft to resume. The active Pages state
    and newest durable snapshot are both checked.
-3. After the single release approval, build, sign, notarize, and
+3. Run the secret-free `qualify-preparation` gate. Classify the candidate
+   against the checked `docs/qualification/release-evidence-v1.json` evidence
+   and `docs/qualification/rc3-signed-qualification-v1.json` qualification file
+   for the `preparation` phase, using the exact `github.sha` and committed
+   Sparkle channel as the release stage. The preparation report is uploaded as
+   an Actions artifact with 30-day retention before enforcement. macOS signing
+   approval cannot be requested until this gate passes.
+4. After the single release approval, build, sign, notarize, and
    Gatekeeper-validate the SwiftUI macOS app and DMG without a write-capable
    repository token. Record its exact name, byte size, SHA-256, and
    `SHA256SUMS` entry, then publish GitHub artifact attestations for the verified
    package before release creation.
-4. Download that exact notarized DMG on the separate macOS 26 runner and repeat
+5. Download that exact notarized DMG on the separate macOS 26 runner and repeat
    checksum, signature, Gatekeeper, startup, bundled-tool, and worker validation.
    Draft creation cannot begin unless this compatibility boundary passes.
-5. Create a draft GitHub Release targeting only `github.sha`, retain its release
+6. Create a draft GitHub Release targeting only `github.sha`, retain its release
    ID for authenticated inspection, freeze the exact UTF-8 release body into a
    digest-bound workflow artifact, and transfer draft assets through release and
    asset IDs rather than runner-dependent tag lookup. Asset overwrite stays
    disabled by default.
-6. In the main-only `sparkle-release` environment, download the verified
+7. In the main-only `sparkle-release` environment, download the verified
    package and release-note workflow artifacts without a write-capable
    repository token, verify their exact identities, load the active durable
    `appcast.xml` selected by Pages state, sign the DMG, and build the cumulative
    snapshot. New items embed the frozen body as
    `<description sparkle:format="markdown">` and retain the GitHub Release page
    as their full-notes link; historical tag-page items remain valid.
-7. Upload `appcast.xml` to the draft, re-download the DMG, checksum, and appcast,
+8. Upload `appcast.xml` to the draft, re-download the DMG, checksum, and appcast,
    and repeat the exact digest, size, notarization, Gatekeeper, bundle-version,
    embedded-release-note, appcast-item, and exact-main-commit GitHub provenance
    checks.
-8. Build a deterministic public-safe `release-receipt.json` from those verified
+9. Build a deterministic public-safe `release-receipt.json` from those verified
    outputs. The receipt binds the route, workflow run and attempt, protected
    source SHA, versions, release ID, release asset IDs/sizes/digests, signed app
    tree, appcast, verification outcomes, and Tier 1 case references. Upload it
    to the draft, re-download it by asset ID, and verify its content and file
    digests before publication. The receipt deliberately excludes credentials,
    approval context, private paths, and diagnostic identifiers.
-9. Publish the verified draft only if it still targets the current `main` HEAD.
+10. Run the secret-free `qualify-artifact` gate. Download the release receipt by
+    its exact GitHub Release asset ID and verify its SHA-256 digest. Then classify
+    the candidate for the `artifact` phase, binding the exact release route,
+    workflow run ID and attempt, release ID, committed versions/tag/DMG name,
+    signed app tree digest, and DMG/checksum/appcast asset IDs and digests. The
+    artifact report is uploaded as an Actions artifact before enforcement.
+    Publication cannot proceed until this gate passes.
+11. Publish the verified draft only if it still targets the current `main` HEAD.
    The release body is hashed again immediately before and after publication so
    edits cannot silently diverge from the updater notes. The reusable engine
    returns Stable Python distributions only as an immutable workflow artifact
@@ -238,15 +252,15 @@ The workflow performs these ordered boundaries:
    and other prerelease routes return no Python artifact. Stable releases then
    publish that verified artifact through PyPI Trusted Publishing with PEP 740
    attestations; Alpha, Beta, and RC releases never publish to PyPI.
-10. Deploy the durable `appcast.xml` release asset to GitHub Pages. A deployment
+12. Deploy the durable `appcast.xml` release asset to GitHub Pages. A deployment
    failure can be retried without rebuilding, retagging, or re-signing.
-11. After the complete reusable engine succeeds, the Stable operator
+13. After the complete reusable engine succeeds, the Stable operator
     revalidates the current protected-main SHA, operator/engine policy evidence,
     GitHub artifact digest, and every distribution checksum, then publishes
     through the pinned PyPI Trusted Publisher with PEP 740 attestations. The publisher remains in
     `briefcase.yml` and the `pypi` environment so its existing OIDC identity does
     not change.
-12. After either operator workflow completes successfully, the secret-free
+14. After either operator workflow completes successfully, the secret-free
    `Release Evidence` workflow revalidates the completed workflow identity,
    immutable release, receipt asset, and live Pages appcast. It copies the exact
    receipt into `docs/release-evidence/<tag>/`, writes the publication record and
@@ -254,7 +268,7 @@ The workflow performs these ordered boundaries:
    or updates `automation/release-evidence-<tag>`. Branch protection, CI, review,
    and normal merge policy remain in force. A reconciliation failure does not
    rebuild, replace, or invalidate the correctly published release.
-13. The separate `cbusillo/homebrew-tap` repository checks the latest stable
+15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,
    source installation, command tests, and linkage checks before merge.

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -39,8 +39,9 @@ successful workflow conclusion and positive release-run ID. Tier 3 receipts
 must name every hardware/environment requirement declared by the case.
 
 Use `--require-evidence` during release preparation. It exits with status `2`
-when any blocking case remains `retest`; Tier 4 `external` cases never affect
-that exit status.
+when any case applicable to the selected workflow phase remains a blocking
+`retest`; later-phase cases remain visible as deferred, and Tier 4 `external`
+cases never affect that exit status.
 
 ```sh
 uv run python -m scripts.qualify_release_scope \
@@ -48,6 +49,7 @@ uv run python -m scripts.qualify_release_scope \
   --qualification docs/qualification/rc3-signed-qualification-v1.json \
   --evidence path/to/checked-evidence.json \
   --release-stage rc \
+  --workflow-phase preparation \
   --require-evidence
 ```
 
@@ -77,6 +79,95 @@ The receipt's `receipt_sha256` is the SHA-256 of canonical compact JSON with the
 the SHA-256 of the exact formatted receipt file downloaded from GitHub. This
 avoids a self-referential file hash while preserving deterministic semantic and
 byte-for-byte identities.
+
+## Workflow Integration
+
+The release engine enforces qualification at two secret-free guarded boundaries.
+Neither job touches signing, notarization, PyPI, or Pages secrets, and both run
+on `ubuntu-latest` without a write-capable repository token.
+
+**Early gate (`qualify-preparation`)** runs after `prepare` and before `package`
+(the macOS signing job). It checks the `preparation` phase using the exact
+`github.sha`, the committed Sparkle channel as the release stage, the checked
+`docs/qualification/release-evidence-v1.json` as evidence, and
+`docs/qualification/rc3-signed-qualification-v1.json` as the candidate file.
+When committed metadata identifies the first candidate of a cycle,
+`--first-candidate-of-cycle` is passed. The preparation report is uploaded as a workflow Actions artifact with
+30-day retention before enforcement exits. macOS signing cannot reach the
+`macos-signing` environment until this gate passes.
+
+The qualification record path is committed release metadata. Release
+preparation must update the workflow and `.github/github.json` catalog to the
+new candidate record before dispatch; a missing, stale, or mismatched record
+fails closed.
+
+**Artifact gate (`qualify-artifact`)** runs after `build-receipt` and before
+`publish-release`. It downloads the release receipt by its exact GitHub Release
+asset ID (`build-receipt.outputs.receipt_asset_id`), verifies its SHA-256 digest
+against `build-receipt.outputs.receipt_file_sha256`, then invokes the `artifact`
+phase binding the exact release route, workflow run ID and attempt, release ID,
+signed app tree digest, and DMG/checksum/appcast asset IDs and digests. The
+artifact report is uploaded before enforcement. Publication cannot proceed until
+this gate passes.
+
+Both gates enforce using `--require-evidence` and upload their reports as Actions
+artifacts rather than GitHub Release assets. The exact CLI interface for the
+engine integration is:
+
+```sh
+# Early gate — preparation phase
+python -m scripts.qualify_release_scope \
+  --policy docs/qualification/release-qualification-policy-v1.json \
+  --candidate-sha "$GITHUB_SHA" \
+  --release-stage "$CHANNEL" \
+  --evidence docs/qualification/release-evidence-v1.json \
+  --qualification docs/qualification/rc3-signed-qualification-v1.json \
+  --workflow-phase preparation \
+  [--first-candidate-of-cycle] \
+  --output release-qualification-preparation.json \
+  --require-evidence
+
+# Artifact gate — artifact phase
+python -m scripts.qualify_release_scope \
+  --policy docs/qualification/release-qualification-policy-v1.json \
+  --candidate-sha "$GITHUB_SHA" \
+  --release-stage "$CHANNEL" \
+  --evidence docs/qualification/release-evidence-v1.json \
+  --qualification docs/qualification/rc3-signed-qualification-v1.json \
+  --workflow-phase artifact \
+  [--first-candidate-of-cycle] \
+  --release-receipt release-receipt.json \
+  --release-route "$RELEASE_ROUTE" \
+  --workflow-run-id "$GITHUB_RUN_ID" \
+  --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+  --release-id "$RELEASE_ID" \
+  --package-version "$PACKAGE_VERSION" \
+  --public-version "$PUBLIC_VERSION" \
+  --build-version "$BUILD_VERSION" \
+  --release-tag "$RELEASE_TAG" \
+  --dmg-name "$DMG_NAME" \
+  --release-receipt-sha256 "$RECEIPT_FILE_SHA256" \
+  --signed-app-tree-sha256 "$SIGNED_APP_TREE_SHA256" \
+  --dmg-asset-id "$DMG_ASSET_ID" \
+  --dmg-sha256 "$DMG_SHA256" \
+  --checksum-asset-id "$CHECKSUM_ASSET_ID" \
+  --checksum-sha256 "$CHECKSUM_SHA256" \
+  --appcast-asset-id "$APPCAST_ASSET_ID" \
+  --appcast-sha256 "$APPCAST_SHA256" \
+  --output release-qualification-final.json \
+  --require-evidence
+```
+
+The `--output` flag writes the JSON report before the enforcement exit,
+so the `if: always()` upload step captures it even when enforcement fails. The
+classifier also writes a structured error report when policy or receipt
+validation fails before case classification. The
+`--workflow-phase` flag keeps publication-owned Tier 1 retests visible but
+explicitly deferred during `preparation`; `artifact` additionally binds the
+exact run, release, and asset identities recorded in the receipt. The receipt's
+appcast digest is the verified snapshot awaiting deployment. Live Pages state
+remains owned by the post-publication deployment and reconciliation boundaries,
+so it is not required before its owning phase exists.
 
 After the operator workflow completes, `.github/workflows/release-evidence.yml`
 validates the successful `workflow_dispatch` run, approved actor, protected

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -14,12 +14,19 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
+from scripts.release_receipt import (
+    ArtifactReceiptExpectation,
+    ReleaseReceiptError,
+    load_validated_artifact_receipt,
+)
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_POLICY_PATH = REPO_ROOT / "docs" / "qualification" / "release-qualification-policy-v1.json"
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 RESULT_STATES = ("covered", "carry", "retest", "external")
+WORKFLOW_PHASES = ("preparation", "artifact")
 
 
 class QualificationScopeError(RuntimeError):
@@ -405,6 +412,47 @@ def _receipt_summary(receipt: Mapping[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def _artifact_receipt_summary(receipt: Mapping[str, Any], path: Path) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt["receipt_sha256"],
+        "reference": path.name,
+        "source_sha": receipt["source_sha"],
+    }
+
+
+def _evidence_requirement(
+    case: Mapping[str, Any],
+    *,
+    status: str,
+    applicable: bool,
+    deferred: bool,
+) -> dict[str, Any]:
+    case_id = cast(str, case["id"])
+    tier = cast(int, case["tier"])
+    source = _strings(case["allowed_evidence_sources"], f"case {case_id!r} evidence sources")[0]
+    if tier == 0:
+        binding = "automatic_per_commit_gate"
+    elif tier == 1:
+        binding = "exact_same_run_release_receipt"
+    elif tier in {2, 3}:
+        binding = "exact_candidate_or_valid_carry_forward"
+    else:
+        binding = "post_publication_observation"
+    required = status == "retest"
+    action: str | None = None
+    if required:
+        timing = "before the artifact phase" if deferred else "before this phase can pass"
+        action = f"Provide accepted {source} evidence {timing}."
+    return {
+        "source": source,
+        "binding": binding,
+        "required": required,
+        "required_for_phase": required and applicable,
+        "satisfied": not required,
+        "action": action,
+    }
+
+
 def classify_release_scope(
     policy: Mapping[str, Any],
     evidence: Mapping[str, Any],
@@ -417,12 +465,17 @@ def classify_release_scope(
     fresh_retest: Mapping[str, bool] | None = None,
     release_stage: str = "rc",
     first_candidate_of_cycle: bool = False,
+    workflow_phase: str = "preparation",
+    artifact_receipt_path: Path | None = None,
+    artifact_receipt_expectation: ArtifactReceiptExpectation | None = None,
     as_of: date | None = None,
 ) -> dict[str, Any]:
     if SHA_PATTERN.fullmatch(candidate_sha) is None:
         raise QualificationScopeError("Candidate SHA must be a full lowercase Git SHA.")
     if release_stage not in {"alpha", "beta", "rc", "stable"}:
         raise QualificationScopeError("Release stage must be alpha, beta, rc, or stable.")
+    if workflow_phase not in WORKFLOW_PHASES:
+        raise QualificationScopeError(f"Workflow phase must be one of {WORKFLOW_PHASES!r}.")
     as_of = as_of or datetime.now(timezone.utc).date()
     contracts = _mapping(policy["contracts"], "release qualification contracts")
     cases = [_mapping(case, "release qualification case") for case in _sequence(policy["cases"], "cases")]
@@ -434,6 +487,35 @@ def classify_release_scope(
         reference_content or git_checked_reference_content(repo),
         as_of,
     )
+    artifact_tier1_cases: set[str] = set()
+    artifact_receipt_evidence: dict[str, Any] | None = None
+    if (artifact_receipt_path is None) != (artifact_receipt_expectation is None):
+        raise QualificationScopeError(
+            "Artifact release receipt and exact run, release, asset, and digest inputs must be supplied together."
+        )
+    if workflow_phase == "preparation" and artifact_receipt_path is not None:
+        raise QualificationScopeError("Preparation workflow phase cannot consume artifact release evidence.")
+    if workflow_phase == "artifact":
+        if artifact_receipt_path is None or artifact_receipt_expectation is None:
+            raise QualificationScopeError(
+                "Artifact workflow phase requires the exact same-run release receipt and all binding inputs."
+            )
+        try:
+            artifact_receipt = load_validated_artifact_receipt(
+                artifact_receipt_path,
+                artifact_receipt_expectation,
+            )
+        except ReleaseReceiptError as error:
+            raise QualificationScopeError(f"Artifact release receipt validation failed: {error}") from error
+        expected_tier1_cases = {case_id for case_id, case in cases_by_id.items() if case["tier"] == 1}
+        artifact_tier1_cases = set(
+            _strings(artifact_receipt.get("tier1_case_references"), "artifact receipt Tier 1 case references")
+        )
+        if artifact_tier1_cases != expected_tier1_cases:
+            raise QualificationScopeError(
+                "Artifact release receipt Tier 1 case references do not match the current qualification policy."
+            )
+        artifact_receipt_evidence = _artifact_receipt_summary(artifact_receipt, artifact_receipt_path)
     fresh_retest = fresh_retest or {}
     unknown_overrides = sorted(set(fresh_retest) - case_ids)
     if unknown_overrides:
@@ -457,6 +539,9 @@ def classify_release_scope(
             status, reason = "covered", "Owned by the automatic per-commit quality gate."
         elif tier == 4:
             status, reason = "external", "Post-publication field evidence cannot block publication."
+        elif tier == 1 and case_id in artifact_tier1_cases:
+            status, reason = "covered", "Validated evidence is bound to the exact artifact workflow run and release."
+            selected_receipt = None
         elif exact is not None:
             status, reason = "covered", "Accepted evidence is bound to the exact candidate SHA."
         elif tier == 1:
@@ -500,21 +585,42 @@ def classify_release_scope(
                     status, reason = "carry", "Accepted prior evidence remains valid because no mapped paths changed."
 
         blocking_phase = cast(str, case["blocking_phase"])
+        deferred = workflow_phase == "preparation" and blocking_phase == "publication"
+        applicable = blocking_phase != "none" and not deferred
+        evidence_summary = (
+            artifact_receipt_evidence
+            if tier == 1 and case_id in artifact_tier1_cases and artifact_receipt_evidence is not None
+            else _receipt_summary(selected_receipt)
+        )
         result = {
             "case_id": case_id,
             "tier": tier,
             "status": status,
             "blocking_phase": blocking_phase,
             "blocking": blocking_phase != "none",
+            "applicable": applicable,
+            "deferred": deferred,
             "reason": reason,
             "invalidating_paths": invalidating_paths,
-            "evidence": _receipt_summary(selected_receipt),
+            "evidence": evidence_summary,
+            "evidence_required": status == "retest",
+            "evidence_requirement": _evidence_requirement(
+                case,
+                status=status,
+                applicable=applicable,
+                deferred=deferred,
+            ),
         }
         results.append(result)
 
     counts = Counter(result["status"] for result in results)
     blocking_retests = [
-        cast(str, result["case_id"]) for result in results if result["status"] == "retest" and result["blocking"]
+        cast(str, result["case_id"])
+        for result in results
+        if result["status"] == "retest" and result["blocking"] and result["applicable"]
+    ]
+    deferred_retests = [
+        cast(str, result["case_id"]) for result in results if result["status"] == "retest" and result["deferred"]
     ]
     return {
         "schema_version": 1,
@@ -523,10 +629,12 @@ def classify_release_scope(
         "candidate_sha": candidate_sha,
         "release_stage": release_stage,
         "first_candidate_of_cycle": first_candidate_of_cycle,
+        "workflow_phase": workflow_phase,
         "as_of": as_of.isoformat(),
         "cases": results,
         "summary": {state: counts[state] for state in RESULT_STATES},
         "blocking_retests": blocking_retests,
+        "deferred_retests": deferred_retests,
         "passed": not blocking_retests,
     }
 
@@ -542,6 +650,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--candidate-sha")
     parser.add_argument("--release-stage", choices=("alpha", "beta", "rc", "stable"), default="rc")
     parser.add_argument("--first-candidate-of-cycle", action="store_true")
+    parser.add_argument("--workflow-phase", choices=WORKFLOW_PHASES, default="preparation")
+    parser.add_argument("--release-receipt", type=Path)
+    parser.add_argument("--release-route", choices=("stable", "prerelease"))
+    parser.add_argument("--workflow-run-id", type=int)
+    parser.add_argument("--workflow-run-attempt", type=int)
+    parser.add_argument("--release-id", type=int)
+    parser.add_argument("--package-version")
+    parser.add_argument("--public-version")
+    parser.add_argument("--build-version")
+    parser.add_argument("--release-tag")
+    parser.add_argument("--dmg-name")
+    parser.add_argument("--release-receipt-sha256")
+    parser.add_argument("--signed-app-tree-sha256")
+    parser.add_argument("--dmg-asset-id", type=int)
+    parser.add_argument("--dmg-sha256")
+    parser.add_argument("--checksum-asset-id", type=int)
+    parser.add_argument("--checksum-sha256")
+    parser.add_argument("--appcast-asset-id", type=int)
+    parser.add_argument("--appcast-sha256")
     parser.add_argument("--as-of", type=date.fromisoformat)
     parser.add_argument("--repo", type=Path, default=REPO_ROOT)
     parser.add_argument("--output", type=Path)
@@ -564,6 +691,56 @@ def main(argv: list[str] | None = None) -> int:
                 raise QualificationScopeError("--candidate-sha is required unless --validate-policy is used.")
             evidence = load_evidence(args.evidence)
             qualification_id, fresh_retest = load_qualification_overrides(args.qualification, policy)
+            artifact_receipt_expectation: ArtifactReceiptExpectation | None = None
+            receipt_inputs = {
+                "--release-receipt": args.release_receipt,
+                "--release-route": args.release_route,
+                "--workflow-run-id": args.workflow_run_id,
+                "--workflow-run-attempt": args.workflow_run_attempt,
+                "--release-id": args.release_id,
+                "--package-version": args.package_version,
+                "--public-version": args.public_version,
+                "--build-version": args.build_version,
+                "--release-tag": args.release_tag,
+                "--dmg-name": args.dmg_name,
+                "--release-receipt-sha256": args.release_receipt_sha256,
+                "--signed-app-tree-sha256": args.signed_app_tree_sha256,
+                "--dmg-asset-id": args.dmg_asset_id,
+                "--dmg-sha256": args.dmg_sha256,
+                "--checksum-asset-id": args.checksum_asset_id,
+                "--checksum-sha256": args.checksum_sha256,
+                "--appcast-asset-id": args.appcast_asset_id,
+                "--appcast-sha256": args.appcast_sha256,
+            }
+            supplied_receipt_inputs = [name for name, value in receipt_inputs.items() if value is not None]
+            if supplied_receipt_inputs:
+                if args.workflow_phase != "artifact":
+                    raise QualificationScopeError("Artifact receipt inputs require --workflow-phase artifact.")
+                missing_inputs = [name for name, value in receipt_inputs.items() if value is None]
+                if missing_inputs:
+                    raise QualificationScopeError(
+                        "Artifact workflow phase requires exact receipt inputs: " + ", ".join(missing_inputs) + "."
+                    )
+                artifact_receipt_expectation = ArtifactReceiptExpectation(
+                    candidate_sha=args.candidate_sha,
+                    release_route=args.release_route,
+                    workflow_run_id=args.workflow_run_id,
+                    workflow_run_attempt=args.workflow_run_attempt,
+                    release_id=args.release_id,
+                    package_version=args.package_version,
+                    public_version=args.public_version,
+                    build_version=args.build_version,
+                    release_tag=args.release_tag,
+                    dmg_name=args.dmg_name,
+                    receipt_file_sha256=args.release_receipt_sha256,
+                    signed_app_tree_sha256=args.signed_app_tree_sha256,
+                    dmg_asset_id=args.dmg_asset_id,
+                    dmg_sha256=args.dmg_sha256,
+                    checksum_asset_id=args.checksum_asset_id,
+                    checksum_sha256=args.checksum_sha256,
+                    appcast_asset_id=args.appcast_asset_id,
+                    appcast_sha256=args.appcast_sha256,
+                )
             payload = classify_release_scope(
                 policy,
                 evidence,
@@ -574,6 +751,9 @@ def main(argv: list[str] | None = None) -> int:
                 fresh_retest=fresh_retest,
                 release_stage=args.release_stage,
                 first_candidate_of_cycle=args.first_candidate_of_cycle,
+                workflow_phase=args.workflow_phase,
+                artifact_receipt_path=args.release_receipt,
+                artifact_receipt_expectation=artifact_receipt_expectation,
                 as_of=args.as_of,
             )
         rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -581,9 +761,33 @@ def main(argv: list[str] | None = None) -> int:
             args.output.write_text(rendered, encoding="utf-8")
         print(rendered, end="")
         if args.require_evidence and not cast(bool, payload.get("passed", True)):
+            print(
+                f"Release qualification evidence is required for workflow phase {payload['workflow_phase']}:",
+                file=sys.stderr,
+            )
+            cases = {cast(str, case["case_id"]): case for case in cast(Sequence[Mapping[str, Any]], payload["cases"])}
+            for case_id in cast(Sequence[str], payload["blocking_retests"]):
+                case = cases[case_id]
+                requirement = _mapping(case["evidence_requirement"], "evidence requirement")
+                print(
+                    f"- {case_id}: {requirement['action']} Reason: {case['reason']}",
+                    file=sys.stderr,
+                )
             return 2
         return 0
     except QualificationScopeError as error:
+        if args.output is not None:
+            failure_payload = {
+                "schema_version": 1,
+                "candidate_sha": args.candidate_sha,
+                "workflow_phase": args.workflow_phase,
+                "passed": False,
+                "error": str(error),
+                "blocking_retests": [],
+                "deferred_retests": [],
+                "cases": [],
+            }
+            args.output.write_text(json.dumps(failure_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         print(f"Release qualification scope failed: {error}", file=sys.stderr)
         return 1
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,6 +113,10 @@ class ReleaseVersion:
         return self.stage if self.prerelease else "stable"
 
     @property
+    def first_candidate_of_cycle(self) -> bool:
+        return self.prerelease_number == 1
+
+    @property
     def order_key(self) -> tuple[int, int, int, int, int]:
         return (
             self.major,
@@ -133,6 +137,7 @@ class ReleaseMetadata:
     dmg_name: str
     channel: str
     prerelease: bool
+    first_candidate_of_cycle: bool
     make_latest: bool
     publish_pypi: bool
 
@@ -643,6 +648,7 @@ def load_release_metadata(
         dmg_name=f"{DMG_NAME_PREFIX}-{version.public_version}.dmg",
         channel=version.channel,
         prerelease=version.prerelease,
+        first_candidate_of_cycle=version.first_candidate_of_cycle,
         make_latest=not version.prerelease,
         publish_pypi=not version.prerelease,
     )

--- a/scripts/release_receipt.py
+++ b/scripts/release_receipt.py
@@ -6,8 +6,12 @@ import json
 import re
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+
+from scripts.release import DMG_NAME_PREFIX, ReleaseError, parse_build_version, parse_release_version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -36,10 +40,36 @@ VERIFICATION_FIELDS = (
     "attestation",
     "appcast",
 )
+TIER1_CASE_VERIFICATIONS = {
+    "release-workflow-identity": VERIFICATION_FIELDS,
+    "signed-packaged-route-parity": ("package_smoke", "asset_redownload", "attestation", "appcast"),
+}
 
 
 class ReleaseReceiptError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class ArtifactReceiptExpectation:
+    candidate_sha: str
+    release_route: str
+    workflow_run_id: int
+    workflow_run_attempt: int
+    release_id: int
+    package_version: str
+    public_version: str
+    build_version: str
+    release_tag: str
+    dmg_name: str
+    receipt_file_sha256: str
+    signed_app_tree_sha256: str
+    dmg_asset_id: int
+    dmg_sha256: str
+    checksum_asset_id: int
+    checksum_sha256: str
+    appcast_asset_id: int
+    appcast_sha256: str
 
 
 def _mapping(value: object, description: str) -> Mapping[str, Any]:
@@ -128,7 +158,14 @@ def _tier1_case_ids(policy_path: Path) -> list[str]:
             case_ids.append(_string(case.get("id"), f"release qualification case {index} id"))
     if not case_ids or len(case_ids) != len(set(case_ids)):
         raise ReleaseReceiptError("Release qualification policy must define unique Tier 1 case IDs.")
-    return sorted(case_ids)
+    policy_case_ids = set(case_ids)
+    mapped_case_ids = set(TIER1_CASE_VERIFICATIONS)
+    if policy_case_ids != mapped_case_ids:
+        raise ReleaseReceiptError(
+            "Release qualification Tier 1 cases require explicit receipt verification mappings; "
+            f"unmapped={sorted(policy_case_ids - mapped_case_ids)}, stale={sorted(mapped_case_ids - policy_case_ids)}."
+        )
+    return sorted(policy_case_ids)
 
 
 def build_receipt(facts: Mapping[str, Any], policy_path: Path = DEFAULT_POLICY_PATH) -> dict[str, Any]:
@@ -254,12 +291,25 @@ def validate_receipt(receipt: Mapping[str, Any]) -> None:
     _exact_keys(versions, {"build", "package", "public"}, "versions")
     for key in versions:
         _string(versions[key], f"versions.{key}")
+    package_version = cast(str, versions["package"])
+    try:
+        parsed_version = parse_release_version(package_version)
+        parse_build_version(cast(str, versions["build"]))
+    except ReleaseError as error:
+        raise ReleaseReceiptError(f"Release receipt version identity is invalid: {error}") from error
+    if versions.get("public") != parsed_version.public_version:
+        raise ReleaseReceiptError("Release receipt public version does not match its package version.")
+    expected_route = "prerelease" if parsed_version.prerelease else "stable"
+    if route != expected_route:
+        raise ReleaseReceiptError("Release receipt route does not match its package version stage.")
 
     release = _mapping(receipt.get("release"), "release")
     _exact_keys(release, {"created_at", "id", "make_latest", "name", "prerelease", "tag", "target_sha"}, "release")
     tag = _string(release.get("tag"), "release tag")
     if TAG_PATTERN.fullmatch(tag) is None:
         raise ReleaseReceiptError("Release receipt tag is not canonical.")
+    if tag != parsed_version.release_tag or release.get("name") != tag:
+        raise ReleaseReceiptError("Release receipt tag or name does not match its package version.")
     _integer(release.get("id"), "release id")
     prerelease = _boolean(release.get("prerelease"), "release prerelease")
     make_latest = _boolean(release.get("make_latest"), "release make_latest")
@@ -270,11 +320,17 @@ def validate_receipt(receipt: Mapping[str, Any]) -> None:
         raise ReleaseReceiptError("Release prerelease and Latest state do not match the guarded route.")
     if release.get("target_sha") != source_sha:
         raise ReleaseReceiptError("Release target SHA does not match source_sha.")
-    _string(release.get("created_at"), "release created_at")
-    _string(release.get("name"), "release name")
+    created_at = _string(release.get("created_at"), "release created_at")
+    try:
+        parsed_created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReleaseReceiptError("Release receipt created_at must be an ISO-8601 timestamp.") from error
+    if parsed_created_at.tzinfo is None:
+        raise ReleaseReceiptError("Release receipt created_at must include a timezone.")
 
     artifacts = _sequence(receipt.get("artifacts"), "artifacts")
     seen: set[str] = set()
+    artifacts_by_kind: dict[str, Mapping[str, Any]] = {}
     for index, raw_artifact in enumerate(artifacts):
         artifact = _mapping(raw_artifact, f"artifact {index}")
         _exact_keys(artifact, {"asset_id", "kind", "name", "sha256", "size_bytes"}, f"artifact {index}")
@@ -282,12 +338,21 @@ def validate_receipt(receipt: Mapping[str, Any]) -> None:
         if kind not in {"dmg", "checksum", "appcast"} or kind in seen:
             raise ReleaseReceiptError("Release receipt artifacts are incomplete or duplicated.")
         seen.add(kind)
+        artifacts_by_kind[kind] = artifact
         _integer(artifact.get("asset_id"), f"artifact {kind} asset_id")
         _integer(artifact.get("size_bytes"), f"artifact {kind} size_bytes")
         _string(artifact.get("name"), f"artifact {kind} name")
         _sha256(artifact.get("sha256"), f"artifact {kind} sha256")
     if seen != {"dmg", "checksum", "appcast"}:
         raise ReleaseReceiptError("Release receipt artifacts are incomplete or duplicated.")
+    expected_names = {
+        "dmg": f"{DMG_NAME_PREFIX}-{parsed_version.public_version}.dmg",
+        "checksum": "SHA256SUMS",
+        "appcast": "appcast.xml",
+    }
+    for kind, expected_name in expected_names.items():
+        if artifacts_by_kind[kind].get("name") != expected_name:
+            raise ReleaseReceiptError(f"Release receipt {kind} asset name does not match its release identity.")
 
     appcast = _mapping(receipt.get("appcast"), "appcast")
     _exact_keys(appcast, {"live_pages_sha256", "live_pages_state", "live_pages_url"}, "appcast")
@@ -311,10 +376,99 @@ def validate_receipt(receipt: Mapping[str, Any]) -> None:
         raise ReleaseReceiptError("Tier 1 case references must contain non-empty strings.")
     if list(case_ids) != sorted(set(cast(list[str], case_ids))):
         raise ReleaseReceiptError("Tier 1 case references must be sorted and unique.")
+    if set(case_ids) != set(TIER1_CASE_VERIFICATIONS):
+        raise ReleaseReceiptError("Tier 1 case references do not match the explicit receipt verification mappings.")
+    for case_id in cast(Sequence[str], case_ids):
+        if any(verification.get(field) != "passed" for field in TIER1_CASE_VERIFICATIONS[case_id]):
+            raise ReleaseReceiptError(f"Tier 1 case {case_id!r} is missing a required verification outcome.")
 
     recorded_digest = _sha256(receipt.get("receipt_sha256"), "receipt_sha256")
     if recorded_digest != receipt_sha256(receipt):
         raise ReleaseReceiptError("Release receipt self-digest mismatch.")
+
+
+def load_validated_artifact_receipt(
+    path: Path,
+    expectation: ArtifactReceiptExpectation,
+) -> Mapping[str, Any]:
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise ReleaseReceiptError(f"Unable to read artifact release receipt at {path}: {error}") from error
+    expected_file_digest = _sha256(expectation.receipt_file_sha256, "expected receipt file SHA-256")
+    if hashlib.sha256(content).hexdigest() != expected_file_digest:
+        raise ReleaseReceiptError("Artifact release receipt file digest does not match the expected digest.")
+    try:
+        receipt = _mapping(json.loads(content), "artifact release receipt")
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseReceiptError(f"Invalid JSON in artifact release receipt at {path}: {error}") from error
+    validate_receipt(receipt)
+
+    candidate_sha = _sha(expectation.candidate_sha, "expected candidate SHA")
+    if receipt.get("source_sha") != candidate_sha:
+        raise ReleaseReceiptError("Artifact release receipt is stale or bound to the wrong candidate SHA.")
+    release_route = _string(expectation.release_route, "expected release route")
+    if release_route not in ROUTES:
+        raise ReleaseReceiptError(f"Expected release route must be one of {sorted(ROUTES)}.")
+    if receipt.get("release_route") != release_route:
+        raise ReleaseReceiptError("Artifact release receipt is bound to the wrong release route.")
+
+    workflow = _mapping(receipt.get("workflow"), "workflow")
+    expected_run_id = _integer(expectation.workflow_run_id, "expected workflow run ID")
+    expected_run_attempt = _integer(expectation.workflow_run_attempt, "expected workflow run attempt")
+    if workflow.get("run_id") != expected_run_id or workflow.get("run_attempt") != expected_run_attempt:
+        raise ReleaseReceiptError("Artifact release receipt is not bound to the exact workflow run and attempt.")
+
+    release = _mapping(receipt.get("release"), "release")
+    if release.get("id") != _integer(expectation.release_id, "expected release ID"):
+        raise ReleaseReceiptError("Artifact release receipt is bound to the wrong GitHub release ID.")
+    expected_release_tag = _string(expectation.release_tag, "expected release tag")
+    if release.get("tag") != expected_release_tag or release.get("name") != expected_release_tag:
+        raise ReleaseReceiptError("Artifact release receipt tag or name does not match the committed release metadata.")
+    versions = _mapping(receipt.get("versions"), "versions")
+    expected_versions = {
+        "package": _string(expectation.package_version, "expected package version"),
+        "public": _string(expectation.public_version, "expected public version"),
+        "build": _string(expectation.build_version, "expected build version"),
+    }
+    if any(versions.get(field) != value for field, value in expected_versions.items()):
+        raise ReleaseReceiptError("Artifact release receipt versions do not match the committed release metadata.")
+    expected_app_tree_digest = _sha256(
+        expectation.signed_app_tree_sha256,
+        "expected signed app tree SHA-256",
+    )
+    if receipt.get("signed_app_tree_sha256") != expected_app_tree_digest:
+        raise ReleaseReceiptError("Artifact release receipt signed app tree digest does not match.")
+
+    expected_artifacts = {
+        "dmg": (
+            _integer(expectation.dmg_asset_id, "expected DMG asset ID"),
+            _sha256(expectation.dmg_sha256, "expected DMG SHA-256"),
+        ),
+        "checksum": (
+            _integer(expectation.checksum_asset_id, "expected checksum asset ID"),
+            _sha256(expectation.checksum_sha256, "expected checksum SHA-256"),
+        ),
+        "appcast": (
+            _integer(expectation.appcast_asset_id, "expected appcast asset ID"),
+            _sha256(expectation.appcast_sha256, "expected appcast SHA-256"),
+        ),
+    }
+    artifacts = {
+        cast(str, artifact["kind"]): artifact
+        for artifact in (
+            _mapping(raw_artifact, "artifact") for raw_artifact in _sequence(receipt.get("artifacts"), "artifacts")
+        )
+    }
+    for kind, (expected_asset_id, expected_digest) in expected_artifacts.items():
+        artifact = artifacts[kind]
+        if artifact.get("asset_id") != expected_asset_id:
+            raise ReleaseReceiptError(f"Artifact release receipt {kind} asset ID does not match.")
+        if artifact.get("sha256") != expected_digest:
+            raise ReleaseReceiptError(f"Artifact release receipt {kind} digest does not match.")
+    if artifacts["dmg"].get("name") != _string(expectation.dmg_name, "expected DMG name"):
+        raise ReleaseReceiptError("Artifact release receipt DMG name does not match the committed release metadata.")
+    return receipt
 
 
 def write_receipt(receipt: Mapping[str, Any], output: Path) -> None:

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -4,7 +4,8 @@ import subprocess
 import tempfile
 import unittest
 
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import replace
 from datetime import date
 from io import StringIO
 from pathlib import Path
@@ -18,12 +19,23 @@ from scripts.qualify_release_scope import (
     load_qualification_overrides,
     main,
 )
+from scripts.release_receipt import (
+    ArtifactReceiptExpectation,
+    build_receipt,
+    file_sha256,
+    receipt_sha256,
+    write_receipt,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RC3_QUALIFICATION_PATH = REPO_ROOT / "docs" / "qualification" / "rc3-signed-qualification-v1.json"
 CANDIDATE_SHA = "b" * 40
 PRIOR_SHA = "a" * 40
+DMG_SHA256 = "c" * 64
+CHECKSUM_SHA256 = "d" * 64
+APPCAST_SHA256 = "e" * 64
+APP_TREE_SHA256 = "f" * 64
 
 
 class ReleaseQualificationScopeTests(unittest.TestCase):
@@ -66,6 +78,9 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         *,
         changed: set[str] | None = None,
         fresh: dict[str, bool] | None = None,
+        workflow_phase: str = "preparation",
+        artifact_receipt_path: Path | None = None,
+        artifact_receipt_expectation: ArtifactReceiptExpectation | None = None,
     ) -> dict[str, Any]:
         return classify_release_scope(
             self.policy,
@@ -75,8 +90,79 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             repo=root,
             reference_content=lambda reference: (root / reference).read_bytes(),
             fresh_retest=fresh,
+            workflow_phase=workflow_phase,
+            artifact_receipt_path=artifact_receipt_path,
+            artifact_receipt_expectation=artifact_receipt_expectation,
             as_of=date(2026, 8, 5),
         )
+
+    def artifact_receipt(
+        self,
+        root: Path,
+    ) -> tuple[Path, ArtifactReceiptExpectation]:
+        facts: dict[str, object] = {
+            "release_route": "prerelease",
+            "source_sha": CANDIDATE_SHA,
+            "workflow_actor": "shiny-code-bot",
+            "workflow_run_id": 12345,
+            "workflow_run_attempt": 2,
+            "package_version": "0.3.0rc3",
+            "public_version": "0.3.0-rc.3",
+            "build_version": "160",
+            "release_tag": "v0.3.0-rc.3",
+            "release_name": "v0.3.0-rc.3",
+            "release_id": 67890,
+            "release_created_at": "2026-08-05T12:00:00Z",
+            "prerelease": True,
+            "make_latest": False,
+            "signed_app_tree_sha256": APP_TREE_SHA256,
+            "artifacts": [
+                {
+                    "kind": "dmg",
+                    "name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+                    "sha256": DMG_SHA256,
+                    "size_bytes": 1000,
+                    "asset_id": 1,
+                },
+                {
+                    "kind": "checksum",
+                    "name": "SHA256SUMS",
+                    "sha256": CHECKSUM_SHA256,
+                    "size_bytes": 100,
+                    "asset_id": 2,
+                },
+                {
+                    "kind": "appcast",
+                    "name": "appcast.xml",
+                    "sha256": APPCAST_SHA256,
+                    "size_bytes": 500,
+                    "asset_id": 3,
+                },
+            ],
+        }
+        receipt_path = root / "release-receipt.json"
+        write_receipt(build_receipt(facts), receipt_path)
+        expectation = ArtifactReceiptExpectation(
+            candidate_sha=CANDIDATE_SHA,
+            release_route="prerelease",
+            workflow_run_id=12345,
+            workflow_run_attempt=2,
+            release_id=67890,
+            package_version="0.3.0rc3",
+            public_version="0.3.0-rc.3",
+            build_version="160",
+            release_tag="v0.3.0-rc.3",
+            dmg_name="3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+            receipt_file_sha256=file_sha256(receipt_path),
+            signed_app_tree_sha256=APP_TREE_SHA256,
+            dmg_asset_id=1,
+            dmg_sha256=DMG_SHA256,
+            checksum_asset_id=2,
+            checksum_sha256=CHECKSUM_SHA256,
+            appcast_asset_id=3,
+            appcast_sha256=APPCAST_SHA256,
+        )
+        return receipt_path, expectation
 
     def result_for(self, report: dict[str, Any], case_id: str) -> dict[str, Any]:
         return next(case for case in report["cases"] if case["case_id"] == case_id)
@@ -198,6 +284,99 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 with self.assertRaises(QualificationScopeError):
                     self.classify(evidence, root)
 
+    def test_preparation_defers_visible_tier1_retests(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            report = self.classify({"schema_version": 1, "receipts": []}, Path(temporary_directory))
+
+        result = self.result_for(report, "release-workflow-identity")
+        self.assertEqual(report["workflow_phase"], "preparation")
+        self.assertEqual(result["status"], "retest")
+        self.assertFalse(result["applicable"])
+        self.assertTrue(result["deferred"])
+        self.assertTrue(result["evidence_required"])
+        self.assertEqual(result["evidence_requirement"]["binding"], "exact_same_run_release_receipt")
+        self.assertNotIn("release-workflow-identity", report["blocking_retests"])
+        self.assertIn("release-workflow-identity", report["deferred_retests"])
+
+    def test_artifact_phase_uses_exact_receipt_to_cover_tier1(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path, expectation = self.artifact_receipt(root)
+            report = self.classify(
+                {"schema_version": 1, "receipts": []},
+                root,
+                workflow_phase="artifact",
+                artifact_receipt_path=receipt_path,
+                artifact_receipt_expectation=expectation,
+            )
+
+        result = self.result_for(report, "release-workflow-identity")
+        self.assertTrue(result["applicable"])
+        self.assertFalse(result["deferred"])
+        self.assertEqual(result["status"], "covered")
+        self.assertEqual(result["evidence"]["reference"], "release-receipt.json")
+        self.assertNotIn("release-workflow-identity", report["blocking_retests"])
+        self.assertEqual(report["deferred_retests"], [])
+
+    def test_artifact_phase_fails_closed_without_receipt_and_requires_exact_policy_tier1_references(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            with self.assertRaisesRegex(QualificationScopeError, "exact same-run release receipt"):
+                classify_release_scope(
+                    self.policy,
+                    {"schema_version": 1, "receipts": []},
+                    candidate_sha=CANDIDATE_SHA,
+                    changed_paths=lambda _base, _candidate: set(),
+                    repo=root,
+                    reference_content=lambda reference: (root / reference).read_bytes(),
+                    workflow_phase="artifact",
+                )
+
+            receipt_path, expectation = self.artifact_receipt(root)
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt["tier1_case_references"].pop()
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            write_receipt(receipt, receipt_path)
+            expectation = replace(expectation, receipt_file_sha256=file_sha256(receipt_path))
+            with self.assertRaisesRegex(QualificationScopeError, "explicit receipt verification mappings"):
+                self.classify(
+                    {"schema_version": 1, "receipts": []},
+                    root,
+                    workflow_phase="artifact",
+                    artifact_receipt_path=receipt_path,
+                    artifact_receipt_expectation=expectation,
+                )
+
+    def test_exact_checked_tier1_evidence_cannot_replace_same_run_artifact_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(
+                root,
+                "release-workflow-identity",
+                source_sha=CANDIDATE_SHA,
+                source="release_run_receipt",
+                tier1=True,
+            )
+
+            with self.assertRaisesRegex(QualificationScopeError, "exact same-run release receipt"):
+                self.classify(evidence, root, workflow_phase="artifact")
+
+    def test_artifact_receipt_does_not_bypass_checked_evidence_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "gui-preview-cancel-cleanup")
+            evidence["receipts"][0]["sha256"] = "0" * 64
+            receipt_path, expectation = self.artifact_receipt(root)
+
+            with self.assertRaisesRegex(QualificationScopeError, "recorded SHA-256"):
+                self.classify(
+                    evidence,
+                    root,
+                    workflow_phase="artifact",
+                    artifact_receipt_path=receipt_path,
+                    artifact_receipt_expectation=expectation,
+                )
+
     def test_periodic_evidence_expires_and_first_rc_forces_retest(self) -> None:
         policy = json.loads(json.dumps(self.policy))
         policy["cases"].append(
@@ -237,6 +416,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 reference_content=lambda reference: (root / reference).read_bytes(),
                 release_stage="rc",
                 first_candidate_of_cycle=True,
+                workflow_phase="preparation",
                 as_of=date(2026, 8, 5),
             )
 
@@ -283,6 +463,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 reference_content=lambda reference: (root / reference).read_bytes(),
                 release_stage="beta",
                 first_candidate_of_cycle=False,
+                workflow_phase="preparation",
                 as_of=date(2026, 8, 5),
             )
 
@@ -329,6 +510,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 reference_content=lambda reference: (root / reference).read_bytes(),
                 release_stage="beta",
                 first_candidate_of_cycle=False,
+                workflow_phase="preparation",
                 as_of=date(2026, 8, 5),
             )
 
@@ -372,6 +554,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     changed_paths=lambda _base, _candidate: set(),
                     repo=root,
                     reference_content=lambda reference: (root / reference).read_bytes(),
+                    workflow_phase="preparation",
                     as_of=date(2026, 8, 5),
                 )
 
@@ -442,6 +625,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     candidate_sha=CANDIDATE_SHA,
                     changed_paths=lambda _base, _candidate: set(),
                     repo=root,
+                    workflow_phase="preparation",
                     as_of=date(2026, 8, 5),
                 )
 
@@ -455,11 +639,14 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         self.assertNotIn("public-diagnostics-and-field-closure", report["blocking_retests"])
 
     def test_require_evidence_returns_nonzero_for_blocking_retests(self) -> None:
-        with redirect_stdout(StringIO()):
+        stderr = StringIO()
+        with redirect_stdout(StringIO()), redirect_stderr(stderr):
             exit_code = main(
                 [
                     "--candidate-sha",
                     CANDIDATE_SHA,
+                    "--workflow-phase",
+                    "preparation",
                     "--require-evidence",
                     "--repo",
                     str(REPO_ROOT),
@@ -467,6 +654,89 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             )
 
         self.assertEqual(exit_code, 2)
+        self.assertIn("gui-preview-failure-cleanup", stderr.getvalue())
+        self.assertIn("signed_artifact_receipt", stderr.getvalue())
+        self.assertIn("before this phase can pass", stderr.getvalue())
+
+    def test_artifact_cli_accepts_exact_receipt_identity_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path, expectation = self.artifact_receipt(root)
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "--candidate-sha",
+                        CANDIDATE_SHA,
+                        "--workflow-phase",
+                        "artifact",
+                        "--release-receipt",
+                        str(receipt_path),
+                        "--release-route",
+                        expectation.release_route,
+                        "--workflow-run-id",
+                        str(expectation.workflow_run_id),
+                        "--workflow-run-attempt",
+                        str(expectation.workflow_run_attempt),
+                        "--release-id",
+                        str(expectation.release_id),
+                        "--package-version",
+                        expectation.package_version,
+                        "--public-version",
+                        expectation.public_version,
+                        "--build-version",
+                        expectation.build_version,
+                        "--release-tag",
+                        expectation.release_tag,
+                        "--dmg-name",
+                        expectation.dmg_name,
+                        "--release-receipt-sha256",
+                        expectation.receipt_file_sha256,
+                        "--signed-app-tree-sha256",
+                        expectation.signed_app_tree_sha256,
+                        "--dmg-asset-id",
+                        str(expectation.dmg_asset_id),
+                        "--dmg-sha256",
+                        expectation.dmg_sha256,
+                        "--checksum-asset-id",
+                        str(expectation.checksum_asset_id),
+                        "--checksum-sha256",
+                        expectation.checksum_sha256,
+                        "--appcast-asset-id",
+                        str(expectation.appcast_asset_id),
+                        "--appcast-sha256",
+                        expectation.appcast_sha256,
+                        "--repo",
+                        str(REPO_ROOT),
+                    ]
+                )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["workflow_phase"], "artifact")
+        self.assertEqual(self.result_for(payload, "release-workflow-identity")["status"], "covered")
+
+    def test_artifact_cli_retains_structured_report_when_receipt_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "report.json"
+            with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+                exit_code = main(
+                    [
+                        "--candidate-sha",
+                        CANDIDATE_SHA,
+                        "--workflow-phase",
+                        "artifact",
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            report = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["workflow_phase"], "artifact")
+        self.assertIn("exact same-run release receipt", report["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -167,6 +167,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg")
         self.assertEqual(metadata.channel, "rc")
         self.assertTrue(metadata.prerelease)
+        self.assertFalse(metadata.first_candidate_of_cycle)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
@@ -451,17 +452,19 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0-beta.3.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
+        self.assertFalse(metadata.first_candidate_of_cycle)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
     def test_metadata_maps_internal_versions_to_public_release_identity(self) -> None:
         cases = (
-            ("1.2.4a1", "1.2.4-alpha.1", "alpha", True),
-            ("1.2.4b2", "1.2.4-beta.2", "beta", True),
-            ("1.2.4rc3", "1.2.4-rc.3", "rc", True),
-            ("1.2.4", "1.2.4", "stable", False),
+            ("1.2.4a1", "1.2.4-alpha.1", "alpha", True, True),
+            ("1.2.4b2", "1.2.4-beta.2", "beta", True, False),
+            ("1.2.4rc1", "1.2.4-rc.1", "rc", True, True),
+            ("1.2.4rc3", "1.2.4-rc.3", "rc", True, False),
+            ("1.2.4", "1.2.4", "stable", False, False),
         )
-        for package_version, public_version, channel, prerelease in cases:
+        for package_version, public_version, channel, prerelease, first_candidate in cases:
             with self.subTest(package_version=package_version), tempfile.TemporaryDirectory() as temp_dir:
                 pyproject_path, lock_path = make_release_files(
                     Path(temp_dir),
@@ -478,6 +481,8 @@ class ReleaseMetadataTests(unittest.TestCase):
             self.assertEqual(metadata.dmg_name, f"3D-Blu-ray-to-Vision-Pro-{public_version}.dmg")
             self.assertEqual(metadata.channel, channel)
             self.assertEqual(metadata.prerelease, prerelease)
+            self.assertEqual(metadata.first_candidate_of_cycle, first_candidate)
+            self.assertEqual(metadata.github_outputs()["first_candidate_of_cycle"], str(first_candidate).lower())
             self.assertEqual(metadata.make_latest, not prerelease)
             self.assertEqual(metadata.publish_pypi, not prerelease)
 

--- a/tests/test_release_receipt.py
+++ b/tests/test_release_receipt.py
@@ -2,13 +2,17 @@ import json
 import tempfile
 import unittest
 
+from dataclasses import replace
 from pathlib import Path
 
 from scripts.release_evidence import ReleaseEvidenceError, reconcile
 from scripts.release_receipt import (
+    ArtifactReceiptExpectation,
+    DEFAULT_POLICY_PATH,
     ReleaseReceiptError,
     build_receipt,
     file_sha256,
+    load_validated_artifact_receipt,
     receipt_sha256,
     validate_receipt,
     write_receipt,
@@ -83,6 +87,29 @@ def workflow_run() -> dict[str, object]:
     }
 
 
+def artifact_expectation(path: Path) -> ArtifactReceiptExpectation:
+    return ArtifactReceiptExpectation(
+        candidate_sha=SOURCE_SHA,
+        release_route="prerelease",
+        workflow_run_id=12345,
+        workflow_run_attempt=2,
+        release_id=67890,
+        package_version="0.3.0rc3",
+        public_version="0.3.0-rc.3",
+        build_version="160",
+        release_tag="v0.3.0-rc.3",
+        dmg_name="3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+        receipt_file_sha256=file_sha256(path),
+        signed_app_tree_sha256=APP_TREE_SHA256,
+        dmg_asset_id=1,
+        dmg_sha256=DMG_SHA256,
+        checksum_asset_id=2,
+        checksum_sha256=CHECKSUM_SHA256,
+        appcast_asset_id=3,
+        appcast_sha256=APPCAST_SHA256,
+    )
+
+
 class ReleaseReceiptTests(unittest.TestCase):
     def test_build_is_deterministic_and_public_safe(self) -> None:
         first = build_receipt(receipt_facts())
@@ -106,8 +133,106 @@ class ReleaseReceiptTests(unittest.TestCase):
 
         receipt = build_receipt(receipt_facts())
         receipt["release"]["name"] = "changed"
-        with self.assertRaisesRegex(ReleaseReceiptError, "self-digest mismatch"):
+        with self.assertRaisesRegex(ReleaseReceiptError, "tag or name"):
             validate_receipt(receipt)
+
+    def test_build_rejects_incoherent_release_identity(self) -> None:
+        mutations = (
+            ("public_version", "0.3.0-beta.99", "public version"),
+            ("release_tag", "v0.3.0-beta.99", "tag or name"),
+            ("release_name", "wrong-name", "tag or name"),
+            ("release_created_at", "not-a-timestamp", "created_at"),
+        )
+        for field, value, message in mutations:
+            with self.subTest(field=field):
+                facts = receipt_facts()
+                facts[field] = value
+                with self.assertRaisesRegex(ReleaseReceiptError, message):
+                    build_receipt(facts)
+
+        facts = receipt_facts()
+        facts["artifacts"][0]["name"] = "wrong.dmg"
+        with self.assertRaisesRegex(ReleaseReceiptError, "dmg asset name"):
+            build_receipt(facts)
+
+    def test_build_requires_explicit_verification_mapping_for_every_tier1_case(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = json.loads(DEFAULT_POLICY_PATH.read_text(encoding="utf-8"))
+            policy["cases"].append(
+                {
+                    "id": "new-tier1-case",
+                    "tier": 1,
+                    "blocking_phase": "publication",
+                    "invalidates_on": {"paths": [], "contracts": ["release-engine"]},
+                    "allowed_evidence_sources": ["release_run_receipt"],
+                    "carry_forward": {
+                        "allowed": False,
+                        "requires_prior_accepted_receipt": False,
+                        "requires_clean_invalidation": False,
+                    },
+                }
+            )
+            policy_path = Path(temporary_directory) / "policy.json"
+            policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseReceiptError, "explicit receipt verification mappings"):
+                build_receipt(receipt_facts(), policy_path)
+
+    def test_artifact_validation_accepts_only_the_exact_same_run_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt_path = Path(temporary_directory) / "release-receipt.json"
+            receipt = build_receipt(receipt_facts())
+            write_receipt(receipt, receipt_path)
+
+            validated = load_validated_artifact_receipt(receipt_path, artifact_expectation(receipt_path))
+
+        self.assertEqual(validated, receipt)
+
+    def test_artifact_validation_fails_closed_for_mismatched_identity_or_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt_path = Path(temporary_directory) / "release-receipt.json"
+            write_receipt(build_receipt(receipt_facts()), receipt_path)
+            exact = artifact_expectation(receipt_path)
+            mismatches = (
+                ("candidate_sha", replace(exact, candidate_sha="f" * 40)),
+                ("release_route", replace(exact, release_route="stable")),
+                ("workflow_run_id", replace(exact, workflow_run_id=54321)),
+                ("workflow_run_attempt", replace(exact, workflow_run_attempt=3)),
+                ("release_id", replace(exact, release_id=9876)),
+                ("package_version", replace(exact, package_version="0.3.0rc2")),
+                ("public_version", replace(exact, public_version="0.3.0-rc.2")),
+                ("build_version", replace(exact, build_version="159")),
+                ("release_tag", replace(exact, release_tag="v0.3.0-rc.2")),
+                ("dmg_name", replace(exact, dmg_name="wrong.dmg")),
+                ("receipt_file_sha256", replace(exact, receipt_file_sha256="0" * 64)),
+                ("signed_app_tree_sha256", replace(exact, signed_app_tree_sha256="1" * 64)),
+                ("dmg_asset_id", replace(exact, dmg_asset_id=11)),
+                ("dmg_sha256", replace(exact, dmg_sha256="2" * 64)),
+                ("checksum_asset_id", replace(exact, checksum_asset_id=12)),
+                ("checksum_sha256", replace(exact, checksum_sha256="3" * 64)),
+                ("appcast_asset_id", replace(exact, appcast_asset_id=13)),
+                ("appcast_sha256", replace(exact, appcast_sha256="4" * 64)),
+            )
+
+            for field, mismatched_expectation in mismatches:
+                with self.subTest(field=field), self.assertRaises(ReleaseReceiptError):
+                    load_validated_artifact_receipt(receipt_path, mismatched_expectation)
+
+    def test_artifact_validation_rejects_missing_or_schema_invalid_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            valid_path = root / "release-receipt.json"
+            write_receipt(build_receipt(receipt_facts()), valid_path)
+            expectation = artifact_expectation(valid_path)
+
+            with self.assertRaisesRegex(ReleaseReceiptError, "Unable to read"):
+                load_validated_artifact_receipt(root / "missing.json", expectation)
+
+            invalid_path = root / "invalid.json"
+            invalid_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+            invalid_expectation = replace(expectation, receipt_file_sha256=file_sha256(invalid_path))
+            with self.assertRaisesRegex(ReleaseReceiptError, "keys changed"):
+                load_validated_artifact_receipt(invalid_path, invalid_expectation)
 
     def test_reconcile_writes_idempotent_checked_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -224,7 +224,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("release_route", policy["outputs"])
         self.assertIn("operator_workflow_path", policy["outputs"])
         self.assertEqual(workflow["jobs"]["prepare"]["needs"], "policy")
-        self.assertEqual(set(workflow["jobs"]["package"]["needs"]), {"policy", "prepare"})
+        self.assertEqual(set(workflow["jobs"]["package"]["needs"]), {"policy", "prepare", "qualify-preparation"})
         self.assertIn("--expected-fingerprint", str(workflow["jobs"]["package"]))
         self.assertIn("needs.policy.outputs.engine_workflow_ref", str(workflow["jobs"]["package"]))
 
@@ -324,7 +324,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         cleanup_script = cleanup_step["run"]
         package_step = next(step for step in package["steps"] if step["name"] == "Package application for GitHub")
 
-        self.assertEqual(set(package["needs"]), {"policy", "prepare"})
+        self.assertEqual(set(package["needs"]), {"policy", "prepare", "qualify-preparation"})
         self.assertEqual(package["environment"], "macos-signing")
         self.assertEqual(package["permissions"]["contents"], "read")
         self.assertEqual(package["runs-on"], "macos-26")
@@ -739,9 +739,10 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("--verify-distribution", str(jobs["verify-draft"]))
         self.assertEqual(
             set(jobs["publish-release"]["needs"]),
-            {"build-python", "create-draft", "prepare", "package", "verify-draft", "build-receipt"},
+            {"build-python", "create-draft", "prepare", "package", "verify-draft", "build-receipt", "qualify-artifact"},
         )
         self.assertIn("needs.create-draft.result == 'success'", jobs["publish-release"]["if"])
+        self.assertIn("needs.qualify-artifact.result == 'success'", jobs["publish-release"]["if"])
         self.assertIn("needs.build-python.result == 'success'", jobs["publish-release"]["if"])
         self.assertIn("draft: false", str(jobs["publish-release"]))
         self.assertIn("--method PATCH", str(jobs["publish-release"]))
@@ -773,6 +774,114 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("Draft release did not become visible through the API", str(workflow))
         self.assertIn('[ "$TOTAL_ASSET_COUNT" = "3" ]', str(jobs["verify-draft"]))
         self.assertIn('[ "$TOTAL_ASSET_COUNT" != "4" ]', str(jobs["publish-release"]))
+
+    def test_qualification_gates_block_signing_and_publication(self) -> None:
+        workflow = load_release_engine()
+        jobs = workflow["jobs"]
+        qualify_prep = jobs["qualify-preparation"]
+        qualify_artifact = jobs["qualify-artifact"]
+
+        operators = [load_workflow("briefcase.yml"), load_workflow("prerelease.yml")]
+        self.assertTrue(
+            all(
+                operator["jobs"]["release"]["uses"] == "./.github/workflows/release-engine.yml"
+                for operator in operators
+            )
+        )
+        self.assertIn("qualify-preparation", set(jobs["package"]["needs"]))
+        self.assertIn("qualify-preparation", set(jobs["build-python"]["needs"]))
+        self.assertEqual(set(qualify_prep["needs"]), {"prepare"})
+        self.assertIn("qualify-artifact", set(jobs["publish-release"]["needs"]))
+        self.assertIn("needs.qualify-artifact.result == 'success'", jobs["publish-release"]["if"])
+        self.assertNotIn("environment", qualify_prep)
+        self.assertNotIn("environment", qualify_artifact)
+        self.assertNotIn("secrets.", str(qualify_prep))
+        self.assertNotIn("secrets.", str(qualify_artifact))
+        self.assertEqual(qualify_prep["permissions"], {"contents": "read"})
+        self.assertEqual(qualify_artifact["permissions"], {"contents": "read"})
+        self.assertIn("qualify_release_scope", str(qualify_prep))
+        self.assertIn("qualify_release_scope", str(qualify_artifact))
+        self.assertIn("--workflow-phase preparation", str(qualify_prep))
+        self.assertIn("--workflow-phase artifact", str(qualify_artifact))
+        self.assertIn("--require-evidence", str(qualify_prep))
+        self.assertIn("--require-evidence", str(qualify_artifact))
+        self.assertEqual(
+            workflow["env"]["RELEASE_QUALIFICATION_EVIDENCE"], "docs/qualification/release-evidence-v1.json"
+        )
+        self.assertEqual(
+            workflow["env"]["RELEASE_QUALIFICATION_POLICY"], "docs/qualification/release-qualification-policy-v1.json"
+        )
+        self.assertEqual(
+            workflow["env"]["RELEASE_QUALIFICATION_RECORD"], "docs/qualification/rc3-signed-qualification-v1.json"
+        )
+        self.assertIn("--candidate-sha", str(qualify_prep))
+        self.assertIn("--release-stage", str(qualify_prep))
+        self.assertIn("first_candidate_of_cycle", jobs["prepare"]["outputs"])
+        self.assertIn("--first-candidate-of-cycle", str(qualify_prep))
+        self.assertIn("GITHUB_SHA", str(qualify_prep))
+        self.assertIn("needs.prepare.outputs.channel", str(qualify_prep))
+        self.assertIn("receipt_asset_id", str(qualify_artifact))
+        self.assertIn("receipt_file_sha256", str(qualify_artifact))
+        self.assertIn("Release receipt digest mismatch", str(qualify_artifact))
+        self.assertIn("release_route", str(qualify_artifact))
+        self.assertIn("GITHUB_RUN_ID", str(qualify_artifact))
+        self.assertIn("GITHUB_RUN_ATTEMPT", str(qualify_artifact))
+        self.assertIn("release_id", str(qualify_artifact))
+        self.assertIn("signed_app_tree_sha256", str(qualify_artifact))
+        self.assertIn("dmg_asset_id", str(qualify_artifact))
+        self.assertIn("dmg_sha256", str(qualify_artifact))
+        self.assertIn("checksum_asset_id", str(qualify_artifact))
+        self.assertIn("checksum_sha256", str(qualify_artifact))
+        self.assertIn("appcast_asset_id", str(qualify_artifact))
+        self.assertIn("appcast_sha256", str(qualify_artifact))
+        self.assertIn("--release-receipt release-receipt.json", str(qualify_artifact))
+        self.assertIn("--release-receipt-sha256", str(qualify_artifact))
+        self.assertIn("--workflow-run-id", str(qualify_artifact))
+        self.assertIn("--workflow-run-attempt", str(qualify_artifact))
+        self.assertIn("--signed-app-tree-sha256", str(qualify_artifact))
+        for metadata_flag in ("package-version", "public-version", "build-version", "release-tag", "dmg-name"):
+            self.assertIn(f"--{metadata_flag}", str(qualify_artifact))
+        prep_uploads = [step for step in qualify_prep["steps"] if "upload-artifact" in step.get("uses", "")]
+        artifact_uploads = [step for step in qualify_artifact["steps"] if "upload-artifact" in step.get("uses", "")]
+        self.assertEqual(len(prep_uploads), 1)
+        self.assertEqual(len(artifact_uploads), 1)
+        self.assertIn("release-qualification-preparation-${{ github.run_attempt }}", str(prep_uploads[0]))
+        self.assertIn("release-qualification-final-${{ github.run_attempt }}", str(artifact_uploads[0]))
+        self.assertEqual(prep_uploads[0]["if"], "always()")
+        self.assertEqual(artifact_uploads[0]["if"], "always()")
+        self.assertIn("--output release-qualification-preparation.json", str(qualify_prep))
+        self.assertIn("--output release-qualification-final.json", str(qualify_artifact))
+        self.assertNotIn("macos-signing", str(qualify_artifact))
+        self.assertNotIn("sparkle-release", str(qualify_artifact))
+        prep_checkouts = [
+            step for step in qualify_prep["steps"] if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        for checkout in prep_checkouts:
+            self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+            self.assertEqual(checkout["with"]["persist-credentials"], "false")
+            self.assertEqual(checkout["with"]["fetch-depth"], "0")
+
+        release_operations = load_github_config()["releaseOperations"]
+        self.assertEqual(
+            release_operations["qualificationPolicyPath"],
+            "docs/qualification/release-qualification-policy-v1.json",
+        )
+        self.assertEqual(
+            release_operations["qualificationEvidencePath"],
+            "docs/qualification/release-evidence-v1.json",
+        )
+        self.assertEqual(
+            release_operations["qualificationRecordPath"],
+            "docs/qualification/rc3-signed-qualification-v1.json",
+        )
+        self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 2)
+        artifact_checkouts = [
+            step for step in qualify_artifact["steps"] if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        for checkout in artifact_checkouts:
+            self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+            self.assertEqual(checkout["with"]["persist-credentials"], "false")
+            self.assertEqual(checkout["with"]["fetch-depth"], "0")
 
     def test_release_receipt_is_verified_before_publication(self) -> None:
         workflow = load_release_engine()


### PR DESCRIPTION
## Summary
- add phase-aware qualification reports with explicit deferred publication evidence
- require exact same-run release receipts and committed release identity before publication
- gate both Stable and Prerelease through the shared reusable release engine
- retain preparation and final reports as rerun-specific Actions artifacts

Refs #475
Parent: #471

## Safety boundaries
- no release workflow was dispatched
- no macos-signing approval was requested
- existing signing, notarization, Gatekeeper, appcast, immutable-history, concurrency, watcher, and secret boundaries remain intact

## Validation
- `uv run python -m unittest tests.test_qualify_release_scope`
- `uv run python -m unittest tests.test_release_receipt`
- `uv run python -m unittest tests.test_sparkle_workflows`
- `uv run python -m unittest tests.test_release`
- `uv run python -m unittest discover -s tests -t .` (1524 tests, 3 skipped)
- `uv run python scripts/native_app.py test` (355 tests)
- `uv run python -m scripts.release validate`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `actionlint`
- JetBrains changed-file inspection: clean