### PR TITLE
Add hosted Stable milestone qualification

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -71,6 +71,7 @@
     "approvalEnvironment": "macos-signing",
     "engineWorkflowPath": ".github/workflows/release-engine.yml",
     "evidenceWorkflowPath": ".github/workflows/release-evidence.yml",
+    "milestoneQualificationWorkflowPath": ".github/workflows/milestone-qualification.yml",
     "qualificationPolicyPath": "docs/qualification/release-qualification-policy-v1.json",
     "qualificationEvidencePath": "docs/qualification/release-evidence-v1.json",
     "qualificationRecordPath": "docs/qualification/stable-signed-qualification-v1.json",
@@ -165,6 +166,7 @@
     "Stable",
     "Prerelease",
     "Release Evidence",
+    "Milestone Qualification",
     "Manage Sparkle Pages",
     "Update FFmpeg Vendor Pins"
   ],

--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -61,14 +61,6 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Check out exact evidence branch data
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          path: evidence
-          persist-credentials: false
-          ref: ${{ inputs.evidence_ref }}
-
       - name: Bind protected code and canonical evidence data
         env:
           CANDIDATE_TAG: ${{ inputs.candidate_tag }}
@@ -87,10 +79,13 @@ jobs:
           test "$GITHUB_REF_NAME" = "main"
           MAIN_REMOTE_HEAD=$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')
           test "$MAIN_REMOTE_HEAD" = "$GITHUB_SHA"
-          EVIDENCE_SHA=$(git -C evidence rev-parse HEAD)
           EVIDENCE_REMOTE_HEAD=$(git ls-remote --heads origin "refs/heads/$EVIDENCE_REF" | awk '{print $1}')
           test -n "$EVIDENCE_REMOTE_HEAD"
+          git fetch --no-tags origin \
+            "refs/heads/$EVIDENCE_REF:refs/remotes/origin/milestone-evidence"
+          EVIDENCE_SHA=$(git rev-parse refs/remotes/origin/milestone-evidence)
           test "$EVIDENCE_REMOTE_HEAD" = "$EVIDENCE_SHA"
+          git worktree add --detach evidence "$EVIDENCE_SHA"
           git -C evidence fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
           UNTRUSTED_PATHS=$(git -C evidence diff --name-only origin/main...HEAD | grep -Ev '^docs/' || true)
           if [ -n "$UNTRUSTED_PATHS" ]; then

--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -1,0 +1,393 @@
+---
+name: Milestone Qualification
+run-name: Milestone qualification ${{ inputs.candidate_tag }}
+
+"on":
+  workflow_dispatch:
+    inputs:
+      evidence_ref:
+        description: Canonical automation/release-evidence-<tag> branch
+        required: true
+        type: string
+      candidate_tag:
+        description: Published candidate tag including the v prefix
+        required: true
+        type: string
+      prior_tag:
+        description: Exact prior release tag including the v prefix
+        required: true
+        type: string
+      route:
+        description: Saved Sparkle route used by the prior installation
+        required: true
+        type: choice
+        options:
+          - stable
+          - rc
+          - beta
+          - alpha
+      signed_ui_artifact_id:
+        description: Exact signed-artifact-ui artifact ID from the candidate release run
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: milestone-qualification-${{ inputs.candidate_tag }}
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  XCODEGEN_VERSION: 2.45.4
+  XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
+  XCODE_VERSION: "26.5"
+  XCODE_BUILD_VERSION: 17F42
+
+jobs:
+  qualify:
+    name: Collect exact post-publication qualification receipts
+    if: github.actor == github.repository_owner
+    runs-on: macos-26
+    timeout-minutes: 90
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out protected main workflow code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Check out exact evidence branch data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          path: evidence
+          persist-credentials: false
+          ref: ${{ inputs.evidence_ref }}
+
+      - name: Bind protected code and canonical evidence data
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          EVIDENCE_REF: ${{ inputs.evidence_ref }}
+          PRIOR_TAG: ${{ inputs.prior_tag }}
+        run: |
+          set -euo pipefail
+          TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$'
+          if [[ ! "$CANDIDATE_TAG" =~ $TAG_PATTERN ]] || [[ ! "$PRIOR_TAG" =~ $TAG_PATTERN ]]; then
+            echo "Candidate and prior tags must use the canonical public tag format." >&2
+            exit 1
+          fi
+          EXPECTED_REF="automation/release-evidence-$CANDIDATE_TAG"
+          test "$EVIDENCE_REF" = "$EXPECTED_REF"
+          test "$GITHUB_REF_TYPE" = "branch"
+          test "$GITHUB_REF_NAME" = "main"
+          MAIN_REMOTE_HEAD=$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')
+          test "$MAIN_REMOTE_HEAD" = "$GITHUB_SHA"
+          EVIDENCE_SHA=$(git -C evidence rev-parse HEAD)
+          EVIDENCE_REMOTE_HEAD=$(git ls-remote --heads origin "refs/heads/$EVIDENCE_REF" | awk '{print $1}')
+          test -n "$EVIDENCE_REMOTE_HEAD"
+          test "$EVIDENCE_REMOTE_HEAD" = "$EVIDENCE_SHA"
+          git -C evidence fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          UNTRUSTED_PATHS=$(git -C evidence diff --name-only origin/main...HEAD | grep -Ev '^docs/' || true)
+          if [ -n "$UNTRUSTED_PATHS" ]; then
+            echo "Evidence branch contains non-documentation changes:" >&2
+            printf '%s\n' "$UNTRUSTED_PATHS" >&2
+            exit 1
+          fi
+          cmp docs/qualification/release-qualification-policy-v1.json \
+            evidence/docs/qualification/release-qualification-policy-v1.json
+          CANDIDATE_RECEIPT="evidence/docs/release-evidence/$CANDIDATE_TAG/release-receipt.json"
+          PRIOR_RECEIPT="evidence/docs/release-evidence/$PRIOR_TAG/release-receipt.json"
+          git -C evidence cat-file -e "HEAD:docs/release-evidence/$CANDIDATE_TAG/release-receipt.json"
+          git -C evidence cat-file -e "HEAD:docs/release-evidence/$PRIOR_TAG/release-receipt.json"
+          test "$(jq -r .release.tag "$CANDIDATE_RECEIPT")" = "$CANDIDATE_TAG"
+          test "$(jq -r .release.tag "$PRIOR_RECEIPT")" = "$PRIOR_TAG"
+          CANDIDATE_SHA=$(jq -r .source_sha "$CANDIDATE_RECEIPT")
+          git merge-base --is-ancestor "$CANDIDATE_SHA" origin/main
+          echo "EVIDENCE_SHA=$EVIDENCE_SHA" >> "$GITHUB_ENV"
+
+      - name: Select pinned macOS UI toolchain
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "arm64"
+          test "$(sw_vers -productVersion | cut -d. -f1)" = "26"
+          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
+          if [ ! -d "$XCODE_PATH" ]; then
+            echo "Pinned Xcode path is unavailable: $XCODE_PATH" >&2
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_PATH"
+          test "$(xcodebuild -version | sed -n '1p')" = "Xcode $XCODE_VERSION"
+          test "$(xcodebuild -version | sed -n '2p')" = "Build version $XCODE_BUILD_VERSION"
+
+      - name: Install pinned XcodeGen
+        run: |
+          set -euo pipefail
+          ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
+          curl --fail --location --silent --show-error \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/$XCODEGEN_VERSION/xcodegen.zip" \
+            --output "$ARCHIVE"
+          printf '%s  %s\n' "$XCODEGEN_SHA256" "$ARCHIVE" | shasum -a 256 --check
+          ditto -x -k "$ARCHIVE" "$RUNNER_TEMP"
+          test "$("$RUNNER_TEMP/xcodegen/bin/xcodegen" --version)" = "Version: $XCODEGEN_VERSION"
+          echo "$RUNNER_TEMP/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies and generate Xcode project
+        run: |
+          set -euo pipefail
+          uv python install 3.12
+          uv sync --locked --all-groups --python 3.12
+          (cd evidence && "$GITHUB_WORKSPACE/.venv/bin/python" scripts/native_app.py generate)
+
+      - name: Download and verify exact release inputs
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          GH_TOKEN: ${{ github.token }}
+          PRIOR_TAG: ${{ inputs.prior_tag }}
+          SIGNED_UI_ARTIFACT_ID: ${{ inputs.signed_ui_artifact_id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SIGNED_UI_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Signed UI artifact ID must be a positive integer." >&2
+            exit 1
+          fi
+          mkdir -p qualification-inputs/signed-ui qualification-output
+          CANDIDATE_RECEIPT="evidence/docs/release-evidence/$CANDIDATE_TAG/release-receipt.json"
+          PRIOR_RECEIPT="evidence/docs/release-evidence/$PRIOR_TAG/release-receipt.json"
+          uv run python -m scripts.release_receipt validate --receipt "$CANDIDATE_RECEIPT"
+          uv run python -m scripts.release_receipt validate --receipt "$PRIOR_RECEIPT"
+
+          verify_release_binding() {
+            local receipt=$1
+            local tag=$2
+            local output=$3
+            local release_id source_sha expected_prerelease asset_count
+            release_id=$(jq -er .release.id "$receipt")
+            source_sha=$(jq -er .source_sha "$receipt")
+            expected_prerelease=$(jq -er .release.prerelease "$receipt")
+            gh api "repos/$GH_REPO/releases/tags/$tag" > "$output"
+            test "$(jq -er .id "$output")" = "$release_id"
+            test "$(jq -er .target_commitish "$output")" = "$source_sha"
+            test "$(jq -er .tag_name "$output")" = "$tag"
+            test "$(jq -er .draft "$output")" = "false"
+            test "$(jq -er .prerelease "$output")" = "$expected_prerelease"
+            asset_count=$(jq -r '.artifacts | length' "$receipt")
+            test "$asset_count" -gt 0
+            while IFS= read -r artifact; do
+              local asset_id name digest size matches
+              asset_id=$(jq -r .asset_id <<< "$artifact")
+              name=$(jq -r .name <<< "$artifact")
+              digest=$(jq -r .sha256 <<< "$artifact")
+              size=$(jq -r .size_bytes <<< "$artifact")
+              matches=$(jq \
+                --argjson asset_id "$asset_id" \
+                --arg name "$name" \
+                --arg digest "sha256:$digest" \
+                --argjson size "$size" \
+                '[.assets[] | select(.id == $asset_id and .name == $name and .digest == $digest and .size == $size)] | length' \
+                "$output")
+              test "$matches" = "1"
+            done < <(jq -c '.artifacts[]' "$receipt")
+          }
+          verify_release_binding "$CANDIDATE_RECEIPT" "$CANDIDATE_TAG" qualification-inputs/candidate-release.json
+          verify_release_binding "$PRIOR_RECEIPT" "$PRIOR_TAG" qualification-inputs/prior-release.json
+
+          download_dmg() {
+            local receipt=$1
+            local prefix=$2
+            local asset_id name expected_sha256 expected_size output
+            asset_id=$(jq -er '[.artifacts[] | select(.kind == "dmg")][0].asset_id' "$receipt")
+            name=$(jq -er '[.artifacts[] | select(.kind == "dmg")][0].name' "$receipt")
+            expected_sha256=$(jq -er '[.artifacts[] | select(.kind == "dmg")][0].sha256' "$receipt")
+            expected_size=$(jq -er '[.artifacts[] | select(.kind == "dmg")][0].size_bytes' "$receipt")
+            output="qualification-inputs/$name"
+            gh api -H "Accept: application/octet-stream" \
+              "repos/$GH_REPO/releases/assets/$asset_id" > "$output"
+            test "$(shasum -a 256 "$output" | awk '{print $1}')" = "$expected_sha256"
+            test "$(stat -f %z "$output")" = "$expected_size"
+            printf '%s=%q\n' "$prefix" "$output" >> qualification-inputs/paths.env
+          }
+          download_dmg "$CANDIDATE_RECEIPT" CANDIDATE_DMG
+          download_dmg "$PRIOR_RECEIPT" PRIOR_DMG
+
+          CANDIDATE_SHA=$(jq -er .source_sha "$CANDIDATE_RECEIPT")
+          CANDIDATE_RUN_ID=$(jq -er .workflow.run_id "$CANDIDATE_RECEIPT")
+          CANDIDATE_RUN_ATTEMPT=$(jq -er .workflow.run_attempt "$CANDIDATE_RECEIPT")
+          CANDIDATE_WORKFLOW_ACTOR=$(jq -er .workflow.actor "$CANDIDATE_RECEIPT")
+          CANDIDATE_WORKFLOW_NAME=$(jq -er .workflow.name "$CANDIDATE_RECEIPT")
+          CANDIDATE_WORKFLOW_PATH=$(jq -er .workflow.path "$CANDIDATE_RECEIPT")
+          RECEIPT_FILE_SHA256=$(shasum -a 256 "$CANDIDATE_RECEIPT" | awk '{print $1}')
+          gh api "repos/$GH_REPO/actions/runs/$CANDIDATE_RUN_ID" > qualification-inputs/candidate-workflow-run.json
+          jq -e \
+            --arg actor "$CANDIDATE_WORKFLOW_ACTOR" \
+            --arg head_sha "$CANDIDATE_SHA" \
+            --arg workflow_name "$CANDIDATE_WORKFLOW_NAME" \
+            --arg workflow_path "$CANDIDATE_WORKFLOW_PATH" \
+            --argjson run_attempt "$CANDIDATE_RUN_ATTEMPT" \
+            --argjson run_id "$CANDIDATE_RUN_ID" \
+            '.id == $run_id and .run_attempt == $run_attempt and .name == $workflow_name and
+             .path == $workflow_path and .head_branch == "main" and .head_sha == $head_sha and
+             .event == "workflow_dispatch" and .status == "completed" and
+             .actor.login == $actor and .triggering_actor.login == $actor and .workflow_id > 0' \
+            qualification-inputs/candidate-workflow-run.json > /dev/null
+          RECEIPT_ASSET_COUNT=$(jq \
+            --arg digest "sha256:$RECEIPT_FILE_SHA256" \
+            '[.assets[] | select(.name == "release-receipt.json" and .digest == $digest)] | length' \
+            qualification-inputs/candidate-release.json)
+          test "$RECEIPT_ASSET_COUNT" = "1"
+          RECEIPT_ASSET_ID=$(jq -er \
+            --arg digest "sha256:$RECEIPT_FILE_SHA256" \
+            '.assets[] | select(.name == "release-receipt.json" and .digest == $digest) | .id' \
+            qualification-inputs/candidate-release.json)
+
+          gh api "repos/$GH_REPO/actions/artifacts/$SIGNED_UI_ARTIFACT_ID" \
+            > qualification-output/signed-artifact-ui-metadata.json
+          EXPECTED_ARTIFACT_NAME="signed-artifact-ui-$CANDIDATE_RUN_ATTEMPT"
+          jq -e \
+            --arg expected_name "$EXPECTED_ARTIFACT_NAME" \
+            --arg head_sha "$CANDIDATE_SHA" \
+            --argjson run_id "$CANDIDATE_RUN_ID" \
+            '.expired == false and .name == $expected_name and .workflow_run.id == $run_id and
+             .workflow_run.head_branch == "main" and .workflow_run.head_sha == $head_sha and
+             (.digest | startswith("sha256:"))' \
+            qualification-output/signed-artifact-ui-metadata.json > /dev/null
+          ARTIFACT_SHA256=$(jq -er '.digest | sub("^sha256:"; "")' \
+            qualification-output/signed-artifact-ui-metadata.json)
+          gh api "repos/$GH_REPO/actions/artifacts/$SIGNED_UI_ARTIFACT_ID/zip" \
+            > qualification-inputs/signed-artifact-ui.zip
+          test "$(shasum -a 256 qualification-inputs/signed-artifact-ui.zip | awk '{print $1}')" = "$ARTIFACT_SHA256"
+          unzip -q qualification-inputs/signed-artifact-ui.zip -d qualification-inputs/signed-ui
+          test "$(find qualification-inputs/signed-ui -type f | wc -l | tr -d ' ')" = "1"
+          SIGNED_UI_RECEIPT=qualification-inputs/signed-ui/signed-artifact-ui-receipt.json
+          test -f "$SIGNED_UI_RECEIPT"
+          SIGNED_UI_RECEIPT_SHA256=$(shasum -a 256 "$SIGNED_UI_RECEIPT" | awk '{print $1}')
+          uv run python -m scripts.signed_artifact_receipt validate \
+            --receipt "$SIGNED_UI_RECEIPT" \
+            --receipt-file-sha256 "$SIGNED_UI_RECEIPT_SHA256" \
+            --release-receipt "$CANDIDATE_RECEIPT" \
+            --release-receipt-asset-id "$RECEIPT_ASSET_ID" \
+            --release-receipt-file-sha256 "$RECEIPT_FILE_SHA256" \
+            --workflow-run-id "$CANDIDATE_RUN_ID" \
+            --workflow-run-attempt "$CANDIDATE_RUN_ATTEMPT"
+          cp "$SIGNED_UI_RECEIPT" qualification-output/signed-artifact-ui-receipt.json
+
+      - name: Preflight exact clean-machine qualification
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          PRIOR_TAG: ${{ inputs.prior_tag }}
+          ROUTE: ${{ inputs.route }}
+        run: |
+          set -euo pipefail
+          source qualification-inputs/paths.env
+          QUALIFICATION_ROOT="$HOME/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          test ! -e "$QUALIFICATION_ROOT"
+          uv run python -m scripts.tier3_clean_machine preflight \
+            --repo evidence \
+            --candidate-release-receipt "evidence/docs/release-evidence/$CANDIDATE_TAG/release-receipt.json" \
+            --candidate-dmg "$CANDIDATE_DMG" \
+            --prior-release-receipt "evidence/docs/release-evidence/$PRIOR_TAG/release-receipt.json" \
+            --prior-dmg "$PRIOR_DMG" \
+            --qualification-root "$QUALIFICATION_ROOT" \
+            --route "$ROUTE" \
+            --environment-class restorable-location
+
+      - name: Run exact clean-machine qualification
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          PRIOR_TAG: ${{ inputs.prior_tag }}
+          ROUTE: ${{ inputs.route }}
+        run: |
+          set -euo pipefail
+          source qualification-inputs/paths.env
+          QUALIFICATION_ROOT="$HOME/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          uv run python -m scripts.tier3_clean_machine run \
+            --repo evidence \
+            --candidate-release-receipt "evidence/docs/release-evidence/$CANDIDATE_TAG/release-receipt.json" \
+            --candidate-dmg "$CANDIDATE_DMG" \
+            --prior-release-receipt "evidence/docs/release-evidence/$PRIOR_TAG/release-receipt.json" \
+            --prior-dmg "$PRIOR_DMG" \
+            --qualification-root "$QUALIFICATION_ROOT" \
+            --route "$ROUTE" \
+            --environment-class restorable-location \
+            --output-receipt qualification-output/clean-machine-signed-update.json \
+            --ui-output-receipt qualification-output/installed-ui-accessibility.json \
+            --evidence-directory qualification-output/clean-machine-signed-update-evidence
+          uv run python -m scripts.tier3_receipt \
+            --case-id clean-machine-signed-update \
+            --receipt qualification-output/clean-machine-signed-update.json \
+            --repo evidence
+          uv run python -m scripts.tier3_receipt \
+            --case-id installed-ui-accessibility \
+            --receipt qualification-output/installed-ui-accessibility.json \
+            --repo evidence
+
+      - name: Summarize exact qualification outputs
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          PRIOR_TAG: ${{ inputs.prior_tag }}
+          ROUTE: ${{ inputs.route }}
+          SIGNED_UI_ARTIFACT_ID: ${{ inputs.signed_ui_artifact_id }}
+          EVIDENCE_REF: ${{ inputs.evidence_ref }}
+        run: |
+          set -euo pipefail
+          REMOTE_HEAD=$(git ls-remote --heads origin "refs/heads/$EVIDENCE_REF" | awk '{print $1}')
+          test "$REMOTE_HEAD" = "$EVIDENCE_SHA"
+          jq -n \
+            --arg candidate_tag "$CANDIDATE_TAG" \
+            --arg evidence_ref "$EVIDENCE_REF" \
+            --arg evidence_sha "$EVIDENCE_SHA" \
+            --arg prior_tag "$PRIOR_TAG" \
+            --arg route "$ROUTE" \
+            --argjson signed_ui_artifact_id "$SIGNED_UI_ARTIFACT_ID" \
+            --slurpfile artifact qualification-output/signed-artifact-ui-metadata.json \
+            --slurpfile clean qualification-output/clean-machine-signed-update.json \
+            --slurpfile ui qualification-output/installed-ui-accessibility.json \
+            '{
+              candidate_tag: $candidate_tag,
+              evidence_ref: $evidence_ref,
+              evidence_sha: $evidence_sha,
+              prior_tag: $prior_tag,
+              route: $route,
+              signed_ui_artifact: {
+                id: $signed_ui_artifact_id,
+                digest: $artifact[0].digest,
+                receipt_sha256: null
+              },
+              tier3_receipts: [
+                {case_id: $clean[0].case_id, receipt_sha256: $clean[0].receipt_sha256},
+                {case_id: $ui[0].case_id, receipt_sha256: $ui[0].receipt_sha256}
+              ]
+            }' > qualification-output/qualification-run.json
+          SIGNED_RECEIPT_SHA256=$(jq -er .receipt_sha256 qualification-output/signed-artifact-ui-receipt.json)
+          jq --arg receipt_sha256 "$SIGNED_RECEIPT_SHA256" \
+            '.signed_ui_artifact.receipt_sha256 = $receipt_sha256' \
+            qualification-output/qualification-run.json \
+            > qualification-output/qualification-run.updated.json
+          mv qualification-output/qualification-run.updated.json qualification-output/qualification-run.json
+          {
+            echo "## Milestone qualification $CANDIDATE_TAG"
+            echo
+            echo "- Protected code: \`main\` at \`$GITHUB_SHA\`"
+            echo "- Evidence branch: \`$EVIDENCE_REF\` at \`$EVIDENCE_SHA\`"
+            echo "- Signed UI receipt: \`$SIGNED_RECEIPT_SHA256\`"
+            echo "- Clean-machine receipt: \`$(jq -r .receipt_sha256 qualification-output/clean-machine-signed-update.json)\`"
+            echo "- Installed UI receipt: \`$(jq -r .receipt_sha256 qualification-output/installed-ui-accessibility.json)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain exact qualification receipts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: milestone-qualification-${{ inputs.candidate_tag }}-${{ github.run_attempt }}
+          path: qualification-output
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -25,6 +25,39 @@ The host must provide:
 - no running production app process; and
 - network access to the real public appcast.
 
+When the operator workstation is not running the policy-required macOS major
+version, use the owner-dispatched `Milestone Qualification` workflow instead of
+weakening the environment check. The workflow runs the same collector on the
+GitHub-hosted `macos-26` image with read-only repository and Actions access. It
+accepts only the canonical `automation/release-evidence-<tag>` branch at its
+exact remote head, rejects non-documentation differences from protected
+`main`, downloads both DMGs by the asset IDs in their checked receipts, and
+recovers the exact signed-artifact UI receipt by immutable Actions artifact ID.
+It cannot push, edit a release, approve an environment, or access release
+secrets.
+
+Dispatch it only after its workflow definition is present on the canonical
+evidence branch:
+
+```sh
+gh workflow run milestone-qualification.yml \
+  --ref main \
+  -f evidence_ref=automation/release-evidence-v0.3.0 \
+  -f candidate_tag=v0.3.0 \
+  -f prior_tag=v0.3.0-rc.3 \
+  -f route=rc \
+  -f signed_ui_artifact_id=<exact-artifact-id>
+```
+
+The successful run uploads the validated signed-artifact UI receipt, both Tier
+3 receipts, normalized evidence, artifact metadata, and a bounded run summary
+with 30-day retention. Download those outputs, validate them again, and add the
+accepted receipts to the same evidence branch. The hosted collector proves the
+real Sparkle install/relaunch path and source-bound release-notes link, but it
+does not by itself prove the visual presentation of native Sparkle release
+notes; that separate live-publication case still requires its targeted
+appearance evidence.
+
 Homebrew may be installed on the host. The package smoke and launched app use a
 system-only runtime `PATH`; host developer tools are not accepted as packaged
 dependencies.

--- a/scripts/signed_artifact_receipt.py
+++ b/scripts/signed_artifact_receipt.py
@@ -23,6 +23,7 @@ TEST_SELECTOR = "BluRayToVisionProUITests/InstalledUIAcceptanceTests/testCandida
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 MAX_RECEIPT_BYTES = 16 * 1024
+MAX_POLICY_BYTES = 256 * 1024
 
 
 class SignedArtifactReceiptError(RuntimeError):
@@ -97,13 +98,13 @@ def _sha256(value: object, description: str) -> str:
     return text
 
 
-def _load_json(path: Path, description: str) -> Mapping[str, Any]:
+def _load_json(path: Path, description: str, *, max_bytes: int = MAX_RECEIPT_BYTES) -> Mapping[str, Any]:
     try:
         content = path.read_bytes()
     except OSError as error:
         raise SignedArtifactReceiptError(f"Unable to read {description} at {path}: {error}") from error
-    if len(content) > MAX_RECEIPT_BYTES:
-        raise SignedArtifactReceiptError(f"{description.capitalize()} exceeds the {MAX_RECEIPT_BYTES}-byte limit.")
+    if len(content) > max_bytes:
+        raise SignedArtifactReceiptError(f"{description.capitalize()} exceeds the {max_bytes}-byte limit.")
     try:
         return _mapping(json.loads(content), description)
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -398,6 +399,51 @@ def load_validated_receipt(
     return receipt
 
 
+def validate_receipt_files(
+    *,
+    receipt_path: Path,
+    release_receipt_path: Path,
+    policy_path: Path,
+    case_id: str,
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+    release_receipt_asset_id: int,
+    release_receipt_file_sha256: str,
+    receipt_file_sha256: str,
+) -> Mapping[str, Any]:
+    expected_release_receipt_file_sha256 = _sha256(
+        release_receipt_file_sha256,
+        "expected release receipt file SHA-256",
+    )
+    try:
+        actual_release_receipt_file_sha256 = hashlib.sha256(release_receipt_path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise SignedArtifactReceiptError(
+            f"Unable to read release receipt at {release_receipt_path}: {error}"
+        ) from error
+    if actual_release_receipt_file_sha256 != expected_release_receipt_file_sha256:
+        raise SignedArtifactReceiptError("Release receipt file digest does not match the expected immutable asset.")
+
+    policy_id = validate_policy_case(
+        _load_json(policy_path, "release qualification policy", max_bytes=MAX_POLICY_BYTES),
+        case_id,
+    )
+    expectation = release_expectation_from_receipt(
+        _load_json(release_receipt_path, "release receipt"),
+        policy_id=policy_id,
+        case_id=case_id,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+        release_receipt_asset_id=release_receipt_asset_id,
+        release_receipt_file_sha256=expected_release_receipt_file_sha256,
+    )
+    return load_validated_receipt(
+        receipt_path,
+        expectation,
+        expected_file_sha256=receipt_file_sha256,
+    )
+
+
 def write_receipt(receipt: Mapping[str, Any], output: Path) -> None:
     content = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode()
     if len(content) > MAX_RECEIPT_BYTES:
@@ -414,11 +460,51 @@ def main(argv: Sequence[str] | None = None) -> int:
     validate_policy_parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
     validate_policy_parser.add_argument("--case-id", default=PROFILE_CASE_ID)
 
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate a signed artifact receipt against an exact checked release receipt.",
+    )
+    validate_parser.add_argument("--receipt", type=Path, required=True)
+    validate_parser.add_argument("--receipt-file-sha256", required=True)
+    validate_parser.add_argument("--release-receipt", type=Path, required=True)
+    validate_parser.add_argument("--release-receipt-asset-id", type=int, required=True)
+    validate_parser.add_argument("--release-receipt-file-sha256", required=True)
+    validate_parser.add_argument("--workflow-run-id", type=int, required=True)
+    validate_parser.add_argument("--workflow-run-attempt", type=int, required=True)
+    validate_parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    validate_parser.add_argument("--case-id", default=PROFILE_CASE_ID)
+
     args = parser.parse_args(argv)
     try:
         if args.command == "validate-policy":
-            policy_id = validate_policy_case(_load_json(args.policy, "release qualification policy"), args.case_id)
+            policy_id = validate_policy_case(
+                _load_json(args.policy, "release qualification policy", max_bytes=MAX_POLICY_BYTES),
+                args.case_id,
+            )
             print(json.dumps({"case_id": args.case_id, "policy_id": policy_id, "valid": True}, sort_keys=True))
+        elif args.command == "validate":
+            receipt = validate_receipt_files(
+                receipt_path=args.receipt,
+                release_receipt_path=args.release_receipt,
+                policy_path=args.policy,
+                case_id=args.case_id,
+                workflow_run_id=args.workflow_run_id,
+                workflow_run_attempt=args.workflow_run_attempt,
+                release_receipt_asset_id=args.release_receipt_asset_id,
+                release_receipt_file_sha256=args.release_receipt_file_sha256,
+                receipt_file_sha256=args.receipt_file_sha256,
+            )
+            print(
+                json.dumps(
+                    {
+                        "candidate_sha": receipt["candidate_sha"],
+                        "case_id": receipt["case_id"],
+                        "receipt_sha256": receipt["receipt_sha256"],
+                        "valid": True,
+                    },
+                    sort_keys=True,
+                )
+            )
     except SignedArtifactReceiptError as error:
         parser.error(str(error))
     return 0

--- a/tests/test_signed_artifact_receipt.py
+++ b/tests/test_signed_artifact_receipt.py
@@ -1,8 +1,10 @@
 import hashlib
+import io
 import json
 import tempfile
 import unittest
 
+from contextlib import redirect_stdout
 from dataclasses import replace
 from pathlib import Path
 
@@ -14,8 +16,10 @@ from scripts.signed_artifact_receipt import (
     SignedArtifactReceiptExpectation,
     build_receipt as build_signed_receipt,
     load_validated_receipt,
+    main,
     release_expectation_from_receipt,
     validate_policy_case,
+    validate_receipt_files,
 )
 from scripts.qualify_release_scope import DEFAULT_POLICY_PATH
 
@@ -155,6 +159,79 @@ class SignedArtifactReceiptTests(unittest.TestCase):
         case["artifact_owned"] = False
         with self.assertRaises(SignedArtifactReceiptError):
             validate_policy_case(policy)
+
+    def test_cli_validates_receipt_against_exact_checked_release_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            release_receipt = build_receipt(release_facts())
+            release_receipt_path = root / "release-receipt.json"
+            release_receipt_path.write_text(
+                json.dumps(release_receipt, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            release_receipt_file_sha256 = hashlib.sha256(release_receipt_path.read_bytes()).hexdigest()
+            expectation = release_expectation_from_receipt(
+                release_receipt,
+                policy_id=validate_policy_case(json.loads(DEFAULT_POLICY_PATH.read_text(encoding="utf-8"))),
+                case_id=PROFILE_CASE_ID,
+                workflow_run_id=12345,
+                workflow_run_attempt=2,
+                release_receipt_asset_id=4,
+                release_receipt_file_sha256=release_receipt_file_sha256,
+            )
+            signed_receipt = build_signed_receipt(expectation=expectation, evidence=evidence())
+            signed_receipt_path = root / "signed-artifact-ui-receipt.json"
+            signed_receipt_path.write_text(
+                json.dumps(signed_receipt, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            signed_receipt_file_sha256 = hashlib.sha256(signed_receipt_path.read_bytes()).hexdigest()
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                result = main(
+                    [
+                        "validate",
+                        "--receipt",
+                        str(signed_receipt_path),
+                        "--receipt-file-sha256",
+                        signed_receipt_file_sha256,
+                        "--release-receipt",
+                        str(release_receipt_path),
+                        "--release-receipt-asset-id",
+                        "4",
+                        "--release-receipt-file-sha256",
+                        release_receipt_file_sha256,
+                        "--workflow-run-id",
+                        "12345",
+                        "--workflow-run-attempt",
+                        "2",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                json.loads(stdout.getvalue()),
+                {
+                    "candidate_sha": CANDIDATE_SHA,
+                    "case_id": PROFILE_CASE_ID,
+                    "receipt_sha256": signed_receipt["receipt_sha256"],
+                    "valid": True,
+                },
+            )
+
+            with self.assertRaisesRegex(SignedArtifactReceiptError, "immutable asset"):
+                validate_receipt_files(
+                    receipt_path=signed_receipt_path,
+                    release_receipt_path=release_receipt_path,
+                    policy_path=DEFAULT_POLICY_PATH,
+                    case_id=PROFILE_CASE_ID,
+                    workflow_run_id=12345,
+                    workflow_run_attempt=2,
+                    release_receipt_asset_id=4,
+                    release_receipt_file_sha256="9" * 64,
+                    receipt_file_sha256=signed_receipt_file_sha256,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1028,7 +1028,6 @@ printf '%s' "$CODESIGN_METADATA"
         qualify = workflow["jobs"]["qualify"]
         steps = qualify["steps"]
         checkout = steps[0]
-        evidence_checkout = steps[1]
         upload = steps[-1]
         workflow_text = str(workflow)
 
@@ -1046,12 +1045,9 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertEqual(checkout["with"]["fetch-depth"], "0")
         self.assertEqual(checkout["with"]["persist-credentials"], "false")
         self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
-        self.assertRegex(evidence_checkout["uses"], r"^actions/checkout@[0-9a-f]{40}$")
-        self.assertEqual(evidence_checkout["with"]["fetch-depth"], "0")
-        self.assertEqual(evidence_checkout["with"]["path"], "evidence")
-        self.assertEqual(evidence_checkout["with"]["persist-credentials"], "false")
-        self.assertEqual(evidence_checkout["with"]["ref"], "${{ inputs.evidence_ref }}")
         self.assertIn('test "$GITHUB_REF_NAME" = "main"', workflow_text)
+        self.assertIn("refs/remotes/origin/milestone-evidence", workflow_text)
+        self.assertIn("git worktree add --detach evidence", workflow_text)
         self.assertIn("origin/main...HEAD", workflow_text)
         self.assertIn("cmp docs/qualification/release-qualification-policy-v1.json", workflow_text)
         self.assertIn("automation/release-evidence-$CANDIDATE_TAG", workflow_text)

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1022,6 +1022,54 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("remains intentionally unmergeable", str(create_pr))
         self.assertIn("peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", str(create_pr))
 
+    def test_milestone_qualification_is_hosted_secret_free_and_read_only(self) -> None:
+        workflow = load_workflow("milestone-qualification.yml")
+        dispatch = workflow["on"]["workflow_dispatch"]
+        qualify = workflow["jobs"]["qualify"]
+        steps = qualify["steps"]
+        checkout = steps[0]
+        evidence_checkout = steps[1]
+        upload = steps[-1]
+        workflow_text = str(workflow)
+
+        self.assertEqual(
+            set(dispatch["inputs"]),
+            {"candidate_tag", "evidence_ref", "prior_tag", "route", "signed_ui_artifact_id"},
+        )
+        self.assertEqual(workflow["permissions"], {})
+        self.assertEqual(qualify["permissions"], {"actions": "read", "contents": "read"})
+        self.assertEqual(qualify["runs-on"], "macos-26")
+        self.assertEqual(qualify["if"], "github.actor == github.repository_owner")
+        self.assertNotIn("environment", qualify)
+        self.assertNotIn("secrets.", workflow_text)
+        self.assertRegex(checkout["uses"], r"^actions/checkout@[0-9a-f]{40}$")
+        self.assertEqual(checkout["with"]["fetch-depth"], "0")
+        self.assertEqual(checkout["with"]["persist-credentials"], "false")
+        self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+        self.assertRegex(evidence_checkout["uses"], r"^actions/checkout@[0-9a-f]{40}$")
+        self.assertEqual(evidence_checkout["with"]["fetch-depth"], "0")
+        self.assertEqual(evidence_checkout["with"]["path"], "evidence")
+        self.assertEqual(evidence_checkout["with"]["persist-credentials"], "false")
+        self.assertEqual(evidence_checkout["with"]["ref"], "${{ inputs.evidence_ref }}")
+        self.assertIn('test "$GITHUB_REF_NAME" = "main"', workflow_text)
+        self.assertIn("origin/main...HEAD", workflow_text)
+        self.assertIn("cmp docs/qualification/release-qualification-policy-v1.json", workflow_text)
+        self.assertIn("automation/release-evidence-$CANDIDATE_TAG", workflow_text)
+        self.assertIn("scripts.signed_artifact_receipt validate", workflow_text)
+        self.assertIn("scripts.tier3_clean_machine preflight", workflow_text)
+        self.assertIn("scripts.tier3_clean_machine run", workflow_text)
+        self.assertIn("scripts.tier3_receipt", workflow_text)
+        self.assertNotRegex(workflow_text, r"\b(git push|git commit|gh release (upload|edit|delete))\b")
+        self.assertRegex(upload["uses"], r"^actions/upload-artifact@[0-9a-f]{40}$")
+        self.assertEqual(upload["with"]["retention-days"], "30")
+
+        config = load_github_config()
+        self.assertIn("Milestone Qualification", config["importantWorkflows"])
+        self.assertEqual(
+            config["releaseOperations"]["milestoneQualificationWorkflowPath"],
+            ".github/workflows/milestone-qualification.yml",
+        )
+
     def test_release_evidence_pr_enforces_post_publication_milestone(self) -> None:
         workflow = load_workflow("ci.yml")
         steps = workflow["jobs"]["validate"]["steps"]


### PR DESCRIPTION
## Summary
- add an owner-dispatched, read-only `macos-26` milestone qualification workflow
- execute trusted code and policy only from protected `main`, treating the canonical release-evidence branch as exact docs-only data
- bind candidate and prior DMGs to checked receipts and live GitHub Release asset identities
- recover and validate the exact signed-artifact UI receipt by immutable Actions artifact ID and GitHub digest
- emit validated clean-machine and installed-UI receipts without mutating releases or repository state
- add an offline signed-artifact receipt validation command and document the hosted workflow

## Safety
- no release/signing/deployment secrets or environments
- `contents: read` and `actions: read` only
- no push, commit, release edit, approval, or publication capability
- exact evidence branch head, exact protected-main code, exact release/run/artifact identities, and policy equality are enforced before UI execution

## Validation
- `uv run python -m unittest discover -s tests -t .` — 1594 passed, 3 skipped
- focused qualification/workflow tests — 58 passed
- changed-file Ruff format and lint checks passed
- real Stable `signed-artifact-ui-1` receipt validated against the immutable v0.3.0 receipt
- JetBrains changed-file inspection was inconclusive due `execution_not_proven`; it reported zero findings but no trustworthy inspection completion

Refs #489
Unblocks #504.