### PR TITLE
Recover Stable PyPI publication safely

### DIFF
--- a/.github/workflows/briefcase.yml
+++ b/.github/workflows/briefcase.yml
@@ -1,11 +1,16 @@
 ---
 name: Stable
+run-name: ${{ inputs.pypi_recovery_evidence_sha256 != '' && 'Stable PyPI recovery' || 'Stable' }}
 
 "on":
   workflow_dispatch:
     inputs:
       release_notes:
         description: Optional notes prepended to the generated GitHub release notes
+        required: false
+        type: string
+      pypi_recovery_evidence_sha256:
+        description: Exact reviewed evidence fingerprint for the one-time Stable 0.3.0 PyPI recovery
         required: false
         type: string
 
@@ -18,6 +23,7 @@ concurrency:
 jobs:
   release:
     name: Run guarded signed-release engine
+    if: inputs.pypi_recovery_evidence_sha256 == ''
     uses: ./.github/workflows/release-engine.yml
     with:
       release_notes: ${{ inputs.release_notes }}
@@ -146,3 +152,137 @@ jobs:
         with:
           attestations: true
           packages-dir: python-distributions/dist
+
+  recover-pypi:
+    name: Recover exact Stable 0.3.0 Python distributions
+    if: inputs.pypi_recovery_evidence_sha256 != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bd-to-avp
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout current protected main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Resolve reviewed recovery evidence
+        id: evidence
+        env:
+          RECOVERY_EVIDENCE_SHA256: ${{ inputs.pypi_recovery_evidence_sha256 }}
+        run: |
+          set -euo pipefail
+          python -m scripts.stable_pypi_recovery \
+            --expected-evidence-sha256 "$RECOVERY_EVIDENCE_SHA256" \
+            outputs \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Verify recovery authorization and immutable source state
+        env:
+          ARTIFACT_ID: ${{ steps.evidence.outputs.artifact_id }}
+          EXPECTED_RELEASE_ID: ${{ steps.evidence.outputs.release_id }}
+          EXPECTED_RELEASE_RUN_ID: ${{ steps.evidence.outputs.release_run_id }}
+          EXPECTED_SOURCE_SHA: ${{ steps.evidence.outputs.release_source_sha }}
+          RECEIPT_ASSET_ID: ${{ steps.evidence.outputs.release_receipt_asset_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "cbusillo/BD_to_AVP"
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_REF_PROTECTED" = "true"
+          test "$GITHUB_WORKFLOW_REF" = \
+            "cbusillo/BD_to_AVP/.github/workflows/briefcase.yml@refs/heads/main"
+          test "$GITHUB_ACTOR" = "shiny-code-bot"
+          test "$GITHUB_TRIGGERING_ACTOR" = "shiny-code-bot"
+          MAIN_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)
+          test "$MAIN_SHA" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$EXPECTED_SOURCE_SHA" "$GITHUB_SHA"
+          TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v0.3.0" --jq .object.sha)
+          test "$TAG_SHA" = "$EXPECTED_SOURCE_SHA"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$EXPECTED_RELEASE_RUN_ID" > workflow-run.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$EXPECTED_RELEASE_RUN_ID/jobs?per_page=100" > workflow-jobs.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" > python-artifact.json
+          gh api "repos/$GITHUB_REPOSITORY/releases/$EXPECTED_RELEASE_ID" > release.json
+          gh api "repos/$GITHUB_REPOSITORY/releases/assets/$RECEIPT_ASSET_ID" \
+            -H "Accept: application/octet-stream" > release-receipt.json
+          python -m scripts.stable_pypi_recovery verify-remote-files \
+            --workflow-run workflow-run.json \
+            --jobs workflow-jobs.json \
+            --artifact python-artifact.json \
+            --release release.json \
+            --receipt release-receipt.json
+          python -m scripts.stable_pypi_recovery verify-pypi \
+            --state recoverable \
+            --retries 6 \
+            --delay 10
+
+      - name: Download exact failed-run Python artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ steps.evidence.outputs.artifact_id }}
+          github-token: ${{ github.token }}
+          merge-multiple: true
+          path: python-distributions
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.evidence.outputs.release_run_id }}
+
+      - name: Verify exact original distribution bytes
+        run: |
+          set -euo pipefail
+          python -m scripts.stable_pypi_recovery verify-payload \
+            --artifact-root python-distributions
+
+      - name: Resolve idempotent PyPI recovery action
+        id: pypi
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          MAIN_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)
+          if [ "$MAIN_SHA" != "$GITHUB_SHA" ]; then
+            echo "Protected main moved immediately before PyPI recovery publication." >&2
+            exit 1
+          fi
+          python -m scripts.stable_pypi_recovery resolve-pypi-action \
+            --github-output "$GITHUB_OUTPUT" \
+            --retries 6 \
+            --delay 10
+
+      - name: Publish exact original bytes with PyPI trusted publishing and attestations
+        if: steps.pypi.outputs.publish_required == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          attestations: true
+          packages-dir: python-distributions/dist
+          skip-existing: true
+
+      - name: Verify recovered PyPI publication
+        run: |
+          set -euo pipefail
+          python -m scripts.stable_pypi_recovery verify-pypi \
+            --state published \
+            --retries 12 \
+            --delay 10
+          python -m scripts.stable_pypi_recovery write-receipt \
+            --output stable-0.3.0-pypi-recovery-receipt.json \
+            --publication-action "${{ steps.pypi.outputs.publication_action }}"
+
+      - name: Upload PyPI recovery receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stable-0.3.0-pypi-recovery-${{ github.run_attempt }}
+          path: stable-0.3.0-pypi-recovery-receipt.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -1243,15 +1243,21 @@ jobs:
         run: |
           set -euo pipefail
           python -m scripts.release validate
-          uv build
-          mkdir -p python-distributions
-          mv dist python-distributions/
+          mkdir -p python-distributions/dist
+          uv build --out-dir python-distributions/dist
           (
             cd python-distributions
+            find dist -mindepth 1 -maxdepth 1 -type f \
+              ! -name '*.whl' ! -name '*.tar.gz' -delete
+            test -z "$(find dist -type l -print -quit)"
+            test "$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l | tr -d ' ')" = "1"
+            test "$(find dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l | tr -d ' ')" = "1"
+            test "$(find dist -maxdepth 1 -type f | wc -l | tr -d ' ')" = "2"
+            test -z "$(find dist -mindepth 1 ! -type f -print -quit)"
             find dist -type f -print | LC_ALL=C sort | while IFS= read -r file; do
               shasum -a 256 "$file"
             done > SHA256SUMS
-            test -s SHA256SUMS
+            test "$(wc -l < SHA256SUMS | tr -d ' ')" = "2"
           )
 
       - name: Upload Python distributions

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -26,6 +26,7 @@ jobs:
       base_main_sha: ${{ steps.base.outputs.sha }}
       has_changes: ${{ steps.stage.outputs.has_changes }}
       receipt_file_sha256: ${{ steps.reconcile.outputs.receipt_file_sha256 }}
+      release_run_id: ${{ steps.reconcile.outputs.release_run_id }}
       release_tag: ${{ steps.reconcile.outputs.release_tag }}
       source_sha: ${{ steps.reconcile.outputs.source_sha }}
     steps:
@@ -45,10 +46,41 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Resolve release evidence source
+        id: source
+        env:
+          COMPLETED_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          COMPLETED_RUN_ID: ${{ github.event.workflow_run.id }}
+          COMPLETED_SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$COMPLETED_DISPLAY_TITLE" = "Stable PyPI recovery" ]; then
+            python -m scripts.stable_pypi_recovery outputs --github-output "$GITHUB_OUTPUT"
+            {
+              echo "recovery=true"
+              echo "recovery_run_id=$COMPLETED_RUN_ID"
+            } >> "$GITHUB_OUTPUT"
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COMPLETED_RUN_ID" > recovery-workflow-run.json
+            python -m scripts.stable_pypi_recovery verify-pypi \
+              --state published \
+              --retries 6 \
+              --delay 10
+            RELEASE_SOURCE_SHA=$(sed -n 's/^release_source_sha=//p' "$GITHUB_OUTPUT" | tail -1)
+            git merge-base --is-ancestor "$RELEASE_SOURCE_SHA" HEAD
+          else
+            {
+              echo "release_run_id=$COMPLETED_RUN_ID"
+              echo "release_source_sha=$COMPLETED_SOURCE_SHA"
+              echo "recovery=false"
+              echo "recovery_run_id="
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve the immutable release and receipt
         env:
-          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
-          EXPECTED_SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          EXPECTED_RUN_ID: ${{ steps.source.outputs.release_run_id }}
+          EXPECTED_SOURCE_SHA: ${{ steps.source.outputs.release_source_sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -121,14 +153,21 @@ jobs:
 
       - name: Reconcile checked evidence
         id: reconcile
+        env:
+          RECOVERY: ${{ steps.source.outputs.recovery }}
         run: |
           set -euo pipefail
+          RECOVERY_ARGS=()
+          if [ "$RECOVERY" = "true" ]; then
+            RECOVERY_ARGS+=(--recovery-workflow-run recovery-workflow-run.json)
+          fi
           python -m scripts.release_evidence \
             --workflow-run workflow-run.json \
             --release release.json \
             --receipt release-receipt.json \
             --live-appcast live-appcast.xml \
             --repo-root "$GITHUB_WORKSPACE" \
+            "${RECOVERY_ARGS[@]}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Stage only generated evidence files
@@ -222,7 +261,7 @@ jobs:
           body: |
             Records the deterministic public-safe receipt and publication evidence for `${{ needs.validate-and-prepare.outputs.release_tag }}`.
 
-            - Release run: `${{ github.event.workflow_run.id }}`
+            - Release run: `${{ needs.validate-and-prepare.outputs.release_run_id }}`
             - Source SHA: `${{ needs.validate-and-prepare.outputs.source_sha }}`
             - Receipt file SHA-256: `${{ needs.validate-and-prepare.outputs.receipt_file_sha256 }}`
 

--- a/docs/0.3.0-cut-packet.md
+++ b/docs/0.3.0-cut-packet.md
@@ -1,9 +1,10 @@
 # 0.3.0 Stable Cut Packet
 
-> **Prepared metadata; publication pending.** Stable may be dispatched only
-> from the exact merged protected-`main` SHA under a temporary merge hold. The
-> `macos-signing` environment requires fresh explicit run-bound authorization
-> in the active conversation.
+> **Published and immutable; PyPI recovery pending.** Stable `v0.3.0` was
+> published from exact protected-`main` SHA
+> `a9abbcf6cd1281d2c701e0c050b68fdafc5b9522` by run `31219050718`. GitHub
+> Release and Sparkle publication succeeded, but the top-level run failed after
+> publication while verifying the transferred Python distributions.
 
 Stable follows immutable RC 3 and promotes the complete `0.3.0` production
 train tested across Alpha, Beta, and RC. GitHub-generated notes compare with the
@@ -61,3 +62,31 @@ watch`. If it exits `20`, obtain fresh explicit run-bound authorization in the
 active conversation and approve only through `scripts.github_release_run
 approve` with the emitted run ID, workflow, full `main` SHA, confirmation SHA,
 and approval fingerprint.
+
+## Post-Publication PyPI Recovery
+
+The Stable run built the correct `0.3.0` wheel and source archive, then generated
+`SHA256SUMS` over those files plus `dist/.gitignore`. GitHub's artifact uploader
+excluded the hidden file, so the downstream transfer verifier failed closed
+before trusted publishing ran. PyPI `0.3.0` therefore remained absent while the
+immutable GitHub release and live Sparkle feed remained valid.
+
+The reviewed one-time recovery evidence is
+`docs/release-evidence/v0.3.0-pypi-recovery.json`, SHA-256
+`46574b247fc9b9ef13cd64aafaa8e859c2cf10fcfde50913cd317ae5bfec361f`.
+It binds failed run `31219050718`, exact artifact `9009656530` with GitHub
+artifact digest `92f3e21084ec98e20e9c18ac3531985d8ad03ee50a514eca841dfe9ce12dd157`,
+the immutable release and receipt, and both original distribution hashes.
+
+Recovery must run only through the existing `Stable` workflow and `pypi`
+environment so the trusted-publisher identity is unchanged. It must publish the
+downloaded original artifact bytes, not a rebuild, verify PyPI absence
+immediately before publication, and verify both published file hashes
+afterward. If an upload succeeds but a later verification step fails, a retry
+accepts only a PyPI file set that exactly matches the reviewed hashes, skips a
+second upload, and completes the recovery receipt and evidence reconciliation.
+The PyPI attestations identify the successful recovery workflow commit while
+the recovery receipt separately preserves the original release source and
+failed run. Dispatch requires fresh explicit authorization for the exact
+evidence fingerprint. Remove the one-time recovery input, job, script, and
+evidence after the checked evidence PR has reconciled the successful recovery.

--- a/docs/release-evidence/v0.3.0-pypi-recovery.json
+++ b/docs/release-evidence/v0.3.0-pypi-recovery.json
@@ -1,0 +1,80 @@
+{
+  "schema": "bd_to_avp.pypi_recovery",
+  "schema_version": 1,
+  "observed_at": "2026-08-07T21:43:40Z",
+  "repository": {
+    "id": 771225421,
+    "node_id": "R_kgDOLff3TQ",
+    "full_name": "cbusillo/BD_to_AVP"
+  },
+  "release": {
+    "id": 367020071,
+    "tag": "v0.3.0",
+    "name": "v0.3.0",
+    "version": "0.3.0",
+    "source_sha": "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522",
+    "published_at": "2026-08-07T21:42:28Z",
+    "immutable": true,
+    "draft": false,
+    "prerelease": false,
+    "receipt_asset_id": 505690975,
+    "receipt_sha256": "f1da7083036120104fe702326cb88224e0233e26a2044a8e0ca0bd57520f9f79",
+    "receipt_size": 2258
+  },
+  "failed_run": {
+    "id": 31219050718,
+    "workflow_id": 101708423,
+    "run_number": 231,
+    "run_attempt": 1,
+    "workflow_name": "Stable",
+    "workflow_path": ".github/workflows/briefcase.yml",
+    "event": "workflow_dispatch",
+    "head_branch": "main",
+    "head_sha": "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522",
+    "actor": "shiny-code-bot",
+    "triggering_actor": "shiny-code-bot",
+    "status": "completed",
+    "conclusion": "failure",
+    "failed_job_id": 93005764021,
+    "failed_job": "Publish stable Python distribution with trusted publishing",
+    "failed_step": "Verify Python distribution transfer",
+    "skipped_publish_step": "Publish with PyPI trusted publishing and attestations"
+  },
+  "artifact": {
+    "id": 9009656530,
+    "node_id": "MDg6QXJ0aWZhY3Q5MDA5NjU2NTMw",
+    "name": "python-distributions",
+    "digest": "92f3e21084ec98e20e9c18ac3531985d8ad03ee50a514eca841dfe9ce12dd157",
+    "size": 11435706,
+    "created_at": "2026-08-07T21:12:37Z",
+    "expires_at": "2026-08-14T21:12:36Z",
+    "manifest_sha256": "ae80b90501b41dc1b3e1b828e0faab94f04449fa710010e12a98220d68aada95",
+    "omitted_hidden_file": {
+      "path": "dist/.gitignore",
+      "sha256": "684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1"
+    }
+  },
+  "distributions": [
+    {
+      "path": "dist/bd_to_avp-0.3.0-py3-none-any.whl",
+      "filename": "bd_to_avp-0.3.0-py3-none-any.whl",
+      "packagetype": "bdist_wheel",
+      "sha256": "cf939a83680bf8df9af465cc337b2de84b79830aae91112f117618de8a7645b0",
+      "size": 5739045
+    },
+    {
+      "path": "dist/bd_to_avp-0.3.0.tar.gz",
+      "filename": "bd_to_avp-0.3.0.tar.gz",
+      "packagetype": "sdist",
+      "sha256": "c325c72b860353df8103e7838655b6f990abbc94c886a097cfd59c8aaea70ff1",
+      "size": 5722488
+    }
+  ],
+  "recovery": {
+    "trusted_workflow": ".github/workflows/briefcase.yml",
+    "environment": "pypi",
+    "requires_original_artifact_bytes": true,
+    "pypi_version_must_be_absent_before_publish": true,
+    "remove_after_verified_recovery": true
+  }
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -351,6 +351,24 @@ only the abandoned unpublished draft after recording its identities, and start a
 fresh release from the new protected-main SHA. If the Pages job fails after publication, rerun the failed job or dispatch
 `Manage Sparkle Pages` from `main` with `deploy` and the release tag.
 
+Stable `0.3.0` has one bounded post-publication PyPI recovery. Run
+`31219050718` published the immutable GitHub release and Sparkle feed, then
+failed before PyPI trusted publishing because its checksum manifest included a
+generated `dist/.gitignore` that the artifact uploader omitted. The temporary
+`Stable` recovery job accepts only the exact reviewed evidence fingerprint in
+`docs/release-evidence/v0.3.0-pypi-recovery.json`, revalidates the failed run,
+immutable release receipt, original artifact ID and digest, and exact wheel and
+source-archive hashes, then publishes those original bytes through the existing
+`pypi` environment. A retry after a partial successful upload may skip
+publication only when PyPI already contains the exact reviewed file set and
+hashes; it then completes the receipt and checked evidence. The resulting PyPI
+attestation is bound to the recovery workflow commit, while durable evidence
+records the original failed release run separately from the successful recovery
+run. Do not rebuild, add another trusted-publisher workflow, use a local token,
+or relax the transfer verifier. Obtain fresh explicit authorization before
+dispatching the recovery fingerprint, and remove the one-time path after PyPI
+and checked release evidence are complete.
+
 For the Beta 3 seed, a pre-publication failure leaves the existing feed and all
 published assets unchanged: retain the matching draft for an exact retry or stop
 the release before publication. After publication, do not upload a replacement

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -14,6 +14,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
+from scripts.release_evidence import effective_successful_workflow_run_id
 from scripts.release_receipt import (
     ArtifactReceiptExpectation,
     ReleaseReceiptError,
@@ -528,7 +529,7 @@ def _validated_receipts(
             raise QualificationScopeError(f"Evidence for {case_id!r} cannot be accepted after {as_of.isoformat()}.")
         tier = cast(int, case["tier"])
         if tier == 1:
-            if receipt.get("workflow_conclusion") != "success":
+            if effective_successful_workflow_run_id(receipt, run_id_field="release_run_id") is None:
                 raise QualificationScopeError(f"Tier 1 case {case_id!r} requires a successful workflow conclusion.")
             run_id = receipt.get("release_run_id")
             if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
@@ -675,12 +676,15 @@ def _validated_receipts(
                 "release_id": release["id"],
                 "source_sha": release_receipt["source_sha"],
                 "workflow_run_id": workflow["run_id"],
-                "workflow_conclusion": "success",
                 "receipt_file_sha256": release_receipt_digest,
             }
             if any(publication.get(field) != expected for field, expected in expected_publication.items()):
                 raise QualificationScopeError(
                     f"Live-publication evidence for {case_id!r} publication record does not match its release receipt."
+                )
+            if effective_successful_workflow_run_id(publication) is None:
+                raise QualificationScopeError(
+                    f"Live-publication evidence for {case_id!r} does not contain a successful release or recovery run."
                 )
             live_pages = _mapping(
                 publication.get("live_pages"),
@@ -851,7 +855,7 @@ def _matches_milestone_tier1_receipt(
     return (
         evidence_receipt.get("source_sha") == release_receipt.get("source_sha")
         and evidence_receipt.get("release_run_id") == workflow.get("run_id")
-        and evidence_receipt.get("workflow_conclusion") == "success"
+        and effective_successful_workflow_run_id(evidence_receipt, run_id_field="release_run_id") is not None
         and evidence_receipt.get("reference") == receipt_reference
         and evidence_receipt.get("sha256") == receipt_file_sha256
     )

--- a/scripts/release_evidence.py
+++ b/scripts/release_evidence.py
@@ -28,6 +28,33 @@ class ReleaseEvidenceError(RuntimeError):
     pass
 
 
+def effective_successful_workflow_run_id(
+    record: Mapping[str, Any],
+    *,
+    run_id_field: str = "workflow_run_id",
+) -> int | None:
+    run_id = record.get(run_id_field)
+    if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id <= 0:
+        return None
+    if record.get("workflow_conclusion") == "success":
+        return run_id
+    if record.get("workflow_conclusion") != "failure":
+        return None
+    recovery = record.get("recovery_workflow_run")
+    if not isinstance(recovery, Mapping) or recovery.get("operation") != "pypi_recovery":
+        return None
+    recovery_run_id = recovery.get("workflow_run_id")
+    if (
+        recovery.get("workflow_conclusion") != "success"
+        or isinstance(recovery_run_id, bool)
+        or not isinstance(recovery_run_id, int)
+        or recovery_run_id <= 0
+        or recovery_run_id == run_id
+    ):
+        return None
+    return recovery_run_id
+
+
 def _mapping(value: object, description: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ReleaseEvidenceError(f"{description} must be a JSON object.")
@@ -94,6 +121,7 @@ def validate_publication(
     receipt: Mapping[str, Any],
     receipt_path: Path,
     live_appcast_path: Path,
+    recovery_workflow_run: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     try:
         validate_receipt(receipt)
@@ -108,8 +136,52 @@ def validate_publication(
         raise ReleaseEvidenceError("Completed workflow identity does not match the release route.")
     if workflow_run.get("event") != "workflow_dispatch":
         raise ReleaseEvidenceError("Evidence reconciliation requires a workflow_dispatch release run.")
-    if workflow_run.get("status") != "completed" or workflow_run.get("conclusion") != "success":
-        raise ReleaseEvidenceError("Evidence reconciliation requires a successful completed release run.")
+    if workflow_run.get("status") != "completed":
+        raise ReleaseEvidenceError("Evidence reconciliation requires a completed release run.")
+    workflow_conclusion = workflow_run.get("conclusion")
+    recovery_workflow_run_id: int | None = None
+    if workflow_conclusion != "success":
+        if workflow_conclusion != "failure" or recovery_workflow_run is None:
+            raise ReleaseEvidenceError("Evidence reconciliation requires a successful release or checked recovery run.")
+        from scripts.stable_pypi_recovery import StablePyPIRecoveryError, load_evidence
+
+        try:
+            recovery_evidence = load_evidence()
+        except StablePyPIRecoveryError as error:
+            raise ReleaseEvidenceError(str(error)) from error
+        expected_failed_run = _mapping(recovery_evidence.get("failed_run"), "Stable PyPI recovery failed run")
+        expected_release = _mapping(recovery_evidence.get("release"), "Stable PyPI recovery release")
+        if (
+            route != "stable"
+            or workflow_run.get("id") != expected_failed_run.get("id")
+            or workflow_run.get("head_sha") != expected_release.get("source_sha")
+            or _mapping(receipt.get("release"), "receipt release").get("tag") != expected_release.get("tag")
+        ):
+            raise ReleaseEvidenceError("Failed release run does not match the reviewed Stable PyPI recovery evidence.")
+        expected_recovery_identity = {
+            "name": "Stable",
+            "path": ".github/workflows/briefcase.yml",
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "success",
+            "head_branch": EXPECTED_BRANCH,
+            "display_title": "Stable PyPI recovery",
+        }
+        for field, expected in expected_recovery_identity.items():
+            if recovery_workflow_run.get(field) != expected:
+                raise ReleaseEvidenceError(f"Checked PyPI recovery run has unexpected {field}.")
+        for actor_field in ("actor", "triggering_actor"):
+            actor = _mapping(recovery_workflow_run.get(actor_field), f"recovery workflow run {actor_field}")
+            if actor.get("login") != "shiny-code-bot":
+                raise ReleaseEvidenceError(f"Recovery workflow run {actor_field} is not the approved release actor.")
+        recovery_repository = _mapping(recovery_workflow_run.get("repository"), "recovery workflow repository")
+        if recovery_repository.get("full_name") != EXPECTED_REPOSITORY:
+            raise ReleaseEvidenceError("Recovery workflow run repository is not canonical.")
+        recovery_workflow_run_id = _integer(recovery_workflow_run.get("id"), "recovery workflow run ID")
+        if recovery_workflow_run_id == workflow_run.get("id"):
+            raise ReleaseEvidenceError("Recovery workflow run must differ from the failed release run.")
+    elif recovery_workflow_run is not None:
+        raise ReleaseEvidenceError("A successful release run must not be reconciled through recovery mode.")
     if workflow_run.get("head_branch") != EXPECTED_BRANCH or workflow_run.get("head_sha") != source_sha:
         raise ReleaseEvidenceError("Completed release run is not bound to the receipt's protected-main SHA.")
     if workflow_run.get("id") != workflow.get("run_id") or workflow_run.get("run_attempt") != workflow.get(
@@ -183,6 +255,8 @@ def validate_publication(
         "receipt_asset_id": _integer(receipt_assets[0].get("id"), "receipt asset id"),
         "receipt_file_sha256": receipt_file_digest,
         "live_appcast_sha256": live_appcast_sha256,
+        "original_workflow_conclusion": workflow_conclusion,
+        "recovery_workflow_run_id": recovery_workflow_run_id,
     }
 
 
@@ -237,9 +311,12 @@ def _update_cut_packet(repo_root: Path, receipt: Mapping[str, Any], publication:
     except OSError as error:
         raise ReleaseEvidenceError(f"Unable to read release cut packet at {path}: {error}") from error
     pending = "**Prepared metadata; publication pending.**"
+    recovery_pending = "**Published and immutable; PyPI recovery pending.**"
     published = "**Published and immutable.**"
     if pending in text:
         text = text.replace(pending, published, 1)
+    elif recovery_pending in text:
+        text = text.replace(recovery_pending, published, 1)
     elif published not in text:
         raise ReleaseEvidenceError("Release cut packet has no recognized publication state.")
     marker = "<!-- release-evidence-receipt-v1 -->"
@@ -273,8 +350,16 @@ def reconcile(
     receipt: Mapping[str, Any],
     receipt_path: Path,
     live_appcast_path: Path,
+    recovery_workflow_run: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    publication = validate_publication(workflow_run, release, receipt, receipt_path, live_appcast_path)
+    publication = validate_publication(
+        workflow_run,
+        release,
+        receipt,
+        receipt_path,
+        live_appcast_path,
+        recovery_workflow_run,
+    )
     release_data = _mapping(receipt.get("release"), "receipt release")
     workflow = _mapping(receipt.get("workflow"), "receipt workflow")
     tag = _string(release_data.get("tag"), "release tag")
@@ -284,6 +369,15 @@ def reconcile(
         raise ReleaseEvidenceError(f"Checked receipt for immutable release {tag} conflicts with the published asset.")
     checked_receipt.parent.mkdir(parents=True, exist_ok=True)
     checked_receipt.write_bytes(receipt_path.read_bytes())
+    recovery_workflow_run = (
+        {
+            "operation": "pypi_recovery",
+            "workflow_conclusion": "success",
+            "workflow_run_id": publication["recovery_workflow_run_id"],
+        }
+        if publication["recovery_workflow_run_id"] is not None
+        else None
+    )
 
     publication_record = {
         "live_pages": {
@@ -298,9 +392,11 @@ def reconcile(
         "release_tag": tag,
         "schema_version": 1,
         "source_sha": receipt["source_sha"],
-        "workflow_conclusion": "success",
+        "workflow_conclusion": publication["original_workflow_conclusion"],
         "workflow_run_id": workflow["run_id"],
     }
+    if recovery_workflow_run is not None:
+        publication_record["recovery_workflow_run"] = recovery_workflow_run
     publication_path = evidence_directory / "publication-record.json"
     if publication_path.exists() and _load_json(publication_path, "publication record") != publication_record:
         raise ReleaseEvidenceError(f"Checked publication record for immutable release {tag} conflicts.")
@@ -328,6 +424,8 @@ def reconcile(
         "tag": tag,
         "workflow_run_id": workflow["run_id"],
     }
+    if recovery_workflow_run is not None:
+        ledger_record["recovery_workflow_run"] = recovery_workflow_run
     _merge_unique_record(releases, ledger_record, "tag")
     ledger["releases"] = sorted(releases, key=lambda item: cast(str, item["tag"]))
     _write_json(ledger_path, ledger)
@@ -357,8 +455,10 @@ def reconcile(
             "source": "release_run_receipt",
             "source_sha": receipt["source_sha"],
             "status": "accepted",
-            "workflow_conclusion": "success",
+            "workflow_conclusion": publication["original_workflow_conclusion"],
         }
+        if recovery_workflow_run is not None:
+            evidence_record["recovery_workflow_run"] = recovery_workflow_run
         _merge_unique_record(receipts, evidence_record, "receipt_id")
     evidence["receipts"] = sorted(receipts, key=lambda item: cast(str, item["receipt_id"]))
     _write_json(evidence_path, evidence)
@@ -373,6 +473,7 @@ def reconcile(
         "receipt": reference,
         "receipt_file_sha256": publication["receipt_file_sha256"],
         "release_ledger": RELEASE_LEDGER_PATH.as_posix(),
+        "release_run_id": workflow["run_id"],
         "release_tag": tag,
         "source_sha": receipt["source_sha"],
     }
@@ -390,6 +491,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--release", type=Path, required=True)
     parser.add_argument("--receipt", type=Path, required=True)
     parser.add_argument("--live-appcast", type=Path, required=True)
+    parser.add_argument("--recovery-workflow-run", type=Path)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
@@ -401,6 +503,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             _load_json(args.receipt, "release receipt"),
             args.receipt,
             args.live_appcast,
+            (
+                _load_json(args.recovery_workflow_run, "recovery workflow run")
+                if args.recovery_workflow_run is not None
+                else None
+            ),
         )
         if args.github_output is not None:
             _write_github_output(args.github_output, outputs)

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -21,6 +21,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 GITHUB_CONFIG_PATH = Path(".github/github.json")
 EVIDENCE_INDEX_PATH = "docs/qualification/release-evidence-v1.json"
 RECEIPT_PATH_PATTERN = re.compile(r"^docs/release-evidence/(v[^/]+)/release-receipt\.json$")
+RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
 
@@ -131,7 +132,9 @@ def discover_milestone_receipt(
         operations.get("qualificationRecordPath"),
         "qualificationRecordPath",
     )
-    checked_release_mutation = any(path.startswith("docs/release-evidence/") for path in changed_paths)
+    checked_release_mutation = any(
+        path.startswith("docs/release-evidence/") and path not in RECOVERY_AUTHORIZATION_PATHS for path in changed_paths
+    )
     evidence_index_mutation = EVIDENCE_INDEX_PATH in changed_paths
     qualification_mutation = qualification_relative in changed_paths
     if not receipt_matches:

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from scripts.release import ReleaseError, parse_release_version
+from scripts.release_evidence import effective_successful_workflow_run_id
 from scripts.release_receipt import ReleaseReceiptError, load_validated_checked_receipt
 
 
@@ -257,7 +258,6 @@ def resolve_milestone_context(repo_root: Path, receipt_path: Path) -> ReleaseMil
         "release_id": release["id"],
         "source_sha": receipt["source_sha"],
         "workflow_run_id": workflow["run_id"],
-        "workflow_conclusion": "success",
         "receipt_file_sha256": receipt_file_sha256,
     }
     for field, expected in expected_publication.items():
@@ -265,6 +265,10 @@ def resolve_milestone_context(repo_root: Path, receipt_path: Path) -> ReleaseMil
             raise ReleaseMilestoneContextError(
                 f"Milestone publication record {field} does not match the checked release receipt."
             )
+    if effective_successful_workflow_run_id(publication) is None:
+        raise ReleaseMilestoneContextError(
+            "Milestone publication record does not contain a successful release or recovery workflow."
+        )
     live_pages = _mapping(publication.get("live_pages"), "milestone publication live_pages")
     if (
         live_pages.get("state") != "verified"

--- a/scripts/stable_pypi_recovery.py
+++ b/scripts/stable_pypi_recovery.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_PATH = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0-pypi-recovery.json"
+EVIDENCE_SHA256 = "46574b247fc9b9ef13cd64aafaa8e859c2cf10fcfde50913cd317ae5bfec361f"
+PYPI_VERSION_URL = "https://pypi.org/pypi/bd-to-avp/0.3.0/json"
+
+
+class StablePyPIRecoveryError(RuntimeError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StablePyPIRecoveryError(f"Duplicate JSON key in recovery evidence: {key!r}")
+        result[key] = value
+    return result
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise StablePyPIRecoveryError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise StablePyPIRecoveryError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(mapping: Mapping[str, Any], key: str, description: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise StablePyPIRecoveryError(f"{description} is missing non-empty string {key!r}.")
+    return value
+
+
+def _integer(mapping: Mapping[str, Any], key: str, description: str) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise StablePyPIRecoveryError(f"{description} is missing positive integer {key!r}.")
+    return value
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_evidence(
+    path: Path = EVIDENCE_PATH,
+    *,
+    expected_sha256: str | None = None,
+) -> dict[str, Any]:
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise StablePyPIRecoveryError(f"Unable to read Stable PyPI recovery evidence: {error}") from error
+    digest = hashlib.sha256(content).hexdigest()
+    if digest != EVIDENCE_SHA256:
+        raise StablePyPIRecoveryError(f"Recovery evidence digest {digest} does not match the reviewed receipt.")
+    if expected_sha256 is not None and expected_sha256 != EVIDENCE_SHA256:
+        raise StablePyPIRecoveryError("Dispatch recovery fingerprint does not match the reviewed evidence.")
+    try:
+        value = json.loads(content, object_pairs_hook=_reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StablePyPIRecoveryError(f"Stable PyPI recovery evidence is invalid JSON: {error}") from error
+    evidence = dict(_mapping(value, "Stable PyPI recovery evidence"))
+    if evidence.get("schema") != "bd_to_avp.pypi_recovery" or evidence.get("schema_version") != 1:
+        raise StablePyPIRecoveryError("Stable PyPI recovery evidence schema is unsupported.")
+    repository = _mapping(evidence.get("repository"), "Recovery repository")
+    if repository.get("id") != 771225421 or repository.get("full_name") != "cbusillo/BD_to_AVP":
+        raise StablePyPIRecoveryError("Recovery evidence does not identify the production repository.")
+    release = _mapping(evidence.get("release"), "Recovery release")
+    failed_run = _mapping(evidence.get("failed_run"), "Recovery failed run")
+    artifact = _mapping(evidence.get("artifact"), "Recovery artifact")
+    if release.get("version") != "0.3.0" or release.get("tag") != "v0.3.0":
+        raise StablePyPIRecoveryError("Recovery evidence does not identify Stable 0.3.0.")
+    if release.get("source_sha") != failed_run.get("head_sha"):
+        raise StablePyPIRecoveryError("Recovery release and failed run source identities differ.")
+    if failed_run.get("id") != 31219050718 or failed_run.get("conclusion") != "failure":
+        raise StablePyPIRecoveryError("Recovery evidence does not identify the reviewed failed Stable run.")
+    if artifact.get("id") != 9009656530 or artifact.get("name") != "python-distributions":
+        raise StablePyPIRecoveryError("Recovery evidence does not identify the reviewed Python artifact.")
+    distributions = _sequence(evidence.get("distributions"), "Recovery distributions")
+    if len(distributions) != 2:
+        raise StablePyPIRecoveryError("Recovery evidence must identify exactly two Python distributions.")
+    paths = {
+        _string(_mapping(item, "Recovery distribution"), "path", "Recovery distribution") for item in distributions
+    }
+    if paths != {"dist/bd_to_avp-0.3.0-py3-none-any.whl", "dist/bd_to_avp-0.3.0.tar.gz"}:
+        raise StablePyPIRecoveryError("Recovery evidence contains an unexpected distribution set.")
+    return evidence
+
+
+def write_outputs(path: Path, evidence: Mapping[str, Any]) -> None:
+    release = _mapping(evidence.get("release"), "Recovery release")
+    failed_run = _mapping(evidence.get("failed_run"), "Recovery failed run")
+    artifact = _mapping(evidence.get("artifact"), "Recovery artifact")
+    outputs = {
+        "artifact_digest": _string(artifact, "digest", "Recovery artifact"),
+        "artifact_id": str(_integer(artifact, "id", "Recovery artifact")),
+        "evidence_sha256": EVIDENCE_SHA256,
+        "release_id": str(_integer(release, "id", "Recovery release")),
+        "release_receipt_asset_id": str(_integer(release, "receipt_asset_id", "Recovery release")),
+        "release_run_id": str(_integer(failed_run, "id", "Recovery failed run")),
+        "release_source_sha": _string(release, "source_sha", "Recovery release"),
+        "release_tag": _string(release, "tag", "Recovery release"),
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for name, value in outputs.items():
+            output.write(f"{name}={value}\n")
+
+
+def verify_payload(root: Path, evidence: Mapping[str, Any]) -> None:
+    root = root.resolve()
+    if not root.is_dir():
+        raise StablePyPIRecoveryError(f"Recovery artifact root does not exist: {root}")
+    if any(path.is_symlink() for path in root.rglob("*")):
+        raise StablePyPIRecoveryError("Recovery artifact must not contain symbolic links.")
+    distributions = [
+        _mapping(item, "Recovery distribution")
+        for item in _sequence(evidence["distributions"], "Recovery distributions")
+    ]
+    expected_files = {"SHA256SUMS", *(_string(item, "path", "Recovery distribution") for item in distributions)}
+    actual_files = {path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file()}
+    if actual_files != expected_files:
+        raise StablePyPIRecoveryError(
+            f"Recovery artifact file set differs from reviewed evidence: expected {sorted(expected_files)}, "
+            f"found {sorted(actual_files)}."
+        )
+    artifact = _mapping(evidence.get("artifact"), "Recovery artifact")
+    manifest_path = root / "SHA256SUMS"
+    if _file_sha256(manifest_path) != _string(artifact, "manifest_sha256", "Recovery artifact"):
+        raise StablePyPIRecoveryError("Recovery artifact checksum manifest differs from the failed run.")
+    for distribution in distributions:
+        path = root / _string(distribution, "path", "Recovery distribution")
+        if path.stat().st_size != _integer(distribution, "size", "Recovery distribution"):
+            raise StablePyPIRecoveryError(f"Recovery distribution size differs: {path.name}")
+        if _file_sha256(path) != _string(distribution, "sha256", "Recovery distribution"):
+            raise StablePyPIRecoveryError(f"Recovery distribution digest differs: {path.name}")
+    omitted = _mapping(artifact.get("omitted_hidden_file"), "Omitted hidden file")
+    expected_manifest = {
+        _string(omitted, "path", "Omitted hidden file"): _string(omitted, "sha256", "Omitted hidden file"),
+        **{
+            _string(item, "path", "Recovery distribution"): _string(item, "sha256", "Recovery distribution")
+            for item in distributions
+        },
+    }
+    parsed_manifest: dict[str, str] = {}
+    for line in manifest_path.read_text(encoding="utf-8").splitlines():
+        digest, separator, name = line.partition("  ")
+        if not separator or name in parsed_manifest:
+            raise StablePyPIRecoveryError("Recovery artifact checksum manifest is malformed.")
+        parsed_manifest[name] = digest
+    if parsed_manifest != expected_manifest:
+        raise StablePyPIRecoveryError("Recovery artifact manifest does not reproduce the reviewed failure.")
+    if (root / _string(omitted, "path", "Omitted hidden file")).exists():
+        raise StablePyPIRecoveryError("The uploader omission premise no longer matches the recovery artifact.")
+
+
+def verify_remote_files(
+    workflow_run_path: Path,
+    jobs_path: Path,
+    artifact_path: Path,
+    release_path: Path,
+    receipt_path: Path,
+    evidence: Mapping[str, Any],
+) -> None:
+    workflow_run = _mapping(json.loads(workflow_run_path.read_text(encoding="utf-8")), "Workflow run")
+    jobs = _mapping(json.loads(jobs_path.read_text(encoding="utf-8")), "Workflow jobs")
+    artifact = _mapping(json.loads(artifact_path.read_text(encoding="utf-8")), "Workflow artifact")
+    release = _mapping(json.loads(release_path.read_text(encoding="utf-8")), "GitHub release")
+    failed_run = _mapping(evidence.get("failed_run"), "Recovery failed run")
+    expected_artifact = _mapping(evidence.get("artifact"), "Recovery artifact")
+    expected_release = _mapping(evidence.get("release"), "Recovery release")
+    expected_run_fields = {
+        "id": failed_run["id"],
+        "workflow_id": failed_run["workflow_id"],
+        "run_number": failed_run["run_number"],
+        "run_attempt": failed_run["run_attempt"],
+        "name": failed_run["workflow_name"],
+        "path": failed_run["workflow_path"],
+        "event": failed_run["event"],
+        "head_branch": failed_run["head_branch"],
+        "head_sha": failed_run["head_sha"],
+        "status": failed_run["status"],
+        "conclusion": failed_run["conclusion"],
+    }
+    for field, expected in expected_run_fields.items():
+        if workflow_run.get(field) != expected:
+            raise StablePyPIRecoveryError(f"Failed Stable run {field} differs from reviewed evidence.")
+    for actor_field in ("actor", "triggering_actor"):
+        if (
+            _mapping(workflow_run.get(actor_field), f"Workflow run {actor_field}").get("login")
+            != failed_run[actor_field]
+        ):
+            raise StablePyPIRecoveryError(f"Failed Stable run {actor_field} differs from reviewed evidence.")
+    job_matches = [
+        _mapping(job, "Workflow job")
+        for job in _sequence(jobs.get("jobs"), "Workflow jobs")
+        if _mapping(job, "Workflow job").get("id") == failed_run["failed_job_id"]
+    ]
+    if (
+        len(job_matches) != 1
+        or job_matches[0].get("name") != failed_run["failed_job"]
+        or job_matches[0].get("conclusion") != "failure"
+    ):
+        raise StablePyPIRecoveryError("Failed PyPI job identity differs from reviewed evidence.")
+    steps = {
+        _mapping(step, "Workflow step").get("name"): _mapping(step, "Workflow step").get("conclusion")
+        for step in _sequence(job_matches[0].get("steps"), "Workflow steps")
+    }
+    if steps.get(failed_run["failed_step"]) != "failure" or steps.get(failed_run["skipped_publish_step"]) != "skipped":
+        raise StablePyPIRecoveryError("Failed PyPI job no longer proves that publication was skipped.")
+    if artifact.get("id") != expected_artifact["id"] or artifact.get("name") != expected_artifact["name"]:
+        raise StablePyPIRecoveryError("Python artifact identity differs from reviewed evidence.")
+    if (
+        artifact.get("digest") != f"sha256:{expected_artifact['digest']}"
+        or artifact.get("size_in_bytes") != expected_artifact["size"]
+    ):
+        raise StablePyPIRecoveryError("Python artifact digest or size differs from reviewed evidence.")
+    if artifact.get("expired") is not False:
+        raise StablePyPIRecoveryError("Python recovery artifact has expired.")
+    artifact_run = _mapping(artifact.get("workflow_run"), "Artifact workflow run")
+    if artifact_run.get("id") != failed_run["id"] or artifact_run.get("head_sha") != failed_run["head_sha"]:
+        raise StablePyPIRecoveryError("Python artifact is not bound to the reviewed Stable run.")
+    expected_release_fields = {
+        "id": expected_release["id"],
+        "tag_name": expected_release["tag"],
+        "name": expected_release["name"],
+        "target_commitish": expected_release["source_sha"],
+        "draft": expected_release["draft"],
+        "prerelease": expected_release["prerelease"],
+        "immutable": expected_release["immutable"],
+        "published_at": expected_release["published_at"],
+    }
+    for field, expected in expected_release_fields.items():
+        if release.get(field) != expected:
+            raise StablePyPIRecoveryError(f"Published Stable release {field} differs from reviewed evidence.")
+    receipt_assets = [
+        _mapping(item, "Release asset")
+        for item in _sequence(release.get("assets"), "Release assets")
+        if _mapping(item, "Release asset").get("id") == expected_release["receipt_asset_id"]
+    ]
+    if len(receipt_assets) != 1 or receipt_assets[0].get("digest") != f"sha256:{expected_release['receipt_sha256']}":
+        raise StablePyPIRecoveryError("Published Stable receipt asset differs from reviewed evidence.")
+    if receipt_assets[0].get("size") != expected_release["receipt_size"]:
+        raise StablePyPIRecoveryError("Published Stable receipt asset size differs from reviewed evidence.")
+    if _file_sha256(receipt_path) != expected_release["receipt_sha256"]:
+        raise StablePyPIRecoveryError("Downloaded Stable release receipt digest differs from reviewed evidence.")
+    receipt = _mapping(json.loads(receipt_path.read_text(encoding="utf-8")), "Release receipt")
+    receipt_workflow = _mapping(receipt.get("workflow"), "Receipt workflow")
+    if (
+        receipt.get("source_sha") != expected_release["source_sha"]
+        or receipt_workflow.get("run_id") != failed_run["id"]
+    ):
+        raise StablePyPIRecoveryError("Stable release receipt is not bound to the reviewed source and run.")
+
+
+def _fetch_pypi() -> tuple[int, Mapping[str, Any] | None]:
+    request = Request(PYPI_VERSION_URL, headers={"Accept": "application/json", "User-Agent": "bd-to-avp-pypi-recovery"})
+    try:
+        with urlopen(request, timeout=30) as response:
+            return response.status, _mapping(json.loads(response.read()), "PyPI response")
+    except HTTPError as error:
+        if error.code == 404:
+            return 404, None
+        raise StablePyPIRecoveryError(f"PyPI returned unexpected HTTP status {error.code}.") from error
+    except (OSError, URLError, json.JSONDecodeError) as error:
+        raise StablePyPIRecoveryError(f"Unable to verify PyPI state: {error}") from error
+
+
+def verify_pypi(state: str, evidence: Mapping[str, Any], *, retries: int = 1, delay: float = 0.0) -> str:
+    expected = {
+        _string(item, "filename", "Recovery distribution"): (
+            _string(item, "sha256", "Recovery distribution"),
+            _integer(item, "size", "Recovery distribution"),
+            _string(item, "packagetype", "Recovery distribution"),
+        )
+        for item in (
+            _mapping(value, "Recovery distribution")
+            for value in _sequence(evidence["distributions"], "Recovery distributions")
+        )
+    }
+    last_error: StablePyPIRecoveryError | None = None
+    for attempt in range(retries):
+        try:
+            status, payload = _fetch_pypi()
+            if state == "absent":
+                if status != 404:
+                    raise StablePyPIRecoveryError("PyPI 0.3.0 already exists; recovery publication is not idempotent.")
+                return "absent"
+            if state == "recoverable" and status == 404:
+                return "absent"
+            if status != 200 or payload is None:
+                raise StablePyPIRecoveryError("PyPI 0.3.0 is not published yet.")
+            urls = [
+                _mapping(item, "PyPI distribution") for item in _sequence(payload.get("urls"), "PyPI distributions")
+            ]
+            actual = {
+                _string(item, "filename", "PyPI distribution"): (
+                    _string(_mapping(item.get("digests"), "PyPI digests"), "sha256", "PyPI digests"),
+                    _integer(item, "size", "PyPI distribution"),
+                    _string(item, "packagetype", "PyPI distribution"),
+                )
+                for item in urls
+            }
+            if state == "recoverable":
+                if not actual or any(expected.get(filename) != details for filename, details in actual.items()):
+                    raise StablePyPIRecoveryError("Published PyPI files differ from the reviewed Stable artifacts.")
+                return "published" if actual == expected else "partial"
+            if actual != expected:
+                raise StablePyPIRecoveryError("Published PyPI files differ from the reviewed Stable artifacts.")
+            return "published"
+        except StablePyPIRecoveryError as error:
+            last_error = error
+            if attempt + 1 < retries:
+                time.sleep(delay)
+    assert last_error is not None
+    raise last_error
+
+
+def write_pypi_action_outputs(
+    path: Path,
+    evidence: Mapping[str, Any],
+    *,
+    retries: int,
+    delay: float,
+) -> None:
+    state = verify_pypi("recoverable", evidence, retries=retries, delay=delay)
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"publish_required={'false' if state == 'published' else 'true'}\n")
+        output.write(f"publication_action={'already_present' if state == 'published' else 'published'}\n")
+
+
+def write_receipt(path: Path, evidence: Mapping[str, Any], publication_action: str) -> None:
+    release = _mapping(evidence.get("release"), "Recovery release")
+    failed_run = _mapping(evidence.get("failed_run"), "Recovery failed run")
+    artifact = _mapping(evidence.get("artifact"), "Recovery artifact")
+    receipt = {
+        "schema": "bd_to_avp.pypi_recovery_receipt",
+        "schema_version": 1,
+        "evidence_sha256": EVIDENCE_SHA256,
+        "repository": "cbusillo/BD_to_AVP",
+        "release": {"tag": release["tag"], "version": release["version"], "source_sha": release["source_sha"]},
+        "original_release_run": {"id": failed_run["id"], "attempt": failed_run["run_attempt"]},
+        "python_artifact": {"id": artifact["id"], "digest": artifact["digest"]},
+        "distributions": evidence["distributions"],
+        "recovery_workflow": {
+            "run_id": int(os.environ["GITHUB_RUN_ID"]),
+            "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+            "workflow_sha": os.environ["GITHUB_SHA"],
+        },
+        "publication_action": publication_action,
+        "pypi_verification": "passed",
+    }
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the one-time Stable 0.3.0 PyPI recovery.")
+    parser.add_argument("--evidence", type=Path, default=EVIDENCE_PATH)
+    parser.add_argument("--expected-evidence-sha256")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    outputs_parser = subparsers.add_parser("outputs")
+    outputs_parser.add_argument("--github-output", type=Path, required=True)
+    payload_parser = subparsers.add_parser("verify-payload")
+    payload_parser.add_argument("--artifact-root", type=Path, required=True)
+    remote_parser = subparsers.add_parser("verify-remote-files")
+    remote_parser.add_argument("--workflow-run", type=Path, required=True)
+    remote_parser.add_argument("--jobs", type=Path, required=True)
+    remote_parser.add_argument("--artifact", type=Path, required=True)
+    remote_parser.add_argument("--release", type=Path, required=True)
+    remote_parser.add_argument("--receipt", type=Path, required=True)
+    pypi_parser = subparsers.add_parser("verify-pypi")
+    pypi_parser.add_argument("--state", choices=("absent", "published", "recoverable"), required=True)
+    pypi_parser.add_argument("--retries", type=int, default=1)
+    pypi_parser.add_argument("--delay", type=float, default=0.0)
+    action_parser = subparsers.add_parser("resolve-pypi-action")
+    action_parser.add_argument("--github-output", type=Path, required=True)
+    action_parser.add_argument("--retries", type=int, default=1)
+    action_parser.add_argument("--delay", type=float, default=0.0)
+    receipt_parser = subparsers.add_parser("write-receipt")
+    receipt_parser.add_argument("--output", type=Path, required=True)
+    receipt_parser.add_argument("--publication-action", choices=("published", "already_present"), required=True)
+    args = parser.parse_args()
+    evidence = load_evidence(args.evidence, expected_sha256=args.expected_evidence_sha256)
+    if args.command == "outputs":
+        write_outputs(args.github_output, evidence)
+    elif args.command == "verify-payload":
+        verify_payload(args.artifact_root, evidence)
+    elif args.command == "verify-remote-files":
+        verify_remote_files(args.workflow_run, args.jobs, args.artifact, args.release, args.receipt, evidence)
+    elif args.command == "verify-pypi":
+        verify_pypi(args.state, evidence, retries=args.retries, delay=args.delay)
+    elif args.command == "resolve-pypi-action":
+        write_pypi_action_outputs(
+            args.github_output,
+            evidence,
+            retries=args.retries,
+            delay=args.delay,
+        )
+    elif args.command == "write-receipt":
+        write_receipt(args.output, evidence, args.publication_action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -14,6 +14,7 @@ from typing import Any
 from scripts.qualify_release_scope import (
     DEFAULT_POLICY_PATH,
     QualificationScopeError,
+    _matches_milestone_tier1_receipt,
     classify_release_scope,
     load_policy,
     load_qualification_overrides,
@@ -45,6 +46,39 @@ APP_TREE_SHA256 = "f" * 64
 class ReleaseQualificationScopeTests(unittest.TestCase):
     def setUp(self) -> None:
         self.policy = load_policy(DEFAULT_POLICY_PATH)
+
+    def test_milestone_tier1_receipt_accepts_explicit_successful_recovery(self) -> None:
+        release_receipt = {"source_sha": CANDIDATE_SHA, "workflow": {"run_id": 12345}}
+        evidence_receipt = {
+            "source_sha": CANDIDATE_SHA,
+            "release_run_id": 12345,
+            "workflow_conclusion": "failure",
+            "recovery_workflow_run": {
+                "operation": "pypi_recovery",
+                "workflow_conclusion": "success",
+                "workflow_run_id": 54321,
+            },
+            "reference": "docs/release-evidence/v0.3.0/release-receipt.json",
+            "sha256": "a" * 64,
+        }
+
+        self.assertTrue(
+            _matches_milestone_tier1_receipt(
+                evidence_receipt,
+                release_receipt,
+                receipt_reference="docs/release-evidence/v0.3.0/release-receipt.json",
+                receipt_file_sha256="a" * 64,
+            )
+        )
+        evidence_receipt["recovery_workflow_run"]["operation"] = "unexpected"
+        self.assertFalse(
+            _matches_milestone_tier1_receipt(
+                evidence_receipt,
+                release_receipt,
+                receipt_reference="docs/release-evidence/v0.3.0/release-receipt.json",
+                receipt_file_sha256="a" * 64,
+            )
+        )
 
     def evidence(
         self,

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -179,7 +179,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `161`", cut_packet)
         self.assertIn("#489", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertIn("Prepared metadata; publication pending", cut_packet)
+        self.assertIn("Published and immutable; PyPI recovery pending", cut_packet)
         self.assertIn("post-publication", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -183,6 +183,24 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         self.assertFalse(context.first_candidate_of_cycle)
         self.assertEqual(context.qualification_path, "docs/qualification/stable-signed-qualification-v1.json")
 
+    def test_accepts_explicit_successful_recovery_for_failed_release_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path = self.build_repository(root)
+            publication_path = root / "docs/release-evidence/v0.3.0/publication-record.json"
+            publication = json.loads(publication_path.read_text(encoding="utf-8"))
+            publication["workflow_conclusion"] = "failure"
+            publication["recovery_workflow_run"] = {
+                "operation": "pypi_recovery",
+                "workflow_conclusion": "success",
+                "workflow_run_id": 54321,
+            }
+            publication_path.write_text(json.dumps(publication) + "\n", encoding="utf-8")
+
+            context = resolve_milestone_context(root, receipt_path)
+
+        self.assertEqual(context.release_tag, "v0.3.0")
+
     def test_rejects_mismatched_qualification_identity(self) -> None:
         for field, value in (
             ("build_version", "162"),

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -322,6 +322,75 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     base_branch="main",
                 )
 
+    def test_recovery_authorization_does_not_impersonate_checked_release_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            recovery_path = root / "docs/release-evidence/v0.3.0-pypi-recovery.json"
+            recovery_path.write_text('{"schema": "bd_to_avp.pypi_recovery"}\n', encoding="utf-8")
+            subprocess.run(["git", "add", recovery_path.relative_to(root)], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "add recovery authorization"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="fix/stable-pypi-recovery",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(discovered)
+
+    def test_other_release_evidence_still_requires_checked_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            unbound_path = root / "docs/release-evidence/v0.3.1-pypi-recovery.json"
+            unbound_path.write_text("{}\n", encoding="utf-8")
+            subprocess.run(["git", "add", unbound_path.relative_to(root)], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "add unbound release evidence"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "exactly one checked release receipt"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="fix/stable-pypi-recovery",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
     def test_rejects_non_docs_changes_on_evidence_branch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_release_receipt.py
+++ b/tests/test_release_receipt.py
@@ -4,8 +4,9 @@ import unittest
 
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
-from scripts.release_evidence import ReleaseEvidenceError, reconcile
+from scripts.release_evidence import ReleaseEvidenceError, effective_successful_workflow_run_id, reconcile
 from scripts.release_receipt import (
     ArtifactReceiptExpectation,
     DEFAULT_POLICY_PATH,
@@ -355,6 +356,56 @@ class ReleaseReceiptTests(unittest.TestCase):
                 reconcile(root, bad_run, release, receipt, receipt_path, live_appcast)
             with self.assertRaisesRegex(ReleaseEvidenceError, "Live Pages appcast"):
                 reconcile(root, workflow_run(), release, receipt, receipt_path, live_appcast)
+
+    def test_reconcile_attributes_recovered_success_to_the_recovery_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path = root / "release-receipt.json"
+            receipt_path.write_text("{}\n", encoding="utf-8")
+            qualification_path = root / "docs" / "qualification.json"
+            cut_packet_path = root / "docs" / "cut-packet.md"
+            qualification_path.parent.mkdir(parents=True)
+            qualification_path.write_text("{}\n", encoding="utf-8")
+            cut_packet_path.write_text("# Cut packet\n", encoding="utf-8")
+            receipt = {
+                "appcast": {"live_pages_url": "https://example.com/appcast.xml"},
+                "release": {"id": 20, "tag": "v0.3.0"},
+                "source_sha": SOURCE_SHA,
+                "tier1_case_references": ["release-workflow-identity"],
+                "workflow": {"run_id": 30},
+            }
+            publication = {
+                "live_appcast_sha256": "a" * 64,
+                "original_workflow_conclusion": "failure",
+                "published_at": "2026-08-07T21:42:28Z",
+                "receipt_asset_id": 40,
+                "receipt_file_sha256": file_sha256(receipt_path),
+                "recovery_workflow_run_id": 50,
+            }
+            with (
+                patch("scripts.release_evidence.validate_publication", return_value=publication),
+                patch("scripts.release_evidence._update_qualification", return_value=qualification_path),
+                patch("scripts.release_evidence._update_cut_packet", return_value=cut_packet_path),
+            ):
+                outputs = reconcile(root, {}, {}, receipt, receipt_path, root / "appcast.xml")
+
+            publication_record = json.loads((root / outputs["publication_record"]).read_text(encoding="utf-8"))
+            self.assertEqual(publication_record["workflow_run_id"], 30)
+            self.assertEqual(publication_record["workflow_conclusion"], "failure")
+            self.assertEqual(
+                publication_record["recovery_workflow_run"],
+                {"operation": "pypi_recovery", "workflow_conclusion": "success", "workflow_run_id": 50},
+            )
+            self.assertEqual(effective_successful_workflow_run_id(publication_record), 50)
+            evidence = json.loads((root / outputs["evidence_index"]).read_text(encoding="utf-8"))
+            self.assertEqual(evidence["receipts"][0]["release_run_id"], 30)
+            self.assertEqual(evidence["receipts"][0]["workflow_conclusion"], "failure")
+            self.assertEqual(evidence["receipts"][0]["recovery_workflow_run"]["workflow_run_id"], 50)
+            self.assertEqual(
+                effective_successful_workflow_run_id(evidence["receipts"][0], run_id_field="release_run_id"),
+                50,
+            )
+            self.assertEqual(outputs["release_run_id"], 30)
 
 
 if __name__ == "__main__":

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -91,7 +91,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
         for name, operator in operators.items():
             with self.subTest(operator=name):
                 self.assertEqual(set(operator["on"]), {"workflow_dispatch"})
-                self.assertEqual(set(operator["on"]["workflow_dispatch"]["inputs"]), {"release_notes"})
+                expected_inputs = (
+                    {"release_notes", "pypi_recovery_evidence_sha256"} if name == "Stable" else {"release_notes"}
+                )
+                self.assertEqual(set(operator["on"]["workflow_dispatch"]["inputs"]), expected_inputs)
                 self.assertEqual(operator["concurrency"]["group"], "release")
                 self.assertEqual(operator["concurrency"]["cancel-in-progress"], "false")
         self.assertEqual(set(workflow["on"]), {"workflow_call"})
@@ -142,9 +145,11 @@ class ReleaseWorkflowTests(unittest.TestCase):
         policy_checkout = policy["steps"][1]
         policy_step = next(step for step in policy["steps"] if step.get("id") == "policy")
 
-        self.assertEqual(set(stable["jobs"]), {"release", "publish-pypi"})
+        self.assertEqual(set(stable["jobs"]), {"release", "publish-pypi", "recover-pypi"})
         self.assertEqual(set(prerelease["jobs"]), {"release"})
-        self.assertEqual(prerelease["jobs"]["release"], release)
+        stable_release = dict(release)
+        stable_release.pop("if")
+        self.assertEqual(prerelease["jobs"]["release"], stable_release)
         self.assertEqual(release["uses"], "./.github/workflows/release-engine.yml")
         self.assertEqual(declared_secret_names, macos_secret_names | sparkle_secret_names)
         self.assertEqual(declared_secret_names, referenced_secret_names)
@@ -1006,6 +1011,9 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertNotIn("environment", create_pr)
         self.assertNotIn("secrets.", str(workflow))
         self.assertIn("python -m scripts.release_evidence", str(prepare))
+        self.assertIn("Stable PyPI recovery", str(prepare))
+        self.assertIn("scripts.stable_pypi_recovery verify-pypi", str(prepare))
+        self.assertIn("--recovery-workflow-run", str(prepare))
         self.assertIn("release-receipt.json", str(prepare))
         self.assertIn(".immutable == true", str(prepare))
         self.assertIn("Preserve an existing idempotent evidence branch", str(prepare))
@@ -1142,7 +1150,14 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertEqual(publish["environment"]["name"], "pypi")
         self.assertEqual(publish["permissions"]["actions"], "read")
         self.assertEqual(publish["permissions"]["id-token"], "write")
-        self.assertIn("uv build", str(build))
+        self.assertIn("uv build --out-dir python-distributions/dist", str(build))
+        self.assertNotIn("mv dist python-distributions", str(build))
+        self.assertIn("find dist -mindepth 1 -maxdepth 1 -type f", str(build))
+        self.assertIn("*.whl", str(build))
+        self.assertIn("*.tar.gz", str(build))
+        self.assertIn("-delete", str(build))
+        self.assertIn("find dist -maxdepth 1 -type f | wc -l", str(build))
+        self.assertIn('= "2"', str(build))
         self.assertNotIn("uv build", str(publish))
         self.assertIn("pypa/gh-action-pypi-publish@", str(publish))
         self.assertIn("attestations", str(publish))
@@ -1187,6 +1202,44 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertNotIn("pypa/gh-action-pypi-publish@", str(prerelease))
         self.assertNotIn("pypa/gh-action-pypi-publish@", str(workflow))
         self.assertNotIn("PYPI_TOKEN", str(operator) + str(prerelease) + str(workflow))
+        recovery = operator["jobs"]["recover-pypi"]
+        recovery_input = operator["on"]["workflow_dispatch"]["inputs"]["pypi_recovery_evidence_sha256"]
+        self.assertEqual(recovery_input["required"], "false")
+        self.assertEqual(operator["jobs"]["release"]["if"], "inputs.pypi_recovery_evidence_sha256 == ''")
+        self.assertEqual(recovery["if"], "inputs.pypi_recovery_evidence_sha256 != ''")
+        self.assertEqual(recovery["environment"]["name"], "pypi")
+        self.assertEqual(recovery["permissions"], {"actions": "read", "contents": "read", "id-token": "write"})
+        self.assertIn("scripts.stable_pypi_recovery", str(recovery))
+        self.assertIn("artifact-ids", str(recovery))
+        self.assertIn("Verify exact original distribution bytes", str(recovery))
+        self.assertIn("Protected main moved immediately before PyPI recovery publication", str(recovery))
+        recovery_steps = {step["name"]: step for step in recovery["steps"]}
+        self.assertIn(
+            "--state recoverable", str(recovery_steps["Verify recovery authorization and immutable source state"])
+        )
+        self.assertIn("resolve-pypi-action", str(recovery_steps["Resolve idempotent PyPI recovery action"]))
+        self.assertEqual(
+            recovery_steps["Publish exact original bytes with PyPI trusted publishing and attestations"]["if"],
+            "steps.pypi.outputs.publish_required == 'true'",
+        )
+        self.assertEqual(
+            recovery_steps["Publish exact original bytes with PyPI trusted publishing and attestations"]["with"][
+                "skip-existing"
+            ],
+            "true",
+        )
+        recovery_download = next(
+            step for step in recovery["steps"] if step["name"] == "Download exact failed-run Python artifact"
+        )
+        self.assertEqual(recovery_download["with"]["github-token"], "${{ github.token }}")
+        self.assertEqual(recovery_download["with"]["repository"], "${{ github.repository }}")
+        self.assertEqual(recovery_download["with"]["run-id"], "${{ steps.evidence.outputs.release_run_id }}")
+        self.assertEqual(
+            next(step for step in recovery["steps"] if "pypa/gh-action-pypi-publish@" in step.get("uses", ""))["with"][
+                "packages-dir"
+            ],
+            "python-distributions/dist",
+        )
         self.assertEqual(
             release_operations["workflows"]["Stable"]["path"],
             ".github/workflows/briefcase.yml",

--- a/tests/test_stable_pypi_recovery.py
+++ b/tests/test_stable_pypi_recovery.py
@@ -1,0 +1,302 @@
+import hashlib
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import stable_pypi_recovery
+
+
+def sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def fixture_evidence(root: Path) -> dict[str, object]:
+    wheel = b"wheel-bytes"
+    sdist = b"sdist-bytes"
+    omitted = b"generated hidden file"
+    manifest = (
+        f"{sha256(omitted)}  dist/.gitignore\n"
+        f"{sha256(wheel)}  dist/bd_to_avp-0.3.0-py3-none-any.whl\n"
+        f"{sha256(sdist)}  dist/bd_to_avp-0.3.0.tar.gz\n"
+    ).encode()
+    (root / "dist").mkdir(parents=True)
+    (root / "dist" / "bd_to_avp-0.3.0-py3-none-any.whl").write_bytes(wheel)
+    (root / "dist" / "bd_to_avp-0.3.0.tar.gz").write_bytes(sdist)
+    (root / "SHA256SUMS").write_bytes(manifest)
+    return {
+        "schema": "bd_to_avp.pypi_recovery",
+        "schema_version": 1,
+        "repository": {"id": 771225421, "full_name": "cbusillo/BD_to_AVP"},
+        "release": {
+            "id": 20,
+            "tag": "v0.3.0",
+            "name": "v0.3.0",
+            "version": "0.3.0",
+            "source_sha": "a" * 40,
+            "published_at": "2026-08-07T21:42:28Z",
+            "immutable": True,
+            "draft": False,
+            "prerelease": False,
+            "receipt_asset_id": 30,
+            "receipt_sha256": "placeholder",
+            "receipt_size": 0,
+        },
+        "failed_run": {
+            "id": 31219050718,
+            "workflow_id": 101708423,
+            "run_number": 231,
+            "run_attempt": 1,
+            "workflow_name": "Stable",
+            "workflow_path": ".github/workflows/briefcase.yml",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": "a" * 40,
+            "actor": "shiny-code-bot",
+            "triggering_actor": "shiny-code-bot",
+            "status": "completed",
+            "conclusion": "failure",
+            "failed_job_id": 40,
+            "failed_job": "Publish stable Python distribution with trusted publishing",
+            "failed_step": "Verify Python distribution transfer",
+            "skipped_publish_step": "Publish with PyPI trusted publishing and attestations",
+        },
+        "artifact": {
+            "id": 9009656530,
+            "name": "python-distributions",
+            "digest": "b" * 64,
+            "size": 123,
+            "manifest_sha256": sha256(manifest),
+            "omitted_hidden_file": {"path": "dist/.gitignore", "sha256": sha256(omitted)},
+        },
+        "distributions": [
+            {
+                "path": "dist/bd_to_avp-0.3.0-py3-none-any.whl",
+                "filename": "bd_to_avp-0.3.0-py3-none-any.whl",
+                "packagetype": "bdist_wheel",
+                "sha256": sha256(wheel),
+                "size": len(wheel),
+            },
+            {
+                "path": "dist/bd_to_avp-0.3.0.tar.gz",
+                "filename": "bd_to_avp-0.3.0.tar.gz",
+                "packagetype": "sdist",
+                "sha256": sha256(sdist),
+                "size": len(sdist),
+            },
+        ],
+    }
+
+
+class StablePyPIRecoveryTests(unittest.TestCase):
+    def test_checked_evidence_is_digest_pinned(self) -> None:
+        evidence = stable_pypi_recovery.load_evidence()
+
+        self.assertEqual(evidence["release"]["source_sha"], "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522")
+        self.assertEqual(evidence["artifact"]["id"], 9009656530)
+        self.assertEqual(len(evidence["distributions"]), 2)
+
+        with tempfile.TemporaryDirectory() as directory:
+            changed = Path(directory) / "evidence.json"
+            changed.write_bytes(stable_pypi_recovery.EVIDENCE_PATH.read_bytes() + b"\n")
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "digest"):
+                stable_pypi_recovery.load_evidence(changed)
+
+    def test_payload_verifier_accepts_only_the_reviewed_failure_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence = fixture_evidence(root)
+
+            stable_pypi_recovery.verify_payload(root, evidence)
+
+            (root / "dist" / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "file set"):
+                stable_pypi_recovery.verify_payload(root, evidence)
+
+    def test_payload_verifier_rejects_distribution_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence = fixture_evidence(root)
+            (root / "dist" / "bd_to_avp-0.3.0.tar.gz").write_bytes(b"changed")
+
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "size differs"):
+                stable_pypi_recovery.verify_payload(root, evidence)
+
+    def test_pypi_verifier_checks_exact_file_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = fixture_evidence(Path(directory))
+        payload = {
+            "urls": [
+                {
+                    "filename": item["filename"],
+                    "digests": {"sha256": item["sha256"]},
+                    "size": item["size"],
+                    "packagetype": item["packagetype"],
+                }
+                for item in evidence["distributions"]
+            ]
+        }
+
+        with patch.object(stable_pypi_recovery, "_fetch_pypi", return_value=(200, payload)):
+            stable_pypi_recovery.verify_pypi("published", evidence)
+            self.assertEqual(stable_pypi_recovery.verify_pypi("recoverable", evidence), "published")
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "already exists"):
+                stable_pypi_recovery.verify_pypi("absent", evidence)
+
+        payload["urls"][0]["digests"]["sha256"] = "0" * 64
+        with patch.object(stable_pypi_recovery, "_fetch_pypi", return_value=(200, payload)):
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "differ"):
+                stable_pypi_recovery.verify_pypi("published", evidence)
+
+    def test_pypi_verifier_retries_transient_fetch_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = fixture_evidence(Path(directory))
+        with patch.object(
+            stable_pypi_recovery,
+            "_fetch_pypi",
+            side_effect=[stable_pypi_recovery.StablePyPIRecoveryError("transient"), (404, None)],
+        ):
+            self.assertEqual(
+                stable_pypi_recovery.verify_pypi("recoverable", evidence, retries=2),
+                "absent",
+            )
+
+    def test_pypi_action_outputs_make_partial_publication_reentrant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            evidence = fixture_evidence(root / "artifact")
+            output = root / "github-output"
+            output.touch()
+            with patch.object(stable_pypi_recovery, "_fetch_pypi", return_value=(404, None)):
+                stable_pypi_recovery.write_pypi_action_outputs(output, evidence, retries=1, delay=0)
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "publish_required=true\npublication_action=published\n",
+            )
+
+            output.write_text("", encoding="utf-8")
+            payload = {
+                "urls": [
+                    {
+                        "filename": item["filename"],
+                        "digests": {"sha256": item["sha256"]},
+                        "size": item["size"],
+                        "packagetype": item["packagetype"],
+                    }
+                    for item in evidence["distributions"]
+                ]
+            }
+            with patch.object(stable_pypi_recovery, "_fetch_pypi", return_value=(200, payload)):
+                stable_pypi_recovery.write_pypi_action_outputs(output, evidence, retries=1, delay=0)
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "publish_required=false\npublication_action=already_present\n",
+            )
+
+            output.write_text("", encoding="utf-8")
+            payload["urls"] = payload["urls"][:1]
+            with patch.object(stable_pypi_recovery, "_fetch_pypi", return_value=(200, payload)):
+                stable_pypi_recovery.write_pypi_action_outputs(output, evidence, retries=1, delay=0)
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "publish_required=true\npublication_action=published\n",
+            )
+
+    def test_remote_verifier_requires_publish_step_to_have_been_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifact-root"
+            evidence = fixture_evidence(artifact_root)
+            receipt = {"source_sha": "a" * 40, "workflow": {"run_id": 31219050718}}
+            receipt_bytes = (json.dumps(receipt) + "\n").encode()
+            evidence["release"]["receipt_sha256"] = sha256(receipt_bytes)
+            evidence["release"]["receipt_size"] = len(receipt_bytes)
+            workflow_run = {
+                "id": 31219050718,
+                "workflow_id": 101708423,
+                "run_number": 231,
+                "run_attempt": 1,
+                "name": "Stable",
+                "path": ".github/workflows/briefcase.yml",
+                "event": "workflow_dispatch",
+                "head_branch": "main",
+                "head_sha": "a" * 40,
+                "status": "completed",
+                "conclusion": "failure",
+                "actor": {"login": "shiny-code-bot"},
+                "triggering_actor": {"login": "shiny-code-bot"},
+            }
+            jobs = {
+                "jobs": [
+                    {
+                        "id": 40,
+                        "name": "Publish stable Python distribution with trusted publishing",
+                        "conclusion": "failure",
+                        "steps": [
+                            {"name": "Verify Python distribution transfer", "conclusion": "failure"},
+                            {
+                                "name": "Publish with PyPI trusted publishing and attestations",
+                                "conclusion": "skipped",
+                            },
+                        ],
+                    }
+                ]
+            }
+            artifact = {
+                "id": 9009656530,
+                "name": "python-distributions",
+                "digest": f"sha256:{evidence['artifact']['digest']}",
+                "size_in_bytes": 123,
+                "expired": False,
+                "workflow_run": {"id": 31219050718, "head_sha": "a" * 40},
+            }
+            release = {
+                "id": 20,
+                "tag_name": "v0.3.0",
+                "name": "v0.3.0",
+                "target_commitish": "a" * 40,
+                "draft": False,
+                "prerelease": False,
+                "immutable": True,
+                "published_at": "2026-08-07T21:42:28Z",
+                "assets": [
+                    {
+                        "id": 30,
+                        "digest": f"sha256:{evidence['release']['receipt_sha256']}",
+                        "size": len(receipt_bytes),
+                    }
+                ],
+            }
+            paths = {}
+            for name, value in {
+                "workflow-run": workflow_run,
+                "jobs": jobs,
+                "artifact": artifact,
+                "release": release,
+            }.items():
+                paths[name] = root / f"{name}.json"
+                paths[name].write_text(json.dumps(value), encoding="utf-8")
+            receipt_path = root / "receipt.json"
+            receipt_path.write_bytes(receipt_bytes)
+
+            stable_pypi_recovery.verify_remote_files(
+                paths["workflow-run"], paths["jobs"], paths["artifact"], paths["release"], receipt_path, evidence
+            )
+
+            jobs["jobs"][0]["steps"][1]["conclusion"] = "success"
+            paths["jobs"].write_text(json.dumps(jobs), encoding="utf-8")
+            with self.assertRaisesRegex(stable_pypi_recovery.StablePyPIRecoveryError, "publication was skipped"):
+                stable_pypi_recovery.verify_remote_files(
+                    paths["workflow-run"],
+                    paths["jobs"],
+                    paths["artifact"],
+                    paths["release"],
+                    receipt_path,
+                    evidence,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix Python artifact production so generated hidden files cannot enter `SHA256SUMS`
- add a temporary, evidence-fingerprint-gated recovery path in the existing Stable/PyPI trusted-publisher workflow
- publish only the exact original wheel and source archive from failed run `31219050718`
- make recovery re-entrant across absent, partial, or fully published exact PyPI states
- reconcile the original failed release run with a separately recorded successful recovery run

## Safety
- exact source SHA: `a9abbcf6cd1281d2c701e0c050b68fdafc5b9522`
- exact artifact ID: `9009656530`
- exact artifact digest: `92f3e21084ec98e20e9c18ac3531985d8ad03ee50a514eca841dfe9ce12dd157`
- exact evidence fingerprint: `46574b247fc9b9ef13cd64aafaa8e859c2cf10fcfde50913cd317ae5bfec361f`
- no release dispatch or PyPI mutation is performed by this PR

## Validation
- `uv run python -m unittest discover -s tests -t .` — 1,589 passed, 3 skipped
- 144 focused recovery/release tests passed after the final cut-packet transition fix
- `actionlint` passed for all changed workflows
- `ruff format --check` and `ruff check --no-fix` passed for changed Python files
- `mypy` passed for changed scripts
- `scripts.release validate` passed
- clean `uv build` reproduced and verified exactly one wheel and one sdist after hidden-file cleanup
- Opus final blocker review clean after consumer and cut-packet compatibility fixes

Closes no issue. Tracks #489.
