### PR TITLE
Add operator-assisted Tier 3 hardware receipts

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -97,6 +97,7 @@
     "releaseProcess": "docs/release-process.md",
     "releaseQualificationPolicy": "docs/release-qualification-policy.md",
     "tier3CleanMachine": "docs/tier3-clean-machine.md",
+    "tier3OperatorHardware": "docs/tier3-operator-hardware.md",
     "releaseWorkflows": [
       ".github/workflows/briefcase.yml",
       ".github/workflows/prerelease.yml",
@@ -128,6 +129,7 @@
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "tier3Receipt": "uv run python -m unittest tests.test_tier3_receipt",
       "tier3CleanMachine": "uv run python -m unittest tests.test_tier3_clean_machine",
+      "tier3OperatorHardware": "uv run python -m unittest tests.test_tier3_operator_receipt",
       "macosApp": "uv run python scripts/native_app.py test",
       "importSmoke": "uv run python -c 'import bd_to_avp; import bd_to_avp.__main__; import bd_to_avp.app'",
       "cliSmoke": "uv run bd-to-avp --help"

--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -326,7 +326,13 @@
       "cadence": {"first_rc": true, "stable_candidate": true},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 90},
       "invalidates_on": {
-        "paths": ["bd_to_avp/modules/disc.py", "bd_to_avp/modules/config.py", "bd_to_avp/preflight.py"],
+        "paths": [
+          "bd_to_avp/modules/disc.py",
+          "bd_to_avp/modules/config.py",
+          "bd_to_avp/preflight.py",
+          "docs/tier3-operator-hardware.md",
+          "scripts/tier3_operator_receipt.py"
+        ],
         "contracts": ["packaged-worker", "conversion-ownership", "tier3-evidence"]
       },
       "allowed_evidence_sources": ["tier3_operator_receipt"],
@@ -360,7 +366,13 @@
       "cadence": {"first_rc": false, "stable_candidate": true},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
       "invalidates_on": {
-        "paths": ["bd_to_avp/modules/disc.py", "bd_to_avp/modules/config.py", "bd_to_avp/modules/video*.py"],
+        "paths": [
+          "bd_to_avp/modules/disc.py",
+          "bd_to_avp/modules/config.py",
+          "bd_to_avp/modules/video*.py",
+          "docs/tier3-operator-hardware.md",
+          "scripts/tier3_operator_receipt.py"
+        ],
         "contracts": ["packaged-worker", "conversion-ownership", "subtitle-recovery", "storage-capacity", "tier3-evidence"]
       },
       "allowed_evidence_sources": ["tier3_operator_receipt"],
@@ -394,7 +406,12 @@
       "cadence": {"first_rc": false, "stable_candidate": true},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
       "invalidates_on": {
-        "paths": ["scripts/add_spatial_video_metadata.py", "scripts/verify_apple_media.py"],
+        "paths": [
+          "docs/tier3-operator-hardware.md",
+          "scripts/add_spatial_video_metadata.py",
+          "scripts/tier3_operator_receipt.py",
+          "scripts/verify_apple_media.py"
+        ],
         "contracts": ["vision-pro-playback", "packaged-worker", "tier3-evidence"]
       },
       "allowed_evidence_sources": ["tier3_operator_receipt"],

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -109,6 +109,12 @@ package smoke, verifies a real-feed update from an exact prior signed release,
 and emits checked `clean-machine-signed-update` and
 `installed-ui-accessibility` receipts.
 
+Physical drive, protected-media conversion, and Vision Pro playback evidence
+uses the bounded operator-assisted helper documented in
+[`docs/tier3-operator-hardware.md`](tier3-operator-hardware.md). The helper
+derives assertion states from exact enums, binds the checked release artifact,
+and rejects private media names, paths, serials, screenshots, and raw logs.
+
 ## Release Engine Receipts
 
 Every successful guarded Stable or Prerelease publication includes a

--- a/docs/tier3-operator-hardware.md
+++ b/docs/tier3-operator-hardware.md
@@ -1,0 +1,96 @@
+# Tier 3 Operator-Assisted Hardware Receipts
+
+`scripts/tier3_operator_receipt.py` is the maintained boundary for physical
+Tier 3 evidence that cannot be truthfully automated without an operator and the
+declared hardware. It supports:
+
+- `usb-bluray-makemkv`;
+- `protected-real-media-conversion`; and
+- `vision-pro-physical-playback`.
+
+The helper never records disc titles, volume names, serial numbers, local file
+paths, media, screenshots, tokens, or raw logs. An answers file contains exact
+bounded outcomes, public device-class identity, the declared environment, and
+timestamps. Unknown fields and free-form observations are rejected before a
+receipt is built.
+
+## Answers Contract
+
+Every answers file has these exact top-level fields:
+
+```json
+{
+  "schema_version": 1,
+  "case_id": "usb-bluray-makemkv",
+  "disposition": "completed",
+  "reason_code": "all-assertions-passed",
+  "started_at": "2026-08-06T12:00:00Z",
+  "completed_at": "2026-08-06T12:10:00Z",
+  "environment": {
+    "environment_class": "dedicated-hardware",
+    "architecture": "arm64",
+    "macos_version": "26.0",
+    "macos_build": "25A123"
+  },
+  "hardware": {
+    "class": "usb-bluray-drive",
+    "identity": {
+      "vendor_id": "1234",
+      "product_id": "5678",
+      "transport": "usb",
+      "makemkv_version": "1.18.1"
+    }
+  },
+  "cleanup_status": "recovered",
+  "observations": {
+    "drive_discovery": "detected",
+    "makemkv": "installed",
+    "cancellation": "recovered",
+    "ejection": "ejected"
+  }
+}
+```
+
+Completed observations are limited to the enums implemented by the helper.
+The helper derives pass/fail assertion states; the operator cannot directly
+mark assertions passed. A skipped receipt uses `disposition: skipped`, an empty
+`observations` object, and one of `hardware-unavailable`,
+`environment-unavailable`, or `operator-cancelled`. Required public hardware
+identity remains mandatory even for skipped audit records.
+
+USB IDs are four-digit public vendor/product identifiers, never serials.
+`makemkv_version` is the application version, never an executable path. Vision
+Pro identity uses only `model_family`, `chip_family`, and `visionos_major`.
+
+## Collection
+
+The release receipt must be committed and byte-identical to repository `HEAD`:
+
+```sh
+uv run python -m scripts.tier3_operator_receipt \
+  --answers /path/to/bounded-answers.json \
+  --release-receipt docs/release-evidence/<candidate>/release-receipt.json \
+  --output-receipt /path/out/<case-id>.json \
+  --evidence-directory /path/out/<case-id>-evidence
+```
+
+Passed or failed runs produce only normalized JSON summaries and their digests.
+Skipped runs produce no evidence summaries. Cleanup, cancellation, ejection,
+recovery, conversion completion, and subjective spatial-presentation outcomes
+remain distinct bounded fields.
+
+Physical receipts run only on policy cadence. The USB/MakeMKV case is eligible
+for first RC and stable-candidate milestones; protected-media conversion and
+Vision Pro playback are stable-candidate cases. They are not prerequisites for
+every prerelease.
+
+## Validation
+
+```sh
+uv run python -m unittest tests.test_tier3_operator_receipt
+uv run python -m scripts.qualify_release_scope --validate-policy
+```
+
+Fixture receipts cover passed, failed, skipped, private-field rejection, and
+missing-hardware rejection. Real hardware collection is performed only when the
+declared cadence requires it.

--- a/scripts/tier3_operator_receipt.py
+++ b/scripts/tier3_operator_receipt.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from scripts.qualify_release_scope import DEFAULT_POLICY_PATH, load_policy
+from scripts.release_receipt import ReleaseReceiptError, validate_receipt as validate_release_receipt
+from scripts.tier3_receipt import Tier3ReceiptError, build_receipt, validate_receipt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CASE_IDS = {
+    "usb-bluray-makemkv",
+    "protected-real-media-conversion",
+    "vision-pro-physical-playback",
+}
+SKIP_REASONS = {"environment-unavailable", "hardware-unavailable", "operator-cancelled"}
+CASE_CONTRACTS: dict[str, dict[str, Any]] = {
+    "usb-bluray-makemkv": {
+        "observations": {
+            "drive_discovery": {"detected", "not-detected"},
+            "makemkv": {"installed", "missing"},
+            "cancellation": {"recovered", "failed"},
+            "ejection": {"ejected", "failed"},
+        },
+        "assertions": {
+            "drive-discovered": ("drive_discovery", "detected"),
+            "makemkv-path-verified": ("makemkv", "installed"),
+            "cancellation-recovered": ("cancellation", "recovered"),
+            "drive-ejected": ("ejection", "ejected"),
+        },
+        "evidence": {
+            "device-probe": ("drive_discovery",),
+            "makemkv-probe": ("makemkv",),
+            "ejection-result": ("cancellation", "ejection"),
+            "cleanup": (),
+        },
+    },
+    "protected-real-media-conversion": {
+        "observations": {
+            "protected_source": {"opened", "failed"},
+            "conversion": {"completed", "failed", "cancelled"},
+            "output": {"verified", "failed", "not-produced"},
+            "recovery": {"clean", "recovered", "failed"},
+        },
+        "assertions": {
+            "protected-source-opened": ("protected_source", "opened"),
+            "conversion-completed": ("conversion", "completed"),
+            "output-verified": ("output", "verified"),
+            "recovery-clean": ("recovery", "clean"),
+        },
+        "evidence": {
+            "conversion-result": ("protected_source", "conversion", "output"),
+            "diagnostic-summary": ("recovery",),
+            "cleanup": (),
+        },
+    },
+    "vision-pro-physical-playback": {
+        "observations": {
+            "transfer": {"completed", "failed"},
+            "stereo_playback": {"started", "failed"},
+            "spatial_presentation": {"verified", "failed"},
+            "playback": {"completed", "interrupted", "failed"},
+        },
+        "assertions": {
+            "artifact-transferred": ("transfer", "completed"),
+            "stereo-playback-started": ("stereo_playback", "started"),
+            "spatial-presentation-verified": ("spatial_presentation", "verified"),
+            "playback-completed": ("playback", "completed"),
+        },
+        "evidence": {
+            "device-probe": (),
+            "playback-result": ("transfer", "stereo_playback", "spatial_presentation", "playback"),
+        },
+    },
+}
+
+
+class OperatorReceiptError(RuntimeError):
+    pass
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OperatorReceiptError(f"{description} must be a JSON object.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise OperatorReceiptError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    if set(value) != expected:
+        raise OperatorReceiptError(f"{description} must contain exactly: {', '.join(sorted(expected))}.")
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    path.write_text(content, encoding="utf-8")
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _checked_release_receipt(repo: Path, path: Path) -> tuple[Mapping[str, Any], str, str]:
+    repo = repo.resolve()
+    resolved = path.resolve()
+    try:
+        reference = resolved.relative_to(repo).as_posix()
+    except ValueError as error:
+        raise OperatorReceiptError("Release receipt must be inside the repository.") from error
+    result = subprocess.run(["git", "show", f"HEAD:{reference}"], cwd=repo, capture_output=True, timeout=60)
+    if result.returncode != 0 or result.stdout != resolved.read_bytes():
+        raise OperatorReceiptError("Release receipt must match the checked repository HEAD.")
+    try:
+        receipt = _mapping(json.loads(result.stdout), "release receipt")
+        validate_release_receipt(receipt)
+    except (json.JSONDecodeError, ReleaseReceiptError) as error:
+        raise OperatorReceiptError(f"Release receipt is invalid: {error}") from error
+    return receipt, reference, hashlib.sha256(result.stdout).hexdigest()
+
+
+def _case(policy: Mapping[str, Any], case_id: str) -> Mapping[str, Any]:
+    cases = [_mapping(item, "qualification case") for item in policy.get("cases", [])]
+    matches = [case for case in cases if case.get("id") == case_id]
+    if len(matches) != 1 or case_id not in CASE_IDS:
+        raise OperatorReceiptError(f"Unsupported operator-assisted Tier 3 case: {case_id}")
+    return matches[0]
+
+
+def build_operator_receipt(
+    answers: Mapping[str, Any],
+    *,
+    repo: Path,
+    release_receipt_path: Path,
+    evidence_directory: Path,
+) -> Mapping[str, Any]:
+    _exact_keys(
+        answers,
+        {
+            "case_id",
+            "cleanup_status",
+            "completed_at",
+            "disposition",
+            "environment",
+            "hardware",
+            "observations",
+            "reason_code",
+            "schema_version",
+            "started_at",
+        },
+        "operator answers",
+    )
+    if answers.get("schema_version") != 1:
+        raise OperatorReceiptError("Operator answers use an unsupported schema version.")
+    case_id = _string(answers.get("case_id"), "case_id")
+    policy = load_policy(repo / DEFAULT_POLICY_PATH.relative_to(REPO_ROOT))
+    case = _case(policy, case_id)
+    contract = CASE_CONTRACTS[case_id]
+    disposition = _string(answers.get("disposition"), "disposition")
+    if disposition not in {"completed", "skipped"}:
+        raise OperatorReceiptError("disposition must be completed or skipped.")
+    reason_code = _string(answers.get("reason_code"), "reason_code")
+    observations = _mapping(answers.get("observations"), "observations")
+
+    evidence: list[Mapping[str, str]] = []
+    if disposition == "skipped":
+        if observations or reason_code not in SKIP_REASONS:
+            raise OperatorReceiptError("Skipped answers require empty observations and a bounded skip reason.")
+        assertions = {assertion_id: "not_run" for assertion_id in contract["assertions"]}
+        result = {"status": "skipped", "reason_code": reason_code}
+    else:
+        expected_observations = contract["observations"]
+        _exact_keys(observations, set(expected_observations), "observations")
+        for field, allowed in expected_observations.items():
+            if observations.get(field) not in allowed:
+                raise OperatorReceiptError(f"observations.{field} is not a supported outcome.")
+        assertions = {
+            assertion_id: "passed" if observations[field] == expected else "failed"
+            for assertion_id, (field, expected) in contract["assertions"].items()
+        }
+        passed = set(assertions.values()) == {"passed"}
+        expected_reason = "all-assertions-passed" if passed else "operator-assertion-failed"
+        if reason_code != expected_reason:
+            raise OperatorReceiptError(f"Completed answers must use reason_code {expected_reason}.")
+        result = {
+            "status": "passed" if passed else "failed",
+            "reason_code": "all_assertions_passed" if passed else "operator_assertion_failed",
+        }
+        if evidence_directory.exists():
+            raise OperatorReceiptError("Evidence directory must not already exist.")
+        evidence_directory.mkdir(parents=True)
+        hardware = _mapping(answers.get("hardware"), "hardware")
+        cleanup_status = _string(answers.get("cleanup_status"), "cleanup_status")
+        for kind, fields in contract["evidence"].items():
+            payload: dict[str, Any] = {field: observations[field] for field in fields}
+            if kind == "device-probe":
+                payload["hardware"] = hardware
+            if kind == "cleanup":
+                payload["status"] = cleanup_status
+            payload["schema_version"] = 1
+            evidence.append({"kind": kind, "sha256": _write_json(evidence_directory / f"{kind}.json", payload)})
+
+    release_receipt, release_reference, release_file_sha256 = _checked_release_receipt(repo, release_receipt_path)
+    cleanup_status = _string(answers.get("cleanup_status"), "cleanup_status")
+    cleanup_digest = next((item["sha256"] for item in evidence if item["kind"] == "cleanup"), None)
+    receipt = build_receipt(
+        {
+            "assertions": assertions,
+            "cleanup": {"status": cleanup_status, "evidence_sha256": cleanup_digest},
+            "completed_at": _string(answers.get("completed_at"), "completed_at"),
+            "environment": dict(_mapping(answers.get("environment"), "environment")),
+            "evidence": evidence,
+            "evidence_source": "tier3_operator_receipt",
+            "hardware": dict(_mapping(answers.get("hardware"), "hardware")),
+            "release_receipt_file_sha256": release_file_sha256,
+            "release_receipt_reference": release_reference,
+            "result": result,
+            "started_at": _string(answers.get("started_at"), "started_at"),
+        },
+        policy_id=_string(policy.get("policy_id"), "policy_id"),
+        case=case,
+        release_receipt=release_receipt,
+    )
+    try:
+        validate_receipt(
+            receipt,
+            policy_id=_string(policy.get("policy_id"), "policy_id"),
+            case=case,
+            reference_content=lambda reference: (repo / reference).read_bytes(),
+        )
+    except Tier3ReceiptError as error:
+        raise OperatorReceiptError(f"Generated operator receipt is invalid: {error}") from error
+    return receipt
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a bounded operator-assisted Tier 3 hardware receipt.")
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--release-receipt", type=Path, required=True)
+    parser.add_argument("--output-receipt", type=Path, required=True)
+    parser.add_argument("--evidence-directory", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        answers = _mapping(json.loads(args.answers.read_text(encoding="utf-8")), "operator answers")
+        if args.output_receipt.exists():
+            raise OperatorReceiptError("Output receipt must not already exist.")
+        receipt = build_operator_receipt(
+            answers,
+            repo=args.repo.resolve(),
+            release_receipt_path=args.release_receipt,
+            evidence_directory=args.evidence_directory,
+        )
+        _write_json(args.output_receipt, receipt)
+        print(json.dumps({"case_id": receipt["case_id"], "result": receipt["result"]}, sort_keys=True))
+        return 0
+    except (OSError, json.JSONDecodeError, OperatorReceiptError) as error:
+        if args.output_receipt.exists():
+            args.output_receipt.unlink()
+        if args.evidence_directory.exists():
+            for path in args.evidence_directory.iterdir():
+                path.unlink()
+            args.evidence_directory.rmdir()
+        print(f"tier3 operator receipt error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tier3_operator_receipt.py
+++ b/tests/test_tier3_operator_receipt.py
@@ -1,0 +1,146 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from typing import Any
+
+from scripts.tier3_operator_receipt import OperatorReceiptError, build_operator_receipt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_RECEIPT = REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json"
+
+
+class Tier3OperatorReceiptTests(unittest.TestCase):
+    @staticmethod
+    def answers(case_id: str) -> dict[str, Any]:
+        hardware: dict[str, Any]
+        cleanup_status: str
+        if case_id == "vision-pro-physical-playback":
+            hardware = {
+                "class": "vision-pro",
+                "identity": {"chip_family": "m2", "model_family": "apple-vision-pro", "visionos_major": "26"},
+            }
+            cleanup_status = "not-applicable"
+            observations = {
+                "playback": "completed",
+                "spatial_presentation": "verified",
+                "stereo_playback": "started",
+                "transfer": "completed",
+            }
+        else:
+            hardware = {
+                "class": "usb-bluray-drive",
+                "identity": {
+                    "makemkv_version": "1.18.1",
+                    "product_id": "5678",
+                    "transport": "usb",
+                    "vendor_id": "1234",
+                },
+            }
+            cleanup_status = "recovered" if case_id == "usb-bluray-makemkv" else "restored"
+            observations = (
+                {
+                    "cancellation": "recovered",
+                    "drive_discovery": "detected",
+                    "ejection": "ejected",
+                    "makemkv": "installed",
+                }
+                if case_id == "usb-bluray-makemkv"
+                else {
+                    "conversion": "completed",
+                    "output": "verified",
+                    "protected_source": "opened",
+                    "recovery": "clean",
+                }
+            )
+        return {
+            "case_id": case_id,
+            "cleanup_status": cleanup_status,
+            "completed_at": "2026-08-06T12:10:00Z",
+            "disposition": "completed",
+            "environment": {
+                "architecture": "arm64",
+                "environment_class": "dedicated-hardware",
+                "macos_build": "25A123",
+                "macos_version": "26.0",
+            },
+            "hardware": hardware,
+            "observations": observations,
+            "reason_code": "all-assertions-passed",
+            "schema_version": 1,
+            "started_at": "2026-08-06T12:00:00Z",
+        }
+
+    @staticmethod
+    def build(answers: dict[str, Any], root: Path) -> dict[str, Any]:
+        return dict(
+            build_operator_receipt(
+                answers,
+                repo=REPO_ROOT,
+                release_receipt_path=RELEASE_RECEIPT,
+                evidence_directory=root / "evidence",
+            )
+        )
+
+    def test_builds_passed_receipts_for_every_physical_case(self) -> None:
+        for case_id in (
+            "usb-bluray-makemkv",
+            "protected-real-media-conversion",
+            "vision-pro-physical-playback",
+        ):
+            with self.subTest(case_id=case_id), tempfile.TemporaryDirectory() as temporary_directory:
+                receipt = self.build(self.answers(case_id), Path(temporary_directory))
+                self.assertEqual(receipt["case_id"], case_id)
+                self.assertEqual(receipt["result"], {"reason_code": "all_assertions_passed", "status": "passed"})
+                self.assertNotIn("/Users/", json.dumps(receipt))
+
+    def test_failed_outcome_derives_failed_assertion_and_reason(self) -> None:
+        answers = self.answers("usb-bluray-makemkv")
+        observations = dict(answers["observations"])
+        observations["ejection"] = "failed"
+        answers["observations"] = observations
+        answers["reason_code"] = "operator-assertion-failed"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt = self.build(answers, Path(temporary_directory))
+        self.assertEqual(receipt["result"], {"reason_code": "operator_assertion_failed", "status": "failed"})
+        assertions = {item["id"]: item["status"] for item in receipt["assertions"]}
+        self.assertEqual(assertions["drive-ejected"], "failed")
+
+    def test_skipped_outcome_requires_empty_observations_and_bounded_reason(self) -> None:
+        answers = self.answers("vision-pro-physical-playback")
+        answers["disposition"] = "skipped"
+        answers["observations"] = {}
+        answers["reason_code"] = "hardware-unavailable"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            receipt = self.build(answers, Path(temporary_directory))
+        self.assertEqual(receipt["result"], {"reason_code": "hardware-unavailable", "status": "skipped"})
+        self.assertEqual({item["status"] for item in receipt["assertions"]}, {"not_run"})
+        self.assertEqual(receipt["evidence"], [])
+
+    def test_rejects_unbounded_or_private_observation_fields(self) -> None:
+        answers = self.answers("protected-real-media-conversion")
+        observations = dict(answers["observations"])
+        observations["disc_title"] = "/Volumes/Private Disc"
+        answers["observations"] = observations
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            self.assertRaisesRegex(OperatorReceiptError, "observations must contain exactly"),
+        ):
+            self.build(answers, Path(temporary_directory))
+
+    def test_rejects_missing_hardware_identity(self) -> None:
+        answers = self.answers("usb-bluray-makemkv")
+        hardware = dict(answers["hardware"])
+        hardware["identity"] = {"transport": "usb"}
+        answers["hardware"] = hardware
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            self.assertRaisesRegex(OperatorReceiptError, "Generated operator receipt is invalid"),
+        ):
+            self.build(answers, Path(temporary_directory))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a bounded operator-assisted collector for USB Blu-ray/MakeMKV, protected real-media conversion, and physical Vision Pro playback cases
- derive assertion statuses from exact outcome enums and reject private fields, paths, serials, media names, screenshots, and raw logs
- bind receipts to the exact checked release receipt and emit normalized public-safe evidence digests for pass/fail while preserving explicit skipped audit records

## Validation
- `uv run python -m unittest tests.test_tier3_operator_receipt tests.test_tier3_receipt tests.test_qualify_release_scope`
- `uv run python -m unittest discover -s tests -t .` (1548 passed, 3 skipped)
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python -m scripts.release validate`
- `uv run ruff format --check scripts/tier3_operator_receipt.py tests/test_tier3_operator_receipt.py`
- `uv run ruff check scripts/tier3_operator_receipt.py tests/test_tier3_operator_receipt.py`
- `uv run mypy scripts/tier3_operator_receipt.py`

JetBrains identified five Python typing findings; they were fixed. The verification rerun reported zero findings but an inconclusive `execution_not_proven` helper result. JSON whitespace findings were IDE parser noise, not repository formatting changes.

Closes #484
