### PR TITLE
Scope Sparkle install button to update window

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -25,11 +25,18 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30))
         openUpdateWindow(in: app)
 
-        let installButton = firstExistingElement(
-            in: app.buttons,
-            identifiers: ["Install and Relaunch", "Install Update", "Relaunch"],
-            timeout: 120
-        )
+        let updateWindow = app.windows.matching(identifier: "SUUpdateAlert").firstMatch
+        XCTAssertTrue(updateWindow.waitForExistence(timeout: 30))
+        let identifiedInstallButton = updateWindow.buttons
+            .matching(identifier: "SPUUserUpdateChoiceInstall")
+            .firstMatch
+        let installButton = identifiedInstallButton.waitForExistence(timeout: 30)
+            ? identifiedInstallButton
+            : firstExistingElement(
+                in: updateWindow.buttons,
+                identifiers: ["Install and Relaunch", "Install Update", "Relaunch"],
+                timeout: 90
+            )
         XCTAssertNotNil(installButton)
         XCTAssertTrue(
             waitForAccessibilityEvidence(context: context, timeout: 30),

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -163,6 +163,16 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn('["-AppleInterfaceStyle", "Dark"]', source)
         self.assertNotIn('executableURL = URL(fileURLWithPath: "/usr/bin/defaults")', source)
 
+    def test_installed_ui_update_button_is_scoped_to_sparkle_window(self) -> None:
+        source = (MACOS_ROOT / "BluRayToVisionProUITests" / "InstalledUIAcceptanceTests.swift").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('app.windows.matching(identifier: "SUUpdateAlert").firstMatch', source)
+        self.assertIn('matching(identifier: "SPUUserUpdateChoiceInstall")', source)
+        self.assertIn("in: updateWindow.buttons", source)
+        self.assertNotIn("in: app.buttons,\n            identifiers:", source)
+
     def test_builds_packaged_mv_hevc_encoder_at_requested_path(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             output_path = Path(temporary_directory) / "tools" / MV_HEVC_ENCODER_NAME


### PR DESCRIPTION
## Summary
- scope the hosted updater qualification query to Sparkle's `SUUpdateAlert` window
- prefer the stable `SPUUserUpdateChoiceInstall` button identifier
- retain a label fallback inside the update window only, excluding the duplicate Touch Bar button
- add a regression assertion for the scoped query

## Evidence
Hosted milestone run `31260254252` reached the exact RC3-to-Stable Sparkle prompt on macOS 26, then failed because XCUITest found both the window button and Touch Bar button titled `Install Update`.

## Validation
- `uv run python -m unittest tests.test_native_app` — 64 passed
- `uv run python scripts/native_app.py test` — 355 passed
- changed Python test formatting and lint checks passed

Refs #489
Unblocks the hosted qualification run for #504.