### PR TITLE
Require current main in hosted evidence branch

### DIFF
--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -87,6 +87,10 @@ jobs:
           test "$EVIDENCE_REMOTE_HEAD" = "$EVIDENCE_SHA"
           git worktree add --detach evidence "$EVIDENCE_SHA"
           git -C evidence fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          if ! git -C evidence merge-base --is-ancestor origin/main HEAD; then
+            echo "Evidence branch does not contain the current protected main commit." >&2
+            exit 1
+          fi
           UNTRUSTED_PATHS=$(git -C evidence diff --name-only origin/main...HEAD | grep -Ev '^docs/' || true)
           if [ -n "$UNTRUSTED_PATHS" ]; then
             echo "Evidence branch contains non-documentation changes:" >&2

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1048,6 +1048,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn('test "$GITHUB_REF_NAME" = "main"', workflow_text)
         self.assertIn("refs/remotes/origin/milestone-evidence", workflow_text)
         self.assertIn("git worktree add --detach evidence", workflow_text)
+        self.assertIn("merge-base --is-ancestor origin/main HEAD", workflow_text)
         self.assertIn("origin/main...HEAD", workflow_text)
         self.assertIn("cmp docs/qualification/release-qualification-policy-v1.json", workflow_text)
         self.assertIn("automation/release-evidence-$CANDIDATE_TAG", workflow_text)


### PR DESCRIPTION
## Summary
- require the canonical evidence branch to contain the current protected `main` commit before hosted qualification runs
- prevent stale non-documentation code from being executed merely because the branch's own diff is docs-only
- retain exact remote-head, docs-only, and policy-equality checks

## Evidence
Hosted run `31262058348` used stale pre-#509 UI-test code because PR #504's evidence branch had not yet incorporated current `main`. The run failed safely without producing receipts.

## Validation
- workflow shell blocks pass `bash -n`
- `tests.test_sparkle_workflows` passes (31 tests)
- changed test formatting and lint checks pass

Refs #489
Unblocks the hosted qualification run for #504.