### PR TITLE
Fix guarded Stable recovery run identity

### DIFF
--- a/scripts/github_release_run.py
+++ b/scripts/github_release_run.py
@@ -27,6 +27,10 @@ NONTERMINAL_STATUSES = {"in_progress", "pending", "queued", "requested"}
 REPOSITORY = "cbusillo/BD_to_AVP"
 WORKFLOW_POLICIES = OPERATOR_WORKFLOWS
 ALLOWED_WORKFLOWS = tuple(WORKFLOW_POLICIES)
+ALLOWED_RUN_NAMES = {
+    "Stable": frozenset({"Stable", "Stable PyPI recovery"}),
+    "Prerelease": frozenset({"Prerelease"}),
+}
 REQUIRED_BRANCH = "main"
 REQUIRED_EVENT = "workflow_dispatch"
 REQUIRED_ENVIRONMENT = "macos-signing"
@@ -245,15 +249,14 @@ def validate_expectation(expectation: RunExpectation) -> None:
 
 
 def validate_run_identity(run: Mapping[str, Any], expectation: RunExpectation) -> ValidatedRunIdentity:
+    actual_workflow_name = _string(run, "name", "Workflow run")
     actual = {
-        "workflow": _string(run, "name", "Workflow run"),
         "workflow_path": _string(run, "path", "Workflow run"),
         "head_sha": _string(run, "head_sha", "Workflow run"),
         "branch": _string(run, "head_branch", "Workflow run"),
         "event": _string(run, "event", "Workflow run"),
     }
     expected = {
-        "workflow": expectation.workflow,
         "workflow_path": expectation.workflow_path,
         "head_sha": expectation.head_sha,
         "branch": expectation.branch,
@@ -264,6 +267,11 @@ def validate_run_identity(run: Mapping[str, Any], expectation: RunExpectation) -
     ]
     if mismatches:
         raise ReleaseRunError("Workflow run identity mismatch: " + ", ".join(mismatches))
+    if actual_workflow_name not in ALLOWED_RUN_NAMES[expectation.workflow]:
+        raise ReleaseRunError(
+            f"Workflow run identity mismatch: workflow={actual_workflow_name!r} "
+            f"(expected one of {sorted(ALLOWED_RUN_NAMES[expectation.workflow])!r})"
+        )
     workflow_id = run.get("workflow_id")
     if isinstance(workflow_id, bool) or not isinstance(workflow_id, int) or workflow_id <= 0:
         raise ReleaseRunError("Workflow run workflow ID must be a positive integer returned by GitHub.")

--- a/scripts/release_evidence.py
+++ b/scripts/release_evidence.py
@@ -159,7 +159,7 @@ def validate_publication(
         ):
             raise ReleaseEvidenceError("Failed release run does not match the reviewed Stable PyPI recovery evidence.")
         expected_recovery_identity = {
-            "name": "Stable",
+            "name": "Stable PyPI recovery",
             "path": ".github/workflows/briefcase.yml",
             "event": "workflow_dispatch",
             "status": "completed",

--- a/tests/test_github_release_run.py
+++ b/tests/test_github_release_run.py
@@ -23,6 +23,7 @@ from scripts.github_release_run import (
     build_approval_fingerprint,
     main,
     parse_args,
+    validate_run_identity,
     watch_release_run,
 )
 from scripts.release_workflow_policy import (
@@ -375,6 +376,14 @@ class GitHubReleaseRunWatchTests(unittest.TestCase):
         self.assertEqual(result, EXIT_SAFETY_ERROR)
         self.assertEqual(events[0]["event"], "safety_error")
         self.assertIn("identity mismatch", str(events[0]["message"]))
+
+    def test_stable_recovery_run_name_preserves_workflow_identity(self) -> None:
+        identity = validate_run_identity(
+            workflow_run(status="in_progress", name="Stable PyPI recovery"),
+            expectation(),
+        )
+
+        self.assertEqual(identity.workflow_id, WORKFLOW_ID)
 
     def test_wrong_workflow_path_is_a_safety_error(self) -> None:
         client = FakeGitHubAPI()

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1012,6 +1012,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertNotIn("secrets.", str(workflow))
         self.assertIn("python -m scripts.release_evidence", str(prepare))
         self.assertIn("Stable PyPI recovery", str(prepare))
+        self.assertIn('"name": "Stable PyPI recovery"', (REPO_ROOT / "scripts/release_evidence.py").read_text())
         self.assertIn("scripts.stable_pypi_recovery verify-pypi", str(prepare))
         self.assertIn("--recovery-workflow-run", str(prepare))
         self.assertIn("release-receipt.json", str(prepare))


### PR DESCRIPTION
## Summary
- allow the guarded Stable watcher to recognize the exact dynamic `Stable PyPI recovery` run name while preserving path, SHA, branch, event, actor, and workflow-ID checks
- align release-evidence recovery validation with GitHub's REST run-name behavior
- keep all unexpected workflow names fail-closed

## Incident evidence
Recovery run `31235374709` was safely cancelled after watcher exit `21`; PyPI `0.3.0` remains absent. Replaying the watcher against that exact cancelled run now validates the identity and reports its actual `cancelled` conclusion instead of a safety mismatch.

## Validation
- 1,592 tests passed, 3 skipped
- 74 focused watcher/evidence tests passed
- Ruff format/check passed
- exact cancelled-run watcher replay passed identity validation

Tracks #489. Does not publish, retag, or alter immutable GitHub/Sparkle assets.
