### PR TITLE
Make operator release evidence nonblocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,21 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Summarize post-publication operational evidence
+        if: always() && steps.milestone-context.outputs.required == 'true'
+        run: |
+          set -euo pipefail
+          test -f release-qualification-milestone.json
+          {
+            echo "## Post-publication qualification"
+            echo
+            jq -r '
+              .cases[]
+              | select(.operational_status != null)
+              | "- `\(.case_id)`: **\(.operational_status)** (release blocking: `\(.blocking)`)"
+            ' release-qualification-milestone.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Enforce post-publication milestone evidence
         if: always() && steps.milestone-context.outputs.required == 'true'
         env:
@@ -197,6 +212,6 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$MILESTONE_OUTCOME" != "success" ]; then
-            echo "Post-publication milestone qualification is incomplete or invalid." >&2
+            echo "Blocking post-publication qualification is incomplete or invalid." >&2
             exit 1
           fi

--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -378,13 +378,13 @@ jobs:
             > qualification-output/qualification-run.updated.json
           mv qualification-output/qualification-run.updated.json qualification-output/qualification-run.json
           {
-            echo "## Milestone qualification $CANDIDATE_TAG"
+            echo "## Blocking automated milestone qualification $CANDIDATE_TAG"
             echo
             echo "- Protected code: \`main\` at \`$GITHUB_SHA\`"
             echo "- Evidence branch: \`$EVIDENCE_REF\` at \`$EVIDENCE_SHA\`"
             echo "- Signed UI receipt: \`$SIGNED_RECEIPT_SHA256\`"
-            echo "- Clean-machine receipt: \`$(jq -r .receipt_sha256 qualification-output/clean-machine-signed-update.json)\`"
-            echo "- Installed UI receipt: \`$(jq -r .receipt_sha256 qualification-output/installed-ui-accessibility.json)\`"
+            echo "- Blocking clean-machine receipt: \`$(jq -r .receipt_sha256 qualification-output/clean-machine-signed-update.json)\`"
+            echo "- Blocking installed UI receipt: \`$(jq -r .receipt_sha256 qualification-output/installed-ui-accessibility.json)\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Retain exact qualification receipts

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -267,4 +267,4 @@ jobs:
 
             The release workflow, immutable asset identities, live Pages appcast, qualification record, release ledger, and cut packet were revalidated before this branch was prepared. Signing and deployment secrets are not available to this workflow.
 
-            Publication is immutable, but this PR remains intentionally unmergeable until its post-publication milestone qualification check has accepted every due live-artifact and Tier 3 receipt. Add validated receipts to this idempotent branch; do not rebuild, retag, or replace the published release.
+            Publication is immutable, but this PR remains intentionally unmergeable until its post-publication milestone qualification check has accepted every blocking live-artifact and automated Tier 3 receipt. Optional physical-hardware and native-window presentation outcomes remain visible without blocking reconciliation. Add validated receipts to this idempotent branch; do not rebuild, retag, or replace the published release.

--- a/docs/qualification/release-qualification-policy-v1.json
+++ b/docs/qualification/release-qualification-policy-v1.json
@@ -143,6 +143,8 @@
       "id": "native-sparkle-release-notes",
       "tier": 2,
       "blocking_phase": "milestone",
+      "release_blocking": false,
+      "evidence_role": "operator_presentation",
       "requires_live_publication": true,
       "live_evidence_case_ids": [
         "native-sparkle-release-notes",
@@ -321,6 +323,7 @@
       "id": "usb-bluray-makemkv",
       "tier": 3,
       "blocking_phase": "milestone",
+      "release_blocking": false,
       "automation_lane": "operator-physical-drive",
       "execution_mode": "operator_assisted",
       "environment": {
@@ -334,7 +337,7 @@
         "classes": ["usb-bluray-drive"],
         "identity_fields": ["vendor_id", "product_id", "transport", "makemkv_version"]
       },
-      "cadence": {"first_rc": true, "stable_candidate": true},
+      "cadence": {"first_rc": true, "stable_candidate": false},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 90},
       "invalidates_on": {
         "paths": [
@@ -361,6 +364,7 @@
       "id": "protected-real-media-conversion",
       "tier": 3,
       "blocking_phase": "milestone",
+      "release_blocking": false,
       "automation_lane": "operator-real-media",
       "execution_mode": "operator_assisted",
       "environment": {
@@ -374,7 +378,7 @@
         "classes": ["usb-bluray-drive"],
         "identity_fields": ["vendor_id", "product_id", "transport", "makemkv_version"]
       },
-      "cadence": {"first_rc": false, "stable_candidate": true},
+      "cadence": {"first_rc": false, "stable_candidate": false},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
       "invalidates_on": {
         "paths": [
@@ -401,6 +405,7 @@
       "id": "vision-pro-physical-playback",
       "tier": 3,
       "blocking_phase": "milestone",
+      "release_blocking": false,
       "automation_lane": "operator-vision-pro",
       "execution_mode": "operator_assisted",
       "environment": {
@@ -414,7 +419,7 @@
         "classes": ["vision-pro"],
         "identity_fields": ["model_family", "chip_family", "visionos_major"]
       },
-      "cadence": {"first_rc": false, "stable_candidate": true},
+      "cadence": {"first_rc": false, "stable_candidate": false},
       "evidence_expiry": {"basis": "completed_at", "max_age_days": 180},
       "invalidates_on": {
         "paths": [

--- a/docs/qualification/stable-signed-qualification-v1.json
+++ b/docs/qualification/stable-signed-qualification-v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "qualification_id": "stable-signed-qualification-v1",
   "status": "preregistered_pending_exact_candidate",
-  "issues": ["#489"],
+  "issues": ["#489", "#516", "#518"],
   "qualification_policy": {
     "id": "release-qualification-policy-v1",
     "path": "docs/qualification/release-qualification-policy-v1.json",
@@ -73,7 +73,7 @@
   "matrix": [
     {"id": "release-workflow-identity", "policy_case_id": "release-workflow-identity", "phase": "workflow", "migration": "release_run_receipt"},
     {"id": "updater-route-rc3-to-stable", "policy_case_id": "sparkle-update-route", "phase": "milestone", "migration": "fresh_retest"},
-    {"id": "native-sparkle-notes-stable", "policy_case_id": "native-sparkle-release-notes", "phase": "milestone", "migration": "fresh_retest"},
+    {"id": "native-sparkle-notes-stable", "policy_case_id": "native-sparkle-release-notes", "phase": "milestone", "migration": "scope_evaluated"},
     {"id": "profile-save-action-accessibility", "policy_case_id": "profile-save-action-accessibility", "phase": "signed_artifact", "migration": "scope_evaluated"},
     {"id": "signed-packaged-route-parity", "policy_case_id": "signed-packaged-route-parity", "phase": "signed_artifact", "migration": "release_run_receipt"},
     {"id": "gui-preview-low-local-ample-destination", "policy_case_id": "gui-preview-low-local-ample-destination", "phase": "signed_artifact", "migration": "scope_evaluated"},
@@ -87,16 +87,15 @@
     {"id": "subtitle-partial-output-diagnostics", "policy_case_id": "subtitle-partial-output-diagnostics", "phase": "signed_artifact", "migration": "scope_evaluated"},
     {"id": "clean-machine-signed-update", "policy_case_id": "clean-machine-signed-update", "phase": "milestone", "migration": "fresh_retest"},
     {"id": "installed-ui-accessibility", "policy_case_id": "installed-ui-accessibility", "phase": "milestone", "migration": "fresh_retest"},
-    {"id": "usb-bluray-makemkv", "policy_case_id": "usb-bluray-makemkv", "phase": "milestone", "migration": "fresh_retest"},
-    {"id": "protected-real-media-conversion", "policy_case_id": "protected-real-media-conversion", "phase": "milestone", "migration": "fresh_retest"},
-    {"id": "vision-pro-physical-playback", "policy_case_id": "vision-pro-physical-playback", "phase": "milestone", "migration": "fresh_retest"},
+    {"id": "usb-bluray-makemkv", "policy_case_id": "usb-bluray-makemkv", "phase": "milestone", "migration": "scope_evaluated"},
+    {"id": "protected-real-media-conversion", "policy_case_id": "protected-real-media-conversion", "phase": "milestone", "migration": "scope_evaluated"},
+    {"id": "vision-pro-physical-playback", "policy_case_id": "vision-pro-physical-playback", "phase": "milestone", "migration": "scope_evaluated"},
     {"id": "public-diagnostics-and-field-closure", "policy_case_id": "public-diagnostics-and-field-closure", "phase": "post_publication", "migration": "external_nonblocking"}
   ],
   "acceptance": {
     "required_case_ids": [
       "release-workflow-identity",
       "sparkle-update-route",
-      "native-sparkle-release-notes",
       "profile-save-action-accessibility",
       "signed-packaged-route-parity",
       "gui-preview-low-local-ample-destination",
@@ -109,10 +108,7 @@
       "malformed-pgs-parser-recovery",
       "subtitle-partial-output-diagnostics",
       "clean-machine-signed-update",
-      "installed-ui-accessibility",
-      "usb-bluray-makemkv",
-      "protected-real-media-conversion",
-      "vision-pro-physical-playback"
+      "installed-ui-accessibility"
     ],
     "preregistered_matrix_case_ids": [
       "release-workflow-identity",
@@ -136,15 +132,17 @@
       "vision-pro-physical-playback",
       "public-diagnostics-and-field-closure"
     ],
-    "nonblocking_case_ids": ["public-diagnostics-and-field-closure"],
-    "blocking_case_ids": [
-      "sparkle-update-route",
+    "nonblocking_case_ids": [
       "native-sparkle-release-notes",
-      "clean-machine-signed-update",
-      "installed-ui-accessibility",
       "usb-bluray-makemkv",
       "protected-real-media-conversion",
-      "vision-pro-physical-playback"
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
     ],
     "milestone_complete": false,
     "passed": false

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -247,8 +247,9 @@ The workflow performs these ordered boundaries:
     and DMG/checksum/appcast asset IDs and digests. The artifact report is
     uploaded as an Actions artifact before enforcement. Publication cannot
     proceed until both gates pass. Cases whose exact evidence requires the live
-    published appcast or physical candidate hardware remain visible but deferred
-    to milestone qualification.
+    published appcast remain visible but deferred to milestone qualification.
+    Operator-only physical and native-window presentation evidence is reported
+    separately and cannot bypass or satisfy these automated gates.
 11. Publish the verified draft only if it still targets the current `main` HEAD.
    The release body is hashed again immediately before and after publication so
    edits cannot silently diverge from the updater notes. The reusable engine
@@ -272,11 +273,13 @@ The workflow performs these ordered boundaries:
    release ledger, updates the matching qualification and cut packet, and opens
    or updates `automation/release-evidence-<tag>`. Protected CI validates the
    checked receipt identity and runs the `milestone` qualification phase. The
-   PR remains intentionally unmergeable until every due live-publication Tier 2
-   and Tier 3 receipt has been added to that same idempotent branch and the
-   milestone report passes. Branch protection, review, and normal merge policy
-   remain in force. A reconciliation or milestone failure does not rebuild,
-   replace, or invalidate the correctly published release.
+   PR remains intentionally unmergeable until every blocking live-publication
+   and automated Tier 3 receipt has been added to that same idempotent branch
+   and the milestone report passes. Physical hardware and manual Sparkle-window
+   evidence remains visible as passed, failed, skipped, missing, or due, but it
+   does not block reconciliation. Branch protection, review, and normal merge
+   policy remain in force. A reconciliation or milestone failure does not
+   rebuild, replace, or invalidate the correctly published release.
 15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -58,14 +58,18 @@ The ordered phases are:
 | --- | --- |
 | `preparation` | Per-commit coverage and ordinary change-scoped Tier 2 evidence required before signing. |
 | `artifact` | Everything from preparation plus exact same-run Tier 1 receipt evidence required before publication. |
-| `milestone` | Everything from earlier phases plus live-publication Tier 2 and due Tier 3 evidence required before milestone closeout. |
+| `milestone` | Everything from earlier phases plus blocking live-publication Tier 2 and automated Tier 3 evidence required before milestone closeout; optional operational evidence remains visible. |
 
 Only Tier 2 cases that explicitly declare `requires_live_publication: true` may
-use the `milestone` blocking phase. This exception is limited to checks such as
-the real Sparkle update route and native release notes, whose exact-candidate
-evidence requires the published DMG, checked release receipt, and live appcast.
-Other Tier 2 invalidations continue to block preparation and require another
-reviewed candidate rather than being deferred through publication.
+use the `milestone` phase. The real Sparkle update route remains blocking because
+its exact-candidate evidence requires the published DMG, checked release receipt,
+and live appcast. Native Sparkle desktop capture is retained as nonblocking
+presentation evidence. Exact release-note source identity, embedded Markdown,
+full-notes URL, appcast identity, installed release-notes URL, and accessibility
+semantics remain enforced by the guarded release engine, live Sparkle route, and
+installed UI receipts. Other Tier 2 invalidations continue to block preparation
+and require another reviewed candidate rather than being deferred through
+publication.
 
 ```sh
 uv run python -m scripts.qualify_release_scope \
@@ -79,11 +83,12 @@ uv run python -m scripts.qualify_release_scope \
 
 Carry-forward is allowed only when an accepted named receipt exists and the
 diff from that receipt's source SHA contains no path covered by the case's
-direct invalidation patterns or referenced contracts. The Stable migration
-keeps the live Sparkle route, native notes, and every Stable-cadence Tier 3 case
-fresh while allowing unchanged ordinary Tier 2 cases to remain scope-evaluated.
-Tier 1 invalidation mappings document release-engine ownership only; Tier 1
-always requires a new exact-candidate receipt and never carries.
+direct invalidation patterns or referenced contracts. Stable continues to
+require the live Sparkle route and automated clean-machine/UI receipts. It does
+not force a fresh physical-hardware receipt or manual native-notes capture solely
+because a Stable milestone is due. Tier 1 invalidation mappings document
+release-engine ownership only; Tier 1 always requires a new exact-candidate
+receipt and never carries.
 
 ## Tier 3 Cadence And Receipts
 
@@ -93,18 +98,30 @@ allowed macOS environment classes and architecture, required public-safe
 hardware fields, first-RC and Stable cadence, expiry, invalidating contracts,
 assertions, evidence digest kinds, and cleanup outcomes.
 
-The classifier requires Tier 3 evidence only when one of these triggers applies:
+The classifier marks Tier 3 evidence due only when one of these triggers applies:
 
 - the case declares the first candidate of an RC cycle;
-- the case declares a Stable candidate;
+- an automated case declares a Stable candidate;
 - checked evidence has passed its receipt-declared expiry; or
-- mapped code, packaging, UI, updater, runtime, or playback paths changed.
+- mapped code, packaging, UI, updater, runtime, or playback paths changed;
+- an environment or device-family change is recorded as an explicit retest; or
+- a maintainer explicitly requests a retest.
 
-An ordinary alpha, beta, or later RC remains non-applicable when a case is not
-expired or invalidated. Valid prior evidence carries without becoming a
-blocking requirement. The report exposes the deterministic trigger for every
-case (`first_rc`, `stable_candidate`, `expired`, `invalidated`, `cadence_valid`,
-or `not_due`).
+An ordinary alpha, beta, later RC, or Stable release remains non-applicable for
+operator-assisted hardware when the case is not expired, invalidated, or
+explicitly requested. The USB/MakeMKV first-RC baseline is still scheduled, but
+it is operational evidence rather than a release blocker. Valid prior evidence
+carries without becoming a blocking requirement. The report exposes the
+deterministic trigger for every case (`first_rc`, `stable_candidate`, `expired`,
+`invalidated`, `explicit_retest`, `cadence_valid`, or `not_due`) and reports
+nonblocking operational status as `passed`, `failed`, `skipped`, `missing`, or
+`due`.
+
+A candidate migration may use `fresh_retest` for nonblocking physical evidence
+only with `retest_reason` set to `first_baseline`, `environment_changed`,
+`device_family_changed`, or `maintainer_request`. Optional native presentation
+may use only `rendering_contract_changed` or `maintainer_request`. This prevents
+an unexplained per-release ceremony from becoming policy by accident.
 
 Tier 3 receipts bind the release source SHA, tag, route, versions, signed app
 tree, DMG/checksum/appcast digests, and both semantic and file digests of the
@@ -122,9 +139,12 @@ uv run python -m scripts.tier3_receipt \
   --receipt path/to/tier3-receipt.json
 ```
 
-Passed receipts require every declared assertion to pass. Failed, skipped, and
-not-applicable receipts remain valid audit records with explicit bounded reason
-codes, but only a passed receipt may be indexed as accepted release evidence.
+Passed receipts require every declared assertion to pass. Failed and skipped
+receipts remain valid audit records with explicit bounded reason codes. For the
+four policy-approved nonblocking operational cases, they may be indexed with
+matching `failed` or `skipped` status so reports remain honest, but they never
+satisfy a blocking assertion. Blocking cases reject failed or skipped index
+entries. Only a passed receipt may be indexed as accepted release evidence.
 
 The maintained clean-machine, Sparkle, and installed UI/accessibility collector is documented in
 [`docs/tier3-clean-machine.md`](tier3-clean-machine.md). It uses an isolated
@@ -138,6 +158,9 @@ uses the bounded operator-assisted helper documented in
 [`docs/tier3-operator-hardware.md`](tier3-operator-hardware.md). The helper
 derives assertion states from exact enums, binds the checked release artifact,
 and rejects private media names, paths, serials, screenshots, and raw logs.
+These cases are visible operational evidence governed by expiry, mapped
+invalidation, environment/device-family changes, and explicit retest requests;
+they do not block release publication or evidence-PR reconciliation.
 
 ## Release Engine Receipts
 
@@ -162,7 +185,8 @@ byte-for-byte identities.
 ## Workflow Integration
 
 The release engine enforces qualification at two secret-free guarded boundaries,
-and protected pull-request CI enforces the post-publication milestone boundary.
+and protected pull-request CI enforces the post-publication blocking milestone
+boundary while reporting nonblocking operational evidence separately.
 None of these checks receives signing, notarization, PyPI, Sparkle, or Pages
 secrets.
 
@@ -287,11 +311,13 @@ python -m scripts.qualify_release_scope \
   --require-evidence
 ```
 
-The initial evidence PR is expected to remain unmergeable while due
-live-artifact or Tier 3 receipts are absent. Collectors add validated receipts
-to that same idempotent branch. A milestone failure never rebuilds, retags,
-re-signs, replaces, or unpublishes the immutable release; it blocks evidence
-reconciliation and milestone completion until the checked evidence passes.
+The initial evidence PR is expected to remain unmergeable while blocking
+live-artifact or automated Tier 3 receipts are absent. Collectors add validated
+receipts to that same idempotent branch. Optional physical and native-window
+presentation outcomes remain visible in the report. A blocking milestone
+failure never rebuilds, retags, re-signs, replaces, or unpublishes the immutable
+release; it blocks evidence reconciliation and milestone completion until the
+checked blocking evidence passes.
 CI discovers checked release-receipt changes from the pull-request diff and
 requires a same-repository PR targeting `main`, the exact
 `automation/release-evidence-<tag>` branch, and a docs-only diff, so a fork or a
@@ -303,10 +329,11 @@ classifier also writes a structured error report when policy or receipt
 validation fails before case classification. The `--workflow-phase` flag keeps
 later-phase retests visible but explicitly deferred. `artifact` additionally
 binds the exact run, release, and asset identities recorded in the receipt.
-`milestone` consumes the checked immutable receipt and enforces every due
-live-publication Tier 2 and Tier 3 case. The receipt's appcast digest is the
-verified snapshot awaiting deployment during the artifact phase; live Pages
-state is required only after publication.
+`milestone` consumes the checked immutable receipt and enforces every blocking
+live-publication Tier 2 and automated Tier 3 case. It reports due nonblocking
+operator evidence without converting it into a pass. The receipt's appcast
+digest is the verified snapshot awaiting deployment during the artifact phase;
+live Pages state is required only after publication.
 
 After the operator workflow completes, `.github/workflows/release-evidence.yml`
 validates the successful `workflow_dispatch` run, approved actor, protected

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -53,10 +53,12 @@ The successful run uploads the validated signed-artifact UI receipt, both Tier
 3 receipts, normalized evidence, artifact metadata, and a bounded run summary
 with 30-day retention. Download those outputs, validate them again, and add the
 accepted receipts to the same evidence branch. The hosted collector proves the
-real Sparkle install/relaunch path and source-bound release-notes link, but it
-does not by itself prove the visual presentation of native Sparkle release
-notes; that separate live-publication case still requires its targeted
-appearance evidence.
+real Sparkle install/relaunch path, exact appcast-bound release-notes URL, and
+installed accessibility semantics. The guarded release engine separately proves
+that the embedded Markdown and full-notes URL match the immutable release-note
+source. Targeted native-window appearance capture remains useful operational
+evidence when Sparkle or release-note rendering changes, but missing or failed
+desktop capture does not block release evidence reconciliation.
 
 Homebrew may be installed on the host. The package smoke and launched app use a
 system-only runtime `PATH`; host developer tools are not accepted as packaged
@@ -73,9 +75,10 @@ route.
 For a newly published candidate, run from the idempotent
 `automation/release-evidence-<tag>` branch created by the Release Evidence
 workflow. Add the validated Tier 3 receipts and their evidence-index entries to
-that branch. Protected CI's `milestone` classifier is expected to remain red
-until all due receipts are present; do not merge around it or create a parallel
-evidence branch.
+that branch. Protected CI's `milestone` classifier remains red until all
+blocking automated receipts are present. It reports optional presentation and
+physical evidence without making those operator-only outcomes release blockers;
+do not create a parallel evidence branch.
 
 Run the read-only preflight first:
 

--- a/docs/tier3-operator-hardware.md
+++ b/docs/tier3-operator-hardware.md
@@ -68,9 +68,11 @@ The release receipt must be committed and byte-identical to repository `HEAD`:
 
 For a newly published candidate, run from the idempotent
 `automation/release-evidence-<tag>` branch created by the Release Evidence
-workflow. Add passed operator receipts and their evidence-index entries to that
-same branch. Skipped or failed receipts remain truthful audit records but cannot
-satisfy protected CI's `milestone` qualification check.
+workflow. Add operator receipts and their evidence-index entries to that same
+branch when collection is due. Passed receipts use `status: accepted`; skipped
+or failed receipts use matching `skipped` or `failed` index status. Those
+outcomes remain visible in the milestone report but cannot satisfy any automated
+or blocking assertion.
 
 ```sh
 uv run python -m scripts.tier3_operator_receipt \
@@ -85,10 +87,12 @@ Skipped runs produce no evidence summaries. Cleanup, cancellation, ejection,
 recovery, conversion completion, and subjective spatial-presentation outcomes
 remain distinct bounded fields.
 
-Physical receipts run only on policy cadence. The USB/MakeMKV case is eligible
-for first RC and stable-candidate milestones; protected-media conversion and
-Vision Pro playback are stable-candidate cases. They are not prerequisites for
-every prerelease.
+Physical receipts run only when risk requires them: an explicitly scheduled
+first baseline, receipt expiry, mapped invalidating changes, environment or
+device-family changes, or a maintainer-requested retest. The USB/MakeMKV case
+retains its first-RC baseline. A Stable milestone alone does not force any of
+the three physical cases, and missing, skipped, failed, or due physical evidence
+does not block publication, the evidence PR, or milestone closeout.
 
 ## Validation
 
@@ -98,5 +102,6 @@ uv run python -m scripts.qualify_release_scope --validate-policy
 ```
 
 Fixture receipts cover passed, failed, skipped, private-field rejection, and
-missing-hardware rejection. Real hardware collection is performed only when the
-declared cadence requires it.
+missing-hardware rejection. Real hardware collection is performed only when a
+risk trigger requires it; release closeout never requires repeated collection
+solely to refresh operator ceremony.

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -64,6 +64,15 @@ TIER3_FORBIDDEN_IDENTITY_FIELDS = {
     "username",
     "volume",
 }
+RECORDED_NONBLOCKING_STATUSES = {"failed", "skipped"}
+OPERATOR_RETEST_REASONS = {"device_family_changed", "environment_changed", "first_baseline", "maintainer_request"}
+PRESENTATION_RETEST_REASONS = {"maintainer_request", "rendering_contract_changed"}
+NONBLOCKING_RELEASE_CASE_IDS = {
+    "native-sparkle-release-notes",
+    "protected-real-media-conversion",
+    "usb-bluray-makemkv",
+    "vision-pro-physical-playback",
+}
 
 
 class QualificationScopeError(RuntimeError):
@@ -170,6 +179,25 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
                 f"Qualification case {case_id!r} blocking_phase must be one of "
                 f"{sorted(allowed_blocking_phases)!r} for tier {tier}."
             )
+        release_blocking = case.get("release_blocking", blocking_phase != "none")
+        if not isinstance(release_blocking, bool):
+            raise QualificationScopeError(f"Qualification case {case_id!r} release_blocking must be boolean.")
+        if blocking_phase == "none" and release_blocking:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} cannot block release closeout with blocking_phase='none'."
+            )
+        if tier in {0, 1} and not release_blocking:
+            raise QualificationScopeError(
+                f"Automatic Tier {tier} qualification case {case_id!r} must remain release blocking."
+            )
+        if blocking_phase != "none" and not release_blocking and case_id not in NONBLOCKING_RELEASE_CASE_IDS:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} is not approved as nonblocking release evidence."
+            )
+        if case_id in NONBLOCKING_RELEASE_CASE_IDS and release_blocking:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} must remain nonblocking operational evidence."
+            )
         if requires_live_publication is not None and not isinstance(requires_live_publication, bool):
             raise QualificationScopeError(
                 f"Qualification case {case_id!r} requires_live_publication must be boolean when present."
@@ -182,10 +210,28 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
             raise QualificationScopeError(
                 f"Milestone-owned Tier 2 case {case_id!r} must declare requires_live_publication=true."
             )
+        if (
+            tier == 2
+            and not release_blocking
+            and (
+                blocking_phase != "milestone"
+                or requires_live_publication is not True
+                or case.get("evidence_role") != "operator_presentation"
+            )
+        ):
+            raise QualificationScopeError(
+                f"Nonblocking Tier 2 qualification case {case_id!r} must be milestone-owned live presentation evidence."
+            )
+        if tier == 2 and release_blocking and case.get("evidence_role") is not None:
+            raise QualificationScopeError(
+                f"Blocking Tier 2 qualification case {case_id!r} cannot declare an operational evidence role."
+            )
         if artifact_owned and (tier != 2 or blocking_phase != "publication" or requires_live_publication is True):
             raise QualificationScopeError(
                 f"Artifact-owned case {case_id!r} must be a publication-owned non-live Tier 2 case."
             )
+        if artifact_owned and not release_blocking:
+            raise QualificationScopeError(f"Artifact-owned case {case_id!r} must remain release blocking.")
         live_evidence_case_ids = case.get("live_evidence_case_ids")
         if requires_live_publication is True:
             accepted_live_case_ids = _strings(
@@ -273,6 +319,10 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
                 raise QualificationScopeError(
                     f"Tier 3 qualification case {case_id!r} execution_mode must be automated or operator_assisted."
                 )
+            if not release_blocking and execution_mode != "operator_assisted":
+                raise QualificationScopeError(
+                    f"Nonblocking Tier 3 qualification case {case_id!r} must be operator_assisted."
+                )
             expected_source = {
                 "automated": "tier3_automation_receipt",
                 "operator_assisted": "tier3_operator_receipt",
@@ -348,6 +398,10 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
     return policy
 
 
+def _release_blocking(case: Mapping[str, Any]) -> bool:
+    return cast(bool, case.get("release_blocking", case.get("blocking_phase") != "none"))
+
+
 def load_evidence(path: Path | None) -> Mapping[str, Any]:
     if path is None:
         return {"schema_version": 1, "receipts": []}
@@ -377,6 +431,7 @@ def load_qualification_overrides(
     }
     overrides: dict[str, bool] = {}
     matrix_case_ids: set[str] = set()
+    unreasoned_nonblocking_retests: list[str] = []
     for raw_case in _sequence(qualification.get("matrix"), "qualification matrix"):
         case = _mapping(raw_case, "qualification matrix case")
         matrix_case_id = case.get("id")
@@ -407,25 +462,63 @@ def load_qualification_overrides(
             raise QualificationScopeError(
                 f"Qualification migration {migration!r} is invalid for tier {tier} case {policy_case_id!r}."
             )
+        retest_reason = case.get("retest_reason")
+        policy_case = policy_cases[policy_case_id]
+        if migration == "fresh_retest" and not _release_blocking(policy_case):
+            allowed_reasons = (
+                PRESENTATION_RETEST_REASONS
+                if policy_case.get("evidence_role") == "operator_presentation"
+                else OPERATOR_RETEST_REASONS
+            )
+            if retest_reason is None:
+                unreasoned_nonblocking_retests.append(policy_case_id)
+            elif retest_reason not in allowed_reasons:
+                raise QualificationScopeError(
+                    f"Nonblocking qualification case {policy_case_id!r} fresh_retest requires one of "
+                    f"{sorted(allowed_reasons)!r}."
+                )
+        elif retest_reason is not None:
+            raise QualificationScopeError(
+                f"Qualification case {policy_case_id!r} may declare retest_reason only for a nonblocking fresh_retest."
+            )
         overrides[policy_case_id] = migration == "fresh_retest"
     acceptance = _mapping(qualification.get("acceptance"), "qualification acceptance")
     required_case_ids = set(_strings(acceptance.get("required_case_ids"), "qualification required case IDs"))
     nonblocking_case_ids = set(_strings(acceptance.get("nonblocking_case_ids"), "qualification nonblocking case IDs"))
+    blocking_case_ids = set(_strings(acceptance.get("blocking_case_ids"), "qualification blocking case IDs"))
     preregistered_case_ids = set(
         _strings(
             acceptance.get("preregistered_matrix_case_ids"),
             "qualification preregistered matrix case IDs",
         )
     )
-    expected_required = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) in {0, 1, 2, 3}}
-    expected_nonblocking = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) == 4}
-    if required_case_ids != expected_required:
+    legacy_required = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) in {0, 1, 2, 3}}
+    policy_required = {case_id for case_id in legacy_required if _release_blocking(policy_cases[case_id])}
+    legacy_nonblocking = {case_id for case_id in overrides if cast(int, policy_cases[case_id]["tier"]) == 4}
+    policy_nonblocking = set(overrides) - policy_required
+    milestone_case_ids = {
+        cast(str, case["policy_case_id"])
+        for case in (_mapping(item, "qualification matrix case") for item in qualification["matrix"])
+        if case.get("phase") == "milestone"
+    }
+    legacy_blocking = milestone_case_ids & legacy_required
+    policy_blocking = milestone_case_ids & policy_required
+    if frozenset(required_case_ids) not in {frozenset(legacy_required), frozenset(policy_required)}:
         raise QualificationScopeError(
-            "Qualification acceptance required_case_ids must use the mapped blocking policy case IDs."
+            "Qualification acceptance required_case_ids must use the mapped release-required policy case IDs."
         )
-    if nonblocking_case_ids != expected_nonblocking:
+    if frozenset(nonblocking_case_ids) not in {frozenset(legacy_nonblocking), frozenset(policy_nonblocking)}:
         raise QualificationScopeError(
-            "Qualification acceptance nonblocking_case_ids must use the mapped Tier 4 policy case IDs."
+            "Qualification acceptance nonblocking_case_ids must use the mapped nonblocking policy case IDs."
+        )
+    if frozenset(blocking_case_ids) not in {frozenset(legacy_blocking), frozenset(policy_blocking)}:
+        raise QualificationScopeError(
+            "Qualification acceptance blocking_case_ids must use the mapped milestone release blockers."
+        )
+    if required_case_ids == policy_required and unreasoned_nonblocking_retests:
+        raise QualificationScopeError(
+            "Nonblocking fresh_retest entries require bounded retest_reason values: "
+            f"{sorted(unreasoned_nonblocking_retests)!r}."
         )
     if preregistered_case_ids != matrix_case_ids:
         raise QualificationScopeError(
@@ -489,6 +582,169 @@ def _parse_accepted_at(value: object, case_id: str) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
+def _validate_live_publication_evidence(
+    reference_bytes: bytes,
+    case: Mapping[str, Any],
+    case_id: str,
+    source_sha: str,
+    reference_content: ReferenceContent,
+    accepted_at: datetime,
+    expected_status: str,
+) -> Mapping[str, str]:
+    try:
+        evidence_document = _mapping(
+            json.loads(reference_bytes),
+            f"live-publication evidence for {case_id!r}",
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationScopeError(f"Live-publication evidence for {case_id!r} must be structured JSON.") from error
+    evidence_candidate = _mapping(
+        evidence_document.get("candidate"),
+        f"live-publication evidence for {case_id!r} candidate",
+    )
+    release_tag = evidence_candidate.get("release_tag")
+    if not isinstance(release_tag, str) or not release_tag:
+        raise QualificationScopeError(f"Live-publication evidence for {case_id!r} candidate requires release_tag.")
+    release_receipt_reference = f"docs/release-evidence/{release_tag}/release-receipt.json"
+    try:
+        release_receipt_bytes = reference_content(release_receipt_reference)
+    except OSError as error:
+        raise QualificationScopeError(
+            f"Unable to read live-publication release receipt {release_receipt_reference!r}: {error}"
+        ) from error
+    release_receipt_digest = hashlib.sha256(release_receipt_bytes).hexdigest()
+    try:
+        release_receipt = _mapping(
+            json.loads(release_receipt_bytes),
+            f"live-publication evidence for {case_id!r} release receipt",
+        )
+        validate_receipt(release_receipt)
+    except (UnicodeDecodeError, json.JSONDecodeError, ReleaseReceiptError) as error:
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} release receipt is invalid: {error}"
+        ) from error
+    release = _mapping(release_receipt.get("release"), f"live-publication evidence for {case_id!r} release")
+    workflow = _mapping(
+        release_receipt.get("workflow"),
+        f"live-publication evidence for {case_id!r} workflow",
+    )
+    versions = _mapping(
+        release_receipt.get("versions"),
+        f"live-publication evidence for {case_id!r} versions",
+    )
+    artifacts = [
+        _mapping(item, f"live-publication evidence for {case_id!r} artifact")
+        for item in _sequence(
+            release_receipt.get("artifacts"),
+            f"live-publication evidence for {case_id!r} artifacts",
+        )
+    ]
+    appcasts = [item for item in artifacts if item.get("kind") == "appcast"]
+    if len(appcasts) != 1:
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} release receipt requires one appcast artifact."
+        )
+    expected_candidate = {
+        "release_tag": release["tag"],
+        "package_version": versions["package"],
+        "public_version": versions["public"],
+        "build": versions["build"],
+        "source_sha": release_receipt["source_sha"],
+        "release_run_id": workflow["run_id"],
+        "release_id": release["id"],
+        "appcast_sha256": appcasts[0]["sha256"],
+    }
+    if source_sha != release_receipt["source_sha"] or any(
+        evidence_candidate.get(field) != expected for field, expected in expected_candidate.items()
+    ):
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} does not match its checked release receipt."
+        )
+    allowed_live_case_ids = set(
+        _strings(
+            case.get("live_evidence_case_ids"),
+            f"live-publication evidence for {case_id!r} accepted case IDs",
+        )
+    )
+    evidence_cases = [
+        _mapping(item, f"live-publication evidence for {case_id!r} case")
+        for item in _sequence(
+            evidence_document.get("cases"),
+            f"live-publication evidence for {case_id!r} cases",
+        )
+    ]
+    if not any(
+        item.get("id") in allowed_live_case_ids and item.get("result") == expected_status for item in evidence_cases
+    ):
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} does not contain a matching {expected_status} case."
+        )
+    publication_reference = f"docs/release-evidence/{release_tag}/publication-record.json"
+    try:
+        publication_bytes = reference_content(publication_reference)
+    except OSError as error:
+        raise QualificationScopeError(
+            f"Unable to read live-publication record {publication_reference!r}: {error}"
+        ) from error
+    publication_digest = hashlib.sha256(publication_bytes).hexdigest()
+    try:
+        publication = _mapping(
+            json.loads(publication_bytes),
+            f"live-publication evidence for {case_id!r} publication record",
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} publication record is invalid."
+        ) from error
+    expected_publication = {
+        "schema_version": 1,
+        "release_tag": release["tag"],
+        "release_id": release["id"],
+        "source_sha": release_receipt["source_sha"],
+        "workflow_run_id": workflow["run_id"],
+        "receipt_file_sha256": release_receipt_digest,
+    }
+    if any(publication.get(field) != expected for field, expected in expected_publication.items()):
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} publication record does not match its release receipt."
+        )
+    if effective_successful_workflow_run_id(publication) is None:
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} does not contain a successful release or recovery run."
+        )
+    live_pages = _mapping(
+        publication.get("live_pages"),
+        f"live-publication evidence for {case_id!r} live_pages",
+    )
+    if (
+        live_pages.get("state") != "verified"
+        or live_pages.get("sha256") != appcasts[0]["sha256"]
+        or live_pages.get("url") != "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+    ):
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} does not match the verified live appcast."
+        )
+    published_at = publication.get("published_at")
+    qualified_at = evidence_document.get("qualified_at")
+    if not isinstance(published_at, str) or not isinstance(qualified_at, str):
+        raise QualificationScopeError(f"Live-publication evidence for {case_id!r} timestamps are invalid.")
+    try:
+        published = datetime.fromisoformat(published_at.replace("Z", "+00:00")).astimezone(timezone.utc)
+        qualified = datetime.fromisoformat(qualified_at.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError as error:
+        raise QualificationScopeError(f"Live-publication evidence for {case_id!r} timestamps are invalid.") from error
+    if qualified < published or accepted_at < published:
+        raise QualificationScopeError(
+            f"Live-publication evidence for {case_id!r} must be observed after publication and accepted afterward."
+        )
+    return {
+        "publication_record_reference": publication_reference,
+        "publication_record_sha256": publication_digest,
+        "release_receipt_reference": release_receipt_reference,
+        "release_receipt_sha256": release_receipt_digest,
+    }
+
+
 def _validated_receipts(
     evidence: Mapping[str, Any],
     cases_by_id: Mapping[str, Mapping[str, Any]],
@@ -503,7 +759,16 @@ def _validated_receipts(
         case_id = receipt.get("case_id")
         if not isinstance(case_id, str) or case_id not in cases_by_id:
             raise QualificationScopeError(f"Evidence receipt {index} references unknown case {case_id!r}.")
-        if receipt.get("status") != "accepted":
+        status = receipt.get("status")
+        if status not in {"accepted", *RECORDED_NONBLOCKING_STATUSES}:
+            raise QualificationScopeError(f"Evidence for {case_id!r} has unsupported status {status!r}.")
+        receipt_id = receipt.get("receipt_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires receipt_id.")
+        if receipt_id in receipt_ids:
+            raise QualificationScopeError(f"Duplicate release qualification receipt ID: {receipt_id}")
+        receipt_ids.add(receipt_id)
+        if status != "accepted":
             continue
         case = cases_by_id[case_id]
         evidence_source = _strings(
@@ -518,12 +783,6 @@ def _validated_receipts(
         source_sha = receipt.get("source_sha")
         if not isinstance(source_sha, str) or SHA_PATTERN.fullmatch(source_sha) is None:
             raise QualificationScopeError(f"Evidence for {case_id!r} requires a full lowercase source_sha.")
-        receipt_id = receipt.get("receipt_id")
-        if not isinstance(receipt_id, str) or not receipt_id:
-            raise QualificationScopeError(f"Evidence for {case_id!r} requires receipt_id.")
-        if receipt_id in receipt_ids:
-            raise QualificationScopeError(f"Duplicate release qualification receipt ID: {receipt_id}")
-        receipt_ids.add(receipt_id)
         accepted_at = _parse_accepted_at(receipt.get("accepted_at"), case_id)
         if accepted_at.date() > as_of:
             raise QualificationScopeError(f"Evidence for {case_id!r} cannot be accepted after {as_of.isoformat()}.")
@@ -556,170 +815,15 @@ def _validated_receipts(
             )
         validated_receipt = dict(receipt)
         if case.get("requires_live_publication") is True:
-            try:
-                evidence_document = _mapping(
-                    json.loads(reference_bytes),
-                    f"live-publication evidence for {case_id!r}",
-                )
-            except (UnicodeDecodeError, json.JSONDecodeError) as error:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} must be structured JSON."
-                ) from error
-            evidence_candidate = _mapping(
-                evidence_document.get("candidate"),
-                f"live-publication evidence for {case_id!r} candidate",
+            validated_receipt["_live_release_binding"] = _validate_live_publication_evidence(
+                reference_bytes,
+                case,
+                case_id,
+                source_sha,
+                reference_content,
+                accepted_at,
+                "passed",
             )
-            release_tag = evidence_candidate.get("release_tag")
-            if not isinstance(release_tag, str) or not release_tag:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} candidate requires release_tag."
-                )
-            release_receipt_reference = f"docs/release-evidence/{release_tag}/release-receipt.json"
-            try:
-                release_receipt_bytes = reference_content(release_receipt_reference)
-            except OSError as error:
-                raise QualificationScopeError(
-                    f"Unable to read live-publication release receipt {release_receipt_reference!r}: {error}"
-                ) from error
-            release_receipt_digest = hashlib.sha256(release_receipt_bytes).hexdigest()
-            try:
-                release_receipt = _mapping(
-                    json.loads(release_receipt_bytes),
-                    f"live-publication evidence for {case_id!r} release receipt",
-                )
-                validate_receipt(release_receipt)
-            except (UnicodeDecodeError, json.JSONDecodeError, ReleaseReceiptError) as error:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} release receipt is invalid: {error}"
-                ) from error
-            release = _mapping(release_receipt.get("release"), f"live-publication evidence for {case_id!r} release")
-            workflow = _mapping(
-                release_receipt.get("workflow"),
-                f"live-publication evidence for {case_id!r} workflow",
-            )
-            artifacts = [
-                _mapping(item, f"live-publication evidence for {case_id!r} artifact")
-                for item in _sequence(
-                    release_receipt.get("artifacts"),
-                    f"live-publication evidence for {case_id!r} artifacts",
-                )
-            ]
-            appcasts = [item for item in artifacts if item.get("kind") == "appcast"]
-            if len(appcasts) != 1:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} release receipt requires one appcast artifact."
-                )
-            expected_candidate = {
-                "release_tag": release["tag"],
-                "package_version": _mapping(
-                    release_receipt.get("versions"),
-                    f"live-publication evidence for {case_id!r} versions",
-                )["package"],
-                "public_version": _mapping(
-                    release_receipt.get("versions"),
-                    f"live-publication evidence for {case_id!r} versions",
-                )["public"],
-                "build": _mapping(
-                    release_receipt.get("versions"),
-                    f"live-publication evidence for {case_id!r} versions",
-                )["build"],
-                "source_sha": release_receipt["source_sha"],
-                "release_run_id": workflow["run_id"],
-                "release_id": release["id"],
-                "appcast_sha256": appcasts[0]["sha256"],
-            }
-            if source_sha != release_receipt["source_sha"] or any(
-                evidence_candidate.get(field) != expected for field, expected in expected_candidate.items()
-            ):
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} does not match its checked release receipt."
-                )
-            allowed_live_case_ids = set(
-                _strings(
-                    case.get("live_evidence_case_ids"),
-                    f"live-publication evidence for {case_id!r} accepted case IDs",
-                )
-            )
-            evidence_cases = [
-                _mapping(item, f"live-publication evidence for {case_id!r} case")
-                for item in _sequence(
-                    evidence_document.get("cases"),
-                    f"live-publication evidence for {case_id!r} cases",
-                )
-            ]
-            if not any(
-                item.get("id") in allowed_live_case_ids and item.get("result") == "passed" for item in evidence_cases
-            ):
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} does not contain a passed matching case."
-                )
-            publication_reference = f"docs/release-evidence/{release_tag}/publication-record.json"
-            try:
-                publication_bytes = reference_content(publication_reference)
-            except OSError as error:
-                raise QualificationScopeError(
-                    f"Unable to read live-publication record {publication_reference!r}: {error}"
-                ) from error
-            publication_digest = hashlib.sha256(publication_bytes).hexdigest()
-            try:
-                publication = _mapping(
-                    json.loads(publication_bytes),
-                    f"live-publication evidence for {case_id!r} publication record",
-                )
-            except (UnicodeDecodeError, json.JSONDecodeError) as error:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} publication record is invalid."
-                ) from error
-            expected_publication = {
-                "schema_version": 1,
-                "release_tag": release["tag"],
-                "release_id": release["id"],
-                "source_sha": release_receipt["source_sha"],
-                "workflow_run_id": workflow["run_id"],
-                "receipt_file_sha256": release_receipt_digest,
-            }
-            if any(publication.get(field) != expected for field, expected in expected_publication.items()):
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} publication record does not match its release receipt."
-                )
-            if effective_successful_workflow_run_id(publication) is None:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} does not contain a successful release or recovery run."
-                )
-            live_pages = _mapping(
-                publication.get("live_pages"),
-                f"live-publication evidence for {case_id!r} live_pages",
-            )
-            if (
-                live_pages.get("state") != "verified"
-                or live_pages.get("sha256") != appcasts[0]["sha256"]
-                or live_pages.get("url") != "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
-            ):
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} does not match the verified live appcast."
-                )
-            published_at = publication.get("published_at")
-            qualified_at = evidence_document.get("qualified_at")
-            if not isinstance(published_at, str) or not isinstance(qualified_at, str):
-                raise QualificationScopeError(f"Live-publication evidence for {case_id!r} timestamps are invalid.")
-            try:
-                published = datetime.fromisoformat(published_at.replace("Z", "+00:00")).astimezone(timezone.utc)
-                qualified = datetime.fromisoformat(qualified_at.replace("Z", "+00:00")).astimezone(timezone.utc)
-            except ValueError as error:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} timestamps are invalid."
-                ) from error
-            if qualified < published or accepted_at < published:
-                raise QualificationScopeError(
-                    f"Live-publication evidence for {case_id!r} must be observed after publication "
-                    "and accepted afterward."
-                )
-            validated_receipt["_live_release_binding"] = {
-                "publication_record_reference": publication_reference,
-                "publication_record_sha256": publication_digest,
-                "release_receipt_reference": release_receipt_reference,
-                "release_receipt_sha256": release_receipt_digest,
-            }
         if tier == 3:
             try:
                 tier3_receipt = load_validated_receipt_bytes(
@@ -760,6 +864,119 @@ def _validated_receipts(
             )
         )
     return receipts
+
+
+def _recorded_nonblocking_outcomes(
+    evidence: Mapping[str, Any],
+    cases_by_id: Mapping[str, Mapping[str, Any]],
+    policy_id: str,
+    candidate_sha: str,
+    reference_content: ReferenceContent,
+    as_of: date,
+) -> dict[str, Mapping[str, Any]]:
+    outcomes: dict[str, Mapping[str, Any]] = {}
+    outcome_times: dict[str, datetime] = {}
+    outcome_ids: set[str] = set()
+    for index, raw_receipt in enumerate(_sequence(evidence.get("receipts"), "release qualification receipts")):
+        receipt = _mapping(raw_receipt, f"release qualification receipt {index}")
+        status = receipt.get("status")
+        if status not in RECORDED_NONBLOCKING_STATUSES:
+            continue
+        case_id = receipt.get("case_id")
+        if not isinstance(case_id, str) or case_id not in cases_by_id:
+            raise QualificationScopeError(f"Evidence receipt {index} references unknown case {case_id!r}.")
+        case = cases_by_id[case_id]
+        if _release_blocking(case):
+            raise QualificationScopeError(
+                f"Failed or skipped evidence for blocking case {case_id!r} cannot replace accepted evidence."
+            )
+        evidence_source = _strings(case["allowed_evidence_sources"], f"case {case_id!r} evidence sources")[0]
+        if receipt.get("source") != evidence_source:
+            raise QualificationScopeError(
+                f"Evidence for {case_id!r} must use source {evidence_source!r}, not {receipt.get('source')!r}."
+            )
+        source_sha = receipt.get("source_sha")
+        if not isinstance(source_sha, str) or SHA_PATTERN.fullmatch(source_sha) is None:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a full lowercase source_sha.")
+        if source_sha != candidate_sha:
+            raise QualificationScopeError(
+                f"Recorded nonblocking evidence for {case_id!r} must match the exact candidate SHA."
+            )
+        receipt_id = receipt.get("receipt_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires receipt_id.")
+        if receipt_id in outcome_ids:
+            raise QualificationScopeError(f"Duplicate release qualification receipt ID: {receipt_id}")
+        outcome_ids.add(receipt_id)
+        recorded_at = _parse_accepted_at(receipt.get("accepted_at"), case_id)
+        if recorded_at.date() > as_of:
+            raise QualificationScopeError(f"Evidence for {case_id!r} cannot be recorded after {as_of.isoformat()}.")
+        reference = receipt.get("reference")
+        digest = receipt.get("sha256")
+        if (
+            not isinstance(reference, str)
+            or not reference
+            or Path(reference).is_absolute()
+            or ".." in Path(reference).parts
+        ):
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a repository-relative reference.")
+        if not isinstance(digest, str) or SHA256_PATTERN.fullmatch(digest) is None:
+            raise QualificationScopeError(f"Evidence for {case_id!r} requires a lowercase SHA-256 digest.")
+        reference_bytes = reference_content(reference)
+        if hashlib.sha256(reference_bytes).hexdigest() != digest:
+            raise QualificationScopeError(
+                f"Evidence reference {reference!r} does not match its recorded SHA-256 digest."
+            )
+        if case["tier"] == 3:
+            try:
+                validated_document = load_validated_receipt_bytes(
+                    reference_bytes,
+                    policy_id=policy_id,
+                    case=case,
+                    reference_content=reference_content,
+                )
+            except Tier3ReceiptError as error:
+                raise QualificationScopeError(
+                    f"Recorded Tier 3 evidence for {case_id!r} is invalid: {error}"
+                ) from error
+            result = _mapping(validated_document.get("result"), f"recorded evidence for {case_id!r} result")
+            release_identity = _mapping(
+                validated_document.get("release_identity"),
+                f"recorded evidence for {case_id!r} release identity",
+            )
+            if release_identity.get("source_sha") != candidate_sha:
+                raise QualificationScopeError(
+                    f"Recorded Tier 3 evidence for {case_id!r} is bound to a different release source."
+                )
+            document_status = result.get("status")
+        elif case.get("requires_live_publication") is True:
+            _validate_live_publication_evidence(
+                reference_bytes,
+                case,
+                case_id,
+                source_sha,
+                reference_content,
+                recorded_at,
+                cast(str, status),
+            )
+            document_status = status
+        else:
+            raise QualificationScopeError(
+                f"Qualification case {case_id!r} does not support recorded nonblocking outcomes."
+            )
+        if document_status != status:
+            raise QualificationScopeError(
+                f"Recorded evidence for {case_id!r} status does not match the referenced report."
+            )
+        if case_id not in outcome_times or recorded_at > outcome_times[case_id]:
+            outcome_times[case_id] = recorded_at
+            outcomes[case_id] = {
+                "receipt_id": receipt_id,
+                "reference": reference,
+                "source_sha": source_sha,
+                "status": status,
+            }
+    return outcomes
 
 
 def _case_patterns(case: Mapping[str, Any], contracts: Mapping[str, Any]) -> tuple[str, ...]:
@@ -923,6 +1140,7 @@ def _tier3_milestone_trigger(
 def _evidence_requirement(
     case: Mapping[str, Any],
     *,
+    due: bool,
     required: bool,
     applicable: bool,
     required_phase: str | None,
@@ -948,12 +1166,16 @@ def _evidence_requirement(
             else "before this phase can pass"
         )
         action = f"Provide accepted {source} evidence {timing}."
+    elif due:
+        action = f"Record {source} evidence when available; this operational evidence does not block release closeout."
     return {
         "source": source,
         "binding": binding,
+        "due": due,
+        "due_for_phase": due and applicable,
         "required": required,
         "required_for_phase": required and applicable,
-        "satisfied": not required,
+        "satisfied": not due,
         "action": action,
     }
 
@@ -994,6 +1216,14 @@ def classify_release_scope(
         evidence,
         cases_by_id,
         cast(str, policy["policy_id"]),
+        read_reference,
+        as_of,
+    )
+    recorded_outcomes = _recorded_nonblocking_outcomes(
+        evidence,
+        cases_by_id,
+        cast(str, policy["policy_id"]),
+        candidate_sha,
         read_reference,
         as_of,
     )
@@ -1103,6 +1333,7 @@ def classify_release_scope(
     for case in cases:
         case_id = cast(str, case["id"])
         tier = cast(int, case["tier"])
+        release_blocking = _release_blocking(case)
         accepted = receipt_map.get(case_id, [])
         exact = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] == candidate_sha), None)
         prior = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] != candidate_sha), None)
@@ -1250,12 +1481,24 @@ def classify_release_scope(
 
         blocking_phase = cast(str, case["blocking_phase"])
         required_phase = BLOCKING_PHASE_OWNERS[blocking_phase]
-        evidence_required = status == "retest" and (tier != 3 or tier3_applicable)
+        evidence_due = status == "retest" and (tier != 3 or tier3_applicable)
+        evidence_required = evidence_due and release_blocking
         phase_deferred = (
             required_phase is not None and WORKFLOW_PHASE_INDEX[workflow_phase] < WORKFLOW_PHASE_INDEX[required_phase]
         )
-        deferred = phase_deferred and evidence_required
+        deferred = phase_deferred and evidence_due
         applicable = blocking_phase != "none" and not phase_deferred and tier3_applicable
+        recorded_outcome = recorded_outcomes.get(case_id)
+        operational_status: str | None = None
+        if not release_blocking and blocking_phase != "none":
+            if status in {"covered", "carry"}:
+                operational_status = "passed"
+            elif recorded_outcome is not None:
+                operational_status = cast(str, recorded_outcome["status"])
+            elif trigger in {"missing_prior_evidence", "not_due"}:
+                operational_status = "missing"
+            else:
+                operational_status = "due"
         evidence_summary = (
             artifact_receipt_evidence
             if tier == 1 and case_id in artifact_tier1_cases and artifact_receipt_evidence is not None
@@ -1264,6 +1507,8 @@ def classify_release_scope(
                 signed_artifact_receipts[case_id][1],
             )
             if case_id in signed_artifact_receipts
+            else dict(recorded_outcome)
+            if recorded_outcome is not None and status == "retest"
             else _receipt_summary(selected_receipt)
         )
         result = {
@@ -1273,16 +1518,19 @@ def classify_release_scope(
             "blocking_phase": blocking_phase,
             "required_phase": required_phase,
             "requires_live_publication": case.get("requires_live_publication", False),
-            "blocking": blocking_phase != "none",
+            "blocking": release_blocking and blocking_phase != "none",
             "applicable": applicable,
             "deferred": deferred,
             "trigger": trigger,
             "reason": reason,
             "invalidating_paths": invalidating_paths,
             "evidence": evidence_summary,
+            "evidence_due": evidence_due,
             "evidence_required": evidence_required,
+            "operational_status": operational_status,
             "evidence_requirement": _evidence_requirement(
                 case,
+                due=evidence_due,
                 required=evidence_required,
                 applicable=applicable,
                 required_phase=required_phase,

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -35,6 +35,7 @@ from scripts.tier3_receipt import receipt_sha256 as tier3_receipt_sha256
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RC3_QUALIFICATION_PATH = REPO_ROOT / "docs" / "qualification" / "rc3-signed-qualification-v1.json"
+STABLE_QUALIFICATION_PATH = REPO_ROOT / "docs" / "qualification" / "stable-signed-qualification-v1.json"
 CANDIDATE_SHA = "b" * 40
 PRIOR_SHA = "a" * 40
 DMG_SHA256 = "c" * 64
@@ -278,6 +279,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         source_sha: str = PRIOR_SHA,
         completed_at: str = "2026-08-01T00:00:00Z",
         accepted_at: str = "2026-08-01T00:10:00Z",
+        result_status: str = "passed",
     ) -> dict[str, Any]:
         case = next(case for case in self.policy["cases"] if case["id"] == case_id)
         release_facts: dict[str, object] = {
@@ -344,8 +346,11 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             if hardware["required"]
             else {"class": "none", "identity": {}}
         )
+        assertion_status = (
+            "passed" if result_status == "passed" else "failed" if result_status == "failed" else "not_run"
+        )
         tier3_facts = {
-            "assertions": {assertion_id: "passed" for assertion_id in case["required_assertions"]},
+            "assertions": {assertion_id: assertion_status for assertion_id in case["required_assertions"]},
             "cleanup": {"status": case["allowed_cleanup_results"][0], "evidence_sha256": "1" * 64},
             "completed_at": completed_at,
             "environment": {
@@ -354,12 +359,19 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 "macos_version": "26.0",
                 "macos_build": "25A123",
             },
-            "evidence": [{"kind": case["allowed_evidence_kinds"][0], "sha256": "2" * 64}],
+            "evidence": (
+                [{"kind": case["allowed_evidence_kinds"][0], "sha256": "2" * 64}]
+                if result_status in {"passed", "failed"}
+                else []
+            ),
             "evidence_source": case["allowed_evidence_sources"][0],
             "hardware": hardware_receipt,
             "release_receipt_file_sha256": file_sha256(release_path),
             "release_receipt_reference": release_reference.as_posix(),
-            "result": {"status": "passed", "reason_code": "all_assertions_passed"},
+            "result": {
+                "status": result_status,
+                "reason_code": "all_assertions_passed" if result_status == "passed" else "operator-deferred",
+            },
             "started_at": completed_at,
         }
         tier3_receipt = build_tier3_receipt(
@@ -379,7 +391,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     "case_id": case_id,
                     "receipt_id": f"{case_id}-receipt-v1",
                     "source": case["allowed_evidence_sources"][0],
-                    "status": "accepted",
+                    "status": "accepted" if result_status == "passed" else result_status,
                     "source_sha": source_sha,
                     "accepted_at": accepted_at,
                     "reference": reference.as_posix(),
@@ -410,6 +422,50 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             "public-diagnostics-and-field-closure",
             qualification["acceptance"]["required_case_ids"],
         )
+
+    def test_stable_migration_separates_release_blockers_from_operational_evidence(self) -> None:
+        qualification_id, overrides = load_qualification_overrides(
+            STABLE_QUALIFICATION_PATH,
+            self.policy,
+        )
+        qualification = json.loads(STABLE_QUALIFICATION_PATH.read_text(encoding="utf-8"))
+        acceptance = qualification["acceptance"]
+        optional_cases = {
+            "native-sparkle-release-notes",
+            "usb-bluray-makemkv",
+            "protected-real-media-conversion",
+            "vision-pro-physical-playback",
+        }
+
+        self.assertEqual(qualification_id, "stable-signed-qualification-v1")
+        self.assertTrue(optional_cases.issubset(acceptance["nonblocking_case_ids"]))
+        self.assertTrue(optional_cases.isdisjoint(acceptance["required_case_ids"]))
+        self.assertTrue(optional_cases.isdisjoint(acceptance["blocking_case_ids"]))
+        self.assertEqual(
+            set(acceptance["blocking_case_ids"]),
+            {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},
+        )
+        self.assertTrue(overrides["sparkle-update-route"])
+        self.assertTrue(overrides["clean-machine-signed-update"])
+        self.assertTrue(overrides["installed-ui-accessibility"])
+        self.assertTrue(all(not overrides[case_id] for case_id in optional_cases))
+
+    def test_nonblocking_fresh_retest_requires_bounded_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            qualification = json.loads(STABLE_QUALIFICATION_PATH.read_text(encoding="utf-8"))
+            physical = next(case for case in qualification["matrix"] if case["policy_case_id"] == "usb-bluray-makemkv")
+            physical["migration"] = "fresh_retest"
+            path = Path(temporary_directory) / "qualification.json"
+            path.write_text(json.dumps(qualification), encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationScopeError, "fresh_retest entries require"):
+                load_qualification_overrides(path, self.policy)
+
+            physical["retest_reason"] = "device_family_changed"
+            path.write_text(json.dumps(qualification), encoding="utf-8")
+            _, overrides = load_qualification_overrides(path, self.policy)
+
+        self.assertTrue(overrides["usb-bluray-makemkv"])
 
     def test_contract_change_forces_retest(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -744,6 +800,156 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         self.assertFalse(real_media_result["applicable"])
         self.assertFalse(real_media_result["evidence_required"])
 
+    def test_stable_does_not_force_operator_hardware_retests(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            report = self.classify(
+                {"schema_version": 1, "receipts": []},
+                root,
+                release_stage="stable",
+                workflow_phase="milestone",
+                milestone_receipt_path=self.milestone_receipt(root),
+            )
+
+        for case_id in (
+            "usb-bluray-makemkv",
+            "protected-real-media-conversion",
+            "vision-pro-physical-playback",
+        ):
+            with self.subTest(case_id=case_id):
+                result = self.result_for(report, case_id)
+                self.assertEqual(result["trigger"], "not_due")
+                self.assertEqual(result["operational_status"], "missing")
+                self.assertFalse(result["blocking"])
+                self.assertFalse(result["applicable"])
+                self.assertFalse(result["evidence_due"])
+                self.assertFalse(result["evidence_required"])
+                self.assertNotIn(case_id, report["blocking_retests"])
+
+        automated = self.result_for(report, "clean-machine-signed-update")
+        self.assertEqual(automated["trigger"], "stable_candidate")
+        self.assertTrue(automated["blocking"])
+        self.assertTrue(automated["evidence_due"])
+        self.assertTrue(automated["evidence_required"])
+        self.assertIn("clean-machine-signed-update", report["blocking_retests"])
+
+    def test_explicit_operator_and_presentation_retests_are_visible_but_nonblocking(self) -> None:
+        optional_cases = {
+            "native-sparkle-release-notes": True,
+            "usb-bluray-makemkv": True,
+            "protected-real-media-conversion": True,
+            "vision-pro-physical-playback": True,
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            report = self.classify(
+                {"schema_version": 1, "receipts": []},
+                root,
+                fresh=optional_cases,
+                release_stage="stable",
+                workflow_phase="milestone",
+                milestone_receipt_path=self.milestone_receipt(root),
+            )
+
+        for case_id in optional_cases:
+            with self.subTest(case_id=case_id):
+                result = self.result_for(report, case_id)
+                self.assertEqual(result["status"], "retest")
+                self.assertEqual(result["operational_status"], "due")
+                self.assertFalse(result["blocking"])
+                self.assertTrue(result["applicable"])
+                self.assertTrue(result["evidence_due"])
+                self.assertFalse(result["evidence_required"])
+                self.assertTrue(result["evidence_requirement"]["due_for_phase"])
+                self.assertFalse(result["evidence_requirement"]["required_for_phase"])
+                self.assertNotIn(case_id, report["blocking_retests"])
+
+    def test_failed_and_skipped_nonblocking_operator_receipts_remain_visible(self) -> None:
+        for outcome in ("failed", "skipped"):
+            with self.subTest(outcome=outcome), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                evidence = self.tier3_evidence(
+                    root,
+                    "usb-bluray-makemkv",
+                    source_sha=CANDIDATE_SHA,
+                    result_status=outcome,
+                )
+                report = self.classify(
+                    evidence,
+                    root,
+                    fresh={"usb-bluray-makemkv": True},
+                    release_stage="stable",
+                    workflow_phase="milestone",
+                    milestone_receipt_path=self.milestone_receipt(root),
+                )
+
+            result = self.result_for(report, "usb-bluray-makemkv")
+            self.assertEqual(result["operational_status"], outcome)
+            self.assertEqual(result["evidence"]["receipt_id"], "usb-bluray-makemkv-receipt-v1")
+            self.assertFalse(result["blocking"])
+            self.assertNotIn("usb-bluray-makemkv", report["blocking_retests"])
+
+    def test_recorded_nonblocking_outcome_requires_exact_candidate_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.tier3_evidence(
+                root,
+                "usb-bluray-makemkv",
+                source_sha=PRIOR_SHA,
+                result_status="failed",
+            )
+
+            with self.assertRaisesRegex(QualificationScopeError, "exact candidate SHA"):
+                self.classify(
+                    evidence,
+                    root,
+                    fresh={"usb-bluray-makemkv": True},
+                    release_stage="stable",
+                    workflow_phase="milestone",
+                    milestone_receipt_path=self.milestone_receipt(root),
+                )
+
+    def test_failed_native_presentation_is_exact_source_visible_and_nonblocking(self) -> None:
+        candidate_sha = "0b06582a83a45bb38d851e62ccf38cd148c7bb95"
+        reference = "docs/qualification/rc3-targeted-qualification-v1.json"
+        document = json.loads((REPO_ROOT / reference).read_text(encoding="utf-8"))
+        case = next(item for item in document["cases"] if item["id"] == "native-sparkle-notes-rc3")
+        case["result"] = "failed"
+        reference_bytes = (json.dumps(document, indent=2) + "\n").encode()
+        evidence = {
+            "schema_version": 1,
+            "receipts": [
+                {
+                    "case_id": "native-sparkle-release-notes",
+                    "receipt_id": "native-sparkle-release-notes-failed-v1",
+                    "source": "signed_artifact_receipt",
+                    "status": "failed",
+                    "source_sha": candidate_sha,
+                    "accepted_at": "2026-08-05T10:30:00Z",
+                    "reference": reference,
+                    "sha256": hashlib.sha256(reference_bytes).hexdigest(),
+                }
+            ],
+        }
+        report = classify_release_scope(
+            self.policy,
+            evidence,
+            candidate_sha=candidate_sha,
+            changed_paths=lambda _base, _candidate: set(),
+            repo=REPO_ROOT,
+            reference_content=lambda path: reference_bytes if path == reference else (REPO_ROOT / path).read_bytes(),
+            fresh_retest={"native-sparkle-release-notes": True},
+            release_stage="rc",
+            workflow_phase="milestone",
+            milestone_receipt_path=REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
+            as_of=date(2026, 8, 8),
+        )
+
+        result = self.result_for(report, "native-sparkle-release-notes")
+        self.assertEqual(result["operational_status"], "failed")
+        self.assertFalse(result["blocking"])
+        self.assertNotIn("native-sparkle-release-notes", report["blocking_retests"])
+
     def test_periodic_evidence_expires_outside_milestone(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -877,10 +1083,22 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                 with self.assertRaises(QualificationScopeError):
                     load_policy(policy_path)
 
+    def test_policy_rejects_nonblocking_automated_tier3_case(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = json.loads(json.dumps(self.policy))
+            case = next(case for case in policy["cases"] if case["id"] == "clean-machine-signed-update")
+            case["release_blocking"] = False
+            policy_path = Path(temporary_directory) / "policy.json"
+            policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationScopeError, "not approved as nonblocking"):
+                load_policy(policy_path)
+
     def test_milestone_owned_tier2_requires_live_publication_declaration(self) -> None:
         mutations = (
             ("sparkle-update-route", "requires_live_publication", False),
             ("sparkle-update-route", "live_evidence_case_ids", ["updater-route-rc2-to-rc3"]),
+            ("native-sparkle-release-notes", "evidence_role", "automated"),
         )
         for case_id, field, value in mutations:
             with self.subTest(case_id=case_id, field=field), tempfile.TemporaryDirectory() as temporary_directory:
@@ -892,6 +1110,29 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
 
                 with self.assertRaises(QualificationScopeError):
                     load_policy(policy_path)
+
+    def test_policy_rejects_nonblocking_tier1_case(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = json.loads(json.dumps(self.policy))
+            case = next(case for case in policy["cases"] if case["id"] == "release-workflow-identity")
+            case["release_blocking"] = False
+            policy_path = Path(temporary_directory) / "policy.json"
+            policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationScopeError, "must remain release blocking"):
+                load_policy(policy_path)
+
+    def test_policy_rejects_demoting_unapproved_live_automation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = json.loads(json.dumps(self.policy))
+            case = next(case for case in policy["cases"] if case["id"] == "sparkle-update-route")
+            case["release_blocking"] = False
+            case["evidence_role"] = "operator_presentation"
+            policy_path = Path(temporary_directory) / "policy.json"
+            policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationScopeError, "not approved as nonblocking"):
+                load_policy(policy_path)
 
     def test_artifact_owned_tier2_requires_explicit_publication_contract(self) -> None:
         mutations = (

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -231,7 +231,6 @@ class ReleaseMetadataTests(unittest.TestCase):
             {
                 "release-workflow-identity",
                 "sparkle-update-route",
-                "native-sparkle-release-notes",
                 "profile-save-action-accessibility",
                 "signed-packaged-route-parity",
                 "gui-preview-low-local-ample-destination",
@@ -245,15 +244,22 @@ class ReleaseMetadataTests(unittest.TestCase):
                 "subtitle-partial-output-diagnostics",
                 "clean-machine-signed-update",
                 "installed-ui-accessibility",
-                "usb-bluray-makemkv",
-                "protected-real-media-conversion",
-                "vision-pro-physical-playback",
             },
         )
         self.assertEqual(set(qualification["acceptance"]["preregistered_matrix_case_ids"]), expected_case_ids)
         self.assertEqual(
-            qualification["acceptance"]["nonblocking_case_ids"],
-            ["public-diagnostics-and-field-closure"],
+            set(qualification["acceptance"]["nonblocking_case_ids"]),
+            {
+                "native-sparkle-release-notes",
+                "usb-bluray-makemkv",
+                "protected-real-media-conversion",
+                "vision-pro-physical-playback",
+                "public-diagnostics-and-field-closure",
+            },
+        )
+        self.assertEqual(
+            set(qualification["acceptance"]["blocking_case_ids"]),
+            {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},
         )
         self.assertEqual(qualification["qualification_policy"]["id"], "release-qualification-policy-v1")
         self.assertEqual(
@@ -289,15 +295,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(qualification["status"], "preregistered_pending_exact_candidate")
         self.assertEqual(
             set(qualification["acceptance"]["blocking_case_ids"]),
-            {
-                "sparkle-update-route",
-                "native-sparkle-release-notes",
-                "clean-machine-signed-update",
-                "installed-ui-accessibility",
-                "usb-bluray-makemkv",
-                "protected-real-media-conversion",
-                "vision-pro-physical-playback",
-            },
+            {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},
         )
         self.assertFalse(qualification["acceptance"]["milestone_complete"])
         self.assertTrue(

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1020,6 +1020,8 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("Preserve an existing idempotent evidence branch", str(prepare))
         self.assertIn("automation/release-evidence-", str(create_pr))
         self.assertIn("remains intentionally unmergeable", str(create_pr))
+        self.assertIn("blocking live-artifact and automated Tier 3 receipt", str(create_pr))
+        self.assertIn("Optional physical-hardware and native-window presentation", str(create_pr))
         self.assertIn("peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", str(create_pr))
 
     def test_milestone_qualification_is_hosted_secret_free_and_read_only(self) -> None:
@@ -1056,6 +1058,9 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("scripts.tier3_clean_machine preflight", workflow_text)
         self.assertIn("scripts.tier3_clean_machine run", workflow_text)
         self.assertIn("scripts.tier3_receipt", workflow_text)
+        self.assertIn("Blocking automated milestone qualification", workflow_text)
+        self.assertIn("Blocking clean-machine receipt", workflow_text)
+        self.assertIn("Blocking installed UI receipt", workflow_text)
         self.assertIn("expected_prerelease=$(jq -r .release.prerelease", workflow_text)
         self.assertNotIn("jq -er .release.prerelease", workflow_text)
         self.assertNotIn("jq -er .draft", workflow_text)
@@ -1078,10 +1083,11 @@ printf '%s' "$CODESIGN_METADATA"
         context = by_name["Resolve post-publication milestone context"]
         classify = by_name["Classify post-publication milestone evidence"]
         upload = by_name["Upload post-publication milestone report"]
+        summarize = by_name["Summarize post-publication operational evidence"]
         enforce = by_name["Enforce post-publication milestone evidence"]
 
         self.assertEqual(context["if"], "github.event_name == 'pull_request'")
-        for step in (classify, upload, enforce):
+        for step in (classify, upload, summarize, enforce):
             self.assertIn("steps.milestone-context.outputs.required == 'true'", step["if"])
         self.assertIn("scripts.release_milestone_context", context["run"])
         self.assertIn("github.event.pull_request.base.sha", context["run"])
@@ -1096,7 +1102,10 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertTrue(classify["continue-on-error"])
         self.assertEqual(upload["with"]["if-no-files-found"], "error")
         self.assertIn("release-qualification-milestone-${{ github.run_attempt }}", upload["with"]["name"])
+        self.assertIn("operational_status", summarize["run"])
+        self.assertIn("release blocking", summarize["run"])
         self.assertIn("steps.milestone-qualification.outcome", str(enforce))
+        self.assertIn("Blocking post-publication qualification", enforce["run"])
 
     def test_release_notes_are_frozen_embedded_and_reverified(self) -> None:
         workflow = load_release_engine()


### PR DESCRIPTION
Closes #516
Closes #518
Refs #515

## Summary
- keeps every automated exact-artifact, publication, live appcast, updater, accessibility, and immutable-receipt gate blocking and fail-closed
- makes physical USB/MakeMKV, protected-media, and Vision Pro evidence risk-triggered and nonblocking
- makes native Sparkle desktop presentation capture visible but nonblocking while preserving automated release-note identity/content/link/accessibility checks
- reports optional evidence as passed, failed, skipped, missing, or due with exact-source validation
- leaves follow-up controller issue #517 untouched

## Immutable boundary
No `v0.3.0` release asset, release receipt, publication record, or existing automated qualification receipt is modified.

## Validation
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python -m unittest discover -s tests -t .` (1608 passed, 3 skipped)
- `uv run ruff format --check scripts/qualify_release_scope.py tests/test_qualify_release_scope.py tests/test_release.py tests/test_sparkle_workflows.py`
- `uv run ruff check scripts/qualify_release_scope.py tests/test_qualify_release_scope.py tests/test_release.py tests/test_sparkle_workflows.py`
- `uv run mypy bd_to_avp`
- `uv build`
- `actionlint .github/workflows/ci.yml .github/workflows/milestone-qualification.yml .github/workflows/release-evidence.yml`

JetBrains inspection was attempted but returned `UNKNOWN` with `execution_not_proven` from the local inspection helper; no actionable findings were returned and the helper directed no retry.