### PR TITLE
Fix audio-less and missing-layout MKV handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ bd-to-avp --source <source> [--source-folder <source-folder>] [options]
 - `--output-root-folder`: Output folder path. Defaults to the current directory.
 - `--audio-mode`: Audio handling mode: `automatic`, `convert_aac`, or `pcm` (default: `automatic`). Automatic copies
   qualified AAC audio to an owned M4A, and converts the whole selected set to AAC if any selected stream is unqualified.
+  Sources without audio produce a video-only movie; the app does not synthesize a silent track.
 - `--transcode-audio`: Legacy alias for `--audio-mode convert_aac`.
 - `--audio-bitrate`: Audio bitrate for AAC conversion in kb/s do not include unit (default: "384").
 - `--audio-preferred-language`: Keep every audio track matching this language metadata. Accepts ISO 639 alpha-2,

--- a/bd_to_avp/modules/audio.py
+++ b/bd_to_avp/modules/audio.py
@@ -59,6 +59,11 @@ EXPLICITLY_UNQUALIFIED_CODECS = frozenset({"ac3", "eac3", "ac-3", "e-ac-3"})
 AAC_COPY_PROFILES = frozenset({"lc", "he-aac", "he-aacv2", "mpeg-4 aac lc", "aac lc"})
 AAC_COPY_SAMPLE_RATES = frozenset({44_100, 48_000})
 AAC_COPY_LAYOUT_CHANNELS = _AAC_COPY_LAYOUT_CHANNELS
+INFERRED_TRANSCODE_LAYOUTS = {1: "mono", 2: "stereo"}
+
+
+class NoAudioStreamsError(RuntimeError):
+    pass
 
 
 def transcode_audio(
@@ -85,6 +90,8 @@ def transcode_audio(
             observability_context=observability_context,
         )
     )
+    if not selected_streams:
+        raise NoAudioStreamsError("The source does not contain an audio stream.")
     layout_plan = plan_aac_layouts(selected_streams)
     enforce_aac_layout_policy(layout_plan, activity)
     selected_inputs = (
@@ -153,11 +160,17 @@ def plan_aac_layouts(streams: list[dict[str, Any]]) -> list[PlannedAudioLayout]:
     for output_index, stream in enumerate(streams):
         stream_index = parse_optional_int(stream.get("index"))
         codec_name = str(stream.get("codec_name") or "unknown").strip().lower() or "unknown"
+        decision = resolve_aac_layout_policy(stream.get("channel_layout"), stream.get("channels"))
+        if decision.reason == "channel_layout_missing":
+            channel_count = parse_optional_int(stream.get("channels"))
+            inferred_layout = INFERRED_TRANSCODE_LAYOUTS.get(channel_count) if channel_count is not None else None
+            if inferred_layout is not None:
+                decision = resolve_aac_layout_policy(inferred_layout, channel_count)
         plans.append(
             PlannedAudioLayout(
                 stream_index=stream_index if stream_index is not None else output_index,
                 codec_name=codec_name,
-                decision=resolve_aac_layout_policy(stream.get("channel_layout"), stream.get("channels")),
+                decision=decision,
             )
         )
     return plans
@@ -356,7 +369,10 @@ def create_prepared_audio_file(
                     cancellation_event=cancellation_event,
                     observability_context=observability_context,
                 )
-                if qualifications and all(qualification.qualified for qualification in qualifications):
+                if not qualifications:
+                    emit_no_audio_warning(activity)
+                    return original_audio_path
+                if all(qualification.qualified for qualification in qualifications):
                     copy_audio(
                         original_audio_path,
                         temporary_audio_path,
@@ -378,16 +394,20 @@ def create_prepared_audio_file(
                         observability_context=observability_context,
                     )
             else:
-                transcode_audio(
-                    original_audio_path,
-                    temporary_audio_path,
-                    config.audio_bitrate,
-                    selection=selection,
-                    activity=activity,
-                    run_context=run_context,
-                    cancellation_event=cancellation_event,
-                    observability_context=observability_context,
-                )
+                try:
+                    transcode_audio(
+                        original_audio_path,
+                        temporary_audio_path,
+                        config.audio_bitrate,
+                        selection=selection,
+                        activity=activity,
+                        run_context=run_context,
+                        cancellation_event=cancellation_event,
+                        observability_context=observability_context,
+                    )
+                except NoAudioStreamsError:
+                    emit_no_audio_warning(activity)
+                    return original_audio_path
             temporary_audio_path.replace(prepared_audio_path)
             persist_audio_selection(prepared_audio_path, selection)
         finally:
@@ -409,6 +429,14 @@ def create_prepared_audio_file(
             "Legacy AAC audio artifact found. Restart from Prepare Audio to regenerate a compatible M4A file: "
             f"{legacy_transcoded_audio_path}"
         )
+    if not get_audio_stream_data(
+        original_audio_path,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        observability_context=observability_context,
+    ):
+        emit_no_audio_warning(activity)
+        return original_audio_path
     raise FileNotFoundError(f"Prepared audio artifact not found: {prepared_audio_path}")
 
 
@@ -512,15 +540,15 @@ def preferred_audio_selection(
     preferred_language = config.audio_preferred_language
     if preferred_language is None:
         return None
-    selection = select_audio_streams(
-        get_audio_stream_data(
-            input_path,
-            run_context=run_context,
-            cancellation_event=cancellation_event,
-            observability_context=observability_context,
-        ),
-        preferred_language,
+    audio_streams = get_audio_stream_data(
+        input_path,
+        run_context=run_context,
+        cancellation_event=cancellation_event,
+        observability_context=observability_context,
     )
+    if not audio_streams:
+        return None
+    selection = select_audio_streams(audio_streams, preferred_language)
     emit_audio_selection_warning(selection, activity, stage=stage)
     return selection
 
@@ -701,4 +729,19 @@ def emit_automatic_fallback_warning(
             }
             for qualification in unqualified
         ],
+    )
+
+
+def emit_no_audio_warning(activity: AudioActivityReporter | None) -> None:
+    message = "The source does not contain audio; the output will remain video-only."
+    if activity is None:
+        cli_message(message)
+        return
+
+    activity.warning(
+        message,
+        stage="transcode_audio",
+        code="audio_not_present",
+        audio_mode=config.audio_mode.value,
+        action="omit_audio",
     )

--- a/bd_to_avp/modules/container.py
+++ b/bd_to_avp/modules/container.py
@@ -65,6 +65,7 @@ def extract_mvc_and_audio(
     run_context: RunContext | None = None,
     cancellation_event: threading.Event | None = None,
     observability_context: ObservabilityContext | None = None,
+    source_audio_streams: list[dict[str, Any]] | None = None,
 ) -> None:
     stream = ffmpeg.input(str(input_path))
     audio_selection = None
@@ -76,17 +77,23 @@ def extract_mvc_and_audio(
         )
 
     if audio_output_path:
-        if config.audio_preferred_language is not None:
-            audio_selection = select_audio_streams(
-                get_audio_stream_data(
-                    input_path,
-                    run_context=run_context,
-                    cancellation_event=cancellation_event,
-                    observability_context=observability_context,
-                ),
-                config.audio_preferred_language,
+        audio_streams = (
+            source_audio_streams
+            if source_audio_streams is not None
+            else get_audio_stream_data(
+                input_path,
+                run_context=run_context,
+                cancellation_event=cancellation_event,
+                observability_context=observability_context,
             )
+        )
+        if not audio_streams:
+            audio_output_path = None
+        elif config.audio_preferred_language is not None:
+            audio_selection = select_audio_streams(audio_streams, config.audio_preferred_language)
             emit_audio_selection_warning(audio_selection, activity, stage="extract_mvc_and_audio")
+
+    if audio_output_path:
         audio_inputs = (
             [stream[selected_stream.selector] for selected_stream in audio_selection.streams]
             if audio_selection is not None
@@ -171,20 +178,30 @@ def create_mvc_and_audio(
     audio_output_path = output_folder / f"{disc_name}_audio_PCM.mov"
     m4a_audio_preparation = is_audio_m4a_preparation_enabled()
     direct_mvc_stream = is_direct_mvc_stream_enabled()
+    source_audio_streams = None
+    if not m4a_audio_preparation:
+        source_audio_streams = get_audio_stream_data(
+            mkv_output_path,
+            run_context=run_context,
+            cancellation_event=cancellation_event,
+            observability_context=observability_context,
+        )
+    audio_source_path = mkv_output_path if m4a_audio_preparation or not source_audio_streams else audio_output_path
 
     if config.start_stage.value <= Stage.EXTRACT_MVC_AND_AUDIO.value:
         extract_mvc_and_audio(
             mkv_output_path,
             None if direct_mvc_stream else video_output_path,
-            None if m4a_audio_preparation else audio_output_path,
+            audio_output_path if audio_source_path == audio_output_path else None,
             activity=activity,
             run_context=run_context,
             cancellation_event=cancellation_event,
             observability_context=observability_context,
+            source_audio_streams=source_audio_streams,
         )
 
     return (
-        mkv_output_path if m4a_audio_preparation else audio_output_path,
+        audio_source_path,
         mkv_output_path if direct_mvc_stream else video_output_path,
     )
 
@@ -206,7 +223,7 @@ def mux_video_audio_subs(
         cancellation_event=cancellation_event,
         observability_context=observability_context,
     )
-    if config.audio_preferred_language is not None:
+    if audio_streams and config.audio_preferred_language is not None:
         selection = select_audio_streams(audio_streams, config.audio_preferred_language)
         audio_streams = [selected_stream.stream for selected_stream in selection.streams]
         if _audio_selection_not_prepared_in_current_run():

--- a/docs/apple-aac-layout-policy.md
+++ b/docs/apple-aac-layout-policy.md
@@ -4,6 +4,8 @@
 
 Use an explicit **preserve / remap / downmix / fail** policy. FFmpeg decode success and audio-track count are not sufficient evidence of Apple compatibility. Every supported output must use a canonical AAC channel configuration, survive both Apple passthrough and Apple LPCM decode, and preserve the expected per-channel identity map.
 
+When transcoding, a missing layout is inferred only for unambiguous one-channel (`mono`) and two-channel (`stereo`) streams. Missing multichannel layouts remain fail-closed. Sources with no audio streams remain video-only rather than receiving fabricated audio.
+
 The production runtime imports this same policy for Automatic and Convert-to-AAC processing. Signed-package and physical Vision Pro validation remains in #382.
 
 ## Evidence Method

--- a/scripts/qualify_apple_aac_layouts.py
+++ b/scripts/qualify_apple_aac_layouts.py
@@ -729,6 +729,12 @@ def render_policy_markdown(report: Mapping[str, object]) -> str:
                 ),
                 "",
                 (
+                    "When transcoding, a missing layout is inferred only for unambiguous one-channel (`mono`) and "
+                    "two-channel (`stereo`) streams. Missing multichannel layouts remain fail-closed. Sources with "
+                    "no audio streams remain video-only rather than receiving fabricated audio."
+                ),
+                "",
+                (
                     "The production runtime imports this same policy for Automatic and Convert-to-AAC processing. "
                     "Signed-package and physical Vision Pro validation remains in #382."
                 ),

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -19,6 +19,55 @@ from bd_to_avp.modules.config import Stage, config
 
 
 class AudioPreparationTests(unittest.TestCase):
+    def test_automatic_no_audio_keeps_source_for_video_only_mux(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            activity = Mock()
+
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
+                patch.object(audio.config, "audio_preferred_language", "eng"),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio, "get_audio_stream_data", return_value=[]),
+                patch.object(audio, "qualify_selected_audio_streams", return_value=[]),
+                patch.object(audio, "copy_audio") as copy,
+                patch.object(audio, "transcode_audio") as transcode,
+            ):
+                result = audio.create_prepared_audio_file(source_path, output_folder, activity)
+
+            self.assertEqual(result, source_path)
+            self.assertFalse((output_folder / "Movie_audio_AAC.m4a").exists())
+            copy.assert_not_called()
+            transcode.assert_not_called()
+            self.assertEqual(activity.warning.call_args.kwargs["code"], "audio_not_present")
+            self.assertEqual(activity.warning.call_args.kwargs["action"], "omit_audio")
+
+    def test_convert_aac_no_audio_keeps_source_for_video_only_mux(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            activity = Mock()
+
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.CONVERT_AAC),
+                patch.object(audio.config, "audio_preferred_language", "eng"),
+                patch.object(audio.config, "start_stage", Stage.CREATE_MKV),
+                patch.object(audio, "get_audio_stream_data", return_value=[]),
+                patch.object(audio, "audio_streams_for_selector", return_value=[]),
+            ):
+                result = audio.create_prepared_audio_file(source_path, output_folder, activity)
+
+            self.assertEqual(result, source_path)
+            self.assertFalse((output_folder / "Movie_audio_AAC.m4a").exists())
+            self.assertEqual(activity.warning.call_args.kwargs["code"], "audio_not_present")
+
     def test_automatic_qualifies_only_retained_preferred_language_tracks(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -367,9 +416,29 @@ class AudioPreparationTests(unittest.TestCase):
             with (
                 patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
                 patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(audio, "get_audio_stream_data", return_value=[qualified_stream(index=0)]),
                 self.assertRaisesRegex(FileNotFoundError, "Prepared audio artifact not found"),
             ):
                 audio.create_prepared_audio_file(source_path, output_folder)
+
+    def test_final_mux_resume_keeps_no_audio_source_video_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "source.mkv"
+            output_folder = temp_path / "Movie"
+            source_path.write_bytes(b"source")
+            output_folder.mkdir()
+            activity = Mock()
+
+            with (
+                patch.object(audio.config, "audio_mode", AudioMode.AUTOMATIC),
+                patch.object(audio.config, "start_stage", Stage.CREATE_FINAL_FILE),
+                patch.object(audio, "get_audio_stream_data", return_value=[]),
+            ):
+                result = audio.create_prepared_audio_file(source_path, output_folder, activity)
+
+            self.assertEqual(result, source_path)
+            self.assertEqual(activity.warning.call_args.kwargs["code"], "audio_not_present")
 
     def test_final_mux_resume_rejects_legacy_aac_mov_with_recovery_guidance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -490,6 +559,26 @@ class AudioPreparationTests(unittest.TestCase):
         self.assertIn("0:a:0", command)
         self.assertIn("file:audio.m4a", command)
         self.assertIn("-map_metadata", command)
+
+    def test_transcode_audio_infers_stereo_for_missing_two_channel_layout(self) -> None:
+        streams = [qualified_stream(index=1, codec_name="pcm_s16le", channel_layout=None)]
+        with (
+            patch.object(audio, "audio_streams_for_selector", return_value=streams),
+            patch.object(audio, "audio_handler_metadata_options", return_value={}),
+            patch.object(audio, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio.transcode_audio(Path("source.mkv"), Path("audio.m4a"), 384)
+
+        command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
+        self.assertEqual(command[command.index("-channel_layout:a:0") + 1], "stereo")
+
+    def test_transcode_audio_keeps_missing_multichannel_layout_fail_closed(self) -> None:
+        layout_plan = audio.plan_aac_layouts(
+            [qualified_stream(index=1, codec_name="pcm_s16le", channels=6, channel_layout=None)]
+        )
+
+        self.assertEqual(layout_plan[0].decision.action, AacLayoutAction.FAIL)
+        self.assertEqual(layout_plan[0].decision.reason, "channel_layout_missing")
 
     def test_copy_audio_maps_all_audio_tracks_without_encoder(self) -> None:
         with (
@@ -791,7 +880,7 @@ def qualified_stream(
     profile: str = "LC",
     sample_rate: str = "48000",
     channels: int = 2,
-    channel_layout: str = "stereo",
+    channel_layout: str | None = "stereo",
     language: str = "eng",
     title: str | None = None,
     is_default: bool = False,

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -20,7 +20,7 @@ class AudioExtractionTests(unittest.TestCase):
     def test_subtitle_filter_does_not_limit_extracted_audio_tracks(self) -> None:
         with (
             patch.object(container.config, "remove_extra_languages", True),
-            patch.object(container, "get_audio_stream_data", return_value=[]),
+            patch.object(container, "get_audio_stream_data", return_value=[audio_stream(0, "eng")]),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
             container.extract_mvc_and_audio(Path("source.mkv"), None, Path("audio.mov"))
@@ -28,6 +28,15 @@ class AudioExtractionTests(unittest.TestCase):
         command = ffmpeg.compile(run_ffmpeg.call_args.args[0])
         self.assertIn("0:a", command)
         self.assertNotIn("0:a:0", command)
+
+    def test_pcm_extraction_skips_audio_output_when_mkv_has_no_audio(self) -> None:
+        with (
+            patch.object(container, "get_audio_stream_data", return_value=[]),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            container.extract_mvc_and_audio(Path("source.mkv"), None, Path("audio.mov"))
+
+        run_ffmpeg.assert_not_called()
 
     def test_pcm_extraction_preserves_audio_titles_as_handler_names(self) -> None:
         with (
@@ -112,6 +121,7 @@ class AudioExtractionTests(unittest.TestCase):
             patch.object(container.config, "audio_mode", AudioMode.PCM),
             patch.object(container.config, "keep_files", False),
             patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "get_audio_stream_data", return_value=[audio_stream(0, "eng")]),
             patch.object(container, "audio_handler_metadata_options", return_value={}),
             patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
         ):
@@ -123,8 +133,45 @@ class AudioExtractionTests(unittest.TestCase):
         self.assertIn("pcm_s24le", command)
         self.assertNotIn("file:output/Movie_mvc.h264", command)
 
+    def test_pcm_mode_uses_source_as_video_only_mux_probe_when_mkv_has_no_audio(self) -> None:
+        with (
+            patch.object(container.config, "audio_mode", AudioMode.PCM),
+            patch.object(container.config, "keep_files", False),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "get_audio_stream_data", return_value=[]),
+            patch.object(container, "run_ffmpeg_print_errors") as run_ffmpeg,
+        ):
+            audio_path, video_path = container.create_mvc_and_audio("Movie", Path("source.mkv"), Path("output"))
+
+        self.assertEqual(audio_path, Path("source.mkv"))
+        self.assertEqual(video_path, Path("source.mkv"))
+        run_ffmpeg.assert_not_called()
+
 
 class MuxCommandTests(unittest.TestCase):
+    def test_final_mux_keeps_no_audio_mkv_video_only(self) -> None:
+        with (
+            patch.object(container.config, "MP4BOX_PATH", Path("/tools/MP4Box")),
+            patch.object(container.config, "audio_preferred_language", "eng"),
+            patch.object(container.config, "start_stage", Stage.CREATE_MKV),
+            patch.object(container, "get_audio_stream_data", return_value=[]),
+            patch.object(container, "sorted_files_by_creation_filtered_on_suffix", return_value=[]),
+            patch.object(container, "run_process_capture") as run_command,
+        ):
+            container.mux_video_audio_subs(
+                Path("movie_MV-HEVC.mov"),
+                Path("source.mkv"),
+                Path("movie_AVP.mov"),
+                Path("."),
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(
+            command[:5],
+            [Path("/tools/MP4Box"), "-new", "-add", "movie_MV-HEVC.mov:forcesync", Path("movie_AVP.mov")],
+        )
+        self.assertFalse(any("source.mkv#" in str(argument) for argument in command))
+
     def test_final_mux_uses_reindexed_prepared_tracks_in_source_order(self) -> None:
         streams = [
             audio_stream(0, "eng", title="English 5.1", default=True),


### PR DESCRIPTION
## Summary
- preserve genuinely audio-less MKVs as video-only outputs instead of synthesizing audio
- infer only unambiguous mono/stereo layouts during AAC transcoding while keeping missing multichannel layouts fail-closed
- add focused automatic, Convert AAC, PCM, resume, and final-mux regression coverage

## Diagnostics
Support code `BDAVP-HBPM4R9G3XKW18F5` showed that the submitted file was not literally streamless: it contained a 2-channel PCM stream whose Matroska metadata omitted `channel_layout`, plus DTS tracks. The runtime rejected the PCM stream before FFmpeg could transcode it. Truly streamless MKVs followed the same failing assumption that audio must exist.

Stable `v0.3.0` contains the same audio pipeline and is affected. Patch-release planning is tracked in #520; no release has been dispatched or authorized.

## Validation
- `uv run python -m unittest discover -s tests -t .` (1,616 passed, 3 skipped)
- `uv run python scripts/native_app.py test` (355 passed)
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv build`
- generated real no-audio MKV -> verified one video track and zero audio tracks after final mux
- generated missing-layout stereo PCM MKV -> verified canonical AAC stereo output
- JetBrains `changed_files` inspection ran, but the plugin returned `UNKNOWN: execution_not_proven` with zero reported problems and explicitly disabled retry

Closes #502
Refs #520