### PR TITLE
Automate installed UI and accessibility evidence

### DIFF
--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -283,7 +283,15 @@
       "cadence": {"first_rc": true, "stable_candidate": true},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 90},
       "invalidates_on": {
-        "paths": ["macos/BluRayToVisionProUITests/**"],
+        "paths": [
+          "docs/tier3-clean-machine.md",
+          "macos/BluRayToVisionPro/Views/ContentView.swift",
+          "macos/BluRayToVisionPro/Views/ConversionSetupView.swift",
+          "macos/BluRayToVisionPro/Views/SettingsView.swift",
+          "macos/BluRayToVisionProUITests/**",
+          "macos/project.yml",
+          "scripts/tier3_clean_machine.py"
+        ],
         "contracts": ["sparkle-update", "profile-storage", "preview-lifecycle", "support-diagnostics", "tier3-evidence"]
       },
       "allowed_evidence_sources": ["tier3_automation_receipt"],

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -102,11 +102,12 @@ Passed receipts require every declared assertion to pass. Failed, skipped, and
 not-applicable receipts remain valid audit records with explicit bounded reason
 codes, but only a passed receipt may be indexed as accepted release evidence.
 
-The maintained clean-machine and Sparkle collector is documented in
+The maintained clean-machine, Sparkle, and installed UI/accessibility collector is documented in
 [`docs/tier3-clean-machine.md`](tier3-clean-machine.md). It uses an isolated
 synthetic home in a runner-owned disposable location, reuses the installed-app
 package smoke, verifies a real-feed update from an exact prior signed release,
-and emits the checked `clean-machine-signed-update` receipt.
+and emits checked `clean-machine-signed-update` and
+`installed-ui-accessibility` receipts.
 
 ## Release Engine Receipts
 

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -1,9 +1,10 @@
 # Tier 3 Clean-Machine And Sparkle Qualification
 
 `scripts/tier3_clean_machine.py` collects the automated
-`clean-machine-signed-update` evidence declared by the release qualification
-policy. It operates only on immutable signed release artifacts and never signs,
-notarizes, publishes, approves an environment, or changes the live appcast.
+`clean-machine-signed-update` and `installed-ui-accessibility` evidence declared
+by the release qualification policy. It operates only on immutable signed
+release artifacts and never signs, notarizes, publishes, approves an
+environment, or changes the live appcast.
 
 ## Maintained Environment
 
@@ -17,7 +18,8 @@ The host must provide:
 
 - macOS 26 on `arm64`;
 - Accessibility control for the terminal or automation host;
-- `defaults`, `ditto`, `hdiutil`, `open`, and `osascript`;
+- Xcode with `xcodebuild`, plus `defaults`, `ditto`, `hdiutil`, `open`, and
+  `osascript`;
 - enough free space for both DMGs, two candidate copies, and 2 GiB of working
   headroom;
 - no running production app process; and
@@ -67,6 +69,7 @@ uv run python -m scripts.tier3_clean_machine run \
   --route rc \
   --environment-class restorable-location \
   --output-receipt /path/out/clean-machine-signed-update.json \
+  --ui-output-receipt /path/out/installed-ui-accessibility.json \
   --evidence-directory /path/out/clean-machine-signed-update-evidence
 ```
 
@@ -77,20 +80,27 @@ The runner performs this bounded sequence:
 2. Clear the owned runtime location, install the exact prior release, and seed a
    valid profile library plus route and unrelated preference sentinels in the
    synthetic home.
-3. Launch the prior app, invoke `Check for Updates…`, click Sparkle's bounded
-   install/relaunch action, and wait for the exact candidate bundle, build, and
-   signed app tree to relaunch.
-4. Verify the selected route, unrelated preference, and byte-for-byte profile
+3. Run the installed-app XCUITest lane against the exact prior app, verifying
+   Sparkle controls and the source-bound release-notes URL without installing.
+4. Launch the prior app again, invoke `Check for Updates…`, click Sparkle's
+   bounded install/relaunch action, and wait for the exact candidate bundle,
+   build, and signed app tree to relaunch.
+5. Verify the selected route, unrelated preference, and byte-for-byte profile
    library are preserved.
-5. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
-   and delete the complete qualification root.
-6. Emit five public-safe evidence summaries and a validated
-   `bd-to-avp-tier3-qualification` receipt with `cleanup.status = disposed`.
+6. Run the candidate installed-app XCUITest lane. It verifies main-window
+   readiness, profile-save accessibility and success, updater settings, the
+   public releases link, and cropped light/dark app-window screenshots.
+7. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
+   and delete the qualification root with raw XCTest and build output.
+8. Emit normalized public-safe evidence and validated receipts for both policy
+   cases with `cleanup.status = disposed`.
 
 Every mount, subprocess, network request, GUI wait, update wait, and cleanup
 action has a timeout. Raw package-smoke output remains inside the disposable
-root and is deleted; public evidence records only its SHA-256 digest. A failed
-run does not emit an accepted receipt.
+root and is deleted; public evidence records only its SHA-256 digest. Raw AX
+trees, XCTest logs, `.xcresult` bundles, local paths, and full-screen captures
+are deleted. Retained screenshots contain only the app window. A failed run
+does not emit either accepted receipt.
 
 If the cleanup ownership marker is missing or changed, the runner refuses to
 delete the qualification root because it can no longer prove ownership. It

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -135,6 +135,7 @@ struct ContentView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
+        .accessibilityIdentifier("main-window-content")
         .toolbar { toolbarContent }
         .animation(.easeInOut(duration: 0.18), value: isShowingActivity)
         .dropDestination(for: URL.self, action: acceptDrop) { targeted in
@@ -378,6 +379,7 @@ struct ContentView: View {
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(statusAccessibilityLabel)
+            .accessibilityIdentifier("main-status")
 
             if viewModel.hasActiveWorker {
                 WorkerProgressGauge(progress: viewModel.state.progress, width: 64)
@@ -409,6 +411,7 @@ struct ContentView: View {
                 .help(diagnosticActionHelp)
                 .accessibilityLabel(diagnosticActionTitle.replacingOccurrences(of: "…", with: ""))
                 .accessibilityHint("Captures diagnostics without stopping the current conversion")
+                .accessibilityIdentifier("diagnostics-action")
             }
 
             Button {
@@ -1007,6 +1010,7 @@ private struct SaveProfileSheet: View {
 
             TextField("Profile name", text: $name)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("save-profile-name-field")
 
             HStack {
                 Spacer()
@@ -1014,11 +1018,13 @@ private struct SaveProfileSheet: View {
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("save-profile-cancel")
 
                 Button("Save", action: save)
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
                     .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityIdentifier("save-profile-confirm")
             }
         }
         .padding(24)

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -53,6 +53,8 @@ struct ConversionSetupView: View {
                 .buttonStyle(.borderless)
                 .help("Save current settings as a new profile")
                 .accessibilityLabel("Save current settings as new profile")
+                .accessibilityHint("Opens a form to name and save these settings as a reusable profile")
+                .accessibilityIdentifier("save-profile-action")
                 .disabled(isLocked)
 
                 Menu {

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -14,7 +14,10 @@ struct SettingsView: View {
                 .tabItem { Label("Profiles", systemImage: "slider.horizontal.3") }
 
             UpdatesSettingsPane(updater: updater)
-                .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
+                .tabItem {
+                    Label("Updates", systemImage: "arrow.triangle.2.circlepath")
+                        .accessibilityIdentifier("updates-settings-tab")
+                }
 
             AdvancedSettingsPane(settings: settings)
                 .tabItem { Label("Advanced", systemImage: "wrench.and.screwdriver") }
@@ -731,6 +734,7 @@ private struct UpdatesSettingsPane: View {
             Section("Update Preferences") {
                 Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
                     .disabled(!updater.supportsAutomaticChecks)
+                    .accessibilityIdentifier("automatic-update-checks-toggle")
 
                 Picker("Update route", selection: $updater.updateChannel) {
                     ForEach(UpdateChannelPreference.allCases) { channel in
@@ -738,6 +742,7 @@ private struct UpdatesSettingsPane: View {
                     }
                 }
                 .disabled(!updater.supportsChannels)
+                .accessibilityIdentifier("update-route-picker")
 
                 Text(updater.updateChannel.explanation)
                     .font(.callout)
@@ -759,13 +764,16 @@ private struct UpdatesSettingsPane: View {
                     updater.performUpdateAction()
                 }
                 .disabled(!updater.canPerformUpdateAction)
+                .accessibilityIdentifier("update-action")
 
                 if updater.mode == .sparkle {
                     Link("View All Releases…", destination: UpdateController.releasesURL)
+                        .accessibilityIdentifier("all-releases-link")
                 }
             }
         }
         .formStyle(.grouped)
+        .accessibilityIdentifier("updates-settings-pane")
     }
 }
 

--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -1,0 +1,464 @@
+import AppKit
+import ApplicationServices
+import XCTest
+
+final class InstalledUIAcceptanceTests: XCTestCase {
+    private static let profileName = "Tier 3 Accessibility"
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+        guard let bundleIdentifier = ProcessInfo.processInfo.environment["BD_TO_AVP_UI_BUNDLE_IDENTIFIER"] else {
+            return
+        }
+        XCUIApplication(bundleIdentifier: bundleIdentifier).terminate()
+    }
+
+    func testPriorUpdaterControlsAndReleaseLinks() throws {
+        let context = try QualificationContext.load(expectedPhase: "updater")
+        let app = try launchInstalledApp(context: context, appearance: .light)
+        defer { app.terminate() }
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
+        openUpdateWindow(in: app)
+
+        let installButton = firstExistingElement(
+            in: app.buttons,
+            identifiers: ["Install and Relaunch", "Install Update", "Relaunch"],
+            timeout: 120
+        )
+        XCTAssertNotNil(installButton)
+
+        let applicationElement = try AXInspector.applicationElement(bundleIdentifier: context.bundleIdentifier)
+        let observedURLs = AXInspector.linkURLs(root: applicationElement)
+        XCTAssertTrue(
+            observedURLs.contains(context.releaseNotesURL),
+            "The Sparkle window did not expose the candidate release-notes URL."
+        )
+
+        try writeJSON(
+            [
+                "install_action": installButton?.label ?? "",
+                "release_notes_url": context.releaseNotesURL,
+                "release_notes_url_observed": true,
+                "schema_version": 1,
+                "status": "passed",
+            ],
+            to: context.outputDirectory.appendingPathComponent("updater-ui.json")
+        )
+    }
+
+    func testCandidateMainWindowProfileAndSettings() throws {
+        let context = try QualificationContext.load(expectedPhase: "candidate")
+        let lightApp = try launchInstalledApp(context: context, appearance: .light)
+        defer {
+            lightApp.terminate()
+            try? setAppearance(.light, syntheticHome: context.syntheticHome)
+        }
+
+        let mainContent = lightApp.descendants(matching: .any)["main-window-content"]
+        XCTAssertTrue(mainContent.waitForExistence(timeout: 30))
+        XCTAssertTrue(lightApp.descendants(matching: .any)["main-status"].waitForExistence(timeout: 20))
+
+        let saveAction = lightApp.buttons["save-profile-action"]
+        XCTAssertTrue(saveAction.waitForExistence(timeout: 20))
+        let applicationElement = try AXInspector.applicationElement(bundleIdentifier: context.bundleIdentifier)
+        let saveRecord = try AXInspector.record(identifier: "save-profile-action", root: applicationElement)
+        XCTAssertEqual(saveRecord.role, kAXButtonRole as String)
+        XCTAssertEqual(saveRecord.label, "Save current settings as new profile")
+        XCTAssertEqual(
+            saveRecord.help,
+            "Opens a form to name and save these settings as a reusable profile"
+        )
+        XCTAssertTrue(saveRecord.enabled)
+        XCTAssertTrue(saveRecord.actions.contains(kAXPressAction as String))
+
+        saveAction.click()
+        let nameField = lightApp.textFields["save-profile-name-field"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 20))
+        nameField.click()
+        nameField.typeText(Self.profileName)
+        let confirmButton = lightApp.buttons["save-profile-confirm"]
+        XCTAssertTrue(confirmButton.isEnabled)
+        confirmButton.click()
+        XCTAssertTrue(waitUntil(timeout: 20) { !nameField.exists })
+
+        let profileSummary = try readProfileSummary(syntheticHome: context.syntheticHome)
+        XCTAssertEqual(profileSummary.version, 5)
+        XCTAssertEqual(profileSummary.count, 1)
+        XCTAssertEqual(profileSummary.name, Self.profileName)
+
+        let lightWindow = lightApp.windows.firstMatch
+        XCTAssertTrue(lightWindow.exists)
+        try lightWindow.screenshot().pngRepresentation.write(
+            to: context.outputDirectory.appendingPathComponent("screenshot-light.png"),
+            options: .atomic
+        )
+
+        openUpdatesSettings(in: lightApp)
+        let updateAction = lightApp.buttons["update-action"]
+        let routePicker = lightApp.descendants(matching: .any)["update-route-picker"]
+        let releasesLink = lightApp.links["all-releases-link"]
+        XCTAssertTrue(updateAction.waitForExistence(timeout: 20))
+        XCTAssertTrue(routePicker.waitForExistence(timeout: 20))
+        XCTAssertTrue(releasesLink.waitForExistence(timeout: 20))
+
+        let updatedApplicationElement = try AXInspector.applicationElement(bundleIdentifier: context.bundleIdentifier)
+        let releasesRecord = try AXInspector.record(identifier: "all-releases-link", root: updatedApplicationElement)
+        XCTAssertEqual(releasesRecord.url, context.releasesURL)
+
+        let updateRecord = try AXInspector.record(identifier: "update-action", root: updatedApplicationElement)
+        let routeRecord = try AXInspector.record(identifier: "update-route-picker", root: updatedApplicationElement)
+        let statusRecord = try AXInspector.record(identifier: "main-status", root: updatedApplicationElement)
+
+        try writeJSON(
+            [
+                "elements": [statusRecord.jsonValue, saveRecord.jsonValue, updateRecord.jsonValue, routeRecord.jsonValue,
+                             releasesRecord.jsonValue],
+                "schema_version": 1,
+            ],
+            to: context.outputDirectory.appendingPathComponent("accessibility-tree.json")
+        )
+
+        try writeJSON(
+            [
+                "main_window_ready": true,
+                "profile_document_version": profileSummary.version,
+                "profile_save_accessible": true,
+                "profile_save_succeeded": true,
+                "profiles_after": profileSummary.count,
+                "release_page_url": context.releasesURL,
+                "release_page_url_observed": true,
+                "schema_version": 1,
+                "status": "passed",
+                "updater_controls_accessible": true,
+            ],
+            to: context.outputDirectory.appendingPathComponent("candidate-ui.json")
+        )
+
+        lightApp.terminate()
+        let darkApp = try launchInstalledApp(context: context, appearance: .dark)
+        defer { darkApp.terminate() }
+        let darkWindow = darkApp.windows.firstMatch
+        XCTAssertTrue(darkWindow.waitForExistence(timeout: 30))
+        try darkWindow.screenshot().pngRepresentation.write(
+            to: context.outputDirectory.appendingPathComponent("screenshot-dark.png"),
+            options: .atomic
+        )
+    }
+
+    private func launchInstalledApp(
+        context: QualificationContext,
+        appearance: QualificationAppearance
+    ) throws -> XCUIApplication {
+        try setAppearance(appearance, syntheticHome: context.syntheticHome)
+        XCUIApplication(bundleIdentifier: context.bundleIdentifier).terminate()
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = [
+            "-n", "-F",
+            "--env", "HOME=\(context.syntheticHome.path)",
+            "--env", "CFFIXED_USER_HOME=\(context.syntheticHome.path)",
+            context.appURL.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+
+        let app = XCUIApplication(bundleIdentifier: context.bundleIdentifier)
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
+        let matches = NSRunningApplication.runningApplications(withBundleIdentifier: context.bundleIdentifier)
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches.first?.bundleURL?.standardizedFileURL, context.appURL.standardizedFileURL)
+        return app
+    }
+
+    private func openUpdateWindow(in app: XCUIApplication) {
+        let helpItem = app.menuBars.menuBarItems["Help"]
+        XCTAssertTrue(helpItem.waitForExistence(timeout: 20))
+        helpItem.click()
+        let checkItem = app.menuItems["Check for Updates…"]
+        XCTAssertTrue(checkItem.waitForExistence(timeout: 20))
+        checkItem.click()
+    }
+
+    private func openUpdatesSettings(in app: XCUIApplication) {
+        app.typeKey(",", modifierFlags: .command)
+        let identifierTab = app.descendants(matching: .any)["updates-settings-tab"]
+        if identifierTab.waitForExistence(timeout: 10) {
+            identifierTab.click()
+        } else {
+            let titledTab = app.buttons["Updates"]
+            XCTAssertTrue(titledTab.waitForExistence(timeout: 10))
+            titledTab.click()
+        }
+        XCTAssertTrue(app.descendants(matching: .any)["updates-settings-pane"].waitForExistence(timeout: 20))
+    }
+
+    private func firstExistingElement(
+        in query: XCUIElementQuery,
+        identifiers: [String],
+        timeout: TimeInterval
+    ) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            for identifier in identifiers {
+                let element = query[identifier]
+                if element.exists {
+                    return element
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        } while Date() < deadline
+        return nil
+    }
+
+    private func waitUntil(timeout: TimeInterval, predicate: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if predicate() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        } while Date() < deadline
+        return predicate()
+    }
+}
+
+private enum QualificationAppearance: Equatable {
+    case light
+    case dark
+}
+
+private struct QualificationContext {
+    let appURL: URL
+    let bundleIdentifier: String
+    let outputDirectory: URL
+    let phase: String
+    let releaseNotesURL: String
+    let releasesURL: String
+    let syntheticHome: URL
+
+    static func load(expectedPhase: String) throws -> QualificationContext {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["BD_TO_AVP_UI_PHASE"] != nil else {
+            throw XCTSkip("Installed UI qualification runs only through the Tier 3 clean-machine runner.")
+        }
+        func required(_ key: String) throws -> String {
+            guard let value = environment[key], !value.isEmpty else {
+                throw QualificationError.missingEnvironment(key)
+            }
+            return value
+        }
+
+        let phase = try required("BD_TO_AVP_UI_PHASE")
+        guard phase == expectedPhase else {
+            throw QualificationError.invalidPhase(expected: expectedPhase, actual: phase)
+        }
+        let outputDirectory = URL(fileURLWithPath: try required("BD_TO_AVP_UI_OUTPUT_DIRECTORY"), isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        return QualificationContext(
+            appURL: URL(fileURLWithPath: try required("BD_TO_AVP_UI_APP_PATH"), isDirectory: true),
+            bundleIdentifier: try required("BD_TO_AVP_UI_BUNDLE_IDENTIFIER"),
+            outputDirectory: outputDirectory,
+            phase: phase,
+            releaseNotesURL: try required("BD_TO_AVP_UI_RELEASE_NOTES_URL"),
+            releasesURL: try required("BD_TO_AVP_UI_RELEASES_URL"),
+            syntheticHome: URL(fileURLWithPath: try required("BD_TO_AVP_UI_HOME"), isDirectory: true)
+        )
+    }
+}
+
+private enum QualificationError: LocalizedError {
+    case invalidPhase(expected: String, actual: String)
+    case missingEnvironment(String)
+    case missingProfileDocument
+    case missingAccessibilityElement(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidPhase(expected, actual):
+            "Expected qualification phase \(expected), found \(actual)."
+        case let .missingEnvironment(key):
+            "Missing required qualification environment variable \(key)."
+        case .missingProfileDocument:
+            "The profile save did not produce the expected profile document."
+        case let .missingAccessibilityElement(identifier):
+            "Unable to find accessibility element \(identifier)."
+        }
+    }
+}
+
+private struct ProfileSummary {
+    let count: Int
+    let name: String
+    let version: Int
+}
+
+private func readProfileSummary(syntheticHome: URL) throws -> ProfileSummary {
+    let profileURL = syntheticHome
+        .appendingPathComponent("Library/Application Support/3D Blu-ray to Vision Pro", isDirectory: true)
+        .appendingPathComponent("profiles.json")
+    let data = try Data(contentsOf: profileURL)
+    guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let version = root["version"] as? Int,
+          let profiles = root["profiles"] as? [[String: Any]],
+          let first = profiles.first,
+          let name = first["name"] as? String
+    else {
+        throw QualificationError.missingProfileDocument
+    }
+    return ProfileSummary(count: profiles.count, name: name, version: version)
+}
+
+private func setAppearance(_ appearance: QualificationAppearance, syntheticHome: URL) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+    process.environment = [
+        "CFFIXED_USER_HOME": syntheticHome.path,
+        "HOME": syntheticHome.path,
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+    ]
+    switch appearance {
+    case .light:
+        process.arguments = ["delete", "NSGlobalDomain", "AppleInterfaceStyle"]
+    case .dark:
+        process.arguments = ["write", "NSGlobalDomain", "AppleInterfaceStyle", "Dark"]
+    }
+    try process.run()
+    process.waitUntilExit()
+    if appearance == .dark, process.terminationStatus != 0 {
+        throw QualificationError.missingEnvironment("synthetic appearance preference")
+    }
+}
+
+private func writeJSON(_ value: [String: Any], to url: URL) throws {
+    guard JSONSerialization.isValidJSONObject(value) else {
+        throw QualificationError.missingEnvironment("valid JSON evidence")
+    }
+    let data = try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .sortedKeys])
+    try (data + Data("\n".utf8)).write(to: url, options: .atomic)
+}
+
+private struct AXRecord {
+    let actions: [String]
+    let enabled: Bool
+    let help: String
+    let identifier: String
+    let label: String
+    let role: String
+    let url: String?
+
+    var jsonValue: [String: Any] {
+        var result: [String: Any] = [
+            "actions": actions,
+            "enabled": enabled,
+            "help": help,
+            "identifier": identifier,
+            "label": label,
+            "role": role,
+        ]
+        if let url {
+            result["url"] = url
+        }
+        return result
+    }
+}
+
+private enum AXInspector {
+    static func applicationElement(bundleIdentifier: String) throws -> AXUIElement {
+        let matches = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+        guard matches.count == 1, let processIdentifier = matches.first?.processIdentifier else {
+            throw QualificationError.missingAccessibilityElement(bundleIdentifier)
+        }
+        return AXUIElementCreateApplication(processIdentifier)
+    }
+
+    static func record(identifier: String, root: AXUIElement) throws -> AXRecord {
+        guard let element = find(identifier: identifier, root: root) else {
+            throw QualificationError.missingAccessibilityElement(identifier)
+        }
+        let actions = actionNames(element).sorted()
+        return AXRecord(
+            actions: actions,
+            enabled: attribute(element, kAXEnabledAttribute) ?? false,
+            help: attribute(element, kAXHelpAttribute) ?? "",
+            identifier: identifier,
+            label: attribute(element, kAXTitleAttribute) ?? attribute(element, kAXDescriptionAttribute) ?? "",
+            role: attribute(element, kAXRoleAttribute) ?? "",
+            url: normalizedURL(attributeValue(element, kAXURLAttribute))
+        )
+    }
+
+    static func linkURLs(root: AXUIElement) -> Set<String> {
+        var urls = Set<String>()
+        walk(root: root) { element in
+            let role: String? = attribute(element, kAXRoleAttribute)
+            guard role == "AXLink",
+                  let url = normalizedURL(attributeValue(element, kAXURLAttribute))
+            else {
+                return
+            }
+            urls.insert(url)
+        }
+        return urls
+    }
+
+    private static func find(identifier: String, root: AXUIElement) -> AXUIElement? {
+        var result: AXUIElement?
+        walk(root: root) { element in
+            guard result == nil else {
+                return
+            }
+            let observed: String? = attribute(element, kAXIdentifierAttribute)
+            if observed == identifier {
+                result = element
+            }
+        }
+        return result
+    }
+
+    private static func walk(root: AXUIElement, visit: (AXUIElement) -> Void) {
+        var pending = [root]
+        var visited = 0
+        while let element = pending.popLast(), visited < 2_000 {
+            visited += 1
+            visit(element)
+            let children: [AXUIElement] = attribute(element, kAXChildrenAttribute) ?? []
+            pending.append(contentsOf: children.reversed())
+        }
+    }
+
+    private static func attribute<T>(_ element: AXUIElement, _ name: String) -> T? {
+        attributeValue(element, name) as? T
+    }
+
+    private static func attributeValue(_ element: AXUIElement, _ name: String) -> CFTypeRef? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+            return nil
+        }
+        return value
+    }
+
+    private static func actionNames(_ element: AXUIElement) -> [String] {
+        var names: CFArray?
+        guard AXUIElementCopyActionNames(element, &names) == .success else {
+            return []
+        }
+        return names as? [String] ?? []
+    }
+
+    private static func normalizedURL(_ value: CFTypeRef?) -> String? {
+        if let url = value as? URL {
+            return url.absoluteString
+        }
+        if let string = value as? String {
+            return string
+        }
+        return nil
+    }
+}

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -77,6 +77,20 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.tests
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/3D Blu-ray to Vision Pro Development.app/Contents/MacOS/3D Blu-ray to Vision Pro Development
 
+  BluRayToVisionProUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: BluRayToVisionProUITests
+    dependencies:
+      - target: BluRayToVisionPro
+    settings:
+      base:
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.ui-tests
+        TEST_TARGET_NAME: BluRayToVisionPro
+
   SpatialPlaybackProbe:
     type: application
     platform: auto
@@ -146,6 +160,15 @@ schemes:
       gatherCoverageData: true
       targets:
         - BluRayToVisionProTests
+
+  BluRayToVisionProInstalledUI:
+    build:
+      targets:
+        BluRayToVisionPro: all
+        BluRayToVisionProUITests: [test]
+    test:
+      targets:
+        - BluRayToVisionProUITests
 
   SpatialPlaybackProbe:
     build:

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -34,7 +34,8 @@ from scripts.tier3_receipt import (
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-CASE_ID = "clean-machine-signed-update"
+CLEAN_MACHINE_CASE_ID = "clean-machine-signed-update"
+INSTALLED_UI_CASE_ID = "installed-ui-accessibility"
 APP_NAME = "3D Blu-ray to Vision Pro.app"
 BUNDLE_IDENTIFIER = "com.shinycomputers.bd-to-avp"
 PREFERENCES_DOMAIN = BUNDLE_IDENTIFIER
@@ -43,6 +44,7 @@ SENTINEL_KEY = "BDToAVPTier3Sentinel"
 AUTOMATIC_CHECKS_KEY = "SUEnableAutomaticChecks"
 SENTINEL_VALUE = "tier3-preserve"
 LIVE_FEED_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+RELEASES_URL = "https://github.com/cbusillo/BD_to_AVP/releases"
 PROFILE_DOCUMENT = {"version": 5, "profiles": []}
 PROFILE_RELATIVE_PATH = Path("Library/Application Support/3D Blu-ray to Vision Pro/profiles.json")
 MAX_FEED_BYTES = 5 * 1024 * 1024
@@ -52,7 +54,9 @@ COMMAND_TIMEOUT_SECONDS = 60
 SMOKE_TIMEOUT_SECONDS = 15 * 60
 GUI_TIMEOUT_SECONDS = 270
 UPDATE_TIMEOUT_SECONDS = 5 * 60
-ROUTE_CHANNELS = {
+UI_TEST_TIMEOUT_SECONDS = 15 * 60
+MAX_UI_SCREENSHOT_BYTES = 20 * 1024 * 1024
+ROUTE_CHANNELS: dict[str, set[str | None]] = {
     "stable": {None},
     "rc": {None, "rc"},
     "beta": {None, "rc", "beta"},
@@ -67,6 +71,7 @@ SYSTEM_TOOL_PATHS = {
     "hdiutil": Path("/usr/bin/hdiutil"),
     "open": Path("/usr/bin/open"),
     "osascript": Path("/usr/bin/osascript"),
+    "xcodebuild": Path("/usr/bin/xcodebuild"),
 }
 
 
@@ -123,6 +128,7 @@ class FeedCandidate:
     download_url: str
     length: int
     minimum_system_version: str
+    release_notes_url: str
 
 
 @dataclass(frozen=True)
@@ -136,6 +142,7 @@ class QualificationConfig:
     route: str
     environment_class: str
     output_receipt: Path | None = None
+    ui_output_receipt: Path | None = None
     evidence_directory: Path | None = None
 
 
@@ -164,6 +171,18 @@ class QualificationOperations(Protocol):
         raise NotImplementedError
 
     def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+        raise NotImplementedError
+
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
         raise NotImplementedError
 
     def app_running(self) -> bool:
@@ -372,6 +391,11 @@ def parse_feed_candidate(feed_bytes: bytes, candidate: ReleaseArtifact, route: s
     minimum_system_version = (item.findtext(f"{SPARKLE}minimumSystemVersion") or "").strip()
     if not minimum_system_version:
         raise CleanMachineError("Live appcast candidate is missing minimum system version.")
+    release_notes_url = (
+        item.findtext(f"{SPARKLE}fullReleaseNotesLink") or item.findtext(f"{SPARKLE}releaseNotesLink") or ""
+    ).strip()
+    if not release_notes_url:
+        raise CleanMachineError("Live appcast candidate is missing its release-notes URL.")
     return FeedCandidate(
         feed_sha256=hashlib.sha256(feed_bytes).hexdigest(),
         build_version=build_version,
@@ -380,6 +404,7 @@ def parse_feed_candidate(feed_bytes: bytes, candidate: ReleaseArtifact, route: s
         download_url=download_url,
         length=candidate.dmg_size,
         minimum_system_version=minimum_system_version,
+        release_notes_url=release_notes_url,
     )
 
 
@@ -465,7 +490,7 @@ def validate_environment(
 
 
 class MacOSOperations:
-    required_tools = ("defaults", "ditto", "hdiutil", "open", "osascript")
+    required_tools = ("defaults", "ditto", "hdiutil", "open", "osascript", "xcodebuild")
 
     @staticmethod
     def _run(
@@ -643,6 +668,59 @@ class MacOSOperations:
         )
         return UpdateInteraction(clicked_button=result.stdout.strip())
 
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        test_names = {
+            "updater": "testPriorUpdaterControlsAndReleaseLinks",
+            "candidate": "testCandidateMainWindowProfileAndSettings",
+        }
+        try:
+            test_name = test_names[phase]
+        except KeyError as error:
+            raise CleanMachineError(f"Unsupported installed UI phase: {phase}") from error
+        output_directory.mkdir(parents=True, exist_ok=True)
+        derived_data = output_directory.parent / f"InstalledUIDerivedData-{phase}"
+        result_bundle = output_directory.parent / f"InstalledUI-{phase}.xcresult"
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "BD_TO_AVP_UI_APP_PATH": str(app_path),
+                "BD_TO_AVP_UI_BUNDLE_IDENTIFIER": BUNDLE_IDENTIFIER,
+                "BD_TO_AVP_UI_HOME": str(synthetic_home),
+                "BD_TO_AVP_UI_OUTPUT_DIRECTORY": str(output_directory),
+                "BD_TO_AVP_UI_PHASE": phase,
+                "BD_TO_AVP_UI_RELEASE_NOTES_URL": release_notes_url,
+                "BD_TO_AVP_UI_RELEASES_URL": RELEASES_URL,
+            }
+        )
+        self._run(
+            [
+                str(SYSTEM_TOOL_PATHS["xcodebuild"]),
+                "-project",
+                str(repo / "macos" / "BluRayToVisionPro.xcodeproj"),
+                "-scheme",
+                "BluRayToVisionProInstalledUI",
+                "-derivedDataPath",
+                str(derived_data),
+                "-resultBundlePath",
+                str(result_bundle),
+                "-destination",
+                "platform=macOS,arch=arm64",
+                "test",
+                f"-only-testing:BluRayToVisionProUITests/InstalledUIAcceptanceTests/{test_name}",
+            ],
+            timeout=UI_TEST_TIMEOUT_SECONDS,
+            env=environment,
+        )
+
     @staticmethod
     def app_running() -> bool:
         script = (
@@ -739,24 +817,33 @@ end tell'''
 end run"""
 
 
-def _case_policy(policy: Mapping[str, Any]) -> Mapping[str, Any]:
+def _case_policy(policy: Mapping[str, Any], case_id: str) -> Mapping[str, Any]:
     matches = [
         _mapping(item, "qualification case")
         for item in _sequence(policy.get("cases"), "qualification cases")
-        if _mapping(item, "qualification case").get("id") == CASE_ID
+        if _mapping(item, "qualification case").get("id") == case_id
     ]
     if len(matches) != 1:
-        raise CleanMachineError(f"Policy must define exactly one {CASE_ID!r} case.")
+        raise CleanMachineError(f"Policy must define exactly one {case_id!r} case.")
     return matches[0]
 
 
 def prepare_qualification(
     config: QualificationConfig,
     operations: QualificationOperations,
-) -> tuple[Mapping[str, Any], Mapping[str, Any], ReleaseArtifact, ReleaseArtifact, EnvironmentFacts, FeedCandidate]:
+) -> tuple[
+    Mapping[str, Any],
+    Mapping[str, Any],
+    Mapping[str, Any],
+    ReleaseArtifact,
+    ReleaseArtifact,
+    EnvironmentFacts,
+    FeedCandidate,
+]:
     repo = config.repo.resolve()
     policy = load_policy(repo / DEFAULT_POLICY_PATH.relative_to(REPO_ROOT))
-    case = _case_policy(policy)
+    clean_machine_case = _case_policy(policy, CLEAN_MACHINE_CASE_ID)
+    installed_ui_case = _case_policy(policy, INSTALLED_UI_CASE_ID)
     candidate = load_release_artifact(
         repo,
         config.candidate_receipt,
@@ -779,25 +866,34 @@ def prepare_qualification(
         raise CleanMachineError("Qualification root must be a dedicated location inside the current home directory.")
     if config.output_receipt is not None and qualification_root in config.output_receipt.resolve().parents:
         raise CleanMachineError("Output receipt must be outside the disposable qualification root.")
+    if config.ui_output_receipt is not None and qualification_root in config.ui_output_receipt.resolve().parents:
+        raise CleanMachineError("Installed UI output receipt must be outside the disposable qualification root.")
+    if (
+        config.output_receipt is not None
+        and config.ui_output_receipt is not None
+        and config.output_receipt.resolve() == config.ui_output_receipt.resolve()
+    ):
+        raise CleanMachineError("Clean-machine and installed UI receipts must use different output paths.")
     if config.evidence_directory is not None and qualification_root in config.evidence_directory.resolve().parents:
         raise CleanMachineError("Evidence directory must be outside the disposable qualification root.")
     required_free_bytes = BASE_FREE_SPACE_BYTES + prior.dmg_size + (candidate.dmg_size * 2)
     environment = operations.inspect_environment(qualification_root, config.environment_class)
-    validate_environment(environment, case, required_free_bytes=required_free_bytes)
+    validate_environment(environment, clean_machine_case, required_free_bytes=required_free_bytes)
+    validate_environment(environment, installed_ui_case, required_free_bytes=required_free_bytes)
     feed = parse_feed_candidate(operations.fetch_live_feed(), candidate, config.route)
     if _version_tuple(environment.macos_version, "Environment macOS version") < _version_tuple(
         feed.minimum_system_version,
         "Appcast minimum system version",
     ):
         raise CleanMachineError("Qualification environment is older than the candidate appcast minimum system version.")
-    return policy, case, prior, candidate, environment, feed
+    return policy, clean_machine_case, installed_ui_case, prior, candidate, environment, feed
 
 
 def preflight_report(
     config: QualificationConfig,
     operations: QualificationOperations,
 ) -> Mapping[str, Any]:
-    _, _, prior, candidate, environment, feed = prepare_qualification(config, operations)
+    _, _, _, prior, candidate, environment, feed = prepare_qualification(config, operations)
     return {
         "candidate": {
             "build_version": candidate.build_version,
@@ -871,20 +967,252 @@ def _reset_runtime_workspace(app_path: Path, synthetic_home: Path) -> None:
     synthetic_home.mkdir(parents=True)
 
 
-def _run_qualification(config: QualificationConfig, operations: QualificationOperations) -> Mapping[str, Any]:
-    if config.output_receipt is None or config.evidence_directory is None:
-        raise CleanMachineError("Run mode requires output receipt and evidence directory paths.")
-    output_receipt = config.output_receipt.resolve()
-    evidence_directory = config.evidence_directory.resolve()
-    if output_receipt.exists() or evidence_directory.exists():
-        raise CleanMachineError("Output receipt and evidence directory must not already exist.")
+def _load_ui_json(path: Path, expected_keys: set[str]) -> Mapping[str, Any]:
+    try:
+        value = _mapping(json.loads(path.read_text(encoding="utf-8")), path.name)
+    except (OSError, json.JSONDecodeError) as error:
+        raise CleanMachineError(f"Installed UI evidence is missing or invalid: {path.name}") from error
+    if set(value) != expected_keys:
+        raise CleanMachineError(f"Installed UI evidence has unexpected fields: {path.name}")
+    return value
 
-    policy, case, prior, candidate, environment, feed = prepare_qualification(config, operations)
+
+def _copy_ui_screenshot(source: Path, destination: Path) -> str:
+    try:
+        payload = source.read_bytes()
+    except OSError as error:
+        raise CleanMachineError(f"Installed UI screenshot is missing: {source.name}") from error
+    if not payload.startswith(b"\x89PNG\r\n\x1a\n"):
+        raise CleanMachineError(f"Installed UI screenshot is not a PNG: {source.name}")
+    if not 64 <= len(payload) <= MAX_UI_SCREENSHOT_BYTES:
+        raise CleanMachineError(f"Installed UI screenshot size is outside the accepted bounds: {source.name}")
+    destination.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _normalize_installed_ui_evidence(
+    raw_directory: Path,
+    evidence_directory: Path,
+    feed: FeedCandidate,
+) -> Mapping[str, str]:
+    updater = _load_ui_json(
+        raw_directory / "updater-ui.json",
+        {"install_action", "release_notes_url", "release_notes_url_observed", "schema_version", "status"},
+    )
+    if updater != {
+        "install_action": updater.get("install_action"),
+        "release_notes_url": feed.release_notes_url,
+        "release_notes_url_observed": True,
+        "schema_version": 1,
+        "status": "passed",
+    }:
+        raise CleanMachineError("Installed UI updater evidence does not match the exact appcast candidate.")
+    if updater.get("install_action") not in {"Install and Relaunch", "Install Update", "Relaunch"}:
+        raise CleanMachineError("Installed UI updater evidence contains an unsupported install action.")
+
+    candidate = _load_ui_json(
+        raw_directory / "candidate-ui.json",
+        {
+            "main_window_ready",
+            "profile_document_version",
+            "profile_save_accessible",
+            "profile_save_succeeded",
+            "profiles_after",
+            "release_page_url",
+            "release_page_url_observed",
+            "schema_version",
+            "status",
+            "updater_controls_accessible",
+        },
+    )
+    expected_candidate = {
+        "main_window_ready": True,
+        "profile_document_version": 5,
+        "profile_save_accessible": True,
+        "profile_save_succeeded": True,
+        "profiles_after": 1,
+        "release_page_url": RELEASES_URL,
+        "release_page_url_observed": True,
+        "schema_version": 1,
+        "status": "passed",
+        "updater_controls_accessible": True,
+    }
+    if candidate != expected_candidate:
+        raise CleanMachineError("Installed UI candidate evidence did not satisfy the maintained acceptance contract.")
+
+    accessibility = _load_ui_json(raw_directory / "accessibility-tree.json", {"elements", "schema_version"})
+    if accessibility.get("schema_version") != 1:
+        raise CleanMachineError("Installed UI accessibility evidence uses an unsupported schema version.")
+    records = [
+        _mapping(item, "installed UI accessibility element")
+        for item in _sequence(accessibility.get("elements"), "installed UI accessibility elements")
+    ]
+    expected_identifiers = {
+        "all-releases-link",
+        "main-status",
+        "save-profile-action",
+        "update-action",
+        "update-route-picker",
+    }
+    normalized_records: list[Mapping[str, Any]] = []
+    observed_identifiers: set[str] = set()
+    for record in records:
+        allowed_keys = {"actions", "enabled", "help", "identifier", "label", "role", "url"}
+        if not set(record).issubset(allowed_keys):
+            raise CleanMachineError("Installed UI accessibility evidence contains unsupported fields.")
+        identifier = _string(record.get("identifier"), "installed UI accessibility identifier")
+        if identifier not in expected_identifiers or identifier in observed_identifiers:
+            raise CleanMachineError("Installed UI accessibility evidence contains an unexpected or duplicate element.")
+        observed_identifiers.add(identifier)
+        role = _string(record.get("role"), f"{identifier} accessibility role")
+        label = _string(record.get("label"), f"{identifier} accessibility label")
+        help_text = record.get("help")
+        actions = record.get("actions")
+        enabled = record.get("enabled")
+        if not isinstance(help_text, str) or len(help_text) > 300:
+            raise CleanMachineError(f"{identifier} accessibility help is invalid.")
+        if (
+            not isinstance(enabled, bool)
+            or not isinstance(actions, list)
+            or not all(isinstance(item, str) for item in actions)
+        ):
+            raise CleanMachineError(f"{identifier} accessibility state is invalid.")
+        if len(label) > 300 or any(character in label for character in ("\n", "\r")):
+            raise CleanMachineError(f"{identifier} accessibility label is invalid.")
+        normalized: dict[str, Any] = {
+            "enabled": enabled,
+            "help": help_text,
+            "identifier": identifier,
+            "label": label,
+            "press_action": "AXPress" in actions,
+            "role": role,
+        }
+        if identifier == "all-releases-link":
+            if record.get("url") != RELEASES_URL:
+                raise CleanMachineError("Installed UI releases link is not bound to the public releases page.")
+            normalized["url_sha256"] = hashlib.sha256(RELEASES_URL.encode()).hexdigest()
+        if identifier == "save-profile-action":
+            if (
+                role != "AXButton"
+                or label != "Save current settings as new profile"
+                or help_text != "Opens a form to name and save these settings as a reusable profile"
+                or not enabled
+                or "AXPress" not in actions
+            ):
+                raise CleanMachineError("Profile save accessibility semantics do not match the maintained contract.")
+        normalized_records.append(normalized)
+    if observed_identifiers != expected_identifiers:
+        raise CleanMachineError("Installed UI accessibility evidence is incomplete.")
+
+    evidence_directory.mkdir(parents=True, exist_ok=True)
+    accessibility_digest = _write_json(
+        evidence_directory / "accessibility-tree.json",
+        {"elements": sorted(normalized_records, key=lambda item: cast(str, item["identifier"])), "schema_version": 1},
+    )
+    ui_result_digest = _write_json(
+        evidence_directory / "ui-result.json",
+        {
+            "main_window_ready": True,
+            "profile_document_version": 5,
+            "profile_save_accessible": True,
+            "profile_save_succeeded": True,
+            "release_notes_url_sha256": hashlib.sha256(feed.release_notes_url.encode()).hexdigest(),
+            "release_page_url_sha256": hashlib.sha256(RELEASES_URL.encode()).hexdigest(),
+            "schema_version": 1,
+            "status": "passed",
+            "updater_controls_accessible": True,
+        },
+    )
+    light_digest = _copy_ui_screenshot(
+        raw_directory / "screenshot-light.png",
+        evidence_directory / "screenshot-light.png",
+    )
+    dark_digest = _copy_ui_screenshot(
+        raw_directory / "screenshot-dark.png",
+        evidence_directory / "screenshot-dark.png",
+    )
+    return {
+        "accessibility-tree": accessibility_digest,
+        "ui-result": ui_result_digest,
+        "screenshot-light": light_digest,
+        "screenshot-dark": dark_digest,
+    }
+
+
+def _build_checked_receipt(
+    *,
+    policy: Mapping[str, Any],
+    case: Mapping[str, Any],
+    candidate: ReleaseArtifact,
+    environment: EnvironmentFacts,
+    assertions: Mapping[str, str],
+    evidence: Sequence[Mapping[str, str]],
+    cleanup_status: str,
+    cleanup_digest: str,
+    started_at: str,
+    completed_at: str,
+    repo: Path,
+) -> Mapping[str, Any]:
+    required_assertions = set(cast(Sequence[str], case["required_assertions"]))
+    if set(assertions) != required_assertions:
+        raise CleanMachineError(
+            f"Runner assertion contract changed; code={sorted(assertions)}, policy={sorted(required_assertions)}."
+        )
+    receipt = build_tier3_receipt(
+        {
+            "assertions": dict(assertions),
+            "cleanup": {"status": cleanup_status, "evidence_sha256": cleanup_digest},
+            "completed_at": completed_at,
+            "environment": {
+                "architecture": environment.architecture,
+                "environment_class": environment.environment_class,
+                "macos_build": environment.macos_build,
+                "macos_version": environment.macos_version,
+            },
+            "evidence": list(evidence),
+            "evidence_source": "tier3_automation_receipt",
+            "hardware": {"class": "none", "identity": {}},
+            "release_receipt_file_sha256": candidate.receipt_file_sha256,
+            "release_receipt_reference": candidate.receipt_reference,
+            "result": {"status": "passed", "reason_code": "all_assertions_passed"},
+            "started_at": started_at,
+        },
+        policy_id=_string(policy.get("policy_id"), "policy_id"),
+        case=case,
+        release_receipt=candidate.receipt,
+    )
+    try:
+        validate_tier3_receipt(
+            receipt,
+            policy_id=_string(policy.get("policy_id"), "policy_id"),
+            case=case,
+            reference_content=lambda reference: (repo / reference).read_bytes(),
+        )
+    except Tier3ReceiptError as error:
+        raise CleanMachineError(f"Generated Tier 3 receipt is invalid: {error}") from error
+    return receipt
+
+
+def _run_qualification(
+    config: QualificationConfig, operations: QualificationOperations
+) -> Mapping[str, Mapping[str, Any]]:
+    if config.output_receipt is None or config.ui_output_receipt is None or config.evidence_directory is None:
+        raise CleanMachineError("Run mode requires both output receipts and the evidence directory path.")
+    output_receipt = config.output_receipt.resolve()
+    ui_output_receipt = config.ui_output_receipt.resolve()
+    evidence_directory = config.evidence_directory.resolve()
+    if output_receipt.exists() or ui_output_receipt.exists() or evidence_directory.exists():
+        raise CleanMachineError("Output receipts and evidence directory must not already exist.")
+
+    policy, clean_machine_case, installed_ui_case, prior, candidate, environment, feed = prepare_qualification(
+        config, operations
+    )
     started_at = _utc_timestamp()
     qualification_root = config.qualification_root.resolve()
     synthetic_home = qualification_root / "Home"
     app_path = qualification_root / "Applications" / APP_NAME
     log_path = qualification_root / "Logs" / "package-smoke.log"
+    raw_ui_directory = qualification_root / "InstalledUIEvidence"
     marker_path = qualification_root / ".bd-to-avp-tier3-owned.json"
     qualification_root.mkdir(parents=True)
     marker = {"owner": "bd-to-avp-tier3-clean-machine", "run_id": str(uuid.uuid4())}
@@ -908,6 +1236,18 @@ def _run_qualification(config: QualificationConfig, operations: QualificationOpe
         if operations.read_preference(synthetic_home, SENTINEL_KEY) != SENTINEL_VALUE:
             raise CleanMachineError("Preference sentinel did not persist before the Sparkle update.")
 
+        operations.collect_ui_evidence(
+            repo=config.repo.resolve(),
+            phase="updater",
+            app_path=app_path,
+            synthetic_home=synthetic_home,
+            output_directory=raw_ui_directory,
+            release_notes_url=feed.release_notes_url,
+        )
+        operations.quit_app()
+        if operations.app_running():
+            raise CleanMachineError("Installed UI updater inspection left the production app running.")
+
         interaction = operations.perform_update(app_path, synthetic_home)
         candidate_identity = _wait_for_candidate(app_path, candidate, operations)
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
@@ -917,6 +1257,19 @@ def _run_qualification(config: QualificationConfig, operations: QualificationOpe
             raise CleanMachineError("Update route or unrelated preference changed across Sparkle relaunch.")
         if profile_after_sha256 != profile_before_sha256:
             raise CleanMachineError("Profile library changed across Sparkle relaunch.")
+
+        operations.quit_app()
+        operations.collect_ui_evidence(
+            repo=config.repo.resolve(),
+            phase="candidate",
+            app_path=app_path,
+            synthetic_home=synthetic_home,
+            output_directory=raw_ui_directory,
+            release_notes_url=feed.release_notes_url,
+        )
+        operations.quit_app()
+        if operations.app_running():
+            raise CleanMachineError("Installed UI candidate inspection left the production app running.")
 
         evidence_directory.mkdir(parents=True)
         install_digest = _write_json(
@@ -968,6 +1321,7 @@ def _run_qualification(config: QualificationConfig, operations: QualificationOpe
                 "sentinel_preserved": sentinel_after == SENTINEL_VALUE,
             },
         )
+        ui_evidence_digests = _normalize_installed_ui_evidence(raw_ui_directory, evidence_directory, feed)
     finally:
         try:
             operations.quit_app()
@@ -994,7 +1348,7 @@ def _run_qualification(config: QualificationConfig, operations: QualificationOpe
     )
 
     completed_at = _utc_timestamp()
-    assertions = {
+    clean_machine_assertions = {
         "exact-app-installed": "passed",
         "final-identity-matched": "passed",
         "package-smoke-passed": "passed",
@@ -1002,59 +1356,62 @@ def _run_qualification(config: QualificationConfig, operations: QualificationOpe
         "profile-preserved": "passed",
         "sparkle-relaunch-passed": "passed",
     }
-    required_assertions = set(cast(Sequence[str], case["required_assertions"]))
-    if set(assertions) != required_assertions:
-        raise CleanMachineError(
-            f"Runner assertion contract changed; code={sorted(assertions)}, policy={sorted(required_assertions)}."
-        )
-    receipt = build_tier3_receipt(
-        {
-            "assertions": assertions,
-            "cleanup": {"status": cleanup_status, "evidence_sha256": cleanup_digest},
-            "completed_at": completed_at,
-            "environment": {
-                "architecture": environment.architecture,
-                "environment_class": environment.environment_class,
-                "macos_build": environment.macos_build,
-                "macos_version": environment.macos_version,
-            },
-            "evidence": [
-                {"kind": "install-log", "sha256": install_digest},
-                {"kind": "package-smoke", "sha256": package_digest},
-                {"kind": "sparkle-update", "sha256": update_digest},
-                {"kind": "profile-snapshot", "sha256": profile_digest},
-                {"kind": "cleanup", "sha256": cleanup_digest},
-            ],
-            "evidence_source": "tier3_automation_receipt",
-            "hardware": {"class": "none", "identity": {}},
-            "release_receipt_file_sha256": candidate.receipt_file_sha256,
-            "release_receipt_reference": candidate.receipt_reference,
-            "result": {"status": "passed", "reason_code": "all_assertions_passed"},
-            "started_at": started_at,
-        },
-        policy_id=_string(policy.get("policy_id"), "policy_id"),
-        case=case,
-        release_receipt=candidate.receipt,
+    clean_machine_receipt = _build_checked_receipt(
+        policy=policy,
+        case=clean_machine_case,
+        candidate=candidate,
+        environment=environment,
+        assertions=clean_machine_assertions,
+        evidence=[
+            {"kind": "install-log", "sha256": install_digest},
+            {"kind": "package-smoke", "sha256": package_digest},
+            {"kind": "sparkle-update", "sha256": update_digest},
+            {"kind": "profile-snapshot", "sha256": profile_digest},
+            {"kind": "cleanup", "sha256": cleanup_digest},
+        ],
+        cleanup_status=cleanup_status,
+        cleanup_digest=cleanup_digest,
+        started_at=started_at,
+        completed_at=completed_at,
+        repo=config.repo.resolve(),
     )
-    try:
-        validate_tier3_receipt(
-            receipt,
-            policy_id=_string(policy.get("policy_id"), "policy_id"),
-            case=case,
-            reference_content=lambda reference: (config.repo.resolve() / reference).read_bytes(),
-        )
-    except Tier3ReceiptError as error:
-        raise CleanMachineError(f"Generated Tier 3 receipt is invalid: {error}") from error
-    _write_json(output_receipt, receipt)
-    return receipt
+    installed_ui_receipt = _build_checked_receipt(
+        policy=policy,
+        case=installed_ui_case,
+        candidate=candidate,
+        environment=environment,
+        assertions={
+            "main-window-ready": "passed",
+            "profile-save-accessible": "passed",
+            "profile-save-succeeded": "passed",
+            "release-note-links-bound": "passed",
+            "updater-controls-accessible": "passed",
+        },
+        evidence=[{"kind": kind, "sha256": digest} for kind, digest in sorted(ui_evidence_digests.items())],
+        cleanup_status=cleanup_status,
+        cleanup_digest=cleanup_digest,
+        started_at=started_at,
+        completed_at=completed_at,
+        repo=config.repo.resolve(),
+    )
+    _write_json(output_receipt, clean_machine_receipt)
+    _write_json(ui_output_receipt, installed_ui_receipt)
+    return {
+        CLEAN_MACHINE_CASE_ID: clean_machine_receipt,
+        INSTALLED_UI_CASE_ID: installed_ui_receipt,
+    }
 
 
-def run_qualification(config: QualificationConfig, operations: QualificationOperations) -> Mapping[str, Any]:
+def run_qualification(
+    config: QualificationConfig, operations: QualificationOperations
+) -> Mapping[str, Mapping[str, Any]]:
     try:
         return _run_qualification(config, operations)
     except BaseException:
         if config.output_receipt is not None and config.output_receipt.exists():
             config.output_receipt.unlink()
+        if config.ui_output_receipt is not None and config.ui_output_receipt.exists():
+            config.ui_output_receipt.unlink()
         if config.evidence_directory is not None and config.evidence_directory.exists():
             shutil.rmtree(config.evidence_directory)
         raise
@@ -1075,6 +1432,7 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--environment-class", choices=("restorable-location",), required=True)
         if command == "run":
             subparser.add_argument("--output-receipt", type=Path, required=True)
+            subparser.add_argument("--ui-output-receipt", type=Path, required=True)
             subparser.add_argument("--evidence-directory", type=Path, required=True)
     return parser
 
@@ -1090,6 +1448,7 @@ def _config_from_args(args: argparse.Namespace) -> QualificationConfig:
         route=args.route,
         environment_class=args.environment_class,
         output_receipt=getattr(args, "output_receipt", None),
+        ui_output_receipt=getattr(args, "ui_output_receipt", None),
         evidence_directory=getattr(args, "evidence_directory", None),
     )
 
@@ -1102,11 +1461,16 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "preflight":
             payload = preflight_report(config, operations)
         else:
-            receipt = run_qualification(config, operations)
+            receipts = run_qualification(config, operations)
             payload = {
-                "case_id": receipt["case_id"],
-                "receipt_sha256": receipt["receipt_sha256"],
-                "result": receipt["result"],
+                "receipts": [
+                    {
+                        "case_id": receipt["case_id"],
+                        "receipt_sha256": receipt["receipt_sha256"],
+                        "result": receipt["result"],
+                    }
+                    for _, receipt in sorted(receipts.items())
+                ]
             }
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -24,6 +24,7 @@ from scripts.tier3_clean_machine import (
     MacOSOperations,
     QualificationConfig,
     QualificationOperations,
+    RELEASES_URL,
     ReleaseArtifact,
     UpdateInteraction,
     file_sha256,
@@ -106,6 +107,106 @@ class FakeOperations(QualificationOperations):
         shutil.copytree(self.candidate_source, app_path, symlinks=True)
         self.running = True
         return UpdateInteraction(clicked_button="Install and Relaunch")
+
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        del repo, app_path, synthetic_home
+        output_directory.mkdir(parents=True, exist_ok=True)
+        if phase == "updater":
+            (output_directory / "updater-ui.json").write_text(
+                json.dumps(
+                    {
+                        "install_action": "Install and Relaunch",
+                        "release_notes_url": release_notes_url,
+                        "release_notes_url_observed": True,
+                        "schema_version": 1,
+                        "status": "passed",
+                    },
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            return
+        if phase != "candidate":
+            raise AssertionError(f"unexpected UI phase: {phase}")
+        (output_directory / "candidate-ui.json").write_text(
+            json.dumps(
+                {
+                    "main_window_ready": True,
+                    "profile_document_version": 5,
+                    "profile_save_accessible": True,
+                    "profile_save_succeeded": True,
+                    "profiles_after": 1,
+                    "release_page_url": RELEASES_URL,
+                    "release_page_url_observed": True,
+                    "schema_version": 1,
+                    "status": "passed",
+                    "updater_controls_accessible": True,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        records = [
+            {
+                "actions": [],
+                "enabled": True,
+                "help": "",
+                "identifier": "main-status",
+                "label": "Status: Ready",
+                "role": "AXStaticText",
+            },
+            {
+                "actions": ["AXPress"],
+                "enabled": True,
+                "help": "Opens a form to name and save these settings as a reusable profile",
+                "identifier": "save-profile-action",
+                "label": "Save current settings as new profile",
+                "role": "AXButton",
+            },
+            {
+                "actions": ["AXPress"],
+                "enabled": True,
+                "help": "",
+                "identifier": "update-action",
+                "label": "Check for Updates…",
+                "role": "AXButton",
+            },
+            {
+                "actions": ["AXPress"],
+                "enabled": True,
+                "help": "",
+                "identifier": "update-route-picker",
+                "label": "Update route",
+                "role": "AXPopUpButton",
+            },
+            {
+                "actions": ["AXPress"],
+                "enabled": True,
+                "help": "",
+                "identifier": "all-releases-link",
+                "label": "View All Releases…",
+                "role": "AXLink",
+                "url": RELEASES_URL,
+            },
+        ]
+        (output_directory / "accessibility-tree.json").write_text(
+            json.dumps({"elements": records, "schema_version": 1}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        screenshot = b"\x89PNG\r\n\x1a\n" + (b"x" * 64)
+        (output_directory / "screenshot-light.png").write_bytes(screenshot)
+        (output_directory / "screenshot-dark.png").write_bytes(screenshot)
 
     def app_running(self) -> bool:
         return self.running
@@ -294,6 +395,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             route="rc",
             environment_class="restorable-location",
             output_receipt=root / "tier3-receipt.json",
+            ui_output_receipt=root / "tier3-ui-receipt.json",
             evidence_directory=root / "evidence",
         )
         operations = FakeOperations(
@@ -319,14 +421,29 @@ class Tier3CleanMachineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
-            receipt = run_qualification(config, operations)
+            receipts = run_qualification(config, operations)
 
             self.assertFalse(config.qualification_root.exists())
             self.assertTrue(config.output_receipt.exists())
-            self.assertEqual(len(list(config.evidence_directory.glob("*.json"))), 5)
-            self.assertEqual(receipt["result"]["status"], "passed")
-            self.assertEqual(receipt["cleanup"]["status"], "disposed")
-            self.assertEqual(receipt["release_identity"]["source_sha"], CANDIDATE_SHA)
+            self.assertTrue(config.ui_output_receipt.exists())
+            self.assertEqual(
+                {path.name for path in config.evidence_directory.iterdir()},
+                {
+                    "accessibility-tree.json",
+                    "cleanup.json",
+                    "install-log.json",
+                    "package-smoke.json",
+                    "profile-snapshot.json",
+                    "screenshot-dark.png",
+                    "screenshot-light.png",
+                    "sparkle-update.json",
+                    "ui-result.json",
+                },
+            )
+            for receipt in receipts.values():
+                self.assertEqual(receipt["result"]["status"], "passed")
+                self.assertEqual(receipt["cleanup"]["status"], "disposed")
+                self.assertEqual(receipt["release_identity"]["source_sha"], CANDIDATE_SHA)
             self.assertFalse(operations.app_running())
 
     def test_run_cleans_workspace_after_update_failure(self) -> None:
@@ -341,6 +458,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertFalse(config.qualification_root.exists())
             self.assertFalse(operations.app_running())
             self.assertFalse(config.output_receipt.exists())
+            self.assertFalse(config.ui_output_receipt.exists())
             self.assertFalse(config.evidence_directory.exists())
 
     def test_preflight_rejects_wrong_macos_major(self) -> None:


### PR DESCRIPTION
## Summary
- add stable production accessibility identifiers and semantics for the main window, profile save, diagnostics, and updater settings
- add a macOS installed-app XCUITest lane that attaches to the exact signed app, verifies Sparkle/release links and profile save, and captures cropped light/dark window evidence
- extend the Tier 3 runner to emit separate checked `clean-machine-signed-update` and `installed-ui-accessibility` receipts with privacy-safe normalized evidence

## Validation
- `uv run python -m unittest discover -s tests -t .` (1543 passed, 3 skipped)
- `uv run python scripts/native_app.py test` (355 passed)
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python -m scripts.release validate`
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run mypy scripts/tier3_clean_machine.py`
- installed UI target `build-for-testing` succeeded

## Environment Boundary
The real accepted lane requires Apple Silicon macOS 26 and a newer eligible signed candidate pair. This host is macOS 27.0, and Xcode UI automation mode could not initialize here, so no qualifying receipt is claimed. The checked deterministic fixtures and UI-test build validate the collector without fabricating runtime evidence.

Closes #483
