### PR TITLE
Support terminal Stable evidence state in tests

### DIFF
--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -954,7 +954,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             repo=REPO_ROOT,
             workflow_phase="milestone",
             milestone_receipt_path=REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
-            as_of=date(2026, 8, 6),
+            as_of=date(2026, 8, 8),
         )
 
         self.assertEqual(self.result_for(report, "sparkle-update-route")["status"], "covered")

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -179,7 +179,15 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `161`", cut_packet)
         self.assertIn("#489", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertIn("Published and immutable; PyPI recovery pending", cut_packet)
+        self.assertTrue(
+            any(
+                state in cut_packet
+                for state in (
+                    "Published and immutable; PyPI recovery pending",
+                    "Published and immutable.",
+                )
+            )
+        )
         self.assertIn("post-publication", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)


### PR DESCRIPTION
## Summary
- allow the Stable cut-packet test to recognize both the recovery-pending and terminal immutable publication states
- evaluate the shared checked evidence index after the August 7 Stable receipts when replaying the RC3 milestone regression

## Failure fixed
Evidence PR #504 correctly advanced the cut packet to `Published and immutable` and added August 7 Stable receipts. CI still assumed the pre-reconciliation banner and an August 6 global evidence horizon, causing one assertion failure and one future-date error.

## Validation
- 1,592 tests passed, 3 skipped
- focused transition tests passed
- Ruff format/check passed

Tracks #489 and unblocks evidence PR #504. No release or artifact mutation.
