### PR TITLE
Define Tier 3 qualification policy and checked receipts

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -125,6 +125,7 @@
       "releaseQualificationPolicy": "uv run python -m scripts.qualify_release_scope --validate-policy",
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
+      "tier3Receipt": "uv run python -m unittest tests.test_tier3_receipt",
       "macosApp": "uv run python scripts/native_app.py test",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"

--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -21,12 +21,7 @@
     "3": {
       "name": "periodic_or_hardware",
       "owner": "qualification",
-      "blocking_phase": "milestone",
-      "default_cadence": {
-        "first_rc_or_stable_candidate": true,
-        "max_age_days": 90
-      },
-      "hardware_receipt_required": true
+      "blocking_phase": "milestone"
     },
     "4": {
       "name": "post_publication_observation",
@@ -109,6 +104,17 @@
       "macos/BluRayToVisionPro/Diagnostics/**",
       "macos/BluRayToVisionPro/Models/ObservabilityEvent.swift",
       "scripts/support_diagnostics.py"
+    ],
+    "tier3-evidence": [
+      "docs/qualification/release-qualification-policy-v1.json",
+      "scripts/qualify_release_scope.py",
+      "scripts/tier3_receipt.py"
+    ],
+    "vision-pro-playback": [
+      "docs/visionos-playback-validator.md",
+      "macos/SpatialPlaybackProbe/**",
+      "macos/SpatialPlaybackProbeTests/**",
+      "macos/SpatialPlaybackProbeUITests/**"
     ]
   },
   "cases": [
@@ -222,6 +228,171 @@
       "blocking_phase": "release_candidate",
       "invalidates_on": {"paths": [], "contracts": ["subtitle-recovery", "support-diagnostics"]},
       "allowed_evidence_sources": ["signed_artifact_receipt"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "tier": 3,
+      "blocking_phase": "milestone",
+      "automation_lane": "clean-machine-updater",
+      "execution_mode": "automated",
+      "environment": {
+        "classes": ["resettable-vm", "disposable-user", "restorable-location"],
+        "architectures": ["arm64"],
+        "macos_major_versions": [26],
+        "identity_fields": ["environment_class", "architecture", "macos_version", "macos_build"]
+      },
+      "hardware": {"required": false, "classes": [], "identity_fields": []},
+      "cadence": {"first_rc": true, "stable_candidate": true},
+      "evidence_expiry": {"basis": "completed_at", "max_age_days": 30},
+      "invalidates_on": {
+        "paths": ["docs/release-routes.md", "pyproject.toml"],
+        "contracts": ["release-engine", "sparkle-update", "packaged-worker", "profile-storage", "tier3-evidence"]
+      },
+      "allowed_evidence_sources": ["tier3_automation_receipt"],
+      "required_assertions": [
+        "preconditions-proven",
+        "exact-app-installed",
+        "package-smoke-passed",
+        "sparkle-relaunch-passed",
+        "final-identity-matched",
+        "profile-preserved"
+      ],
+      "allowed_evidence_kinds": ["install-log", "package-smoke", "sparkle-update", "profile-snapshot", "cleanup"],
+      "allowed_cleanup_results": ["disposed", "restored"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "tier": 3,
+      "blocking_phase": "milestone",
+      "automation_lane": "installed-ui-accessibility",
+      "execution_mode": "automated",
+      "environment": {
+        "classes": ["resettable-vm", "disposable-user", "restorable-location"],
+        "architectures": ["arm64"],
+        "macos_major_versions": [26],
+        "identity_fields": ["environment_class", "architecture", "macos_version", "macos_build"]
+      },
+      "hardware": {"required": false, "classes": [], "identity_fields": []},
+      "cadence": {"first_rc": true, "stable_candidate": true},
+      "evidence_expiry": {"basis": "completed_at", "max_age_days": 90},
+      "invalidates_on": {
+        "paths": ["macos/BluRayToVisionProUITests/**"],
+        "contracts": ["sparkle-update", "profile-storage", "preview-lifecycle", "support-diagnostics", "tier3-evidence"]
+      },
+      "allowed_evidence_sources": ["tier3_automation_receipt"],
+      "required_assertions": [
+        "main-window-ready",
+        "profile-save-accessible",
+        "profile-save-succeeded",
+        "updater-controls-accessible",
+        "release-note-links-bound"
+      ],
+      "allowed_evidence_kinds": ["accessibility-tree", "ui-result", "screenshot-light", "screenshot-dark"],
+      "allowed_cleanup_results": ["disposed", "restored"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "tier": 3,
+      "blocking_phase": "milestone",
+      "automation_lane": "operator-physical-drive",
+      "execution_mode": "operator_assisted",
+      "environment": {
+        "classes": ["dedicated-hardware", "restorable-location"],
+        "architectures": ["arm64"],
+        "macos_major_versions": [26],
+        "identity_fields": ["environment_class", "architecture", "macos_version", "macos_build"]
+      },
+      "hardware": {
+        "required": true,
+        "classes": ["usb-bluray-drive"],
+        "identity_fields": ["vendor_id", "product_id", "transport", "makemkv_version"]
+      },
+      "cadence": {"first_rc": true, "stable_candidate": true},
+      "evidence_expiry": {"basis": "completed_at", "max_age_days": 90},
+      "invalidates_on": {
+        "paths": ["bd_to_avp/modules/disc.py", "bd_to_avp/modules/config.py", "bd_to_avp/preflight.py"],
+        "contracts": ["packaged-worker", "conversion-ownership", "tier3-evidence"]
+      },
+      "allowed_evidence_sources": ["tier3_operator_receipt"],
+      "required_assertions": [
+        "drive-discovered",
+        "makemkv-path-verified",
+        "cancellation-recovered",
+        "drive-ejected"
+      ],
+      "allowed_evidence_kinds": ["device-probe", "makemkv-probe", "ejection-result", "cleanup"],
+      "allowed_cleanup_results": ["recovered", "not-applicable"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "tier": 3,
+      "blocking_phase": "milestone",
+      "automation_lane": "operator-real-media",
+      "execution_mode": "operator_assisted",
+      "environment": {
+        "classes": ["dedicated-hardware", "restorable-location"],
+        "architectures": ["arm64"],
+        "macos_major_versions": [26],
+        "identity_fields": ["environment_class", "architecture", "macos_version", "macos_build"]
+      },
+      "hardware": {
+        "required": true,
+        "classes": ["usb-bluray-drive"],
+        "identity_fields": ["vendor_id", "product_id", "transport", "makemkv_version"]
+      },
+      "cadence": {"first_rc": false, "stable_candidate": true},
+      "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
+      "invalidates_on": {
+        "paths": ["bd_to_avp/modules/disc.py", "bd_to_avp/modules/config.py", "bd_to_avp/modules/video*.py"],
+        "contracts": ["packaged-worker", "conversion-ownership", "subtitle-recovery", "storage-capacity", "tier3-evidence"]
+      },
+      "allowed_evidence_sources": ["tier3_operator_receipt"],
+      "required_assertions": [
+        "protected-source-opened",
+        "conversion-completed",
+        "output-verified",
+        "recovery-clean"
+      ],
+      "allowed_evidence_kinds": ["conversion-result", "diagnostic-summary", "cleanup"],
+      "allowed_cleanup_results": ["recovered", "restored"],
+      "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "tier": 3,
+      "blocking_phase": "milestone",
+      "automation_lane": "operator-vision-pro",
+      "execution_mode": "operator_assisted",
+      "environment": {
+        "classes": ["dedicated-hardware", "restorable-location"],
+        "architectures": ["arm64"],
+        "macos_major_versions": [26],
+        "identity_fields": ["environment_class", "architecture", "macos_version", "macos_build"]
+      },
+      "hardware": {
+        "required": true,
+        "classes": ["vision-pro"],
+        "identity_fields": ["model_family", "chip_family", "visionos_major"]
+      },
+      "cadence": {"first_rc": false, "stable_candidate": true},
+      "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
+      "invalidates_on": {
+        "paths": ["scripts/add_spatial_video_metadata.py", "scripts/verify_apple_media.py"],
+        "contracts": ["vision-pro-playback", "packaged-worker", "tier3-evidence"]
+      },
+      "allowed_evidence_sources": ["tier3_operator_receipt"],
+      "required_assertions": [
+        "artifact-transferred",
+        "stereo-playback-started",
+        "spatial-presentation-verified",
+        "playback-completed"
+      ],
+      "allowed_evidence_kinds": ["device-probe", "playback-result"],
+      "allowed_cleanup_results": ["not-applicable", "recovered"],
       "carry_forward": {"allowed": true, "requires_prior_accepted_receipt": true, "requires_clean_invalidation": true}
     },
     {

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -35,8 +35,9 @@ names a stable policy case, evidence source, source SHA, acceptance timestamp,
 repository-relative reference, and SHA-256 digest. The referenced receipt must
 be committed in the current repository `HEAD`, so an untracked local file can
 never satisfy release preparation. Tier 1 receipts additionally record a
-successful workflow conclusion and positive release-run ID. Tier 3 receipts
-must name every hardware/environment requirement declared by the case.
+successful workflow conclusion and positive release-run ID. Tier 3 evidence
+references a checked `bd-to-avp-tier3-qualification` receipt that is validated
+against the selected case and its exact checked release receipt.
 
 Use `--require-evidence` during release preparation. It exits with status `2`
 when any case applicable to the selected workflow phase remains a blocking
@@ -59,6 +60,47 @@ direct invalidation patterns or referenced contracts. RC3 migration overrides
 keep its Sparkle, accessibility, PGS, and subtitle-diagnostic checks fresh.
 Tier 1 invalidation mappings document release-engine ownership only; Tier 1
 always requires a new exact-candidate receipt and never carries.
+
+## Tier 3 Cadence And Receipts
+
+Tier 3 is risk- and cadence-based, not a blanket prerelease matrix. Each case
+declares its automation lane, automated or operator-assisted execution mode,
+allowed macOS environment classes and architecture, required public-safe
+hardware fields, first-RC and Stable cadence, expiry, invalidating contracts,
+assertions, evidence digest kinds, and cleanup outcomes.
+
+The classifier requires Tier 3 evidence only when one of these triggers applies:
+
+- the case declares the first candidate of an RC cycle;
+- the case declares a Stable candidate;
+- checked evidence has passed its receipt-declared expiry; or
+- mapped code, packaging, UI, updater, runtime, or playback paths changed.
+
+An ordinary alpha, beta, or later RC remains non-applicable when a case is not
+expired or invalidated. Valid prior evidence carries without becoming a
+blocking requirement. The report exposes the deterministic trigger for every
+case (`first_rc`, `stable_candidate`, `expired`, `invalidated`, `cadence_valid`,
+or `not_due`).
+
+Tier 3 receipts bind the release source SHA, tag, route, versions, signed app
+tree, DMG/checksum/appcast digests, and both semantic and file digests of the
+checked release receipt. Environment identity is limited to environment class,
+architecture, public macOS version, and public Apple build. Hardware identity
+uses only the bounded field names declared by policy; hostnames, usernames,
+paths, volume or disc titles, serials, tokens, media, and free-form logs are not
+accepted. Evidence is represented by at most eight named SHA-256 digests.
+
+Validate a checked Tier 3 receipt offline with:
+
+```sh
+uv run python -m scripts.tier3_receipt \
+  --case-id clean-machine-signed-update \
+  --receipt path/to/tier3-receipt.json
+```
+
+Passed receipts require every declared assertion to pass. Failed, skipped, and
+not-applicable receipts remain valid audit records with explicit bounded reason
+codes, but only a passed receipt may be indexed as accepted release evidence.
 
 ## Release Engine Receipts
 

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -19,6 +19,7 @@ from scripts.release_receipt import (
     ReleaseReceiptError,
     load_validated_artifact_receipt,
 )
+from scripts.tier3_receipt import Tier3ReceiptError, load_validated_receipt_bytes
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -27,6 +28,24 @@ SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 RESULT_STATES = ("covered", "carry", "retest", "external")
 WORKFLOW_PHASES = ("preparation", "artifact")
+TIER3_EXECUTION_MODES = {"automated", "operator_assisted"}
+TIER3_ENVIRONMENT_IDENTITY_FIELDS = {
+    "environment_class",
+    "architecture",
+    "macos_version",
+    "macos_build",
+}
+TIER3_FORBIDDEN_IDENTITY_FIELDS = {
+    "disc",
+    "hostname",
+    "media",
+    "path",
+    "serial",
+    "title",
+    "token",
+    "username",
+    "volume",
+}
 
 
 class QualificationScopeError(RuntimeError):
@@ -154,15 +173,102 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
             )
         if tier == 3:
             cadence = _mapping(case.get("cadence"), f"qualification case {case_id!r} cadence")
-            max_age_days = cadence.get("max_age_days")
-            if not isinstance(max_age_days, int) or isinstance(max_age_days, bool) or max_age_days <= 0:
-                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires positive max_age_days.")
-            if not isinstance(cadence.get("first_rc_or_stable_candidate"), bool):
+            if set(cadence) != {"first_rc", "stable_candidate"}:
                 raise QualificationScopeError(
-                    f"Tier 3 qualification case {case_id!r} requires boolean first_rc_or_stable_candidate."
+                    f"Tier 3 qualification case {case_id!r} cadence must declare first_rc and stable_candidate."
                 )
-            if not _strings(cadence.get("hardware"), f"Tier 3 qualification case {case_id!r} hardware"):
-                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires hardware metadata.")
+            if not isinstance(cadence.get("first_rc"), bool) or not isinstance(cadence.get("stable_candidate"), bool):
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} cadence values must be boolean.")
+            expiry = _mapping(case.get("evidence_expiry"), f"qualification case {case_id!r} evidence_expiry")
+            if set(expiry) != {"basis", "max_age_days"} or expiry.get("basis") != "completed_at":
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} expiry must be based on completed_at."
+                )
+            max_age_days = expiry.get("max_age_days")
+            if not isinstance(max_age_days, int) or isinstance(max_age_days, bool) or max_age_days <= 0:
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} requires positive evidence expiry max_age_days."
+                )
+            lane = case.get("automation_lane")
+            if not isinstance(lane, str) or not lane:
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires automation_lane.")
+            execution_mode = case.get("execution_mode")
+            if execution_mode not in TIER3_EXECUTION_MODES:
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} execution_mode must be automated or operator_assisted."
+                )
+            expected_source = {
+                "automated": "tier3_automation_receipt",
+                "operator_assisted": "tier3_operator_receipt",
+            }[cast(str, execution_mode)]
+            if evidence_sources != (expected_source,):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} must use {expected_source!r} evidence."
+                )
+            environment = _mapping(case.get("environment"), f"qualification case {case_id!r} environment")
+            if set(environment) != {"classes", "architectures", "macos_major_versions", "identity_fields"}:
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} environment metadata is incomplete."
+                )
+            if not _strings(environment.get("classes"), f"Tier 3 qualification case {case_id!r} environment classes"):
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} requires environment classes.")
+            if not _strings(
+                environment.get("architectures"),
+                f"Tier 3 qualification case {case_id!r} environment architectures",
+            ):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} requires environment architectures."
+                )
+            major_versions = _sequence(
+                environment.get("macos_major_versions"),
+                f"Tier 3 qualification case {case_id!r} macOS major versions",
+            )
+            if not major_versions or any(
+                not isinstance(version, int) or isinstance(version, bool) or version <= 0 for version in major_versions
+            ):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} requires positive macOS major versions."
+                )
+            if (
+                set(
+                    _strings(
+                        environment.get("identity_fields"),
+                        f"Tier 3 qualification case {case_id!r} environment identity fields",
+                    )
+                )
+                != TIER3_ENVIRONMENT_IDENTITY_FIELDS
+            ):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} must use the public-safe environment identity fields."
+                )
+            hardware = _mapping(case.get("hardware"), f"qualification case {case_id!r} hardware")
+            if set(hardware) != {"required", "classes", "identity_fields"} or not isinstance(
+                hardware.get("required"), bool
+            ):
+                raise QualificationScopeError(f"Tier 3 qualification case {case_id!r} hardware metadata is incomplete.")
+            hardware_classes = _strings(
+                hardware.get("classes"),
+                f"Tier 3 qualification case {case_id!r} hardware classes",
+            )
+            hardware_fields = _strings(
+                hardware.get("identity_fields"),
+                f"Tier 3 qualification case {case_id!r} hardware identity fields",
+            )
+            if cast(bool, hardware["required"]) != bool(hardware_classes and hardware_fields):
+                raise QualificationScopeError(
+                    f"Tier 3 qualification case {case_id!r} required hardware needs classes and identity fields."
+                )
+            for field in hardware_fields:
+                if any(forbidden in field.lower() for forbidden in TIER3_FORBIDDEN_IDENTITY_FIELDS):
+                    raise QualificationScopeError(
+                        f"Tier 3 qualification case {case_id!r} hardware field {field!r} is not public-safe."
+                    )
+            for field in ("required_assertions", "allowed_evidence_kinds", "allowed_cleanup_results"):
+                values = _strings(case.get(field), f"Tier 3 qualification case {case_id!r} {field}")
+                if not values or len(values) != len(set(values)):
+                    raise QualificationScopeError(
+                        f"Tier 3 qualification case {case_id!r} {field} must contain unique values."
+                    )
     return policy
 
 
@@ -310,6 +416,7 @@ def _parse_accepted_at(value: object, case_id: str) -> datetime:
 def _validated_receipts(
     evidence: Mapping[str, Any],
     cases_by_id: Mapping[str, Mapping[str, Any]],
+    policy_id: str,
     reference_content: ReferenceContent,
     as_of: date,
 ) -> dict[str, list[Mapping[str, Any]]]:
@@ -351,15 +458,6 @@ def _validated_receipts(
             run_id = receipt.get("release_run_id")
             if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
                 raise QualificationScopeError(f"Tier 1 case {case_id!r} requires a positive release_run_id.")
-        if tier == 3:
-            cadence = _mapping(case["cadence"], f"case {case_id!r} cadence")
-            required_hardware = set(_strings(cadence["hardware"], f"case {case_id!r} hardware"))
-            receipt_hardware = set(_strings(receipt.get("hardware"), f"evidence for {case_id!r} hardware"))
-            if not required_hardware.issubset(receipt_hardware):
-                raise QualificationScopeError(
-                    f"Evidence for {case_id!r} does not cover required hardware: "
-                    f"{sorted(required_hardware - receipt_hardware)!r}."
-                )
         reference = receipt.get("reference")
         digest = receipt.get("sha256")
         if (
@@ -372,14 +470,47 @@ def _validated_receipts(
         if not isinstance(digest, str) or SHA256_PATTERN.fullmatch(digest) is None:
             raise QualificationScopeError(f"Evidence for {case_id!r} requires a lowercase SHA-256 digest.")
         try:
-            actual_digest = hashlib.sha256(reference_content(reference)).hexdigest()
+            reference_bytes = reference_content(reference)
+            actual_digest = hashlib.sha256(reference_bytes).hexdigest()
         except OSError as error:
             raise QualificationScopeError(f"Unable to read evidence reference {reference!r}: {error}") from error
         if actual_digest != digest:
             raise QualificationScopeError(
                 f"Evidence reference {reference!r} does not match its recorded SHA-256 digest."
             )
-        receipts[case_id].append(receipt)
+        validated_receipt = dict(receipt)
+        if tier == 3:
+            try:
+                tier3_receipt = load_validated_receipt_bytes(
+                    reference_bytes,
+                    policy_id=policy_id,
+                    case=case,
+                    reference_content=reference_content,
+                )
+            except Tier3ReceiptError as error:
+                raise QualificationScopeError(f"Tier 3 evidence for {case_id!r} is invalid: {error}") from error
+            result = _mapping(tier3_receipt.get("result"), f"Tier 3 evidence for {case_id!r} result")
+            if result.get("status") != "passed":
+                raise QualificationScopeError(f"Accepted Tier 3 evidence for {case_id!r} must have passed.")
+            release_identity = _mapping(
+                tier3_receipt.get("release_identity"),
+                f"Tier 3 evidence for {case_id!r} release identity",
+            )
+            if release_identity.get("source_sha") != source_sha:
+                raise QualificationScopeError(
+                    f"Tier 3 evidence for {case_id!r} source_sha does not match its release receipt."
+                )
+            timestamps = _mapping(
+                tier3_receipt.get("timestamps"),
+                f"Tier 3 evidence for {case_id!r} timestamps",
+            )
+            completed_at = _parse_accepted_at(timestamps.get("completed_at"), case_id)
+            if accepted_at < completed_at:
+                raise QualificationScopeError(
+                    f"Tier 3 evidence for {case_id!r} cannot be accepted before it completed."
+                )
+            validated_receipt["_tier3_receipt"] = tier3_receipt
+        receipts[case_id].append(validated_receipt)
     for case_receipts in receipts.values():
         case_receipts.sort(
             key=lambda receipt: (
@@ -405,11 +536,25 @@ def _matching_paths(changed_paths: set[str], patterns: Sequence[str]) -> list[st
 def _receipt_summary(receipt: Mapping[str, Any] | None) -> dict[str, Any]:
     if receipt is None:
         return {"receipt_id": None, "reference": None, "source_sha": None}
-    return {
+    summary = {
         "receipt_id": receipt["receipt_id"],
         "reference": receipt["reference"],
         "source_sha": receipt["source_sha"],
     }
+    tier3_receipt = receipt.get("_tier3_receipt")
+    if isinstance(tier3_receipt, Mapping):
+        cadence = _mapping(tier3_receipt.get("cadence"), "Tier 3 receipt cadence")
+        environment = _mapping(tier3_receipt.get("environment"), "Tier 3 receipt environment")
+        hardware = _mapping(tier3_receipt.get("hardware"), "Tier 3 receipt hardware")
+        summary.update(
+            {
+                "expires_on": cadence["expires_on"],
+                "environment_class": environment["environment_class"],
+                "hardware_class": hardware["class"],
+                "tier3_receipt_sha256": tier3_receipt["receipt_sha256"],
+            }
+        )
+    return summary
 
 
 def _artifact_receipt_summary(receipt: Mapping[str, Any], path: Path) -> dict[str, Any]:
@@ -420,10 +565,36 @@ def _artifact_receipt_summary(receipt: Mapping[str, Any], path: Path) -> dict[st
     }
 
 
+def _tier3_expiry(receipt: Mapping[str, Any], case_id: str) -> date:
+    tier3_receipt = _mapping(receipt.get("_tier3_receipt"), f"Tier 3 evidence for {case_id!r}")
+    cadence = _mapping(tier3_receipt.get("cadence"), f"Tier 3 evidence for {case_id!r} cadence")
+    expires_on = cadence.get("expires_on")
+    if not isinstance(expires_on, str):
+        raise QualificationScopeError(f"Tier 3 evidence for {case_id!r} requires expires_on.")
+    try:
+        return date.fromisoformat(expires_on)
+    except ValueError as error:
+        raise QualificationScopeError(f"Tier 3 evidence for {case_id!r} has invalid expires_on.") from error
+
+
+def _tier3_milestone_trigger(
+    case: Mapping[str, Any],
+    *,
+    release_stage: str,
+    first_candidate_of_cycle: bool,
+) -> str | None:
+    cadence = _mapping(case["cadence"], f"case {case['id']!r} cadence")
+    if release_stage == "stable" and cadence.get("stable_candidate") is True:
+        return "stable_candidate"
+    if release_stage == "rc" and first_candidate_of_cycle and cadence.get("first_rc") is True:
+        return "first_rc"
+    return None
+
+
 def _evidence_requirement(
     case: Mapping[str, Any],
     *,
-    status: str,
+    required: bool,
     applicable: bool,
     deferred: bool,
 ) -> dict[str, Any]:
@@ -438,7 +609,6 @@ def _evidence_requirement(
         binding = "exact_candidate_or_valid_carry_forward"
     else:
         binding = "post_publication_observation"
-    required = status == "retest"
     action: str | None = None
     if required:
         timing = "before the artifact phase" if deferred else "before this phase can pass"
@@ -484,6 +654,7 @@ def classify_release_scope(
     receipt_map = _validated_receipts(
         evidence,
         cases_by_id,
+        cast(str, policy["policy_id"]),
         reference_content or git_checked_reference_content(repo),
         as_of,
     )
@@ -534,29 +705,62 @@ def classify_release_scope(
         reason: str
         invalidating_paths: list[str] = []
         selected_receipt: Mapping[str, Any] | None = exact or prior
+        trigger = "policy"
+        tier3_milestone = (
+            _tier3_milestone_trigger(
+                case,
+                release_stage=release_stage,
+                first_candidate_of_cycle=first_candidate_of_cycle,
+            )
+            if tier == 3
+            else None
+        )
+        tier3_applicable = tier != 3 or tier3_milestone is not None
 
         if tier == 0:
             status, reason = "covered", "Owned by the automatic per-commit quality gate."
+            trigger = "per_commit"
         elif tier == 4:
             status, reason = "external", "Post-publication field evidence cannot block publication."
+            trigger = "post_publication"
         elif tier == 1 and case_id in artifact_tier1_cases:
             status, reason = "covered", "Validated evidence is bound to the exact artifact workflow run and release."
             selected_receipt = None
+            trigger = "exact_artifact"
         elif exact is not None:
-            status, reason = "covered", "Accepted evidence is bound to the exact candidate SHA."
+            if tier == 3 and as_of > _tier3_expiry(exact, case_id):
+                status, reason = "retest", "Tier 3 evidence exceeded its declared expiry."
+                trigger = "expired"
+                tier3_applicable = True
+            else:
+                status, reason = "covered", "Accepted evidence is bound to the exact candidate SHA."
+                trigger = tier3_milestone or "exact_candidate"
         elif tier == 1:
             status, reason = "retest", "The guarded release engine has no accepted receipt for the exact candidate SHA."
             selected_receipt = None
+            trigger = "missing_exact_artifact"
         elif fresh_retest.get(case_id, False):
             status, reason = "retest", "The candidate migration explicitly requires fresh targeted evidence."
             selected_receipt = None
+            trigger = "explicit_retest"
+            tier3_applicable = True
         elif prior is None:
-            status, reason = "retest", "No accepted prior evidence receipt is available for carry-forward."
+            selected_receipt = None
+            if tier == 3 and tier3_milestone is None:
+                status = "retest"
+                reason = "Tier 3 evidence is not due for this release stage and has no prior receipt to carry."
+                trigger = "not_due"
+                tier3_applicable = False
+            else:
+                status, reason = "retest", "No accepted prior evidence receipt is available for carry-forward."
+                trigger = tier3_milestone or "missing_prior_evidence"
+                tier3_applicable = True
         else:
             carry = _mapping(case["carry_forward"], f"case {case_id!r} carry_forward")
             if not carry["allowed"]:
                 status, reason = "retest", "The policy does not allow this evidence to carry forward."
                 selected_receipt = None
+                trigger = "carry_disallowed"
             else:
                 patterns = _case_patterns(case, contracts)
                 invalidating_paths = _matching_paths(
@@ -565,28 +769,32 @@ def classify_release_scope(
                 )
                 if invalidating_paths:
                     status, reason = "retest", "Candidate changes invalidate the accepted prior evidence."
+                    trigger = "invalidated"
+                    tier3_applicable = True
                 elif tier == 3:
-                    cadence = _mapping(case["cadence"], f"case {case_id!r} cadence")
-                    accepted_date = _parse_accepted_at(prior["accepted_at"], case_id).date()
-                    age_days = (as_of - accepted_date).days
-                    due_for_milestone = bool(cadence.get("first_rc_or_stable_candidate")) and (
-                        release_stage == "stable" or (release_stage == "rc" and first_candidate_of_cycle)
-                    )
-                    if due_for_milestone:
+                    if tier3_milestone is not None:
                         status, reason = "retest", "Tier 3 evidence is due for this release milestone."
-                    elif age_days > cast(int, cadence["max_age_days"]):
-                        status, reason = "retest", "Tier 3 evidence exceeded its maximum age."
+                        trigger = tier3_milestone
+                        tier3_applicable = True
+                    elif as_of > _tier3_expiry(prior, case_id):
+                        status, reason = "retest", "Tier 3 evidence exceeded its declared expiry."
+                        trigger = "expired"
+                        tier3_applicable = True
                     else:
                         status, reason = (
                             "carry",
                             "Tier 3 evidence remains within cadence and no invalidating paths changed.",
                         )
+                        trigger = "cadence_valid"
+                        tier3_applicable = False
                 else:
                     status, reason = "carry", "Accepted prior evidence remains valid because no mapped paths changed."
+                    trigger = "clean_invalidation"
 
         blocking_phase = cast(str, case["blocking_phase"])
         deferred = workflow_phase == "preparation" and blocking_phase == "publication"
-        applicable = blocking_phase != "none" and not deferred
+        applicable = blocking_phase != "none" and not deferred and tier3_applicable
+        evidence_required = status == "retest" and (tier != 3 or tier3_applicable)
         evidence_summary = (
             artifact_receipt_evidence
             if tier == 1 and case_id in artifact_tier1_cases and artifact_receipt_evidence is not None
@@ -600,13 +808,14 @@ def classify_release_scope(
             "blocking": blocking_phase != "none",
             "applicable": applicable,
             "deferred": deferred,
+            "trigger": trigger,
             "reason": reason,
             "invalidating_paths": invalidating_paths,
             "evidence": evidence_summary,
-            "evidence_required": status == "retest",
+            "evidence_required": evidence_required,
             "evidence_requirement": _evidence_requirement(
                 case,
-                status=status,
+                required=evidence_required,
                 applicable=applicable,
                 deferred=deferred,
             ),

--- a/scripts/tier3_receipt.py
+++ b/scripts/tier3_receipt.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.release_receipt import ReleaseReceiptError, validate_receipt as validate_release_receipt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_PATH = REPO_ROOT / "docs" / "qualification" / "release-qualification-policy-v1.json"
+RECEIPT_TYPE = "bd-to-avp-tier3-qualification"
+SCHEMA_VERSION = 1
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_IDENTITY_VALUE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
+MACOS_VERSION_PATTERN = re.compile(r"^(?P<major>[0-9]{1,2})(?:\.[0-9]{1,2}){1,2}$")
+MACOS_BUILD_PATTERN = re.compile(r"^[0-9]{2}[A-Z][0-9A-Za-z]{1,12}$")
+RESULT_STATUSES = {"passed", "failed", "skipped", "not_applicable"}
+ASSERTION_STATUSES = {"passed", "failed", "not_run"}
+FORBIDDEN_IDENTITY_FIELDS = {
+    "disc",
+    "hostname",
+    "media",
+    "path",
+    "serial",
+    "title",
+    "token",
+    "username",
+    "volume",
+}
+
+
+class Tier3ReceiptError(RuntimeError):
+    pass
+
+
+ReferenceContent = Callable[[str], bytes]
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise Tier3ReceiptError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise Tier3ReceiptError(f"{description} must be a JSON array.")
+    return value
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise Tier3ReceiptError(
+            f"{description} keys changed; missing={sorted(expected - actual)}, extra={sorted(actual - expected)}."
+        )
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise Tier3ReceiptError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _strings(value: object, description: str) -> tuple[str, ...]:
+    items = _sequence(value, description)
+    if not all(isinstance(item, str) and item for item in items):
+        raise Tier3ReceiptError(f"{description} must contain non-empty strings.")
+    return tuple(cast(str, item) for item in items)
+
+
+def _boolean(value: object, description: str) -> bool:
+    if not isinstance(value, bool):
+        raise Tier3ReceiptError(f"{description} must be a boolean.")
+    return value
+
+
+def _positive_integer(value: object, description: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise Tier3ReceiptError(f"{description} must be a positive integer.")
+    return value
+
+
+def _sha256(value: object, description: str) -> str:
+    digest = _string(value, description)
+    if SHA256_PATTERN.fullmatch(digest) is None:
+        raise Tier3ReceiptError(f"{description} must be a lowercase SHA-256 digest.")
+    return digest
+
+
+def _optional_sha256(value: object, description: str) -> str | None:
+    if value is None:
+        return None
+    return _sha256(value, description)
+
+
+def _relative_reference(value: object, description: str) -> str:
+    reference = _string(value, description)
+    path = Path(reference)
+    if path.is_absolute() or ".." in path.parts or reference.startswith("./"):
+        raise Tier3ReceiptError(f"{description} must be a repository-relative path.")
+    return reference
+
+
+def _timestamp(value: object, description: str) -> datetime:
+    text = _string(value, description)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise Tier3ReceiptError(f"{description} must be an ISO-8601 timestamp.") from error
+    if parsed.tzinfo is None:
+        raise Tier3ReceiptError(f"{description} must include a timezone.")
+    return parsed.astimezone(timezone.utc)
+
+
+def _date(value: object, description: str) -> date:
+    text = _string(value, description)
+    try:
+        return date.fromisoformat(text)
+    except ValueError as error:
+        raise Tier3ReceiptError(f"{description} must be an ISO-8601 date.") from error
+
+
+def canonical_payload_bytes(receipt: Mapping[str, Any]) -> bytes:
+    payload = dict(receipt)
+    payload.pop("receipt_sha256", None)
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def receipt_sha256(receipt: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_payload_bytes(receipt)).hexdigest()
+
+
+def _artifact_digests(release_receipt: Mapping[str, Any]) -> dict[str, str]:
+    artifacts: dict[str, str] = {}
+    for raw_artifact in _sequence(release_receipt.get("artifacts"), "release receipt artifacts"):
+        artifact = _mapping(raw_artifact, "release receipt artifact")
+        kind = _string(artifact.get("kind"), "release receipt artifact kind")
+        artifacts[kind] = _sha256(artifact.get("sha256"), f"release receipt {kind} sha256")
+    if set(artifacts) != {"appcast", "checksum", "dmg"}:
+        raise Tier3ReceiptError("Release receipt must contain appcast, checksum, and DMG artifacts.")
+    return dict(sorted(artifacts.items()))
+
+
+def _release_identity(
+    release_receipt: Mapping[str, Any],
+    *,
+    reference: str,
+    file_sha256: str,
+) -> dict[str, Any]:
+    try:
+        validate_release_receipt(release_receipt)
+    except ReleaseReceiptError as error:
+        raise Tier3ReceiptError(f"Referenced release receipt is invalid: {error}") from error
+    release = _mapping(release_receipt.get("release"), "release receipt release")
+    return {
+        "artifact_sha256": _artifact_digests(release_receipt),
+        "release_receipt": {
+            "file_sha256": _sha256(file_sha256, "release receipt file_sha256"),
+            "receipt_sha256": _sha256(release_receipt.get("receipt_sha256"), "release receipt receipt_sha256"),
+            "reference": _relative_reference(reference, "release receipt reference"),
+        },
+        "release_route": _string(release_receipt.get("release_route"), "release receipt release_route"),
+        "release_tag": _string(release.get("tag"), "release receipt release tag"),
+        "signed_app_tree_sha256": _sha256(
+            release_receipt.get("signed_app_tree_sha256"),
+            "release receipt signed_app_tree_sha256",
+        ),
+        "source_sha": _string(release_receipt.get("source_sha"), "release receipt source_sha"),
+        "versions": dict(_mapping(release_receipt.get("versions"), "release receipt versions")),
+    }
+
+
+def _safe_identity(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SAFE_IDENTITY_VALUE_PATTERN.fullmatch(text) is None:
+        raise Tier3ReceiptError(
+            f"{description} must be a bounded public-safe identifier without spaces, paths, or free-form text."
+        )
+    return text
+
+
+def _case_metadata(case: Mapping[str, Any]) -> tuple[str, str, Mapping[str, Any], Mapping[str, Any]]:
+    case_id = _string(case.get("id"), "Tier 3 case id")
+    if case.get("tier") != 3:
+        raise Tier3ReceiptError(f"Case {case_id!r} is not Tier 3.")
+    lane = _string(case.get("automation_lane"), f"case {case_id!r} automation_lane")
+    execution_mode = _string(case.get("execution_mode"), f"case {case_id!r} execution_mode")
+    if execution_mode not in {"automated", "operator_assisted"}:
+        raise Tier3ReceiptError(f"Case {case_id!r} execution_mode is unsupported.")
+    environment = _mapping(case.get("environment"), f"case {case_id!r} environment")
+    hardware = _mapping(case.get("hardware"), f"case {case_id!r} hardware")
+    return lane, execution_mode, environment, hardware
+
+
+def build_receipt(
+    facts: Mapping[str, Any],
+    *,
+    policy_id: str,
+    case: Mapping[str, Any],
+    release_receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    lane, execution_mode, _, _ = _case_metadata(case)
+    completed_at = _timestamp(facts.get("completed_at"), "completed_at")
+    expiry = _mapping(case.get("evidence_expiry"), f"case {case['id']!r} evidence_expiry")
+    max_age_days = _positive_integer(expiry.get("max_age_days"), "evidence_expiry.max_age_days")
+    receipt: dict[str, Any] = {
+        "assertions": [
+            {"id": assertion_id, "status": assertion_status}
+            for assertion_id, assertion_status in sorted(
+                _mapping(facts.get("assertions"), "assertions").items(),
+                key=lambda item: str(item[0]),
+            )
+        ],
+        "automation_lane": lane,
+        "cadence": {
+            "expires_on": (completed_at.date() + timedelta(days=max_age_days)).isoformat(),
+            "expiry_basis": _string(expiry.get("basis"), "evidence_expiry.basis"),
+            "first_rc": _boolean(_mapping(case["cadence"], "case cadence").get("first_rc"), "cadence.first_rc"),
+            "max_age_days": max_age_days,
+            "stable_candidate": _boolean(
+                _mapping(case["cadence"], "case cadence").get("stable_candidate"),
+                "cadence.stable_candidate",
+            ),
+        },
+        "case_id": _string(case.get("id"), "case id"),
+        "cleanup": dict(_mapping(facts.get("cleanup"), "cleanup")),
+        "environment": dict(_mapping(facts.get("environment"), "environment")),
+        "evidence": [dict(_mapping(item, "evidence item")) for item in _sequence(facts.get("evidence"), "evidence")],
+        "evidence_source": _string(facts.get("evidence_source"), "evidence_source"),
+        "execution_mode": execution_mode,
+        "hardware": dict(_mapping(facts.get("hardware"), "hardware")),
+        "policy_id": _string(policy_id, "policy_id"),
+        "receipt_type": RECEIPT_TYPE,
+        "release_identity": _release_identity(
+            release_receipt,
+            reference=_relative_reference(facts.get("release_receipt_reference"), "release_receipt_reference"),
+            file_sha256=_sha256(facts.get("release_receipt_file_sha256"), "release_receipt_file_sha256"),
+        ),
+        "result": dict(_mapping(facts.get("result"), "result")),
+        "schema_version": SCHEMA_VERSION,
+        "timestamps": {
+            "completed_at": _string(facts.get("completed_at"), "completed_at"),
+            "started_at": _string(facts.get("started_at"), "started_at"),
+        },
+    }
+    receipt["receipt_sha256"] = receipt_sha256(receipt)
+    return receipt
+
+
+def _validate_environment(environment: Mapping[str, Any], case_environment: Mapping[str, Any]) -> None:
+    required_fields = set(_strings(case_environment.get("identity_fields"), "environment identity_fields"))
+    _exact_keys(environment, required_fields, "Tier 3 environment")
+    environment_class = _safe_identity(environment.get("environment_class"), "environment.environment_class")
+    if environment_class not in set(_strings(case_environment.get("classes"), "environment classes")):
+        raise Tier3ReceiptError("Tier 3 environment class is not allowed by the case.")
+    architecture = _safe_identity(environment.get("architecture"), "environment.architecture")
+    if architecture not in set(_strings(case_environment.get("architectures"), "environment architectures")):
+        raise Tier3ReceiptError("Tier 3 environment architecture is not allowed by the case.")
+    macos_version = _safe_identity(environment.get("macos_version"), "environment.macos_version")
+    match = MACOS_VERSION_PATTERN.fullmatch(macos_version)
+    if match is None:
+        raise Tier3ReceiptError("environment.macos_version must be a public major.minor version.")
+    allowed_majors = set(_sequence(case_environment.get("macos_major_versions"), "environment macOS major versions"))
+    if int(match.group("major")) not in allowed_majors:
+        raise Tier3ReceiptError("Tier 3 environment macOS major version is not allowed by the case.")
+    macos_build = _safe_identity(environment.get("macos_build"), "environment.macos_build")
+    if MACOS_BUILD_PATTERN.fullmatch(macos_build) is None:
+        raise Tier3ReceiptError("environment.macos_build must be a public Apple build identifier.")
+
+
+def _validate_hardware(hardware: Mapping[str, Any], case_hardware: Mapping[str, Any]) -> None:
+    _exact_keys(hardware, {"class", "identity"}, "Tier 3 hardware")
+    required = _boolean(case_hardware.get("required"), "case hardware.required")
+    hardware_class = _safe_identity(hardware.get("class"), "hardware.class")
+    identity = _mapping(hardware.get("identity"), "hardware.identity")
+    if not required:
+        if hardware_class != "none" or identity:
+            raise Tier3ReceiptError("A case without required hardware must record class 'none' and empty identity.")
+        return
+    if hardware_class not in set(_strings(case_hardware.get("classes"), "case hardware classes")):
+        raise Tier3ReceiptError("Tier 3 hardware class is not allowed by the case.")
+    required_fields = set(_strings(case_hardware.get("identity_fields"), "case hardware identity_fields"))
+    _exact_keys(identity, required_fields, "Tier 3 hardware identity")
+    for field, raw_value in identity.items():
+        lowered = str(field).lower()
+        if any(forbidden in lowered for forbidden in FORBIDDEN_IDENTITY_FIELDS):
+            raise Tier3ReceiptError(f"Tier 3 hardware identity field {field!r} is not public-safe.")
+        _safe_identity(raw_value, f"hardware.identity.{field}")
+
+
+def _validate_assertions(
+    assertions: Sequence[Any],
+    case: Mapping[str, Any],
+    result_status: str,
+) -> None:
+    required_ids = set(_strings(case.get("required_assertions"), "case required_assertions"))
+    observed: dict[str, str] = {}
+    for index, raw_assertion in enumerate(assertions):
+        assertion = _mapping(raw_assertion, f"assertion {index}")
+        _exact_keys(assertion, {"id", "status"}, f"assertion {index}")
+        assertion_id = _safe_identity(assertion.get("id"), f"assertion {index} id")
+        status = _string(assertion.get("status"), f"assertion {index} status")
+        if status not in ASSERTION_STATUSES:
+            raise Tier3ReceiptError(f"Tier 3 assertion {assertion_id!r} has unsupported status {status!r}.")
+        if assertion_id in observed:
+            raise Tier3ReceiptError(f"Tier 3 assertion ID {assertion_id!r} is duplicated.")
+        observed[assertion_id] = status
+    if set(observed) != required_ids:
+        raise Tier3ReceiptError("Tier 3 receipt assertions do not match the case's required assertions.")
+    if result_status == "passed" and set(observed.values()) != {"passed"}:
+        raise Tier3ReceiptError("A passed Tier 3 receipt requires every assertion to pass.")
+    if result_status == "failed" and "failed" not in observed.values():
+        raise Tier3ReceiptError("A failed Tier 3 receipt requires at least one failed assertion.")
+    if result_status in {"skipped", "not_applicable"} and set(observed.values()) != {"not_run"}:
+        raise Tier3ReceiptError("Skipped or not-applicable Tier 3 receipts must mark every assertion not_run.")
+
+
+def validate_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    policy_id: str,
+    case: Mapping[str, Any],
+    reference_content: ReferenceContent,
+) -> None:
+    _exact_keys(
+        receipt,
+        {
+            "assertions",
+            "automation_lane",
+            "cadence",
+            "case_id",
+            "cleanup",
+            "environment",
+            "evidence",
+            "evidence_source",
+            "execution_mode",
+            "hardware",
+            "policy_id",
+            "receipt_sha256",
+            "receipt_type",
+            "release_identity",
+            "result",
+            "schema_version",
+            "timestamps",
+        },
+        "Tier 3 receipt",
+    )
+    if receipt.get("schema_version") != SCHEMA_VERSION or receipt.get("receipt_type") != RECEIPT_TYPE:
+        raise Tier3ReceiptError("Unsupported Tier 3 receipt schema or type.")
+    if receipt.get("policy_id") != policy_id:
+        raise Tier3ReceiptError("Tier 3 receipt policy_id does not match the active policy.")
+    lane, execution_mode, case_environment, case_hardware = _case_metadata(case)
+    if receipt.get("case_id") != case.get("id"):
+        raise Tier3ReceiptError("Tier 3 receipt case_id does not match the selected case.")
+    if receipt.get("automation_lane") != lane or receipt.get("execution_mode") != execution_mode:
+        raise Tier3ReceiptError("Tier 3 receipt lane or execution mode does not match policy.")
+    allowed_sources = _strings(case.get("allowed_evidence_sources"), "case allowed_evidence_sources")
+    if receipt.get("evidence_source") not in allowed_sources:
+        raise Tier3ReceiptError("Tier 3 receipt evidence source does not match policy.")
+
+    release_identity = _mapping(receipt.get("release_identity"), "release_identity")
+    _exact_keys(
+        release_identity,
+        {
+            "artifact_sha256",
+            "release_receipt",
+            "release_route",
+            "release_tag",
+            "signed_app_tree_sha256",
+            "source_sha",
+            "versions",
+        },
+        "release_identity",
+    )
+    release_reference = _mapping(release_identity.get("release_receipt"), "release_identity.release_receipt")
+    _exact_keys(
+        release_reference,
+        {"file_sha256", "receipt_sha256", "reference"},
+        "release_identity.release_receipt",
+    )
+    reference = _relative_reference(release_reference.get("reference"), "release receipt reference")
+    try:
+        release_bytes = reference_content(reference)
+    except OSError as error:
+        raise Tier3ReceiptError(f"Unable to read referenced release receipt {reference!r}: {error}") from error
+    release_file_sha256 = hashlib.sha256(release_bytes).hexdigest()
+    if release_file_sha256 != _sha256(
+        release_reference.get("file_sha256"),
+        "release receipt file_sha256",
+    ):
+        raise Tier3ReceiptError("Referenced release receipt file digest does not match Tier 3 evidence.")
+    try:
+        release_receipt = _mapping(json.loads(release_bytes), "referenced release receipt")
+    except json.JSONDecodeError as error:
+        raise Tier3ReceiptError("Referenced release receipt is not valid JSON.") from error
+    expected_release_identity = _release_identity(
+        release_receipt,
+        reference=reference,
+        file_sha256=release_file_sha256,
+    )
+    if dict(release_identity) != expected_release_identity:
+        raise Tier3ReceiptError("Tier 3 release or artifact identity does not match the referenced release receipt.")
+
+    _validate_environment(_mapping(receipt.get("environment"), "environment"), case_environment)
+    _validate_hardware(_mapping(receipt.get("hardware"), "hardware"), case_hardware)
+
+    timestamps = _mapping(receipt.get("timestamps"), "timestamps")
+    _exact_keys(timestamps, {"completed_at", "started_at"}, "timestamps")
+    started_at = _timestamp(timestamps.get("started_at"), "timestamps.started_at")
+    completed_at = _timestamp(timestamps.get("completed_at"), "timestamps.completed_at")
+    if completed_at < started_at:
+        raise Tier3ReceiptError("Tier 3 completed_at cannot precede started_at.")
+
+    cadence = _mapping(receipt.get("cadence"), "cadence")
+    _exact_keys(cadence, {"expires_on", "expiry_basis", "first_rc", "max_age_days", "stable_candidate"}, "cadence")
+    case_cadence = _mapping(case.get("cadence"), "case cadence")
+    case_expiry = _mapping(case.get("evidence_expiry"), "case evidence_expiry")
+    max_age_days = _positive_integer(case_expiry.get("max_age_days"), "case evidence_expiry.max_age_days")
+    if cadence.get("first_rc") != case_cadence.get("first_rc") or cadence.get("stable_candidate") != case_cadence.get(
+        "stable_candidate"
+    ):
+        raise Tier3ReceiptError("Tier 3 receipt milestone cadence does not match policy.")
+    if cadence.get("expiry_basis") != case_expiry.get("basis") or cadence.get("max_age_days") != max_age_days:
+        raise Tier3ReceiptError("Tier 3 receipt expiry metadata does not match policy.")
+    expected_expiry = completed_at.date() + timedelta(days=max_age_days)
+    if _date(cadence.get("expires_on"), "cadence.expires_on") != expected_expiry:
+        raise Tier3ReceiptError("Tier 3 receipt expires_on does not match completed_at and policy max age.")
+
+    result = _mapping(receipt.get("result"), "result")
+    _exact_keys(result, {"reason_code", "status"}, "result")
+    result_status = _string(result.get("status"), "result.status")
+    if result_status not in RESULT_STATUSES:
+        raise Tier3ReceiptError("Tier 3 result.status is unsupported.")
+    reason_code = _safe_identity(result.get("reason_code"), "result.reason_code")
+    if result_status == "passed" and reason_code != "all_assertions_passed":
+        raise Tier3ReceiptError("A passed Tier 3 receipt must use all_assertions_passed.")
+    _validate_assertions(_sequence(receipt.get("assertions"), "assertions"), case, result_status)
+
+    allowed_evidence_kinds = set(_strings(case.get("allowed_evidence_kinds"), "case allowed_evidence_kinds"))
+    evidence = _sequence(receipt.get("evidence"), "evidence")
+    if len(evidence) > 8:
+        raise Tier3ReceiptError("Tier 3 receipt evidence is limited to eight bounded digests.")
+    seen_evidence: set[str] = set()
+    for index, raw_item in enumerate(evidence):
+        item = _mapping(raw_item, f"evidence {index}")
+        _exact_keys(item, {"kind", "sha256"}, f"evidence {index}")
+        kind = _safe_identity(item.get("kind"), f"evidence {index} kind")
+        _sha256(item.get("sha256"), f"evidence {index} sha256")
+        if kind not in allowed_evidence_kinds or kind in seen_evidence:
+            raise Tier3ReceiptError("Tier 3 evidence kind is unsupported or duplicated.")
+        seen_evidence.add(kind)
+    if result_status in {"passed", "failed"} and not evidence:
+        raise Tier3ReceiptError("Passed or failed Tier 3 receipts require bounded evidence digests.")
+
+    cleanup = _mapping(receipt.get("cleanup"), "cleanup")
+    _exact_keys(cleanup, {"evidence_sha256", "status"}, "cleanup")
+    cleanup_status = _safe_identity(cleanup.get("status"), "cleanup.status")
+    allowed_cleanup = set(_strings(case.get("allowed_cleanup_results"), "case allowed_cleanup_results"))
+    if cleanup_status not in allowed_cleanup:
+        raise Tier3ReceiptError("Tier 3 cleanup status is not allowed by the case.")
+    _optional_sha256(cleanup.get("evidence_sha256"), "cleanup.evidence_sha256")
+
+    expected_digest = receipt_sha256(receipt)
+    if _sha256(receipt.get("receipt_sha256"), "receipt_sha256") != expected_digest:
+        raise Tier3ReceiptError("Tier 3 receipt_sha256 does not match the canonical payload.")
+
+
+def load_validated_receipt_bytes(
+    content: bytes,
+    *,
+    policy_id: str,
+    case: Mapping[str, Any],
+    reference_content: ReferenceContent,
+) -> Mapping[str, Any]:
+    try:
+        receipt = _mapping(json.loads(content), "Tier 3 receipt")
+    except json.JSONDecodeError as error:
+        raise Tier3ReceiptError("Tier 3 receipt is not valid JSON.") from error
+    validate_receipt(receipt, policy_id=policy_id, case=case, reference_content=reference_content)
+    return receipt
+
+
+def _load_policy(path: Path) -> Mapping[str, Any]:
+    try:
+        return _mapping(json.loads(path.read_text(encoding="utf-8")), "release qualification policy")
+    except OSError as error:
+        raise Tier3ReceiptError(f"Unable to read release qualification policy at {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise Tier3ReceiptError(f"Release qualification policy at {path} is not valid JSON.") from error
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate a checked Tier 3 qualification receipt.")
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        policy = _load_policy(args.policy)
+        cases = {
+            _string(case.get("id"), "case id"): case
+            for case in (_mapping(item, "qualification case") for item in _sequence(policy.get("cases"), "cases"))
+        }
+        case = cases.get(args.case_id)
+        if case is None:
+            raise Tier3ReceiptError(f"Unknown Tier 3 case: {args.case_id}")
+        content = args.receipt.read_bytes()
+        receipt = load_validated_receipt_bytes(
+            content,
+            policy_id=_string(policy.get("policy_id"), "policy_id"),
+            case=case,
+            reference_content=lambda reference: (args.repo / reference).read_bytes(),
+        )
+        print(
+            json.dumps(
+                {
+                    "case_id": receipt["case_id"],
+                    "receipt_sha256": receipt["receipt_sha256"],
+                    "result": receipt["result"],
+                    "valid": True,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (OSError, Tier3ReceiptError) as error:
+        print(f"tier3 receipt error: {error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -26,6 +26,8 @@ from scripts.release_receipt import (
     receipt_sha256,
     write_receipt,
 )
+from scripts.tier3_receipt import build_receipt as build_tier3_receipt
+from scripts.tier3_receipt import receipt_sha256 as tier3_receipt_sha256
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -81,6 +83,9 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         workflow_phase: str = "preparation",
         artifact_receipt_path: Path | None = None,
         artifact_receipt_expectation: ArtifactReceiptExpectation | None = None,
+        release_stage: str = "rc",
+        first_candidate_of_cycle: bool = False,
+        as_of: date = date(2026, 8, 5),
     ) -> dict[str, Any]:
         return classify_release_scope(
             self.policy,
@@ -90,10 +95,12 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             repo=root,
             reference_content=lambda reference: (root / reference).read_bytes(),
             fresh_retest=fresh,
+            release_stage=release_stage,
+            first_candidate_of_cycle=first_candidate_of_cycle,
             workflow_phase=workflow_phase,
             artifact_receipt_path=artifact_receipt_path,
             artifact_receipt_expectation=artifact_receipt_expectation,
-            as_of=date(2026, 8, 5),
+            as_of=as_of,
         )
 
     def artifact_receipt(
@@ -164,6 +171,124 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         )
         return receipt_path, expectation
 
+    def tier3_evidence(
+        self,
+        root: Path,
+        case_id: str,
+        *,
+        source_sha: str = PRIOR_SHA,
+        completed_at: str = "2026-08-01T00:00:00Z",
+        accepted_at: str = "2026-08-01T00:10:00Z",
+    ) -> dict[str, Any]:
+        case = next(case for case in self.policy["cases"] if case["id"] == case_id)
+        release_facts: dict[str, object] = {
+            "release_route": "prerelease",
+            "source_sha": source_sha,
+            "workflow_actor": "shiny-code-bot",
+            "workflow_run_id": 12345,
+            "workflow_run_attempt": 1,
+            "package_version": "0.3.0rc3",
+            "public_version": "0.3.0-rc.3",
+            "build_version": "160",
+            "release_tag": "v0.3.0-rc.3",
+            "release_name": "v0.3.0-rc.3",
+            "release_id": 67890,
+            "release_created_at": "2026-06-01T00:00:00Z",
+            "prerelease": True,
+            "make_latest": False,
+            "signed_app_tree_sha256": APP_TREE_SHA256,
+            "artifacts": [
+                {
+                    "kind": "dmg",
+                    "name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+                    "sha256": DMG_SHA256,
+                    "size_bytes": 1000,
+                    "asset_id": 1,
+                },
+                {
+                    "kind": "checksum",
+                    "name": "SHA256SUMS",
+                    "sha256": CHECKSUM_SHA256,
+                    "size_bytes": 100,
+                    "asset_id": 2,
+                },
+                {
+                    "kind": "appcast",
+                    "name": "appcast.xml",
+                    "sha256": APPCAST_SHA256,
+                    "size_bytes": 500,
+                    "asset_id": 3,
+                },
+            ],
+        }
+        release_reference = Path("docs") / "release-evidence" / case_id / "release-receipt.json"
+        release_path = root / release_reference
+        release_path.parent.mkdir(parents=True, exist_ok=True)
+        release_receipt = build_receipt(release_facts)
+        write_receipt(release_receipt, release_path)
+
+        identity_values = {
+            "vendor_id": "05e3",
+            "product_id": "0749",
+            "transport": "usb",
+            "makemkv_version": "1.18.1",
+            "model_family": "vision-pro",
+            "chip_family": "m2",
+            "visionos_major": "26",
+        }
+        hardware = case["hardware"]
+        hardware_receipt = (
+            {
+                "class": hardware["classes"][0],
+                "identity": {field: identity_values[field] for field in hardware["identity_fields"]},
+            }
+            if hardware["required"]
+            else {"class": "none", "identity": {}}
+        )
+        tier3_facts = {
+            "assertions": {assertion_id: "passed" for assertion_id in case["required_assertions"]},
+            "cleanup": {"status": case["allowed_cleanup_results"][0], "evidence_sha256": "1" * 64},
+            "completed_at": completed_at,
+            "environment": {
+                "environment_class": case["environment"]["classes"][0],
+                "architecture": "arm64",
+                "macos_version": "26.0",
+                "macos_build": "25A123",
+            },
+            "evidence": [{"kind": case["allowed_evidence_kinds"][0], "sha256": "2" * 64}],
+            "evidence_source": case["allowed_evidence_sources"][0],
+            "hardware": hardware_receipt,
+            "release_receipt_file_sha256": file_sha256(release_path),
+            "release_receipt_reference": release_reference.as_posix(),
+            "result": {"status": "passed", "reason_code": "all_assertions_passed"},
+            "started_at": completed_at,
+        }
+        tier3_receipt = build_tier3_receipt(
+            tier3_facts,
+            policy_id=self.policy["policy_id"],
+            case=case,
+            release_receipt=release_receipt,
+        )
+        reference = Path("docs") / "qualification" / f"{case_id}-tier3.json"
+        receipt_path = root / reference
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps(tier3_receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return {
+            "schema_version": 1,
+            "receipts": [
+                {
+                    "case_id": case_id,
+                    "receipt_id": f"{case_id}-receipt-v1",
+                    "source": case["allowed_evidence_sources"][0],
+                    "status": "accepted",
+                    "source_sha": source_sha,
+                    "accepted_at": accepted_at,
+                    "reference": reference.as_posix(),
+                    "sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+                }
+            ],
+        }
+
     def result_for(self, report: dict[str, Any], case_id: str) -> dict[str, Any]:
         return next(case for case in report["cases"] if case["case_id"] == case_id)
 
@@ -177,7 +302,8 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         mapped_case_ids = {case["policy_case_id"] for case in qualification["matrix"]}
 
         self.assertEqual(qualification_id, "rc3-signed-qualification-v1")
-        self.assertEqual(mapped_case_ids, policy_case_ids)
+        self.assertTrue(mapped_case_ids.issubset(policy_case_ids))
+        self.assertTrue({case["id"] for case in self.policy["cases"] if case["tier"] == 3}.isdisjoint(mapped_case_ids))
         self.assertTrue(overrides["sparkle-update-route"])
         self.assertTrue(overrides["profile-save-action-accessibility"])
         self.assertFalse(overrides["gui-preview-cancel-cleanup"])
@@ -377,212 +503,127 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     artifact_receipt_expectation=expectation,
                 )
 
-    def test_periodic_evidence_expires_and_first_rc_forces_retest(self) -> None:
-        policy = json.loads(json.dumps(self.policy))
-        policy["cases"].append(
-            {
-                "id": "real-drive-qualification",
-                "tier": 3,
-                "blocking_phase": "milestone",
-                "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
-                "allowed_evidence_sources": ["hardware_qualification_receipt"],
-                "carry_forward": {
-                    "allowed": True,
-                    "requires_prior_accepted_receipt": True,
-                    "requires_clean_invalidation": True,
-                },
-                "cadence": {
-                    "first_rc_or_stable_candidate": True,
-                    "max_age_days": 30,
-                    "hardware": ["usb_bluray_drive"],
-                },
-            }
-        )
+    def test_first_rc_forces_only_declared_tier3_cases_to_retest(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            evidence = self.evidence(
+            clean_evidence = self.tier3_evidence(root, "clean-machine-signed-update")
+            clean_report = self.classify(
+                clean_evidence,
                 root,
-                "real-drive-qualification",
-                source="hardware_qualification_receipt",
-                accepted_at="2026-06-01T00:00:00Z",
-            )
-            evidence["receipts"][0]["hardware"] = ["usb_bluray_drive"]
-            report = classify_release_scope(
-                policy,
-                evidence,
-                candidate_sha=CANDIDATE_SHA,
-                changed_paths=lambda _base, _candidate: set(),
-                repo=root,
-                reference_content=lambda reference: (root / reference).read_bytes(),
                 release_stage="rc",
                 first_candidate_of_cycle=True,
-                workflow_phase="preparation",
-                as_of=date(2026, 8, 5),
+            )
+            empty_report = self.classify(
+                {"schema_version": 1, "receipts": []},
+                root,
+                release_stage="rc",
+                first_candidate_of_cycle=True,
             )
 
-        result = self.result_for(report, "real-drive-qualification")
-        self.assertEqual(result["status"], "retest")
-        self.assertIn("release milestone", result["reason"])
+        clean_result = self.result_for(clean_report, "clean-machine-signed-update")
+        real_media_result = self.result_for(empty_report, "protected-real-media-conversion")
+        self.assertEqual(clean_result["status"], "retest")
+        self.assertEqual(clean_result["trigger"], "first_rc")
+        self.assertTrue(clean_result["applicable"])
+        self.assertEqual(real_media_result["trigger"], "not_due")
+        self.assertFalse(real_media_result["applicable"])
+        self.assertFalse(real_media_result["evidence_required"])
 
     def test_periodic_evidence_expires_outside_milestone(self) -> None:
-        policy = json.loads(json.dumps(self.policy))
-        policy["cases"].append(
-            {
-                "id": "clean-machine-installation",
-                "tier": 3,
-                "blocking_phase": "milestone",
-                "invalidates_on": {"paths": ["scripts/macos_release.py"], "contracts": []},
-                "allowed_evidence_sources": ["hardware_qualification_receipt"],
-                "carry_forward": {
-                    "allowed": True,
-                    "requires_prior_accepted_receipt": True,
-                    "requires_clean_invalidation": True,
-                },
-                "cadence": {
-                    "first_rc_or_stable_candidate": True,
-                    "max_age_days": 30,
-                    "hardware": ["disposable_macos_vm"],
-                },
-            }
-        )
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            evidence = self.evidence(
+            evidence = self.tier3_evidence(
                 root,
-                "clean-machine-installation",
-                source="hardware_qualification_receipt",
-                accepted_at="2026-06-01T00:00:00Z",
+                "clean-machine-signed-update",
+                completed_at="2026-06-01T00:00:00Z",
+                accepted_at="2026-06-01T00:10:00Z",
             )
-            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
-            report = classify_release_scope(
-                policy,
+            report = self.classify(
                 evidence,
-                candidate_sha=CANDIDATE_SHA,
-                changed_paths=lambda _base, _candidate: set(),
-                repo=root,
-                reference_content=lambda reference: (root / reference).read_bytes(),
+                root,
                 release_stage="beta",
-                first_candidate_of_cycle=False,
-                workflow_phase="preparation",
                 as_of=date(2026, 8, 5),
             )
 
-        result = self.result_for(report, "clean-machine-installation")
+        result = self.result_for(report, "clean-machine-signed-update")
         self.assertEqual(result["status"], "retest")
-        self.assertIn("maximum age", result["reason"])
+        self.assertEqual(result["trigger"], "expired")
+        self.assertTrue(result["applicable"])
 
-    def test_periodic_evidence_carries_with_matching_hardware_inside_cadence(self) -> None:
-        policy = json.loads(json.dumps(self.policy))
-        policy["cases"].append(
-            {
-                "id": "clean-machine-installation",
-                "tier": 3,
-                "blocking_phase": "milestone",
-                "invalidates_on": {"paths": ["scripts/macos_release.py"], "contracts": []},
-                "allowed_evidence_sources": ["hardware_qualification_receipt"],
-                "carry_forward": {
-                    "allowed": True,
-                    "requires_prior_accepted_receipt": True,
-                    "requires_clean_invalidation": True,
-                },
-                "cadence": {
-                    "first_rc_or_stable_candidate": True,
-                    "max_age_days": 30,
-                    "hardware": ["disposable_macos_vm"],
-                },
-            }
-        )
+    def test_exact_candidate_tier3_evidence_still_expires(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            evidence = self.evidence(
+            evidence = self.tier3_evidence(
                 root,
-                "clean-machine-installation",
-                source="hardware_qualification_receipt",
-                accepted_at="2026-08-01T00:00:00Z",
+                "clean-machine-signed-update",
+                source_sha=CANDIDATE_SHA,
+                completed_at="2026-06-01T00:00:00Z",
+                accepted_at="2026-06-01T00:10:00Z",
             )
-            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
-            report = classify_release_scope(
-                policy,
+            report = self.classify(
                 evidence,
-                candidate_sha=CANDIDATE_SHA,
-                changed_paths=lambda _base, _candidate: set(),
-                repo=root,
-                reference_content=lambda reference: (root / reference).read_bytes(),
+                root,
                 release_stage="beta",
-                first_candidate_of_cycle=False,
-                workflow_phase="preparation",
                 as_of=date(2026, 8, 5),
             )
 
-        self.assertEqual(self.result_for(report, "clean-machine-installation")["status"], "carry")
+        result = self.result_for(report, "clean-machine-signed-update")
+        self.assertEqual(result["status"], "retest")
+        self.assertEqual(result["trigger"], "expired")
+        self.assertTrue(result["applicable"])
 
-    def test_periodic_evidence_requires_matching_hardware(self) -> None:
-        policy = json.loads(json.dumps(self.policy))
-        policy["cases"].append(
-            {
-                "id": "real-drive-qualification",
-                "tier": 3,
-                "blocking_phase": "milestone",
-                "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
-                "allowed_evidence_sources": ["hardware_qualification_receipt"],
-                "carry_forward": {
-                    "allowed": True,
-                    "requires_prior_accepted_receipt": True,
-                    "requires_clean_invalidation": True,
-                },
-                "cadence": {
-                    "first_rc_or_stable_candidate": True,
-                    "max_age_days": 30,
-                    "hardware": ["usb_bluray_drive"],
-                },
-            }
-        )
+    def test_periodic_evidence_carries_inside_cadence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            evidence = self.evidence(
+            evidence = self.tier3_evidence(root, "clean-machine-signed-update")
+            report = self.classify(evidence, root, release_stage="beta")
+
+        result = self.result_for(report, "clean-machine-signed-update")
+        self.assertEqual(result["status"], "carry")
+        self.assertEqual(result["trigger"], "cadence_valid")
+        self.assertFalse(result["applicable"])
+        self.assertEqual(result["evidence"]["environment_class"], "resettable-vm")
+
+    def test_tier3_invalidation_triggers_outside_milestone(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.tier3_evidence(root, "clean-machine-signed-update")
+            report = self.classify(
+                evidence,
                 root,
-                "real-drive-qualification",
-                source="hardware_qualification_receipt",
+                changed={"scripts/sparkle_bundle.py"},
+                release_stage="beta",
             )
-            evidence["receipts"][0]["hardware"] = ["disposable_macos_vm"]
 
-            with self.assertRaises(QualificationScopeError):
-                classify_release_scope(
-                    policy,
-                    evidence,
-                    candidate_sha=CANDIDATE_SHA,
-                    changed_paths=lambda _base, _candidate: set(),
-                    repo=root,
-                    reference_content=lambda reference: (root / reference).read_bytes(),
-                    workflow_phase="preparation",
-                    as_of=date(2026, 8, 5),
-                )
+        result = self.result_for(report, "clean-machine-signed-update")
+        self.assertEqual(result["status"], "retest")
+        self.assertEqual(result["trigger"], "invalidated")
+        self.assertTrue(result["applicable"])
 
-    def test_periodic_policy_rejects_noncanonical_cadence_types(self) -> None:
-        for field, value in (("max_age_days", True), ("first_rc_or_stable_candidate", "false")):
-            with self.subTest(field=field), tempfile.TemporaryDirectory() as temporary_directory:
+    def test_tier3_evidence_rejects_mismatched_hardware_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.tier3_evidence(root, "usb-bluray-makemkv")
+            receipt_path = root / evidence["receipts"][0]["reference"]
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt["hardware"]["class"] = "vision-pro"
+            receipt["receipt_sha256"] = tier3_receipt_sha256(receipt)
+            receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            evidence["receipts"][0]["sha256"] = hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+
+            with self.assertRaisesRegex(QualificationScopeError, "hardware class"):
+                self.classify(evidence, root, release_stage="beta")
+
+    def test_periodic_policy_rejects_noncanonical_cadence_and_expiry(self) -> None:
+        mutations = (
+            ("cadence", "first_rc", "yes"),
+            ("evidence_expiry", "max_age_days", True),
+        )
+        for section, field, value in mutations:
+            with self.subTest(section=section, field=field), tempfile.TemporaryDirectory() as temporary_directory:
                 policy = json.loads(json.dumps(self.policy))
-                cadence = {
-                    "first_rc_or_stable_candidate": True,
-                    "max_age_days": 30,
-                    "hardware": ["usb_bluray_drive"],
-                }
-                cadence[field] = value
-                policy["cases"].append(
-                    {
-                        "id": "real-drive-qualification",
-                        "tier": 3,
-                        "blocking_phase": "milestone",
-                        "invalidates_on": {"paths": ["bd_to_avp/modules/disc.py"], "contracts": []},
-                        "allowed_evidence_sources": ["hardware_qualification_receipt"],
-                        "carry_forward": {
-                            "allowed": True,
-                            "requires_prior_accepted_receipt": True,
-                            "requires_clean_invalidation": True,
-                        },
-                        "cadence": cadence,
-                    }
-                )
+                case = next(case for case in policy["cases"] if case["id"] == "clean-machine-signed-update")
+                case[section][field] = value
                 policy_path = Path(temporary_directory) / "policy.json"
                 policy_path.write_text(json.dumps(policy), encoding="utf-8")
 

--- a/tests/test_tier3_receipt.py
+++ b/tests/test_tier3_receipt.py
@@ -1,0 +1,222 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from typing import Any
+
+from scripts.qualify_release_scope import DEFAULT_POLICY_PATH, load_policy
+from scripts.release_receipt import build_receipt as build_release_receipt
+from scripts.release_receipt import file_sha256, write_receipt
+from scripts.tier3_receipt import (
+    Tier3ReceiptError,
+    build_receipt as build_tier3_receipt,
+    load_validated_receipt_bytes,
+    receipt_sha256,
+    validate_receipt,
+)
+
+
+SOURCE_SHA = "a" * 40
+APP_TREE_SHA256 = "b" * 64
+DMG_SHA256 = "c" * 64
+CHECKSUM_SHA256 = "d" * 64
+APPCAST_SHA256 = "e" * 64
+
+
+def release_facts() -> dict[str, object]:
+    return {
+        "release_route": "prerelease",
+        "source_sha": SOURCE_SHA,
+        "workflow_actor": "shiny-code-bot",
+        "workflow_run_id": 12345,
+        "workflow_run_attempt": 1,
+        "package_version": "0.3.0rc3",
+        "public_version": "0.3.0-rc.3",
+        "build_version": "160",
+        "release_tag": "v0.3.0-rc.3",
+        "release_name": "v0.3.0-rc.3",
+        "release_id": 67890,
+        "release_created_at": "2026-08-01T09:00:00Z",
+        "prerelease": True,
+        "make_latest": False,
+        "signed_app_tree_sha256": APP_TREE_SHA256,
+        "artifacts": [
+            {
+                "kind": "dmg",
+                "name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
+                "sha256": DMG_SHA256,
+                "size_bytes": 1000,
+                "asset_id": 1,
+            },
+            {
+                "kind": "checksum",
+                "name": "SHA256SUMS",
+                "sha256": CHECKSUM_SHA256,
+                "size_bytes": 100,
+                "asset_id": 2,
+            },
+            {
+                "kind": "appcast",
+                "name": "appcast.xml",
+                "sha256": APPCAST_SHA256,
+                "size_bytes": 500,
+                "asset_id": 3,
+            },
+        ],
+    }
+
+
+class Tier3ReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy(DEFAULT_POLICY_PATH)
+        self.cases = {case["id"]: case for case in self.policy["cases"]}
+
+    def write_release_receipt(self, root: Path) -> tuple[Path, dict[str, Any]]:
+        path = root / "docs" / "release-evidence" / "test" / "release-receipt.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        receipt = build_release_receipt(release_facts())
+        write_receipt(receipt, path)
+        return path, receipt
+
+    def hardware(self, case: dict[str, Any]) -> dict[str, Any]:
+        hardware = case["hardware"]
+        if not hardware["required"]:
+            return {"class": "none", "identity": {}}
+        values = {
+            "vendor_id": "05e3",
+            "product_id": "0749",
+            "transport": "usb",
+            "makemkv_version": "1.18.1",
+            "model_family": "vision-pro",
+            "chip_family": "m2",
+            "visionos_major": "26",
+        }
+        return {
+            "class": hardware["classes"][0],
+            "identity": {field: values[field] for field in hardware["identity_fields"]},
+        }
+
+    def build(
+        self,
+        root: Path,
+        case_id: str = "clean-machine-signed-update",
+        *,
+        result_status: str = "passed",
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        release_path, release_receipt = self.write_release_receipt(root)
+        case = self.cases[case_id]
+        assertion_status = {
+            "failed": "failed",
+            "not_applicable": "not_run",
+            "passed": "passed",
+            "skipped": "not_run",
+        }[result_status]
+        evidence = (
+            [{"kind": case["allowed_evidence_kinds"][0], "sha256": "f" * 64}]
+            if result_status in {"passed", "failed"}
+            else []
+        )
+        cleanup_status = case["allowed_cleanup_results"][0]
+        if result_status in {"skipped", "not_applicable"} and "not-applicable" in case["allowed_cleanup_results"]:
+            cleanup_status = "not-applicable"
+        facts = {
+            "assertions": {assertion_id: assertion_status for assertion_id in case["required_assertions"]},
+            "cleanup": {"status": cleanup_status, "evidence_sha256": "1" * 64},
+            "completed_at": "2026-08-01T10:10:00Z",
+            "environment": {
+                "environment_class": case["environment"]["classes"][0],
+                "architecture": "arm64",
+                "macos_version": "26.0",
+                "macos_build": "25A123",
+            },
+            "evidence": evidence,
+            "evidence_source": case["allowed_evidence_sources"][0],
+            "hardware": self.hardware(case),
+            "release_receipt_file_sha256": file_sha256(release_path),
+            "release_receipt_reference": release_path.relative_to(root).as_posix(),
+            "result": {
+                "status": result_status,
+                "reason_code": "all_assertions_passed" if result_status == "passed" else "operator-deferred",
+            },
+            "started_at": "2026-08-01T10:00:00Z",
+        }
+        receipt = build_tier3_receipt(
+            facts,
+            policy_id=self.policy["policy_id"],
+            case=case,
+            release_receipt=release_receipt,
+        )
+        return receipt, case
+
+    def validate(self, receipt: dict[str, Any], case: dict[str, Any], root: Path) -> None:
+        validate_receipt(
+            receipt,
+            policy_id=self.policy["policy_id"],
+            case=case,
+            reference_content=lambda reference: (root / reference).read_bytes(),
+        )
+
+    def test_build_is_deterministic_and_binds_exact_release_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first, case = self.build(root)
+            second, _ = self.build(root)
+            self.validate(first, case, root)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["release_identity"]["source_sha"], SOURCE_SHA)
+        self.assertEqual(first["release_identity"]["artifact_sha256"]["dmg"], DMG_SHA256)
+        self.assertEqual(first["cadence"]["expires_on"], "2026-08-31")
+        self.assertEqual(first["receipt_sha256"], receipt_sha256(first))
+
+    def test_validation_rejects_private_or_mismatched_environment_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt, case = self.build(root)
+            receipt["environment"]["hostname"] = "private-mac"
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            with self.assertRaisesRegex(Tier3ReceiptError, "keys changed"):
+                self.validate(receipt, case, root)
+
+            receipt, case = self.build(root)
+            receipt["environment"]["architecture"] = "x86_64"
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            with self.assertRaisesRegex(Tier3ReceiptError, "architecture"):
+                self.validate(receipt, case, root)
+
+    def test_validation_rejects_release_or_artifact_identity_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt, case = self.build(root)
+            receipt["release_identity"]["artifact_sha256"]["dmg"] = "0" * 64
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            with self.assertRaisesRegex(Tier3ReceiptError, "release or artifact identity"):
+                self.validate(receipt, case, root)
+
+    def test_operator_receipt_records_explicit_skipped_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt, case = self.build(root, "usb-bluray-makemkv", result_status="skipped")
+            self.validate(receipt, case, root)
+
+        self.assertEqual(receipt["result"], {"status": "skipped", "reason_code": "operator-deferred"})
+        self.assertTrue(all(assertion["status"] == "not_run" for assertion in receipt["assertions"]))
+
+    def test_loader_rejects_mutated_receipt_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt, case = self.build(root)
+            receipt["cleanup"]["status"] = "restored"
+            content = (json.dumps(receipt, sort_keys=True) + "\n").encode()
+            with self.assertRaisesRegex(Tier3ReceiptError, "receipt_sha256"):
+                load_validated_receipt_bytes(
+                    content,
+                    policy_id=self.policy["policy_id"],
+                    case=case,
+                    reference_content=lambda reference: (root / reference).read_bytes(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add five explicit Tier 3 clean-machine, installed UI, physical drive, real-media, and Vision Pro cases with per-case cadence, expiry, identity, invalidation, and evidence metadata
- add deterministic public-safe Tier 3 receipt construction and offline validation bound to the exact checked release receipt and artifact digests
- make classifier applicability cadence-aware so ordinary prereleases do not blanket-trigger Tier 3 while first RC, Stable, expiry, and invalidation do
- document the contract and register the focused receipt gate

## Validation
- `uv run python -m unittest tests.test_tier3_receipt tests.test_qualify_release_scope tests.test_release_receipt`
- `uv run python -m unittest discover -s tests -t .` (1531 tests, 3 skipped)
- `uv run python scripts/native_app.py test` (355 tests)
- `uv run python -m scripts.release validate`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- JetBrains changed-file inspection: clean

Refs #481
Refs #477