### PR TITLE
Wait for enabled Sparkle install action

### DIFF
--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -53,7 +53,7 @@ NETWORK_TIMEOUT_SECONDS = 30
 COMMAND_TIMEOUT_SECONDS = 60
 SMOKE_TIMEOUT_SECONDS = 15 * 60
 GUI_TIMEOUT_SECONDS = 270
-UPDATE_TIMEOUT_SECONDS = 5 * 60
+UPDATE_TIMEOUT_SECONDS = 15 * 60
 UI_TEST_TIMEOUT_SECONDS = 15 * 60
 ACCESSIBILITY_COLLECTOR_FINISH_TIMEOUT_SECONDS = 15
 MAX_UI_SCREENSHOT_BYTES = 20 * 1024 * 1024
@@ -992,12 +992,33 @@ end tell'''
                 set targetProcess to first application process whose bundle identifier is targetBundleID
                 tell targetProcess
                     repeat with targetWindow in windows
-                        repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Relaunch"}
-                            if exists button (buttonTitle as text) of targetWindow then
-                                click button (buttonTitle as text) of targetWindow
-                                return buttonTitle as text
-                            end if
+                        set identifiedButton to missing value
+                        repeat with targetButton in buttons of targetWindow
+                            try
+                                set buttonIdentifier to value of attribute "AXIdentifier" of targetButton
+                                if buttonIdentifier is "SPUUserUpdateChoiceInstall" then
+                                    set identifiedButton to targetButton
+                                    exit repeat
+                                end if
+                            end try
                         end repeat
+                        if identifiedButton is not missing value then
+                            if enabled of identifiedButton then
+                                set clickedTitle to name of identifiedButton as text
+                                click identifiedButton
+                                return clickedTitle
+                            end if
+                        else
+                            repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Relaunch"}
+                                if exists button (buttonTitle as text) of targetWindow then
+                                    set titledButton to button (buttonTitle as text) of targetWindow
+                                    if enabled of titledButton then
+                                        click titledButton
+                                        return buttonTitle as text
+                                    end if
+                                end if
+                            end repeat
+                        end if
                     end repeat
                 end tell
             end if

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -785,6 +785,14 @@ class Tier3CleanMachineTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_updater_waits_for_identified_enabled_install_button(self) -> None:
+        script = MacOSOperations()._updater_script()
+
+        self.assertIn('attribute "AXIdentifier"', script)
+        self.assertIn('"SPUUserUpdateChoiceInstall"', script)
+        self.assertIn("enabled of identifiedButton", script)
+        self.assertIn("enabled of titledButton", script)
+
     @unittest.skipUnless(platform.system() == "Darwin", "DMG mount integration requires macOS")
     def test_synthetic_dmg_mount_and_detach(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- prefer Sparkle's stable `SPUUserUpdateChoiceInstall` accessibility identifier in the AppleScript installer lane
- wait until the identified or fallback install action is enabled before clicking
- extend the bounded exact-candidate install/relaunch wait from 5 to 15 minutes for the 409 MB signed update
- retain fail-closed timeout behavior and add AppleScript contract tests

## Evidence
Hosted milestone run `31263841071` completed exact inputs, preflight, and prior UI inspection, but the app remained on RC3 after the five-minute candidate wait. The interaction returned without error, indicating the existing script clicked as soon as a titled button existed rather than waiting for an enabled identified action.

## Validation
- `tests.test_tier3_clean_machine` — 17 passed
- focused AppleScript compile/contract tests pass
- changed files pass Ruff format and lint checks

Refs #489
Unblocks the hosted qualification run for #504.