### PR TITLE
Fix hosted installed UI appearance switching

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -51,10 +51,7 @@ final class InstalledUIAcceptanceTests: XCTestCase {
     func testCandidateMainWindowProfileAndSettings() throws {
         let context = try QualificationContext.load(expectedPhase: "candidate")
         let lightApp = try launchInstalledApp(context: context, appearance: .light)
-        defer {
-            lightApp.terminate()
-            try? setAppearance(.light, syntheticHome: context.syntheticHome)
-        }
+        defer { lightApp.terminate() }
 
         let mainContent = lightApp.descendants(matching: .any)["main-window-content"]
         XCTAssertTrue(mainContent.waitForExistence(timeout: 30))
@@ -129,12 +126,12 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         context: QualificationContext,
         appearance: QualificationAppearance
     ) throws -> XCUIApplication {
-        try setAppearance(appearance, syntheticHome: context.syntheticHome)
         let app = XCUIApplication(url: context.appURL)
         app.launchEnvironment = [
             "HOME": context.syntheticHome.path,
             "CFFIXED_USER_HOME": context.syntheticHome.path,
         ]
+        app.launchArguments = appearance.launchArguments
         app.launch()
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
         let matches = NSRunningApplication.runningApplications(withBundleIdentifier: context.bundleIdentifier)
@@ -235,6 +232,15 @@ final class InstalledUIAcceptanceTests: XCTestCase {
 private enum QualificationAppearance: Equatable {
     case light
     case dark
+
+    var launchArguments: [String] {
+        switch self {
+        case .light:
+            ["-NSRequiresAquaSystemAppearance", "YES"]
+        case .dark:
+            ["-AppleInterfaceStyle", "Dark"]
+        }
+    }
 }
 
 private struct QualificationContext {
@@ -315,25 +321,4 @@ private func readProfileSummary(syntheticHome: URL) throws -> ProfileSummary {
         throw QualificationError.missingProfileDocument
     }
     return ProfileSummary(count: profiles.count, name: name, version: version)
-}
-
-private func setAppearance(_ appearance: QualificationAppearance, syntheticHome: URL) throws {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-    process.environment = [
-        "CFFIXED_USER_HOME": syntheticHome.path,
-        "HOME": syntheticHome.path,
-        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-    ]
-    switch appearance {
-    case .light:
-        process.arguments = ["delete", "NSGlobalDomain", "AppleInterfaceStyle"]
-    case .dark:
-        process.arguments = ["write", "NSGlobalDomain", "AppleInterfaceStyle", "Dark"]
-    }
-    try process.run()
-    process.waitUntilExit()
-    if appearance == .dark, process.terminationStatus != 0 {
-        throw QualificationError.missingEnvironment("synthetic appearance preference")
-    }
 }

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -153,6 +153,16 @@ class NativeAppPackagingTests(unittest.TestCase):
             {key: f"$({key})" for key in environment_keys},
         )
 
+    def test_installed_ui_appearance_uses_app_launch_arguments(self) -> None:
+        source = (MACOS_ROOT / "BluRayToVisionProUITests" / "InstalledUIAcceptanceTests.swift").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("app.launchArguments = appearance.launchArguments", source)
+        self.assertIn('["-NSRequiresAquaSystemAppearance", "YES"]', source)
+        self.assertIn('["-AppleInterfaceStyle", "Dark"]', source)
+        self.assertNotIn('executableURL = URL(fileURLWithPath: "/usr/bin/defaults")', source)
+
     def test_builds_packaged_mv_hevc_encoder_at_requested_path(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             output_path = Path(temporary_directory) / "tools" / MV_HEVC_ENCODER_NAME


### PR DESCRIPTION
## Summary

- stop mutating synthetic global preferences with `/usr/bin/defaults` from XCUITest
- force light mode per launch with `-NSRequiresAquaSystemAppearance YES`
- force dark mode per launch with `-AppleInterfaceStyle Dark`
- retain exact installed-app URL and synthetic-home isolation checks

## Root Cause

Stable run `31210272999` completed the light-mode signed-app interaction and candidate evidence, then the GitHub macOS 26 runner rejected the synthetic global preference write used to switch to dark mode:

`Could not write domain Apple Global Domain; exiting`

The test failed before the dark screenshot even though the application behavior and earlier evidence had passed.

## Validation

- exact draft DMG asset `505579190` and release receipt asset `505581263` from failed run `31210272999` downloaded and hash-verified
- exact signed-artifact UI lane passed locally with profile save, updater settings, trusted AX evidence, receipt generation, and both screenshots
- screenshots visually verified as genuinely Aqua/light and dark on a dark-host macOS 27 machine
- `uv run python -m unittest discover -s tests -t .` — 1,579 passed, 3 skipped
- `xcodebuild ... build-for-testing` — passed
- focused native/release/UI/workflow suite — 113 passed
- two independent blocker reviews — clean

No release was published. Matching unpublished draft `366970674` remains preserved for exact source SHA `4e8ce9987fbf329a5c575e1b9f47c313665efda8`.

Refs #489
