### PR TITLE
Stabilize worker backpressure startup wait

### DIFF
--- a/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
+++ b/macos/BluRayToVisionProTests/WorkerProcessClientTests.swift
@@ -71,7 +71,7 @@ final class WorkerProcessClientTests: XCTestCase {
             }
         }
 
-        await fulfillment(of: [slowHandlerStarted], timeout: 5)
+        await fulfillment(of: [slowHandlerStarted], timeout: 15)
         let writerStarted = await waitForDiagnosticMarker("WRITER-STARTED", client: client)
         XCTAssertTrue(writerStarted)
         guard writerStarted else {


### PR DESCRIPTION
## Summary

- extend the backpressure test's worker startup deadline from 5 to 15 seconds
- preserve the production pull-driven reader and every substantive backpressure assertion
- address the exact post-merge CI failure at `WorkerProcessClientTests.swift:74`

## Evidence

- exact failure reproduced twice on merge commit `7ed7f8acd9c0e9f0338c463f6ae0d76bbb2e5ce7`
- both failures were `Exceeded timeout of 5 seconds` for `slow handler started`
- PR head and merge commit had identical trees; no production regression was introduced by the merge

## Validation

- exact XCTest: 25/25 iterations passed under local Xcode 27.0
- `uv run python scripts/native_app.py test`: 355/355 tests passed
- Xcode 26.6 is not installed locally; CI remains the authoritative runner validation

Refs #492