### PR TITLE
Automate Tier 3 signed-app installation and Sparkle updates

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -96,6 +96,7 @@
     "releaseRoutes": "docs/release-routes.md",
     "releaseProcess": "docs/release-process.md",
     "releaseQualificationPolicy": "docs/release-qualification-policy.md",
+    "tier3CleanMachine": "docs/tier3-clean-machine.md",
     "releaseWorkflows": [
       ".github/workflows/briefcase.yml",
       ".github/workflows/prerelease.yml",
@@ -126,6 +127,7 @@
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "tier3Receipt": "uv run python -m unittest tests.test_tier3_receipt",
+      "tier3CleanMachine": "uv run python -m unittest tests.test_tier3_clean_machine",
       "macosApp": "uv run python scripts/native_app.py test",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"

--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -246,7 +246,12 @@
       "cadence": {"first_rc": true, "stable_candidate": true},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 30},
       "invalidates_on": {
-        "paths": ["docs/release-routes.md", "pyproject.toml"],
+        "paths": [
+          "docs/release-routes.md",
+          "docs/tier3-clean-machine.md",
+          "pyproject.toml",
+          "scripts/tier3_clean_machine.py"
+        ],
         "contracts": ["release-engine", "sparkle-update", "packaged-worker", "profile-storage", "tier3-evidence"]
       },
       "allowed_evidence_sources": ["tier3_automation_receipt"],

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -102,6 +102,12 @@ Passed receipts require every declared assertion to pass. Failed, skipped, and
 not-applicable receipts remain valid audit records with explicit bounded reason
 codes, but only a passed receipt may be indexed as accepted release evidence.
 
+The maintained clean-machine and Sparkle collector is documented in
+[`docs/tier3-clean-machine.md`](tier3-clean-machine.md). It uses an isolated
+synthetic home in a runner-owned disposable location, reuses the installed-app
+package smoke, verifies a real-feed update from an exact prior signed release,
+and emits the checked `clean-machine-signed-update` receipt.
+
 ## Release Engine Receipts
 
 Every successful guarded Stable or Prerelease publication includes a

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -1,0 +1,113 @@
+# Tier 3 Clean-Machine And Sparkle Qualification
+
+`scripts/tier3_clean_machine.py` collects the automated
+`clean-machine-signed-update` evidence declared by the release qualification
+policy. It operates only on immutable signed release artifacts and never signs,
+notarizes, publishes, approves an environment, or changes the live appcast.
+
+## Maintained Environment
+
+The first maintained lane is `restorable-location` on Apple Silicon macOS 26.
+The qualification root must not exist before the run and must be a dedicated
+location under the current user's home directory. The runner creates an
+isolated synthetic home with `HOME` and `CFFIXED_USER_HOME`, installs the app
+under that owned root, and deletes the complete root after bounded cleanup.
+
+The host must provide:
+
+- macOS 26 on `arm64`;
+- Accessibility control for the terminal or automation host;
+- `defaults`, `ditto`, `hdiutil`, `open`, and `osascript`;
+- enough free space for both DMGs, two candidate copies, and 2 GiB of working
+  headroom;
+- no running production app process; and
+- network access to the real public appcast.
+
+Homebrew may be installed on the host. The package smoke and launched app use a
+system-only runtime `PATH`; host developer tools are not accepted as packaged
+dependencies.
+
+## Inputs
+
+Both the prior and candidate release receipts must be committed at the current
+repository `HEAD`. Their local DMGs must match the exact names, sizes, and
+SHA-256 digests in those receipts. The candidate build must be newer than the
+prior build and must be present on the live public appcast for the selected
+route.
+
+Run the read-only preflight first:
+
+```sh
+uv run python -m scripts.tier3_clean_machine preflight \
+  --candidate-release-receipt docs/release-evidence/<candidate>/release-receipt.json \
+  --candidate-dmg ~/Downloads/<candidate>.dmg \
+  --prior-release-receipt docs/release-evidence/<prior>/release-receipt.json \
+  --prior-dmg ~/Downloads/<prior>.dmg \
+  --qualification-root ~/Tier3-BD-to-AVP-Qualification \
+  --route rc \
+  --environment-class restorable-location
+```
+
+Preflight validates checked receipt bytes, both DMGs, build ordering, the
+environment, free space, Accessibility, process state, required tools, network
+access, appcast structure, source-bound release notes, enclosure identity, and
+route eligibility. Its JSON output omits hostnames, usernames, and local paths.
+
+## Qualification Run
+
+After preflight passes, run:
+
+```sh
+uv run python -m scripts.tier3_clean_machine run \
+  --candidate-release-receipt docs/release-evidence/<candidate>/release-receipt.json \
+  --candidate-dmg ~/Downloads/<candidate>.dmg \
+  --prior-release-receipt docs/release-evidence/<prior>/release-receipt.json \
+  --prior-dmg ~/Downloads/<prior>.dmg \
+  --qualification-root ~/Tier3-BD-to-AVP-Qualification \
+  --route rc \
+  --environment-class restorable-location \
+  --output-receipt /path/out/clean-machine-signed-update.json \
+  --evidence-directory /path/out/clean-machine-signed-update-evidence
+```
+
+The runner performs this bounded sequence:
+
+1. Install the exact candidate from its DMG, verify bundle and signed app-tree
+   identity, and run `scripts/smoke_release_app.py` from the installed copy.
+2. Clear the owned runtime location, install the exact prior release, and seed a
+   valid profile library plus route and unrelated preference sentinels in the
+   synthetic home.
+3. Launch the prior app, invoke `Check for Updates…`, click Sparkle's bounded
+   install/relaunch action, and wait for the exact candidate bundle, build, and
+   signed app tree to relaunch.
+4. Verify the selected route, unrelated preference, and byte-for-byte profile
+   library are preserved.
+5. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
+   and delete the complete qualification root.
+6. Emit five public-safe evidence summaries and a validated
+   `bd-to-avp-tier3-qualification` receipt with `cleanup.status = disposed`.
+
+Every mount, subprocess, network request, GUI wait, update wait, and cleanup
+action has a timeout. Raw package-smoke output remains inside the disposable
+root and is deleted; public evidence records only its SHA-256 digest. A failed
+run does not emit an accepted receipt.
+
+If the cleanup ownership marker is missing or changed, the runner refuses to
+delete the qualification root because it can no longer prove ownership. It
+removes partial public outputs, reports the ownership failure, and leaves that
+root for operator inspection. After confirming that the location contains only
+qualification data, remove it manually before retrying with the same path.
+
+## Validation
+
+The deterministic runner fixtures use fake signed app trees, checked release
+receipts, a generated valid appcast, isolated preferences, and a simulated
+Sparkle replacement/relaunch:
+
+```sh
+uv run python -m unittest tests.test_tier3_clean_machine
+```
+
+The real lane must still run on the declared macOS 26 environment and a newer
+published candidate before its receipt can be checked into the release evidence
+index.

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1,0 +1,1113 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+import uuid
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, cast
+from urllib.parse import quote
+from xml.etree import ElementTree
+
+from scripts.artifact_identity import app_tree_sha256
+from scripts.qualify_release_scope import DEFAULT_POLICY_PATH, load_policy
+from scripts.release_receipt import ReleaseReceiptError, validate_receipt as validate_release_receipt
+from scripts.sparkle_appcast import AppcastError, SPARKLE, validate_appcast_channel
+from scripts.tier3_receipt import (
+    Tier3ReceiptError,
+    build_receipt as build_tier3_receipt,
+    validate_receipt as validate_tier3_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CASE_ID = "clean-machine-signed-update"
+APP_NAME = "3D Blu-ray to Vision Pro.app"
+BUNDLE_IDENTIFIER = "com.shinycomputers.bd-to-avp"
+PREFERENCES_DOMAIN = BUNDLE_IDENTIFIER
+UPDATE_ROUTE_KEY = "BDToAVPUpdateChannel"
+SENTINEL_KEY = "BDToAVPTier3Sentinel"
+AUTOMATIC_CHECKS_KEY = "SUEnableAutomaticChecks"
+SENTINEL_VALUE = "tier3-preserve"
+LIVE_FEED_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+PROFILE_DOCUMENT = {"version": 5, "profiles": []}
+PROFILE_RELATIVE_PATH = Path("Library/Application Support/3D Blu-ray to Vision Pro/profiles.json")
+MAX_FEED_BYTES = 5 * 1024 * 1024
+BASE_FREE_SPACE_BYTES = 2 * 1024 * 1024 * 1024
+NETWORK_TIMEOUT_SECONDS = 30
+COMMAND_TIMEOUT_SECONDS = 60
+SMOKE_TIMEOUT_SECONDS = 15 * 60
+GUI_TIMEOUT_SECONDS = 270
+UPDATE_TIMEOUT_SECONDS = 5 * 60
+ROUTE_CHANNELS = {
+    "stable": {None},
+    "rc": {None, "rc"},
+    "beta": {None, "rc", "beta"},
+    "alpha": {None, "rc", "beta", "alpha"},
+}
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+APPLE_BUILD_PATTERN = re.compile(r"^[0-9]{2}[A-Z][0-9A-Za-z]{1,12}$")
+SYSTEM_TOOL_PATHS = {
+    "defaults": Path("/usr/bin/defaults"),
+    "ditto": Path("/usr/bin/ditto"),
+    "hdiutil": Path("/usr/bin/hdiutil"),
+    "open": Path("/usr/bin/open"),
+    "osascript": Path("/usr/bin/osascript"),
+}
+
+
+class CleanMachineError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class BundleIdentity:
+    bundle_identifier: str
+    package_version: str
+    build_version: str
+    distribution_channel: str
+    feed_url: str
+
+
+@dataclass(frozen=True)
+class ReleaseArtifact:
+    receipt: Mapping[str, Any]
+    receipt_path: Path
+    receipt_reference: str
+    receipt_file_sha256: str
+    dmg_path: Path
+    dmg_name: str
+    dmg_sha256: str
+    dmg_size: int
+    source_sha: str
+    release_tag: str
+    package_version: str
+    public_version: str
+    build_version: str
+    signed_app_tree_sha256: str
+
+
+@dataclass(frozen=True)
+class EnvironmentFacts:
+    environment_class: str
+    architecture: str
+    macos_version: str
+    macos_build: str
+    free_bytes: int
+    accessibility_enabled: bool
+    homebrew_present: bool
+    app_running: bool
+    required_tools: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FeedCandidate:
+    feed_sha256: str
+    build_version: str
+    short_version: str
+    channel: str | None
+    download_url: str
+    length: int
+    minimum_system_version: str
+
+
+@dataclass(frozen=True)
+class QualificationConfig:
+    repo: Path
+    candidate_receipt: Path
+    candidate_dmg: Path
+    prior_receipt: Path
+    prior_dmg: Path
+    qualification_root: Path
+    route: str
+    environment_class: str
+    output_receipt: Path | None = None
+    evidence_directory: Path | None = None
+
+
+@dataclass(frozen=True)
+class UpdateInteraction:
+    clicked_button: str
+
+
+class QualificationOperations(Protocol):
+    def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts: ...
+
+    def fetch_live_feed(self) -> bytes: ...
+
+    def install_app(self, dmg_path: Path, destination: Path) -> None: ...
+
+    def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str: ...
+
+    def write_preferences(self, synthetic_home: Path, route: str) -> None: ...
+
+    def read_preference(self, synthetic_home: Path, key: str) -> str: ...
+
+    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction: ...
+
+    def app_running(self) -> bool: ...
+
+    def quit_app(self) -> None: ...
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CleanMachineError(f"{description} must be a JSON object.")
+    return value
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise CleanMachineError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CleanMachineError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise CleanMachineError(f"{description} must be a positive integer.")
+    return value
+
+
+def _sha256(value: object, description: str) -> str:
+    digest = _string(value, description)
+    if SHA256_PATTERN.fullmatch(digest) is None:
+        raise CleanMachineError(f"{description} must be a lowercase SHA-256 digest.")
+    return digest
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    path.write_text(content, encoding="utf-8")
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _relative_checked_path(repo: Path, path: Path, description: str) -> str:
+    repo = repo.resolve()
+    resolved = path.resolve()
+    try:
+        reference = resolved.relative_to(repo).as_posix()
+    except ValueError as error:
+        raise CleanMachineError(f"{description} must be inside the repository.") from error
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{reference}"],
+        cwd=repo,
+        capture_output=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        raise CleanMachineError(f"{description} must be checked at repository HEAD: {reference}")
+    local_bytes = resolved.read_bytes()
+    if result.stdout != local_bytes:
+        raise CleanMachineError(f"{description} differs from the checked repository HEAD: {reference}")
+    return reference
+
+
+def load_release_artifact(
+    repo: Path,
+    receipt_path: Path,
+    dmg_path: Path,
+    *,
+    description: str,
+) -> ReleaseArtifact:
+    reference = _relative_checked_path(repo, receipt_path, f"{description} release receipt")
+    try:
+        receipt = _mapping(json.loads(receipt_path.read_text(encoding="utf-8")), f"{description} release receipt")
+    except (OSError, json.JSONDecodeError) as error:
+        raise CleanMachineError(f"Unable to load {description} release receipt: {error}") from error
+    try:
+        validate_release_receipt(receipt)
+    except ReleaseReceiptError as error:
+        raise CleanMachineError(f"{description.capitalize()} release receipt is invalid: {error}") from error
+
+    dmg_artifacts = [
+        _mapping(item, f"{description} release artifact")
+        for item in _sequence(receipt.get("artifacts"), f"{description} release artifacts")
+        if _mapping(item, f"{description} release artifact").get("kind") == "dmg"
+    ]
+    if len(dmg_artifacts) != 1:
+        raise CleanMachineError(f"{description.capitalize()} release receipt must contain exactly one DMG.")
+    dmg = dmg_artifacts[0]
+    expected_name = _string(dmg.get("name"), f"{description} DMG name")
+    expected_size = _integer(dmg.get("size_bytes"), f"{description} DMG size")
+    expected_sha256 = _sha256(dmg.get("sha256"), f"{description} DMG sha256")
+    if dmg_path.name != expected_name:
+        raise CleanMachineError(f"{description.capitalize()} DMG name does not match its release receipt.")
+    try:
+        actual_size = dmg_path.stat().st_size
+    except OSError as error:
+        raise CleanMachineError(f"Unable to inspect {description} DMG: {error}") from error
+    if actual_size != expected_size or file_sha256(dmg_path) != expected_sha256:
+        raise CleanMachineError(f"{description.capitalize()} DMG size or digest does not match its release receipt.")
+
+    release = _mapping(receipt.get("release"), f"{description} release identity")
+    versions = _mapping(receipt.get("versions"), f"{description} release versions")
+    source_sha = _string(receipt.get("source_sha"), f"{description} source SHA")
+    if SHA_PATTERN.fullmatch(source_sha) is None:
+        raise CleanMachineError(f"{description.capitalize()} source SHA is not canonical.")
+    return ReleaseArtifact(
+        receipt=receipt,
+        receipt_path=receipt_path.resolve(),
+        receipt_reference=reference,
+        receipt_file_sha256=file_sha256(receipt_path),
+        dmg_path=dmg_path.resolve(),
+        dmg_name=expected_name,
+        dmg_sha256=expected_sha256,
+        dmg_size=expected_size,
+        source_sha=source_sha,
+        release_tag=_string(release.get("tag"), f"{description} release tag"),
+        package_version=_string(versions.get("package"), f"{description} package version"),
+        public_version=_string(versions.get("public"), f"{description} public version"),
+        build_version=_string(versions.get("build"), f"{description} build version"),
+        signed_app_tree_sha256=_sha256(
+            receipt.get("signed_app_tree_sha256"),
+            f"{description} signed app tree sha256",
+        ),
+    )
+
+
+def validate_release_order(prior: ReleaseArtifact, candidate: ReleaseArtifact) -> None:
+    try:
+        prior_build = int(prior.build_version)
+        candidate_build = int(candidate.build_version)
+    except ValueError as error:
+        raise CleanMachineError("Prior and candidate build versions must be numeric.") from error
+    if candidate_build <= prior_build:
+        raise CleanMachineError("Candidate build version must be newer than the prior installed release.")
+    if prior.source_sha == candidate.source_sha or prior.dmg_sha256 == candidate.dmg_sha256:
+        raise CleanMachineError("Prior and candidate releases must bind different immutable artifacts.")
+
+
+def parse_feed_candidate(feed_bytes: bytes, candidate: ReleaseArtifact, route: str) -> FeedCandidate:
+    if len(feed_bytes) > MAX_FEED_BYTES:
+        raise CleanMachineError("Live appcast exceeds the bounded feed size.")
+    try:
+        root = ElementTree.fromstring(feed_bytes)
+    except ElementTree.ParseError as error:
+        raise CleanMachineError(f"Live appcast is invalid XML: {error}") from error
+    if root.tag != "rss" or root.get("version") != "2.0":
+        raise CleanMachineError("Live appcast root must be RSS 2.0.")
+    channel = root.find("channel")
+    if channel is None:
+        raise CleanMachineError("Live appcast is missing its channel.")
+    try:
+        validate_appcast_channel(channel)
+    except AppcastError as error:
+        raise CleanMachineError(f"Live appcast validation failed: {error}") from error
+
+    matches = [
+        item
+        for item in channel.findall("item")
+        if (item.findtext(f"{SPARKLE}shortVersionString") or "").strip() == candidate.package_version
+    ]
+    if len(matches) != 1:
+        detail = f"found {len(matches)}"
+        raise CleanMachineError(
+            f"Live appcast must contain exactly one candidate item for {candidate.package_version}; {detail}."
+        )
+    item = matches[0]
+    build_version = (item.findtext(f"{SPARKLE}version") or "").strip()
+    if build_version != candidate.build_version:
+        raise CleanMachineError("Live appcast candidate build does not match the release receipt.")
+    channel_name = (item.findtext(f"{SPARKLE}channel") or "").strip() or None
+    if channel_name not in ROUTE_CHANNELS[route]:
+        display_channel = channel_name or "stable"
+        raise CleanMachineError(f"Candidate channel {display_channel} is not eligible for route {route}.")
+    enclosure = item.find("enclosure")
+    if enclosure is None:
+        raise CleanMachineError("Live appcast candidate is missing its enclosure.")
+    expected_url = (
+        f"https://github.com/cbusillo/BD_to_AVP/releases/download/{candidate.release_tag}/{quote(candidate.dmg_name)}"
+    )
+    download_url = enclosure.get("url", "")
+    if download_url != expected_url:
+        raise CleanMachineError("Live appcast candidate enclosure is not bound to the exact release DMG.")
+    if enclosure.get("length") != str(candidate.dmg_size):
+        raise CleanMachineError("Live appcast candidate enclosure length does not match the exact release DMG.")
+    minimum_system_version = (item.findtext(f"{SPARKLE}minimumSystemVersion") or "").strip()
+    if not minimum_system_version:
+        raise CleanMachineError("Live appcast candidate is missing minimum system version.")
+    return FeedCandidate(
+        feed_sha256=hashlib.sha256(feed_bytes).hexdigest(),
+        build_version=build_version,
+        short_version=candidate.package_version,
+        channel=channel_name,
+        download_url=download_url,
+        length=candidate.dmg_size,
+        minimum_system_version=minimum_system_version,
+    )
+
+
+def _version_tuple(value: str, description: str) -> tuple[int, ...]:
+    try:
+        parts = tuple(int(part) for part in value.split("."))
+    except ValueError as error:
+        raise CleanMachineError(f"{description} must contain numeric dot-separated components.") from error
+    if not parts or any(part < 0 for part in parts):
+        raise CleanMachineError(f"{description} is invalid.")
+    return parts
+
+
+def read_bundle_identity(app_path: Path) -> BundleIdentity:
+    plist_path = app_path / "Contents" / "Info.plist"
+    try:
+        info = plistlib.loads(plist_path.read_bytes())
+    except (OSError, plistlib.InvalidFileException) as error:
+        raise CleanMachineError(f"Unable to read installed app identity: {error}") from error
+    return BundleIdentity(
+        bundle_identifier=_string(info.get("CFBundleIdentifier"), "CFBundleIdentifier"),
+        package_version=_string(info.get("CFBundleShortVersionString"), "CFBundleShortVersionString"),
+        build_version=_string(info.get("CFBundleVersion"), "CFBundleVersion"),
+        distribution_channel=_string(info.get("BDToAVPDistributionChannel"), "BDToAVPDistributionChannel"),
+        feed_url=_string(info.get("SUFeedURL"), "SUFeedURL"),
+    )
+
+
+def verify_installed_app(app_path: Path, release: ReleaseArtifact) -> BundleIdentity:
+    identity = read_bundle_identity(app_path)
+    expected = BundleIdentity(
+        bundle_identifier=BUNDLE_IDENTIFIER,
+        package_version=release.package_version,
+        build_version=release.build_version,
+        distribution_channel="direct",
+        feed_url=LIVE_FEED_URL,
+    )
+    if identity != expected:
+        raise CleanMachineError(
+            f"Installed app identity mismatch: expected {expected.package_version}/{expected.build_version}, "
+            f"found {identity.package_version}/{identity.build_version}."
+        )
+    if app_tree_sha256(app_path) != release.signed_app_tree_sha256:
+        raise CleanMachineError("Installed app tree does not match the exact signed release receipt.")
+    return identity
+
+
+def validate_environment(
+    facts: EnvironmentFacts,
+    case: Mapping[str, Any],
+    *,
+    required_free_bytes: int,
+) -> None:
+    environment = _mapping(case.get("environment"), "Tier 3 case environment")
+    if facts.environment_class not in set(cast(Sequence[str], environment.get("classes", []))):
+        raise CleanMachineError("Qualification environment class is not allowed by policy.")
+    if facts.environment_class != "restorable-location":
+        raise CleanMachineError("This runner currently supports the fully disposable restorable-location lane.")
+    if facts.architecture not in set(cast(Sequence[str], environment.get("architectures", []))):
+        raise CleanMachineError("Qualification architecture is not allowed by policy.")
+    try:
+        macos_major = int(facts.macos_version.split(".", maxsplit=1)[0])
+    except ValueError as error:
+        raise CleanMachineError("Qualification macOS version is not canonical.") from error
+    required_versions = tuple(cast(Sequence[int], environment.get("macos_major_versions", [])))
+    if macos_major not in set(required_versions):
+        raise CleanMachineError(
+            f"Qualification requires macOS major versions {required_versions}, found {facts.macos_version}."
+        )
+    if APPLE_BUILD_PATTERN.fullmatch(facts.macos_build) is None:
+        raise CleanMachineError("Qualification macOS build is not a public Apple build identifier.")
+    if facts.free_bytes < required_free_bytes:
+        raise CleanMachineError(
+            f"Qualification location requires at least {required_free_bytes} free bytes; found {facts.free_bytes}."
+        )
+    if not facts.accessibility_enabled:
+        raise CleanMachineError("Accessibility control is required for bounded Sparkle UI interaction.")
+    if facts.app_running:
+        raise CleanMachineError("The production app must not be running before qualification starts.")
+    missing_tools = [tool for tool in facts.required_tools if not SYSTEM_TOOL_PATHS[tool].is_file()]
+    if missing_tools:
+        raise CleanMachineError(f"Qualification host is missing required tools: {', '.join(missing_tools)}.")
+
+
+class MacOSOperations:
+    required_tools = ("defaults", "ditto", "hdiutil", "open", "osascript")
+
+    @staticmethod
+    def _run(
+        command: Sequence[str],
+        *,
+        timeout: int = COMMAND_TIMEOUT_SECONDS,
+        env: Mapping[str, str] | None = None,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=dict(env) if env is not None else None,
+            input=input_text,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "command failed"
+            raise CleanMachineError(f"Command failed ({command[0]}): {detail}")
+        return result
+
+    @staticmethod
+    def _synthetic_env(synthetic_home: Path) -> dict[str, str]:
+        env = dict(os.environ)
+        env["HOME"] = str(synthetic_home)
+        env["CFFIXED_USER_HOME"] = str(synthetic_home)
+        env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+        return env
+
+    def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
+        if platform.system() != "Darwin":
+            raise CleanMachineError("Tier 3 clean-machine qualification requires macOS.")
+        version = self._run(["sw_vers", "-productVersion"]).stdout.strip()
+        build = self._run(["sw_vers", "-buildVersion"]).stdout.strip()
+        accessibility = (
+            self._run(["osascript", "-e", 'tell application "System Events" to return UI elements enabled'])
+            .stdout.strip()
+            .lower()
+        )
+        return EnvironmentFacts(
+            environment_class=environment_class,
+            architecture=platform.machine(),
+            macos_version=version,
+            macos_build=build,
+            free_bytes=shutil.disk_usage(qualification_root.parent).free,
+            accessibility_enabled=accessibility == "true",
+            homebrew_present=Path("/opt/homebrew/bin/brew").exists() or Path("/usr/local/bin/brew").exists(),
+            app_running=self.app_running(),
+            required_tools=self.required_tools,
+        )
+
+    @staticmethod
+    def fetch_live_feed() -> bytes:
+        request = urllib.request.Request(LIVE_FEED_URL, headers={"User-Agent": "BD-to-AVP-Tier3/1"})
+        try:
+            with urllib.request.urlopen(request, timeout=NETWORK_TIMEOUT_SECONDS) as response:
+                content = response.read(MAX_FEED_BYTES + 1)
+        except OSError as error:
+            raise CleanMachineError(f"Unable to download live appcast: {error}") from error
+        if len(content) > MAX_FEED_BYTES:
+            raise CleanMachineError("Live appcast exceeds the bounded feed size.")
+        return content
+
+    @staticmethod
+    def _mount_dmg(dmg_path: Path, mount_point: Path) -> Path:
+        mount_point.mkdir(parents=True)
+        result = subprocess.run(
+            [
+                "hdiutil",
+                "attach",
+                "-nobrowse",
+                "-readonly",
+                "-mountpoint",
+                str(mount_point),
+                str(dmg_path),
+            ],
+            capture_output=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            try:
+                mount_point.rmdir()
+            except OSError:
+                pass
+            raise CleanMachineError(f"Unable to mount release DMG: {result.stderr.decode(errors='replace').strip()}")
+        return mount_point
+
+    @staticmethod
+    def _detach_mounts(mount_points: Sequence[Path]) -> None:
+        failures: list[str] = []
+        for mount_point in reversed(mount_points):
+            result = subprocess.run(
+                ["hdiutil", "detach", str(mount_point)],
+                capture_output=True,
+                text=True,
+                timeout=COMMAND_TIMEOUT_SECONDS,
+            )
+            if result.returncode != 0:
+                failures.append(result.stderr.strip() or str(mount_point))
+            elif mount_point.exists():
+                mount_point.rmdir()
+        if failures:
+            raise CleanMachineError(f"Unable to detach qualification mounts: {'; '.join(failures)}")
+
+    def install_app(self, dmg_path: Path, destination: Path) -> None:
+        mount_point = destination.parent.parent / "Mount"
+        if mount_point.exists():
+            raise CleanMachineError("Qualification mount point already exists before DMG installation.")
+        self._mount_dmg(dmg_path, mount_point)
+        try:
+            candidates = [
+                path
+                for path in mount_point.glob("*.app")
+                if (path / "Contents" / "Info.plist").exists()
+                and read_bundle_identity(path).bundle_identifier == BUNDLE_IDENTIFIER
+            ]
+            if len(candidates) != 1:
+                raise CleanMachineError("Mounted release DMG must contain exactly one production app bundle.")
+            if destination.exists():
+                shutil.rmtree(destination)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            self._run(["ditto", str(candidates[0]), str(destination)], timeout=SMOKE_TIMEOUT_SECONDS)
+        finally:
+            self._detach_mounts([mount_point])
+
+    def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
+        env = self._synthetic_env(synthetic_home)
+        result = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "smoke_release_app.py"), "--app-path", str(app_path)],
+            capture_output=True,
+            timeout=SMOKE_TIMEOUT_SECONDS,
+            env=env,
+        )
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_log = result.stdout + b"\n--- stderr ---\n" + result.stderr
+        log_path.write_bytes(raw_log)
+        if result.returncode != 0:
+            raise CleanMachineError("Maintained installed-app package smoke failed.")
+        return hashlib.sha256(raw_log).hexdigest()
+
+    def write_preferences(self, synthetic_home: Path, route: str) -> None:
+        synthetic_home.mkdir(parents=True, exist_ok=True)
+        env = self._synthetic_env(synthetic_home)
+        self._run(["defaults", "write", PREFERENCES_DOMAIN, UPDATE_ROUTE_KEY, route], env=env)
+        self._run(["defaults", "write", PREFERENCES_DOMAIN, SENTINEL_KEY, SENTINEL_VALUE], env=env)
+        self._run(
+            ["defaults", "write", PREFERENCES_DOMAIN, AUTOMATIC_CHECKS_KEY, "-bool", "false"],
+            env=env,
+        )
+
+    def read_preference(self, synthetic_home: Path, key: str) -> str:
+        result = self._run(
+            ["defaults", "read", PREFERENCES_DOMAIN, key],
+            env=self._synthetic_env(synthetic_home),
+        )
+        return result.stdout.strip()
+
+    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+        env = self._synthetic_env(synthetic_home)
+        self._run(
+            [
+                "open",
+                "-n",
+                "-F",
+                "--env",
+                f"HOME={synthetic_home}",
+                "--env",
+                f"CFFIXED_USER_HOME={synthetic_home}",
+                str(app_path),
+            ],
+            env=env,
+        )
+        result = self._run(
+            ["osascript", "-", BUNDLE_IDENTIFIER],
+            timeout=GUI_TIMEOUT_SECONDS,
+            input_text=self._updater_script(),
+        )
+        return UpdateInteraction(clicked_button=result.stdout.strip())
+
+    @staticmethod
+    def app_running() -> bool:
+        script = (
+            'tell application "System Events" to return exists '
+            f'(first application process whose bundle identifier is "{BUNDLE_IDENTIFIER}")'
+        )
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+    def quit_app(self) -> None:
+        script = f'''tell application "System Events"
+    set matches to every application process whose bundle identifier is "{BUNDLE_IDENTIFIER}"
+    repeat with targetProcess in matches
+        try
+            tell targetProcess to set frontmost to true
+            keystroke "q" using command down
+        end try
+    end repeat
+end tell'''
+        subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        deadline = time.monotonic() + 20
+        while self.app_running() and time.monotonic() < deadline:
+            time.sleep(0.5)
+        if self.app_running():
+            force_script = f'''tell application "System Events"
+    set matches to every application process whose bundle identifier is "{BUNDLE_IDENTIFIER}"
+    repeat with targetProcess in matches
+        try
+            set unixID to unix id of targetProcess
+            do shell script "kill -TERM " & unixID
+        end try
+    end repeat
+end tell'''
+            subprocess.run(
+                ["osascript", "-e", force_script],
+                capture_output=True,
+                timeout=COMMAND_TIMEOUT_SECONDS,
+            )
+        deadline = time.monotonic() + 10
+        while self.app_running() and time.monotonic() < deadline:
+            time.sleep(0.5)
+        if self.app_running():
+            raise CleanMachineError("Production app did not terminate during cleanup.")
+
+    @staticmethod
+    def _updater_script() -> str:
+        return """on run argv
+    set targetBundleID to item 1 of argv
+    set processDeadline to (current date) + 60
+    tell application "System Events"
+        repeat
+            if exists (first application process whose bundle identifier is targetBundleID) then exit repeat
+            if (current date) > processDeadline then error "Timed out waiting for the application process."
+            delay 0.5
+        end repeat
+        set targetProcess to first application process whose bundle identifier is targetBundleID
+        tell targetProcess
+            set frontmost to true
+            set menuDeadline to (current date) + 60
+            repeat until exists menu item "Check for Updates…" of menu 1 of menu bar item "Help" of menu bar 1
+                if (current date) > menuDeadline then error "Timed out waiting for Check for Updates."
+                delay 0.5
+            end repeat
+            click menu item "Check for Updates…" of menu 1 of menu bar item "Help" of menu bar 1
+        end tell
+        set updateDeadline to (current date) + 120
+        repeat
+            if exists (first application process whose bundle identifier is targetBundleID) then
+                set targetProcess to first application process whose bundle identifier is targetBundleID
+                tell targetProcess
+                    repeat with targetWindow in windows
+                        repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Relaunch"}
+                            if exists button (buttonTitle as text) of targetWindow then
+                                click button (buttonTitle as text) of targetWindow
+                                return buttonTitle as text
+                            end if
+                        end repeat
+                    end repeat
+                end tell
+            end if
+            if (current date) > updateDeadline then error "Timed out waiting for a Sparkle install button."
+            delay 0.5
+        end repeat
+    end tell
+end run"""
+
+
+def _case_policy(policy: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = [
+        _mapping(item, "qualification case")
+        for item in _sequence(policy.get("cases"), "qualification cases")
+        if _mapping(item, "qualification case").get("id") == CASE_ID
+    ]
+    if len(matches) != 1:
+        raise CleanMachineError(f"Policy must define exactly one {CASE_ID!r} case.")
+    return matches[0]
+
+
+def prepare_qualification(
+    config: QualificationConfig,
+    operations: QualificationOperations,
+) -> tuple[Mapping[str, Any], Mapping[str, Any], ReleaseArtifact, ReleaseArtifact, EnvironmentFacts, FeedCandidate]:
+    repo = config.repo.resolve()
+    policy = load_policy(repo / DEFAULT_POLICY_PATH.relative_to(REPO_ROOT))
+    case = _case_policy(policy)
+    candidate = load_release_artifact(
+        repo,
+        config.candidate_receipt,
+        config.candidate_dmg,
+        description="candidate",
+    )
+    prior = load_release_artifact(
+        repo,
+        config.prior_receipt,
+        config.prior_dmg,
+        description="prior",
+    )
+    validate_release_order(prior, candidate)
+    if config.route not in ROUTE_CHANNELS:
+        raise CleanMachineError(f"Unsupported update route: {config.route}")
+    qualification_root = config.qualification_root.resolve()
+    if qualification_root.exists():
+        raise CleanMachineError("Qualification root must not exist before the runner starts.")
+    if qualification_root == Path.home().resolve() or Path.home().resolve() not in qualification_root.parents:
+        raise CleanMachineError("Qualification root must be a dedicated location inside the current home directory.")
+    if config.output_receipt is not None and qualification_root in config.output_receipt.resolve().parents:
+        raise CleanMachineError("Output receipt must be outside the disposable qualification root.")
+    if config.evidence_directory is not None and qualification_root in config.evidence_directory.resolve().parents:
+        raise CleanMachineError("Evidence directory must be outside the disposable qualification root.")
+    required_free_bytes = BASE_FREE_SPACE_BYTES + prior.dmg_size + (candidate.dmg_size * 2)
+    environment = operations.inspect_environment(qualification_root, config.environment_class)
+    validate_environment(environment, case, required_free_bytes=required_free_bytes)
+    feed = parse_feed_candidate(operations.fetch_live_feed(), candidate, config.route)
+    if _version_tuple(environment.macos_version, "Environment macOS version") < _version_tuple(
+        feed.minimum_system_version,
+        "Appcast minimum system version",
+    ):
+        raise CleanMachineError("Qualification environment is older than the candidate appcast minimum system version.")
+    return policy, case, prior, candidate, environment, feed
+
+
+def preflight_report(
+    config: QualificationConfig,
+    operations: QualificationOperations,
+) -> Mapping[str, Any]:
+    _, _, prior, candidate, environment, feed = prepare_qualification(config, operations)
+    return {
+        "candidate": {
+            "build_version": candidate.build_version,
+            "dmg_sha256": candidate.dmg_sha256,
+            "package_version": candidate.package_version,
+            "release_tag": candidate.release_tag,
+            "source_sha": candidate.source_sha,
+        },
+        "developer_state": {
+            "homebrew_present": environment.homebrew_present,
+            "runtime_path": "sanitized-system-only",
+        },
+        "environment": {
+            "architecture": environment.architecture,
+            "environment_class": environment.environment_class,
+            "free_bytes": environment.free_bytes,
+            "macos_build": environment.macos_build,
+            "macos_version": environment.macos_version,
+        },
+        "feed": {
+            "candidate_channel": feed.channel,
+            "candidate_download_url_sha256": hashlib.sha256(feed.download_url.encode()).hexdigest(),
+            "feed_sha256": feed.feed_sha256,
+            "route": config.route,
+        },
+        "prior": {
+            "build_version": prior.build_version,
+            "dmg_sha256": prior.dmg_sha256,
+            "package_version": prior.package_version,
+            "release_tag": prior.release_tag,
+            "source_sha": prior.source_sha,
+        },
+        "preflight": "passed",
+        "schema_version": 1,
+    }
+
+
+def _wait_for_candidate(
+    app_path: Path,
+    candidate: ReleaseArtifact,
+    operations: QualificationOperations,
+) -> BundleIdentity:
+    deadline = time.monotonic() + UPDATE_TIMEOUT_SECONDS
+    last_error: CleanMachineError | None = None
+    while time.monotonic() < deadline:
+        if app_path.exists():
+            try:
+                identity = verify_installed_app(app_path, candidate)
+            except CleanMachineError as error:
+                last_error = error
+            else:
+                if operations.app_running():
+                    return identity
+        time.sleep(1)
+    detail = f" Last identity error: {last_error}" if last_error is not None else ""
+    raise CleanMachineError(f"Sparkle did not install and relaunch the exact candidate before timeout.{detail}")
+
+
+def _seed_profile(synthetic_home: Path) -> tuple[Path, str]:
+    profile_path = synthetic_home / PROFILE_RELATIVE_PATH
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    profile_path.write_bytes(_canonical_json_bytes(PROFILE_DOCUMENT))
+    return profile_path, file_sha256(profile_path)
+
+
+def _reset_runtime_workspace(app_path: Path, synthetic_home: Path) -> None:
+    if app_path.exists():
+        shutil.rmtree(app_path)
+    if synthetic_home.exists():
+        shutil.rmtree(synthetic_home)
+    synthetic_home.mkdir(parents=True)
+
+
+def _run_qualification(config: QualificationConfig, operations: QualificationOperations) -> Mapping[str, Any]:
+    if config.output_receipt is None or config.evidence_directory is None:
+        raise CleanMachineError("Run mode requires output receipt and evidence directory paths.")
+    output_receipt = config.output_receipt.resolve()
+    evidence_directory = config.evidence_directory.resolve()
+    if output_receipt.exists() or evidence_directory.exists():
+        raise CleanMachineError("Output receipt and evidence directory must not already exist.")
+
+    policy, case, prior, candidate, environment, feed = prepare_qualification(config, operations)
+    started_at = _utc_timestamp()
+    qualification_root = config.qualification_root.resolve()
+    synthetic_home = qualification_root / "Home"
+    app_path = qualification_root / "Applications" / APP_NAME
+    log_path = qualification_root / "Logs" / "package-smoke.log"
+    marker_path = qualification_root / ".bd-to-avp-tier3-owned.json"
+    qualification_root.mkdir(parents=True)
+    marker = {"owner": "bd-to-avp-tier3-clean-machine", "run_id": str(uuid.uuid4())}
+    marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        synthetic_home.mkdir(parents=True)
+        operations.install_app(candidate.dmg_path, app_path)
+        candidate_install_identity = verify_installed_app(app_path, candidate)
+        package_smoke_log_sha256 = operations.smoke_app(app_path, synthetic_home, log_path)
+        operations.quit_app()
+        if operations.app_running():
+            raise CleanMachineError("Candidate package smoke left the production app running.")
+
+        _reset_runtime_workspace(app_path, synthetic_home)
+        operations.install_app(prior.dmg_path, app_path)
+        prior_identity = verify_installed_app(app_path, prior)
+        profile_path, profile_before_sha256 = _seed_profile(synthetic_home)
+        operations.write_preferences(synthetic_home, config.route)
+        if operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY) != config.route:
+            raise CleanMachineError("Update route did not persist before launching the prior release.")
+        if operations.read_preference(synthetic_home, SENTINEL_KEY) != SENTINEL_VALUE:
+            raise CleanMachineError("Preference sentinel did not persist before the Sparkle update.")
+
+        interaction = operations.perform_update(app_path, synthetic_home)
+        candidate_identity = _wait_for_candidate(app_path, candidate, operations)
+        route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
+        sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
+        profile_after_sha256 = file_sha256(profile_path)
+        if route_after != config.route or sentinel_after != SENTINEL_VALUE:
+            raise CleanMachineError("Update route or unrelated preference changed across Sparkle relaunch.")
+        if profile_after_sha256 != profile_before_sha256:
+            raise CleanMachineError("Profile library changed across Sparkle relaunch.")
+
+        evidence_directory.mkdir(parents=True)
+        install_digest = _write_json(
+            evidence_directory / "install-log.json",
+            {
+                "candidate": {
+                    "build_version": candidate_install_identity.build_version,
+                    "package_version": candidate_install_identity.package_version,
+                    "signed_app_tree_sha256": candidate.signed_app_tree_sha256,
+                },
+                "prior": {
+                    "build_version": prior_identity.build_version,
+                    "package_version": prior_identity.package_version,
+                    "signed_app_tree_sha256": prior.signed_app_tree_sha256,
+                },
+                "status": "passed",
+            },
+        )
+        package_digest = _write_json(
+            evidence_directory / "package-smoke.json",
+            {
+                "maintained_smoke": "scripts/smoke_release_app.py",
+                "raw_log_sha256": package_smoke_log_sha256,
+                "status": "passed",
+            },
+        )
+        update_digest = _write_json(
+            evidence_directory / "sparkle-update.json",
+            {
+                "button": interaction.clicked_button,
+                "candidate": {
+                    "build_version": candidate_identity.build_version,
+                    "package_version": candidate_identity.package_version,
+                    "signed_app_tree_sha256": candidate.signed_app_tree_sha256,
+                },
+                "feed_sha256": feed.feed_sha256,
+                "route": config.route,
+                "status": "passed",
+            },
+        )
+        profile_digest = _write_json(
+            evidence_directory / "profile-snapshot.json",
+            {
+                "profile_after_sha256": profile_after_sha256,
+                "profile_before_sha256": profile_before_sha256,
+                "profile_preserved": True,
+                "route_after": route_after,
+                "route_preserved": True,
+                "sentinel_preserved": sentinel_after == SENTINEL_VALUE,
+            },
+        )
+    finally:
+        try:
+            operations.quit_app()
+        finally:
+            if qualification_root.exists():
+                try:
+                    observed_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError) as error:
+                    raise CleanMachineError("Qualification cleanup ownership marker is missing or invalid.") from error
+                if observed_marker != marker:
+                    raise CleanMachineError("Qualification cleanup ownership marker changed during the run.")
+                shutil.rmtree(qualification_root)
+            cleanup_status = "disposed"
+
+    if operations.app_running() or qualification_root.exists():
+        raise CleanMachineError("Qualification cleanup did not remove the app process and disposable location.")
+    cleanup_digest = _write_json(
+        evidence_directory / "cleanup.json",
+        {
+            "app_running": False,
+            "qualification_root_exists": False,
+            "status": cleanup_status,
+        },
+    )
+
+    completed_at = _utc_timestamp()
+    assertions = {
+        "exact-app-installed": "passed",
+        "final-identity-matched": "passed",
+        "package-smoke-passed": "passed",
+        "preconditions-proven": "passed",
+        "profile-preserved": "passed",
+        "sparkle-relaunch-passed": "passed",
+    }
+    required_assertions = set(cast(Sequence[str], case["required_assertions"]))
+    if set(assertions) != required_assertions:
+        raise CleanMachineError(
+            f"Runner assertion contract changed; code={sorted(assertions)}, policy={sorted(required_assertions)}."
+        )
+    receipt = build_tier3_receipt(
+        {
+            "assertions": assertions,
+            "cleanup": {"status": cleanup_status, "evidence_sha256": cleanup_digest},
+            "completed_at": completed_at,
+            "environment": {
+                "architecture": environment.architecture,
+                "environment_class": environment.environment_class,
+                "macos_build": environment.macos_build,
+                "macos_version": environment.macos_version,
+            },
+            "evidence": [
+                {"kind": "install-log", "sha256": install_digest},
+                {"kind": "package-smoke", "sha256": package_digest},
+                {"kind": "sparkle-update", "sha256": update_digest},
+                {"kind": "profile-snapshot", "sha256": profile_digest},
+                {"kind": "cleanup", "sha256": cleanup_digest},
+            ],
+            "evidence_source": "tier3_automation_receipt",
+            "hardware": {"class": "none", "identity": {}},
+            "release_receipt_file_sha256": candidate.receipt_file_sha256,
+            "release_receipt_reference": candidate.receipt_reference,
+            "result": {"status": "passed", "reason_code": "all_assertions_passed"},
+            "started_at": started_at,
+        },
+        policy_id=_string(policy.get("policy_id"), "policy_id"),
+        case=case,
+        release_receipt=candidate.receipt,
+    )
+    try:
+        validate_tier3_receipt(
+            receipt,
+            policy_id=_string(policy.get("policy_id"), "policy_id"),
+            case=case,
+            reference_content=lambda reference: (config.repo.resolve() / reference).read_bytes(),
+        )
+    except Tier3ReceiptError as error:
+        raise CleanMachineError(f"Generated Tier 3 receipt is invalid: {error}") from error
+    _write_json(output_receipt, receipt)
+    return receipt
+
+
+def run_qualification(config: QualificationConfig, operations: QualificationOperations) -> Mapping[str, Any]:
+    try:
+        return _run_qualification(config, operations)
+    except BaseException:
+        if config.output_receipt is not None and config.output_receipt.exists():
+            config.output_receipt.unlink()
+        if config.evidence_directory is not None and config.evidence_directory.exists():
+            shutil.rmtree(config.evidence_directory)
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Qualify exact signed-app installation and Sparkle update evidence.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("preflight", "run"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--repo", type=Path, default=REPO_ROOT)
+        subparser.add_argument("--candidate-release-receipt", type=Path, required=True)
+        subparser.add_argument("--candidate-dmg", type=Path, required=True)
+        subparser.add_argument("--prior-release-receipt", type=Path, required=True)
+        subparser.add_argument("--prior-dmg", type=Path, required=True)
+        subparser.add_argument("--qualification-root", type=Path, required=True)
+        subparser.add_argument("--route", choices=tuple(ROUTE_CHANNELS), required=True)
+        subparser.add_argument("--environment-class", choices=("restorable-location",), required=True)
+        if command == "run":
+            subparser.add_argument("--output-receipt", type=Path, required=True)
+            subparser.add_argument("--evidence-directory", type=Path, required=True)
+    return parser
+
+
+def _config_from_args(args: argparse.Namespace) -> QualificationConfig:
+    return QualificationConfig(
+        repo=args.repo,
+        candidate_receipt=args.candidate_release_receipt,
+        candidate_dmg=args.candidate_dmg,
+        prior_receipt=args.prior_release_receipt,
+        prior_dmg=args.prior_dmg,
+        qualification_root=args.qualification_root,
+        route=args.route,
+        environment_class=args.environment_class,
+        output_receipt=getattr(args, "output_receipt", None),
+        evidence_directory=getattr(args, "evidence_directory", None),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = _config_from_args(args)
+    operations = MacOSOperations()
+    try:
+        if args.command == "preflight":
+            payload = preflight_report(config, operations)
+        else:
+            receipt = run_qualification(config, operations)
+            payload = {
+                "case_id": receipt["case_id"],
+                "receipt_sha256": receipt["receipt_sha256"],
+                "result": receipt["result"],
+            }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    except (CleanMachineError, OSError, subprocess.TimeoutExpired) as error:
+        print(f"tier3 clean-machine error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -145,23 +145,32 @@ class UpdateInteraction:
 
 
 class QualificationOperations(Protocol):
-    def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts: ...
+    def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
+        raise NotImplementedError
 
-    def fetch_live_feed(self) -> bytes: ...
+    def fetch_live_feed(self) -> bytes:
+        raise NotImplementedError
 
-    def install_app(self, dmg_path: Path, destination: Path) -> None: ...
+    def install_app(self, dmg_path: Path, destination: Path) -> None:
+        raise NotImplementedError
 
-    def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str: ...
+    def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
+        raise NotImplementedError
 
-    def write_preferences(self, synthetic_home: Path, route: str) -> None: ...
+    def write_preferences(self, synthetic_home: Path, route: str) -> None:
+        raise NotImplementedError
 
-    def read_preference(self, synthetic_home: Path, key: str) -> str: ...
+    def read_preference(self, synthetic_home: Path, key: str) -> str:
+        raise NotImplementedError
 
-    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction: ...
+    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+        raise NotImplementedError
 
-    def app_running(self) -> bool: ...
+    def app_running(self) -> bool:
+        raise NotImplementedError
 
-    def quit_app(self) -> None: ...
+    def quit_app(self) -> None:
+        raise NotImplementedError
 
 
 def _mapping(value: object, description: str) -> Mapping[str, Any]:
@@ -538,10 +547,7 @@ class MacOSOperations:
             timeout=COMMAND_TIMEOUT_SECONDS,
         )
         if result.returncode != 0:
-            try:
-                mount_point.rmdir()
-            except OSError:
-                pass
+            shutil.rmtree(mount_point, ignore_errors=True)
             raise CleanMachineError(f"Unable to mount release DMG: {result.stderr.decode(errors='replace').strip()}")
         return mount_point
 

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -1,0 +1,485 @@
+import base64
+import json
+import platform
+import plistlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from datetime import datetime, timezone
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+from scripts import sparkle_appcast
+from scripts.artifact_identity import app_tree_sha256
+from scripts.release_receipt import build_receipt as build_release_receipt
+from scripts.release_receipt import write_receipt
+from scripts.tier3_clean_machine import (
+    APP_NAME,
+    BUNDLE_IDENTIFIER,
+    CleanMachineError,
+    EnvironmentFacts,
+    MacOSOperations,
+    QualificationConfig,
+    QualificationOperations,
+    ReleaseArtifact,
+    UpdateInteraction,
+    file_sha256,
+    parse_feed_candidate,
+    preflight_report,
+    run_qualification,
+    validate_release_order,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_SHA = "b" * 40
+PRIOR_SHA = "a" * 40
+SIGNATURE = base64.b64encode(b"s" * 64).decode("ascii")
+
+
+class FakeOperations(QualificationOperations):
+    def __init__(
+        self,
+        app_sources: dict[Path, Path],
+        feed_bytes: bytes,
+        candidate_dmg: Path,
+        *,
+        macos_version: str = "26.0",
+        update_failure: bool = False,
+        sentinel_failure: bool = False,
+        tamper_marker: bool = False,
+    ) -> None:
+        self.app_sources = app_sources
+        self.feed_bytes = feed_bytes
+        self.macos_version = macos_version
+        self.update_failure = update_failure
+        self.sentinel_failure = sentinel_failure
+        self.tamper_marker = tamper_marker
+        self.preferences: dict[str, str] = {}
+        self.running = False
+        self.candidate_source = app_sources[candidate_dmg.resolve()]
+
+    def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
+        return EnvironmentFacts(
+            environment_class=environment_class,
+            architecture="arm64",
+            macos_version=self.macos_version,
+            macos_build="25A123",
+            free_bytes=20 * 1024 * 1024 * 1024,
+            accessibility_enabled=True,
+            homebrew_present=True,
+            app_running=self.running,
+            required_tools=(),
+        )
+
+    def fetch_live_feed(self) -> bytes:
+        return self.feed_bytes
+
+    def install_app(self, dmg_path: Path, destination: Path) -> None:
+        shutil.copytree(self.app_sources[dmg_path], destination, symlinks=True)
+
+    def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("smoke passed\n", encoding="utf-8")
+        return file_sha256(log_path)
+
+    def write_preferences(self, synthetic_home: Path, route: str) -> None:
+        self.preferences = {
+            "BDToAVPUpdateChannel": route,
+            "BDToAVPTier3Sentinel": "changed" if self.sentinel_failure else "tier3-preserve",
+            "SUEnableAutomaticChecks": "0",
+        }
+
+    def read_preference(self, synthetic_home: Path, key: str) -> str:
+        return self.preferences[key]
+
+    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+        if self.update_failure:
+            raise CleanMachineError("simulated Sparkle failure")
+        if self.tamper_marker:
+            marker_path = synthetic_home.parent / ".bd-to-avp-tier3-owned.json"
+            marker_path.write_text('{"owner":"changed"}\n', encoding="utf-8")
+        shutil.rmtree(app_path)
+        shutil.copytree(self.candidate_source, app_path, symlinks=True)
+        self.running = True
+        return UpdateInteraction(clicked_button="Install and Relaunch")
+
+    def app_running(self) -> bool:
+        return self.running
+
+    def quit_app(self) -> None:
+        self.running = False
+
+
+class Tier3CleanMachineTests(unittest.TestCase):
+    @staticmethod
+    def make_app(root: Path, package_version: str, build_version: str, payload: str) -> Path:
+        app = root / f"app-{package_version}" / APP_NAME
+        contents = app / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "Info.plist").write_bytes(
+            plistlib.dumps(
+                {
+                    "BDToAVPDistributionChannel": "direct",
+                    "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+                    "CFBundleShortVersionString": package_version,
+                    "CFBundleVersion": build_version,
+                    "SUFeedURL": "https://cbusillo.github.io/BD_to_AVP/appcast.xml",
+                }
+            )
+        )
+        executable = contents / "MacOS" / "app"
+        executable.parent.mkdir(parents=True)
+        executable.write_text(payload, encoding="utf-8")
+        executable.chmod(0o755)
+        return app
+
+    @staticmethod
+    def release_facts(
+        *,
+        source_sha: str,
+        package_version: str,
+        public_version: str,
+        build_version: str,
+        release_tag: str,
+        release_id: int,
+        dmg_path: Path,
+        app_path: Path,
+    ) -> dict[str, object]:
+        return {
+            "release_route": "prerelease",
+            "source_sha": source_sha,
+            "workflow_actor": "shiny-code-bot",
+            "workflow_run_id": release_id + 1000,
+            "workflow_run_attempt": 1,
+            "package_version": package_version,
+            "public_version": public_version,
+            "build_version": build_version,
+            "release_tag": release_tag,
+            "release_name": release_tag,
+            "release_id": release_id,
+            "release_created_at": "2026-08-05T12:00:00Z",
+            "prerelease": True,
+            "make_latest": False,
+            "signed_app_tree_sha256": app_tree_sha256(app_path),
+            "artifacts": [
+                {
+                    "kind": "dmg",
+                    "name": dmg_path.name,
+                    "sha256": file_sha256(dmg_path),
+                    "size_bytes": dmg_path.stat().st_size,
+                    "asset_id": release_id + 1,
+                },
+                {
+                    "kind": "checksum",
+                    "name": "SHA256SUMS",
+                    "sha256": "c" * 64,
+                    "size_bytes": 100,
+                    "asset_id": release_id + 2,
+                },
+                {
+                    "kind": "appcast",
+                    "name": "appcast.xml",
+                    "sha256": "d" * 64,
+                    "size_bytes": 500,
+                    "asset_id": release_id + 3,
+                },
+            ],
+        }
+
+    @staticmethod
+    def make_feed(root: Path, candidate_dmg: Path, *, minimum_system_version: str = "26.0") -> bytes:
+        root.mkdir(parents=True, exist_ok=True)
+        empty_feed = root / "empty.xml"
+        empty_feed.write_text(
+            f"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+     xmlns:sparkle="{sparkle_appcast.SPARKLE_NAMESPACE}"
+     xmlns:dc="{sparkle_appcast.DC_NAMESPACE}">
+  <channel>
+    <title>3D Blu-ray to Vision Pro Updates</title>
+    <link>https://github.com/cbusillo/BD_to_AVP</link>
+    <description>Updates.</description>
+    <language>en</language>
+  </channel>
+</rss>
+""",
+            encoding="utf-8",
+        )
+        feed = root / "appcast.xml"
+        sparkle_appcast.append_item(
+            empty_feed,
+            feed,
+            sparkle_appcast.AppcastItem(
+                build_version="160",
+                short_version="0.3.0rc3",
+                channel="rc",
+                download_url=(
+                    f"https://github.com/cbusillo/BD_to_AVP/releases/download/v0.3.0-rc.3/{candidate_dmg.name}"
+                ),
+                length=candidate_dmg.stat().st_size,
+                signature=SIGNATURE,
+                release_notes_markdown="RC 3 qualification fixture.",
+                full_release_notes_url="https://github.com/cbusillo/BD_to_AVP/releases/tag/v0.3.0-rc.3",
+                minimum_system_version=minimum_system_version,
+                published_at=datetime(2026, 8, 5, 12, tzinfo=timezone.utc),
+            ),
+        )
+        return feed.read_bytes()
+
+    def fixture(self, root: Path) -> tuple[QualificationConfig, FakeOperations]:
+        repo = root / "repo"
+        repo.mkdir()
+        policy_path = repo / "docs" / "qualification" / "release-qualification-policy-v1.json"
+        policy_path.parent.mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / "docs" / "qualification" / "release-qualification-policy-v1.json", policy_path)
+
+        prior_app = self.make_app(root, "0.3.0rc2", "159", "prior")
+        candidate_app = self.make_app(root, "0.3.0rc3", "160", "candidate")
+        prior_dmg = root / "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.2.dmg"
+        candidate_dmg = root / "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg"
+        prior_dmg.write_bytes(b"prior-dmg")
+        candidate_dmg.write_bytes(b"candidate-dmg")
+
+        prior_receipt = repo / "docs" / "release-evidence" / "prior" / "release-receipt.json"
+        candidate_receipt = repo / "docs" / "release-evidence" / "candidate" / "release-receipt.json"
+        prior_receipt.parent.mkdir(parents=True)
+        candidate_receipt.parent.mkdir(parents=True)
+        write_receipt(
+            build_release_receipt(
+                self.release_facts(
+                    source_sha=PRIOR_SHA,
+                    package_version="0.3.0rc2",
+                    public_version="0.3.0-rc.2",
+                    build_version="159",
+                    release_tag="v0.3.0-rc.2",
+                    release_id=100,
+                    dmg_path=prior_dmg,
+                    app_path=prior_app,
+                )
+            ),
+            prior_receipt,
+        )
+        write_receipt(
+            build_release_receipt(
+                self.release_facts(
+                    source_sha=CANDIDATE_SHA,
+                    package_version="0.3.0rc3",
+                    public_version="0.3.0-rc.3",
+                    build_version="160",
+                    release_tag="v0.3.0-rc.3",
+                    release_id=200,
+                    dmg_path=candidate_dmg,
+                    app_path=candidate_app,
+                )
+            ),
+            candidate_receipt,
+        )
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+
+        config = QualificationConfig(
+            repo=repo,
+            candidate_receipt=candidate_receipt,
+            candidate_dmg=candidate_dmg,
+            prior_receipt=prior_receipt,
+            prior_dmg=prior_dmg,
+            qualification_root=Path.home() / f"tier3-test-{root.name}",
+            route="rc",
+            environment_class="restorable-location",
+            output_receipt=root / "tier3-receipt.json",
+            evidence_directory=root / "evidence",
+        )
+        operations = FakeOperations(
+            {prior_dmg.resolve(): prior_app, candidate_dmg.resolve(): candidate_app},
+            self.make_feed(root, candidate_dmg),
+            candidate_dmg,
+        )
+        return config, operations
+
+    def test_preflight_binds_checked_artifacts_environment_and_live_feed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config, operations = self.fixture(Path(temporary_directory))
+            report = preflight_report(config, operations)
+
+        self.assertEqual(report["preflight"], "passed")
+        self.assertEqual(report["environment"]["environment_class"], "restorable-location")
+        self.assertEqual(report["candidate"]["build_version"], "160")
+        self.assertEqual(report["prior"]["build_version"], "159")
+        self.assertEqual(report["feed"]["route"], "rc")
+        self.assertNotIn("hostname", json.dumps(report).lower())
+
+    def test_run_emits_valid_receipt_and_disposes_owned_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            receipt = run_qualification(config, operations)
+
+            self.assertFalse(config.qualification_root.exists())
+            self.assertTrue(config.output_receipt.exists())
+            self.assertEqual(len(list(config.evidence_directory.glob("*.json"))), 5)
+            self.assertEqual(receipt["result"]["status"], "passed")
+            self.assertEqual(receipt["cleanup"]["status"], "disposed")
+            self.assertEqual(receipt["release_identity"]["source_sha"], CANDIDATE_SHA)
+            self.assertFalse(operations.app_running())
+
+    def test_run_cleans_workspace_after_update_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.update_failure = True
+
+            with self.assertRaisesRegex(CleanMachineError, "simulated Sparkle failure"):
+                run_qualification(config, operations)
+
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(operations.app_running())
+            self.assertFalse(config.output_receipt.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_preflight_rejects_wrong_macos_major(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config, operations = self.fixture(Path(temporary_directory))
+            operations.macos_version = "27.0"
+
+            with self.assertRaisesRegex(CleanMachineError, "requires macOS"):
+                preflight_report(config, operations)
+
+    def test_preflight_rejects_candidate_not_newer_than_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config, operations = self.fixture(Path(temporary_directory))
+            report = preflight_report(config, operations)
+            self.assertEqual(report["candidate"]["build_version"], "160")
+            candidate = json.loads(config.candidate_receipt.read_text(encoding="utf-8"))
+            prior = json.loads(config.prior_receipt.read_text(encoding="utf-8"))
+            candidate_release = self.release_artifact(config.candidate_receipt, config.candidate_dmg, candidate)
+            prior_release = self.release_artifact(config.prior_receipt, config.prior_dmg, prior)
+            candidate_release = replace(candidate_release, build_version=prior_release.build_version)
+
+            with self.assertRaisesRegex(CleanMachineError, "must be newer"):
+                validate_release_order(prior_release, candidate_release)
+
+    def test_preflight_rejects_root_outside_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            config = replace(config, qualification_root=root / "outside-home")
+
+            with self.assertRaisesRegex(CleanMachineError, "inside the current home"):
+                preflight_report(config, operations)
+
+    def test_preflight_rejects_candidate_minimum_system_above_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.feed_bytes = self.make_feed(
+                root / "new-feed", config.candidate_dmg, minimum_system_version="26.1"
+            )
+
+            with self.assertRaisesRegex(CleanMachineError, "older than the candidate"):
+                preflight_report(config, operations)
+
+    def test_preflight_rejects_preference_sentinel_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.sentinel_failure = True
+
+            with self.assertRaisesRegex(CleanMachineError, "Preference sentinel"):
+                run_qualification(config, operations)
+
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_marker_tampering_retains_root_for_investigation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.tamper_marker = True
+
+            with self.assertRaisesRegex(CleanMachineError, "ownership marker changed"):
+                run_qualification(config, operations)
+
+            self.assertTrue(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+            shutil.rmtree(config.qualification_root)
+
+    def test_feed_rejects_route_that_excludes_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            report = preflight_report(config, operations)
+            self.assertEqual(report["feed"]["route"], "rc")
+            candidate = json.loads(config.candidate_receipt.read_text(encoding="utf-8"))
+            release_artifact = self.release_artifact(config.candidate_receipt, config.candidate_dmg, candidate)
+
+            with self.assertRaisesRegex(CleanMachineError, "not eligible"):
+                parse_feed_candidate(operations.feed_bytes, release_artifact, "stable")
+
+    @staticmethod
+    def release_artifact(receipt_path: Path, dmg_path: Path, receipt: dict[str, Any]) -> ReleaseArtifact:
+        release = cast(dict[str, Any], receipt["release"])
+        versions = cast(dict[str, Any], receipt["versions"])
+        artifacts = cast(list[dict[str, Any]], receipt["artifacts"])
+        artifact = next(item for item in artifacts if item["kind"] == "dmg")
+        return ReleaseArtifact(
+            receipt=receipt,
+            receipt_path=receipt_path,
+            receipt_reference="docs/release-evidence/test/release-receipt.json",
+            receipt_file_sha256=file_sha256(receipt_path),
+            dmg_path=dmg_path,
+            dmg_name=artifact["name"],
+            dmg_sha256=artifact["sha256"],
+            dmg_size=artifact["size_bytes"],
+            source_sha=receipt["source_sha"],
+            release_tag=release["tag"],
+            package_version=versions["package"],
+            public_version=versions["public"],
+            build_version=versions["build"],
+            signed_app_tree_sha256=receipt["signed_app_tree_sha256"],
+        )
+
+    @unittest.skipUnless(platform.system() == "Darwin", "AppleScript compilation requires macOS")
+    def test_updater_applescript_compiles(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source = Path(temporary_directory) / "updater.applescript"
+            output = Path(temporary_directory) / "updater.scpt"
+            source.write_text(MacOSOperations()._updater_script(), encoding="utf-8")
+            result = subprocess.run(
+                ["osacompile", "-o", str(output), str(source)],
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(platform.system() == "Darwin", "DMG mount integration requires macOS")
+    def test_synthetic_dmg_mount_and_detach(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source"
+            source.mkdir()
+            (source / "fixture.txt").write_text("fixture\n", encoding="utf-8")
+            dmg = root / "fixture.dmg"
+            create = subprocess.run(
+                ["hdiutil", "create", "-quiet", "-ov", "-format", "UDZO", "-srcfolder", str(source), str(dmg)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(create.returncode, 0, create.stderr)
+            mount_point = root / "mount"
+            operations = MacOSOperations()
+            operations._mount_dmg(dmg, mount_point)
+            self.assertEqual((mount_point / "fixture.txt").read_text(encoding="utf-8"), "fixture\n")
+            operations._detach_mounts([mount_point])
+            self.assertFalse(mount_point.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a macOS 26 `restorable-location` runner with exact checked release-receipt and DMG validation, real public appcast verification, free-space/accessibility/process/tool preconditions, and runner-owned synthetic-home isolation
- install and smoke the exact candidate, reinstall the exact prior release, drive bounded Sparkle Install and Relaunch, then verify final bundle/build/signed-tree identity plus route, unrelated preference, and profile preservation
- detach mounts, terminate the app, enforce cleanup ownership, delete the disposable location, and emit five public-safe evidence summaries plus a validated Tier 3 receipt
- add deterministic fake-release/appcast/relaunch tests, AppleScript compilation, synthetic DMG mount/detach integration, negative-path cleanup tests, documentation, policy invalidation, and quality-gate metadata

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (12 tests)
- `uv run python -m unittest tests.test_tier3_clean_machine tests.test_tier3_receipt tests.test_qualify_release_scope`
- `uv run python -m unittest discover -s tests -t .` (1,543 tests, 3 skipped)
- `uv run python scripts/native_app.py test` (355 tests)
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python -m scripts.release validate`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- JetBrains: all surfaced Python findings were fixed; final PyCharm capture reported zero problems but ended `UNKNOWN` with helper reason `execution_not_proven`, so the inspection tool could not issue a trustworthy green verdict

## Environment Boundary
- This host is macOS 27.0, while policy intentionally requires macOS 26, and no newer published candidate exists after RC3. The real signed prior-to-candidate Sparkle receipt therefore remains cadence-bound to the next eligible macOS 26 qualification run; this PR supplies and tests the maintained runner without weakening that requirement.

Refs #482
Refs #477