### PR TITLE
Record Sparkle install action identifier

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -30,7 +30,8 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         let identifiedInstallButton = updateWindow.buttons
             .matching(identifier: "SPUUserUpdateChoiceInstall")
             .firstMatch
-        let installButton = identifiedInstallButton.waitForExistence(timeout: 30)
+        let identifiedInstallButtonExists = identifiedInstallButton.waitForExistence(timeout: 30)
+        let installButton = identifiedInstallButtonExists
             ? identifiedInstallButton
             : firstExistingElement(
                 in: updateWindow.buttons,
@@ -45,7 +46,9 @@ final class InstalledUIAcceptanceTests: XCTestCase {
 
         try attachJSON(
             [
-                "install_action": installButton?.label ?? "",
+                "install_action": identifiedInstallButtonExists
+                    ? "SPUUserUpdateChoiceInstall"
+                    : installButton?.label ?? "",
                 "release_notes_url": context.releaseNotesURL,
                 "release_notes_url_observed": false,
                 "schema_version": 1,

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -57,7 +57,13 @@ UPDATE_TIMEOUT_SECONDS = 5 * 60
 UI_TEST_TIMEOUT_SECONDS = 15 * 60
 ACCESSIBILITY_COLLECTOR_FINISH_TIMEOUT_SECONDS = 15
 MAX_UI_SCREENSHOT_BYTES = 20 * 1024 * 1024
-SPARKLE_INSTALL_ACTIONS = ("Install Update", "Install and Relaunch", "Install on Quit")
+SPARKLE_INSTALL_IDENTIFIER = "SPUUserUpdateChoiceInstall"
+SPARKLE_INSTALL_ACTIONS = (
+    SPARKLE_INSTALL_IDENTIFIER,
+    "Install Update",
+    "Install and Relaunch",
+    "Install on Quit",
+)
 ROUTE_CHANNELS: dict[str, set[str | None]] = {
     "stable": {None},
     "rc": {None, "rc"},
@@ -1006,10 +1012,12 @@ end tell'''
                         end repeat
                         set selectedButton to missing value
                         set selectedTitle to ""
+                        set selectedByIdentifier to false
                         if identifiedButton is not missing value then
                             if enabled of identifiedButton then
                                 set selectedButton to identifiedButton
                                 set selectedTitle to name of identifiedButton as text
+                                set selectedByIdentifier to true
                             end if
                         else
                             repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Install on Quit"}
@@ -1033,6 +1041,7 @@ end tell'''
                                 exit repeat
                             else
                                 perform action "AXPress" of selectedButton
+                                if selectedByIdentifier then return "SPUUserUpdateChoiceInstall"
                                 return selectedTitle
                             end if
                         end if

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -828,6 +828,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
         self.assertIn('perform action "AXPress" of selectedButton', script)
         self.assertIn("set installStarted to true", script)
         self.assertIn('"Install on Quit"', script)
+        self.assertIn('return "SPUUserUpdateChoiceInstall"', script)
 
     @unittest.skipUnless(platform.system() == "Darwin", "DMG mount integration requires macOS")
     def test_synthetic_dmg_mount_and_detach(self) -> None:


### PR DESCRIPTION
## Summary
- record Sparkle's stable `SPUUserUpdateChoiceInstall` accessibility identifier when the localized button label is empty
- preserve label fallbacks for older or alternate Sparkle presentation paths
- keep empty or unknown actions rejected and all release/source/artifact identity checks unchanged

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (19 passed)
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`

Refs #489
Refs #504