### PR TITLE
Prepare v0.3.1 Stable patch release

### DIFF
--- a/docs/0.3.1-cut-packet.md
+++ b/docs/0.3.1-cut-packet.md
@@ -1,0 +1,65 @@
+# 0.3.1 Stable Cut Packet
+
+> **Prepared metadata; publication pending.** Stable may be dispatched only
+> from the exact merged protected-`main` SHA under a temporary merge hold. The
+> `macos-signing` environment requires fresh explicit run-bound authorization
+> in the active conversation.
+
+Stable `0.3.1` is a focused patch over immutable Stable `0.3.0`. It contains
+the verified MKV audio-handling fix from PR #521 and does not change the product
+identity, update routes, signing identity, diagnostics endpoint, or publication
+policy. Issue #520 owns preparation, publication, qualification, and closeout.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.1` |
+| Public version | `0.3.1` |
+| Bundle and Sparkle build | `162` |
+| GitHub tag and release title | `v0.3.1` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.1.dmg` |
+| Sparkle channel | absent (Stable default) |
+| GitHub prerelease | `false` |
+| GitHub Latest | `true` |
+| Publish to PyPI | `true` |
+| Downstream Homebrew update | `true` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `162` is globally newer than immutable Stable `0.3.0` build `161`, RC 3
+build `160`, and all earlier production history. Burned builds `147` and `154`
+and abandoned metadata build `157` remain absent. Live state was reconfirmed on
+August 9, 2026: no `v0.3.1` tag, release, draft, PyPI version, Homebrew pull
+request, appcast item, remote preparation branch, or release freeze exists.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.1` fixes MKV conversion when audio is absent or channel-layout
+> metadata is incomplete. Genuinely audio-less MKVs now produce video-only
+> output. During audio transcoding, missing layouts are inferred only for
+> unambiguous mono or stereo tracks; ambiguous or multichannel missing-layout
+> inputs remain fail-closed. The app does not fabricate or synthesize audio.
+
+GitHub-generated notes compare with immutable Stable `v0.3.0`, so the published
+notes remain focused on this patch and PR #521.
+
+## Qualification And Authorization
+
+Immutable Stable `v0.3.0` is the exact prior artifact and update-route input.
+Preparation may carry only evidence whose mapped paths and contracts remain
+clean. The MKV container change requires fresh candidate evidence for generated
+final-output behavior before signing. Exact same-run release, signed-artifact,
+live Sparkle, clean-machine, and installed UI evidence remains owned by the
+guarded artifact and post-publication milestone phases.
+
+Native Sparkle presentation plus USB Blu-ray/MakeMKV, protected-media
+conversion, Vision Pro playback, and public field follow-up remain visible but
+nonblocking under the current qualification policy. Missing or due operator
+evidence must remain honest and never become a fabricated pass.
+
+Before dispatch, record the exact protected `main` SHA and establish a temporary
+merge hold. Monitor only with `uv run python -m scripts.github_release_run
+watch`. If it exits `20`, obtain fresh explicit run-bound authorization in the
+active conversation and approve only through `scripts.github_release_run
+approve` with the emitted run ID, workflow, full `main` SHA, confirmation SHA,
+and approval fingerprint.

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -103,10 +103,10 @@ document it as an external dependency with preflight behavior.
   immutable. RC 1 (`v0.3.0-rc.1`, internal version `0.3.0rc1`, build `158`) is
   published and immutable. RC 2 (`v0.3.0-rc.2`, internal version `0.3.0rc2`,
   build `159`) and RC 3 (`v0.3.0-rc.3`, internal version `0.3.0rc3`, build
-  `160`) are also published and immutable. The next prepared
-  production-identity field build is Stable `v0.3.0` build `161`. It remains
-  unpublished until exact-SHA signing and public verification complete. Beta 3
-  build `148` remains the
+  `160`) are also published and immutable. Stable `v0.3.0` build `161` is
+  published and immutable. The next prepared production-identity field build
+  is Stable `v0.3.1` build `162`; it remains unpublished until exact-SHA
+  signing and public verification complete. Beta 3 build `148` remains the
   manual-download seed and immutable appcast history below the later Beta
   releases.
 - Stable, RC, Beta, and Alpha are routes for the same product, bundle identifier,

--- a/docs/macos-app-packaging.md
+++ b/docs/macos-app-packaging.md
@@ -119,10 +119,11 @@ older Stable and RC installations cannot discover it, while an installed Beta
   are published and immutable. Abandoned Beta 12 metadata build `157` has no
   public artifact. RC 1 (`0.3.0rc1`, build `158`), RC 2 (`0.3.0rc2`, build
   `159`), and RC 3 (`0.3.0rc3`, build `160`) are published and immutable.
-  Stable `0.3.0` build `161` is the next prepared target for the guarded
-  exact-SHA Stable workflow. Its future unchanneled cumulative item must sit
-  above RC 3 and all earlier history, skip builds `147`, `154`, and `157`, and
-  be visible to Stable, RC, Beta, and Alpha.
+  Stable `0.3.0` build `161` is published and immutable. Stable `0.3.1` build
+  `162` is the next prepared target for the guarded exact-SHA Stable workflow.
+  Its future unchanneled cumulative item must sit above Stable `0.3.0` and all
+  earlier history, skip builds `147`, `154`, and `157`, and be visible to
+  Stable, RC, Beta, and Alpha.
 
 ## Release Workflow
 

--- a/docs/qualification/release-evidence-v1.json
+++ b/docs/qualification/release-evidence-v1.json
@@ -267,6 +267,16 @@
       "source": "tier3_automation_receipt",
       "source_sha": "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522",
       "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-09T14:07:15Z",
+      "case_id": "network-generated-final-output",
+      "receipt_id": "v0.3.1:network-generated-final-output:95e374e",
+      "reference": "docs/qualification/v0.3.1-mkv-audio-handling-v1.json",
+      "sha256": "222bcf0fef2cb0825641e4c60ff94930239b0974ff1ac728154ad911bc9c4665",
+      "source": "signed_artifact_receipt",
+      "source_sha": "95e374ed0a9aee092713cb76e323a54c1f552aca",
+      "status": "accepted"
     }
   ],
   "schema_version": 1

--- a/docs/qualification/stable-signed-qualification-v1.json
+++ b/docs/qualification/stable-signed-qualification-v1.json
@@ -16,7 +16,7 @@
     "passed": false,
     "preregistered_matrix_case_ids": [
       "release-workflow-identity",
-      "updater-route-rc3-to-stable",
+      "updater-route-v0.3.0-to-v0.3.1",
       "native-sparkle-notes-stable",
       "profile-save-action-accessibility",
       "signed-packaged-route-parity",
@@ -55,20 +55,20 @@
     ]
   },
   "candidate": {
-    "appcast_sha256": "d1682c4b79c42ec0a24b98c74a03dcde3e00186d4ccbacfad0c3e0a91362c7b2",
-    "build_version": "161",
-    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.0.dmg",
-    "dmg_sha256": "12fec196fea9faec1519a4e9f51133a9dd7a4690dff5ea342b7bae4ab2643ef1",
+    "appcast_sha256": null,
+    "build_version": "162",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg",
+    "dmg_sha256": null,
     "mapping_version": 2,
-    "package_version": "0.3.0",
-    "public_version": "0.3.0",
-    "release_id": 367020071,
-    "release_run_id": 31219050718,
-    "release_tag": "v0.3.0",
+    "package_version": "0.3.1",
+    "public_version": "0.3.1",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.1",
     "route_table_id": "route-relative-video-quality-v2",
     "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
-    "signed_app_tree_sha256": "f0980d2a4206905cd56405a82c8e473a8342a819c78129f1c387d1273a4aea85",
-    "source_git_sha": "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
     "worker_protocol_version": 12,
     "workflow": "Stable"
   },
@@ -91,11 +91,17 @@
       154
     ],
     "previous_stable": {
-      "build_version": "146",
+      "appcast_sha256": "d1682c4b79c42ec0a24b98c74a03dcde3e00186d4ccbacfad0c3e0a91362c7b2",
+      "build_version": "161",
+      "dmg_sha256": "12fec196fea9faec1519a4e9f51133a9dd7a4690dff5ea342b7bae4ab2643ef1",
       "must_not_rebuild": true,
-      "package_version": "0.2.143",
-      "release_tag": "v0.2.143",
-      "source_git_sha": "03fe03ab58abf85b74c32f6b3b7387d9ad6f1941"
+      "package_version": "0.3.0",
+      "published_at": "2026-08-07T21:42:28Z",
+      "release_id": 367020071,
+      "release_run_id": 31219050718,
+      "release_tag": "v0.3.0",
+      "signed_app_tree_sha256": "f0980d2a4206905cd56405a82c8e473a8342a819c78129f1c387d1273a4aea85",
+      "source_git_sha": "a9abbcf6cd1281d2c701e0c050b68fdafc5b9522"
     },
     "rc3": {
       "appcast_sha256": "6404424910172cfccc9f23472e8748eda7bfba5b1f07d373e69cdb9b0679e9ed",
@@ -112,9 +118,8 @@
     }
   },
   "issues": [
-    "#489",
-    "#516",
-    "#518"
+    "#520",
+    "#502"
   ],
   "matrix": [
     {
@@ -124,7 +129,7 @@
       "policy_case_id": "release-workflow-identity"
     },
     {
-      "id": "updater-route-rc3-to-stable",
+      "id": "updater-route-v0.3.0-to-v0.3.1",
       "migration": "fresh_retest",
       "phase": "milestone",
       "policy_case_id": "sparkle-update-route"
@@ -240,11 +245,11 @@
   ],
   "prior_evidence": [
     {
-      "id": "rc3-signed-qualification-v1",
-      "scope": "immutable qualified RC3 release identity and signed-artifact inputs"
+      "id": "v0.3.0-release-evidence-v1",
+      "scope": "immutable qualified Stable 0.3.0 release identity, signed-artifact inputs, and publication receipts"
     },
     {
-      "id": "v0.2.143-appcast",
+      "id": "v0.3.0-appcast",
       "scope": "previous Stable update-route and release-note base"
     }
   ],

--- a/docs/qualification/v0.3.1-mkv-audio-handling-v1.json
+++ b/docs/qualification/v0.3.1-mkv-audio-handling-v1.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "qualification_id": "v0.3.1-mkv-audio-handling-v1",
+  "recorded_at": "2026-08-09T14:07:15Z",
+  "source": {
+    "build_version": "162",
+    "package_version": "0.3.1",
+    "public_version": "0.3.1",
+    "release_tag": "v0.3.1",
+    "source_sha": "95e374ed0a9aee092713cb76e323a54c1f552aca"
+  },
+  "packaged_candidate": {
+    "app_tree_sha256": "919eef671195acf59620a67e1a4fdf5520804083225aa69c9179044c06ac3b7f",
+    "architecture": "arm64",
+    "bundle_identifier": "com.shinycomputers.bd-to-avp",
+    "codesign_verification": "passed",
+    "package_command": "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package",
+    "preview_presentation_smoke": "passed",
+    "signing": "ad_hoc_local",
+    "worker_cancellation_smoke": "passed"
+  },
+  "cases": [
+    {
+      "case_id": "network-generated-final-output",
+      "observations": {
+        "focused_regression_tests": {
+          "command": "uv run python -m unittest tests.test_audio tests.test_container",
+          "passed": 59
+        },
+        "missing_multichannel_layout": {
+          "input_channels": 6,
+          "input_layout_present": false,
+          "result": "failed_closed_as_required"
+        },
+        "missing_stereo_layout": {
+          "input_channels": 2,
+          "input_layout_present": false,
+          "output_codec": "aac",
+          "output_layout": "stereo",
+          "result": "passed"
+        },
+        "no_audio_final_mux": {
+          "audio_tracks": 0,
+          "result": "passed",
+          "video_tracks": 1
+        }
+      },
+      "status": "passed"
+    }
+  ],
+  "privacy": {
+    "diagnostic_tokens_recorded": false,
+    "private_hostnames_recorded": false,
+    "private_media_identifiers_recorded": false,
+    "private_paths_recorded": false
+  },
+  "result": "accepted_public_safe_summary"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,7 +17,11 @@ records historical preparation, [the Beta 12 cut packet](0.3.0-beta.12-cut-packe
 records abandoned Beta metadata, [the RC 1 cut packet](0.3.0-rc.1-cut-packet.md)
 records immutable publication, [the RC 2 cut packet](0.3.0-rc.2-cut-packet.md)
 records immutable publication, and [the RC 3 cut packet](0.3.0-rc.3-cut-packet.md)
-records immutable publication plus its targeted qualification result.
+records immutable publication plus its targeted qualification result. Stable
+`0.3.0` build `161` is published and immutable; its publication and bounded
+PyPI recovery are recorded in [the Stable cut packet](0.3.0-cut-packet.md).
+The next prepared identity is Stable `0.3.1` build `162`, tracked in
+[the 0.3.1 cut packet](0.3.1-cut-packet.md) and issue #520.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -194,10 +194,13 @@ Pull-request CI distinguishes release preparation evidence from checked
 post-publication evidence. A preparation PR may update the configured evidence
 index without a checked release receipt only when the same diff updates the
 configured qualification record and every immutable candidate field remains
-unbound. Any mutation under `docs/release-evidence/`, any evidence-index change
-without that unbound preparation record, or any qualification record carrying
-release IDs, run IDs, source SHA, artifact digests, or appcast digest still
-requires exactly one canonical checked release receipt on the idempotent
+unbound. The candidate must advance from the bound published Stable identity to
+a newer derived Stable version and global build, and the evidence index may only
+append receipts without modifying or deleting accepted history. Any mutation
+under `docs/release-evidence/`, any evidence-index change without that validated
+preparation transition, or any qualification record carrying release IDs, run
+IDs, source SHA, artifact digests, or appcast digest still requires exactly one
+canonical checked release receipt on the idempotent
 `automation/release-evidence-<tag>` branch.
 
 **Early gate (`qualify-preparation`)** runs after `prepare` and before `package`

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -194,8 +194,9 @@ Pull-request CI distinguishes release preparation evidence from checked
 post-publication evidence. A preparation PR may update the configured evidence
 index without a checked release receipt only when the same diff updates the
 configured qualification record and every immutable candidate field remains
-unbound. The candidate must advance from the bound published Stable identity to
-a newer derived Stable version and global build, and the evidence index may only
+present with an explicit JSON `null`. The candidate must advance from the bound
+published Stable identity to a newer derived Stable version and global build,
+and the evidence index may only
 append receipts without modifying or deleting accepted history. Any mutation
 under `docs/release-evidence/`, any evidence-index change without that validated
 preparation transition, or any qualification record carrying release IDs, run

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -190,6 +190,16 @@ boundary while reporting nonblocking operational evidence separately.
 None of these checks receives signing, notarization, PyPI, Sparkle, or Pages
 secrets.
 
+Pull-request CI distinguishes release preparation evidence from checked
+post-publication evidence. A preparation PR may update the configured evidence
+index without a checked release receipt only when the same diff updates the
+configured qualification record and every immutable candidate field remains
+unbound. Any mutation under `docs/release-evidence/`, any evidence-index change
+without that unbound preparation record, or any qualification record carrying
+release IDs, run IDs, source SHA, artifact digests, or appcast digest still
+requires exactly one canonical checked release receipt on the idempotent
+`automation/release-evidence-<tag>` branch.
+
 **Early gate (`qualify-preparation`)** runs after `prepare` and before `package`
 (the macOS signing job). It checks the `preparation` phase using the exact
 `github.sha`, the committed Sparkle channel as the release stage, the checked

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -11,8 +11,9 @@ published and immutable at builds `148` through `156`, excluding permanently
 burned builds `147`, `154`, and abandoned metadata build `157`. Failed Beta 9
 (`0.3.0b9`, build `154`) was never published. RC 1 (`0.3.0rc1`, build `158`),
 RC 2 (`0.3.0rc2`, build `159`), and RC 3 (`0.3.0rc3`, build `160`) are
-published and immutable. The next prepared target is Stable `0.3.0` build
-`161`; issue #489 owns publication and exact-artifact qualification.
+published and immutable. Stable `0.3.0` build `161` is also published and
+immutable. The next prepared target is Stable `0.3.1` build `162`; issue #520
+owns publication and exact-artifact qualification.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -297,9 +298,9 @@ privacy-safe subtitle diagnostics are fully qualified.
 The immutable metadata and checked publication evidence are in
 [the RC 3 cut packet](0.3.0-rc.3-cut-packet.md).
 
-## Stable 0.3.0 Prepared Target
+## Published Stable 0.3.0
 
-The repository is prepared for review of the guarded `v0.3.0` Stable workflow:
+Stable `v0.3.0` is published and immutable:
 
 - internal and public version `0.3.0`;
 - public tag and title `v0.3.0`;
@@ -310,16 +311,39 @@ The repository is prepared for review of the guarded `v0.3.0` Stable workflow:
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as RC 3.
 
-Publication must place Stable above immutable RC 3 build `160` and all earlier
+Publication placed Stable above immutable RC 3 build `160` and all earlier
 history, with burned builds `147` and `154` and abandoned build `157` absent.
 Stable, RC, Beta, and Alpha clients can all select the newer Stable item without
-changing their saved route.
+changing their saved route. The release targets exact source SHA
+`a9abbcf6cd1281d2c701e0c050b68fdafc5b9522`; its checked receipt and publication
+record remain immutable.
+
+The reviewed metadata, release notes, publication effects, recovery history,
+and exact qualification evidence are in
+[the Stable cut packet](0.3.0-cut-packet.md).
+
+## Stable 0.3.1 Prepared Target
+
+The repository is prepared for review of the guarded `v0.3.1` Stable workflow:
+
+- internal and public version `0.3.1`;
+- public tag and title `v0.3.1`;
+- global build `162`;
+- no Sparkle channel, making the item eligible on every route;
+- GitHub Stable and Latest;
+- PyPI publication and downstream Homebrew update; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Stable `0.3.0`.
+
+Publication must place Stable `0.3.1` above immutable Stable `0.3.0` build
+`161` and all earlier history. Stable, RC, Beta, and Alpha clients can all
+select the newer Stable item without changing their saved route.
 
 The repository has no freeze entry for this exact tag and no conflicting tag,
 draft, release, PyPI version, Homebrew pull request, or appcast item. Dispatch
 requires explicit release authorization under a fixed-`main` merge hold. The
 reviewed metadata, release-note seed, publication effects, and post-publication
-qualification boundary are in [the Stable cut packet](0.3.0-cut-packet.md).
+qualification boundary are in [the 0.3.1 cut packet](0.3.1-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -278,9 +278,11 @@ excluded from Stable and admitted on RC, Beta, and Alpha. Its updater path and
 content-aware native release-note link qualification passed. The immutable notes
 contain no issue URL, so that category is explicitly not applicable; every PR,
 comparison, and full-release link present in the source notes opened externally.
-Stable `v0.3.0` build `161` is the next prepared target. Its item omits
-`sparkle:channel`, supersedes RC 3 for every route, and must not enter the live
-feed until guarded publication succeeds.
+Stable `v0.3.0` build `161` is published and immutable. Its item omits
+`sparkle:channel` and is the current head for every route. Stable `v0.3.1`
+build `162` is the next prepared target; its unchanneled cumulative item must
+supersede Stable `v0.3.0` without entering the live feed before guarded
+publication succeeds.
 
 ## Runtime Integration and UX
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 161
+        CURRENT_PROJECT_VERSION: 162
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.0
+        MARKETING_VERSION: 0.3.1
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -111,7 +111,7 @@ universal_build = false
 min_os_version = "14.0"
 
 [tool.briefcase.app.bd-to-avp.macOS.info]
-CFBundleVersion = "161"
+CFBundleVersion = "162"
 BDToAVPDistributionChannel = "direct"
 SUFeedURL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 SUPublicEDKey = "nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU="

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -138,10 +138,11 @@ def discover_milestone_receipt(
     evidence_index_mutation = EVIDENCE_INDEX_PATH in changed_paths
     qualification_mutation = qualification_relative in changed_paths
     if not receipt_matches:
-        if checked_release_mutation or evidence_index_mutation:
+        if checked_release_mutation:
             raise ReleaseMilestoneContextError(
                 "Release evidence changes require exactly one checked release receipt in the pull-request diff."
             )
+        unbound_candidate = False
         if qualification_mutation:
             qualification = _load_json(repo_root / qualification_relative, "configured qualification record")
             candidate = _mapping(qualification.get("candidate"), "configured qualification candidate")
@@ -157,6 +158,11 @@ def discover_milestone_receipt(
                 raise ReleaseMilestoneContextError(
                     "Published qualification record changes require the checked release receipt and milestone gate."
                 )
+            unbound_candidate = True
+        if evidence_index_mutation and not unbound_candidate:
+            raise ReleaseMilestoneContextError(
+                "Release evidence changes require exactly one checked release receipt in the pull-request diff."
+            )
         return None
     if len(receipt_matches) != 1:
         raise ReleaseMilestoneContextError(

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -112,7 +112,7 @@ def _validate_prepublication_candidate_transition(
         "base qualification record",
     )
     base_candidate = _mapping(base_qualification.get("candidate"), "base qualification candidate")
-    if any(base_candidate.get(field) is None for field in IMMUTABLE_CANDIDATE_FIELDS):
+    if any(field not in base_candidate or base_candidate[field] is None for field in IMMUTABLE_CANDIDATE_FIELDS):
         raise ReleaseMilestoneContextError(
             "Prepublication qualification must advance from a bound published candidate."
         )
@@ -238,7 +238,12 @@ def discover_milestone_receipt(
         if qualification_mutation:
             qualification = _load_json(repo_root / qualification_relative, "configured qualification record")
             candidate = _mapping(qualification.get("candidate"), "configured qualification candidate")
-            if any(candidate.get(field) is not None for field in IMMUTABLE_CANDIDATE_FIELDS):
+            missing_immutable_fields = [field for field in IMMUTABLE_CANDIDATE_FIELDS if field not in candidate]
+            if missing_immutable_fields:
+                raise ReleaseMilestoneContextError(
+                    "Prepublication qualification must explicitly include every immutable candidate field as null."
+                )
+            if any(candidate[field] is not None for field in IMMUTABLE_CANDIDATE_FIELDS):
                 raise ReleaseMilestoneContextError(
                     "Published qualification record changes require the checked release receipt and milestone gate."
                 )

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
-from scripts.release import ReleaseError, parse_release_version
+from scripts.release import ReleaseError, parse_build_version, parse_release_version
 from scripts.release_evidence import effective_successful_workflow_run_id
 from scripts.release_receipt import ReleaseReceiptError, load_validated_checked_receipt
 
@@ -24,6 +24,14 @@ RECEIPT_PATH_PATTERN = re.compile(r"^docs/release-evidence/(v[^/]+)/release-rece
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
+IMMUTABLE_CANDIDATE_FIELDS = (
+    "source_git_sha",
+    "release_run_id",
+    "release_id",
+    "dmg_sha256",
+    "appcast_sha256",
+    "signed_app_tree_sha256",
+)
 
 
 class ReleaseMilestoneContextError(RuntimeError):
@@ -61,6 +69,90 @@ def _load_json(path: Path, description: str) -> Mapping[str, Any]:
         raise ReleaseMilestoneContextError(f"Unable to read {description} at {path}: {error}") from error
     except json.JSONDecodeError as error:
         raise ReleaseMilestoneContextError(f"Invalid JSON in {description} at {path}: {error}") from error
+
+
+def _load_json_at_revision(
+    repo_root: Path,
+    revision: str,
+    relative_path: str,
+    description: str,
+) -> Mapping[str, Any]:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseMilestoneContextError(f"Unable to read {description} from the pull-request base.")
+    try:
+        return _mapping(json.loads(result.stdout), description)
+    except json.JSONDecodeError as error:
+        raise ReleaseMilestoneContextError(f"Invalid JSON in base {description}: {error}") from error
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ReleaseMilestoneContextError(f"{description} must be a JSON array.")
+    return cast(Sequence[Any], value)
+
+
+def _validate_prepublication_candidate_transition(
+    repo_root: Path,
+    *,
+    base_sha: str,
+    qualification_relative: str,
+    candidate: Mapping[str, Any],
+) -> None:
+    base_qualification = _load_json_at_revision(
+        repo_root,
+        base_sha,
+        qualification_relative,
+        "base qualification record",
+    )
+    base_candidate = _mapping(base_qualification.get("candidate"), "base qualification candidate")
+    if any(base_candidate.get(field) is None for field in IMMUTABLE_CANDIDATE_FIELDS):
+        raise ReleaseMilestoneContextError(
+            "Prepublication qualification must advance from a bound published candidate."
+        )
+    try:
+        base_version = parse_release_version(cast(str, base_candidate.get("package_version")))
+        next_version = parse_release_version(cast(str, candidate.get("package_version")))
+        base_build = parse_build_version(cast(str, base_candidate.get("build_version")))
+        next_build = parse_build_version(cast(str, candidate.get("build_version")))
+    except (ReleaseError, TypeError) as error:
+        raise ReleaseMilestoneContextError(f"Prepublication qualification identity is invalid: {error}") from error
+    if next_version.stage != "stable" or next_version.order_key <= base_version.order_key or next_build <= base_build:
+        raise ReleaseMilestoneContextError(
+            "Prepublication qualification must advance to a newer Stable version and global build."
+        )
+    expected_identity = {
+        "package_version": next_version.text,
+        "public_version": next_version.public_version,
+        "build_version": str(next_build),
+        "release_tag": next_version.release_tag,
+        "dmg_name": f"3D-Blu-ray-to-Vision-Pro-{next_version.public_version}.dmg",
+        "workflow": "Stable",
+    }
+    for field, expected in expected_identity.items():
+        if candidate.get(field) != expected:
+            raise ReleaseMilestoneContextError(
+                f"Prepublication qualification candidate.{field} does not match the derived Stable identity."
+            )
+
+
+def _validate_append_only_evidence_index(repo_root: Path, *, base_sha: str) -> None:
+    base_evidence = _load_json_at_revision(repo_root, base_sha, EVIDENCE_INDEX_PATH, "base qualification evidence")
+    head_evidence = _load_json(repo_root / EVIDENCE_INDEX_PATH, "qualification evidence")
+    if base_evidence.get("schema_version") != 1 or head_evidence.get("schema_version") != 1:
+        raise ReleaseMilestoneContextError("Qualification evidence schema_version must remain 1.")
+    base_receipts = list(_sequence(base_evidence.get("receipts"), "base qualification receipts"))
+    head_receipts = list(_sequence(head_evidence.get("receipts"), "qualification receipts"))
+    if len(head_receipts) <= len(base_receipts) or head_receipts[: len(base_receipts)] != base_receipts:
+        raise ReleaseMilestoneContextError(
+            "Prepublication qualification evidence may only append receipts without changing accepted history."
+        )
 
 
 def _repository_path(repo_root: Path, value: object, description: str) -> tuple[Path, str]:
@@ -146,23 +238,23 @@ def discover_milestone_receipt(
         if qualification_mutation:
             qualification = _load_json(repo_root / qualification_relative, "configured qualification record")
             candidate = _mapping(qualification.get("candidate"), "configured qualification candidate")
-            immutable_fields = (
-                "source_git_sha",
-                "release_run_id",
-                "release_id",
-                "dmg_sha256",
-                "appcast_sha256",
-                "signed_app_tree_sha256",
-            )
-            if any(candidate.get(field) is not None for field in immutable_fields):
+            if any(candidate.get(field) is not None for field in IMMUTABLE_CANDIDATE_FIELDS):
                 raise ReleaseMilestoneContextError(
                     "Published qualification record changes require the checked release receipt and milestone gate."
                 )
+            _validate_prepublication_candidate_transition(
+                repo_root,
+                base_sha=base_sha,
+                qualification_relative=qualification_relative,
+                candidate=candidate,
+            )
             unbound_candidate = True
         if evidence_index_mutation and not unbound_candidate:
             raise ReleaseMilestoneContextError(
                 "Release evidence changes require exactly one checked release receipt in the pull-request diff."
             )
+        if evidence_index_mutation:
+            _validate_append_only_evidence_index(repo_root, base_sha=base_sha)
         return None
     if len(receipt_matches) != 1:
         raise ReleaseMilestoneContextError(

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.0")
-        self.assertEqual(NATIVE_BUILD_VERSION, "161")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.1")
+        self.assertEqual(NATIVE_BUILD_VERSION, "162")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -942,7 +942,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             release_stage="rc",
             workflow_phase="milestone",
             milestone_receipt_path=REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
-            as_of=date(2026, 8, 8),
+            as_of=date(2026, 8, 9),
         )
 
         result = self.result_for(report, "native-sparkle-release-notes")
@@ -1195,7 +1195,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             repo=REPO_ROOT,
             workflow_phase="milestone",
             milestone_receipt_path=REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
-            as_of=date(2026, 8, 8),
+            as_of=date(2026, 8, 9),
         )
 
         self.assertEqual(self.result_for(report, "sparkle-update-route")["status"], "covered")

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -159,12 +159,12 @@ class ReleaseMetadataTests(unittest.TestCase):
     def test_repository_is_prepared_for_stable(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.0")
-        self.assertEqual(metadata.public_version, "0.3.0")
-        self.assertEqual(metadata.build_version, "161")
-        self.assertEqual(metadata.release_tag, "v0.3.0")
-        self.assertEqual(metadata.release_name, "v0.3.0")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.0.dmg")
+        self.assertEqual(metadata.package_version, "0.3.1")
+        self.assertEqual(metadata.public_version, "0.3.1")
+        self.assertEqual(metadata.build_version, "162")
+        self.assertEqual(metadata.release_tag, "v0.3.1")
+        self.assertEqual(metadata.release_name, "v0.3.1")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg")
         self.assertEqual(metadata.channel, "stable")
         self.assertFalse(metadata.prerelease)
         self.assertFalse(metadata.first_candidate_of_cycle)
@@ -172,19 +172,18 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertTrue(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.0", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.1", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.0-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.0`", cut_packet)
-        self.assertIn("Build `161`", cut_packet)
-        self.assertIn("#489", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.1-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.1`", cut_packet)
+        self.assertIn("Build `162`", cut_packet)
+        self.assertIn("#520", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
         self.assertTrue(
             any(
                 state in cut_packet
                 for state in (
-                    "Published and immutable; PyPI recovery pending",
-                    "Published and immutable.",
+                    "Prepared metadata; publication pending.",
                 )
             )
         )
@@ -195,8 +194,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         qualification = json.loads(
             (REPO_ROOT / "docs" / "qualification" / "stable-signed-qualification-v1.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.0")
-        self.assertEqual(qualification["candidate"]["build_version"], "161")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.1")
+        self.assertEqual(qualification["candidate"]["build_version"], "162")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
         self.assertEqual(
@@ -205,7 +204,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-rc3-to-stable",
+            "updater-route-v0.3.0-to-v0.3.1",
             "native-sparkle-notes-stable",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
@@ -274,7 +273,13 @@ class ReleaseMetadataTests(unittest.TestCase):
             "release_id",
             "appcast_sha256",
         )
-        stable_receipt_path = REPO_ROOT / "docs" / "release-evidence" / "v0.3.0" / "release-receipt.json"
+        stable_receipt_path = (
+            REPO_ROOT
+            / "docs"
+            / "release-evidence"
+            / qualification["candidate"]["public_version"]
+            / "release-receipt.json"
+        )
         if stable_receipt_path.exists():
             stable_receipt = json.loads(stable_receipt_path.read_text(encoding="utf-8"))
             artifacts_by_kind = {artifact["kind"]: artifact for artifact in stable_receipt["artifacts"]}

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -179,14 +179,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `162`", cut_packet)
         self.assertIn("#520", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertTrue(
-            any(
-                state in cut_packet
-                for state in (
-                    "Prepared metadata; publication pending.",
-                )
-            )
-        )
+        self.assertTrue(any(state in cut_packet for state in ("Prepared metadata; publication pending.",)))
         self.assertIn("post-publication", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -267,11 +267,7 @@ class ReleaseMetadataTests(unittest.TestCase):
             "appcast_sha256",
         )
         stable_receipt_path = (
-            REPO_ROOT
-            / "docs"
-            / "release-evidence"
-            / qualification["candidate"]["public_version"]
-            / "release-receipt.json"
+            REPO_ROOT / "docs" / "release-evidence" / qualification["candidate"]["release_tag"] / "release-receipt.json"
         )
         if stable_receipt_path.exists():
             stable_receipt = json.loads(stable_receipt_path.read_text(encoding="utf-8"))

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -322,6 +322,76 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     base_branch="main",
                 )
 
+    def test_allows_prepublication_qualification_evidence_change(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            for field in (
+                "source_git_sha",
+                "release_run_id",
+                "release_id",
+                "dmg_sha256",
+                "appcast_sha256",
+                "signed_app_tree_sha256",
+            ):
+                qualification["candidate"][field] = None
+            qualification["candidate"].update(
+                {
+                    "package_version": "0.3.1",
+                    "public_version": "0.3.1",
+                    "build_version": "162",
+                    "release_tag": "v0.3.1",
+                    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg",
+                }
+            )
+            qualification_path.write_text(json.dumps(qualification) + "\n", encoding="utf-8")
+            evidence_path = root / "docs/qualification/release-evidence-v1.json"
+            evidence_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "receipts": [
+                            {
+                                "case_id": "network-generated-final-output",
+                                "receipt_id": "v0.3.1-preparation",
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", qualification_path, evidence_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "prepare release evidence"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="release/v0.3.1",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(discovered)
+
     def test_recovery_authorization_does_not_impersonate_checked_release_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -436,6 +436,60 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     base_branch="main",
                 )
 
+    def test_rejects_missing_prepublication_immutable_field(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            for field in (
+                "source_git_sha",
+                "release_run_id",
+                "release_id",
+                "dmg_sha256",
+                "appcast_sha256",
+                "signed_app_tree_sha256",
+            ):
+                qualification["candidate"][field] = None
+            del qualification["candidate"]["source_git_sha"]
+            qualification["candidate"].update(
+                {
+                    "package_version": "0.3.1",
+                    "public_version": "0.3.1",
+                    "build_version": "162",
+                    "release_tag": "v0.3.1",
+                    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg",
+                }
+            )
+            qualification_path.write_text(json.dumps(qualification) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", qualification_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "omit immutable field"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "explicitly include"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="release/v0.3.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
     def test_rejects_prepublication_evidence_history_rewrite(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -392,6 +392,114 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
 
         self.assertIsNone(discovered)
 
+    def test_rejects_same_version_prepublication_reset(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            for field in (
+                "source_git_sha",
+                "release_run_id",
+                "release_id",
+                "dmg_sha256",
+                "appcast_sha256",
+                "signed_app_tree_sha256",
+            ):
+                qualification["candidate"][field] = None
+            qualification_path.write_text(json.dumps(qualification) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", qualification_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "reset same candidate"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "newer Stable"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="release/v0.3.0",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_prepublication_evidence_history_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            evidence_path = root / "docs/qualification/release-evidence-v1.json"
+            evidence_path.write_text(
+                json.dumps({"schema_version": 1, "receipts": [{"receipt_id": "existing"}]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", evidence_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "record existing evidence"], cwd=root, check=True)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            for field in (
+                "source_git_sha",
+                "release_run_id",
+                "release_id",
+                "dmg_sha256",
+                "appcast_sha256",
+                "signed_app_tree_sha256",
+            ):
+                qualification["candidate"][field] = None
+            qualification["candidate"].update(
+                {
+                    "package_version": "0.3.1",
+                    "public_version": "0.3.1",
+                    "build_version": "162",
+                    "release_tag": "v0.3.1",
+                    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg",
+                }
+            )
+            qualification_path.write_text(json.dumps(qualification) + "\n", encoding="utf-8")
+            evidence_path.write_text(
+                json.dumps({"schema_version": 1, "receipts": [{"receipt_id": "replacement"}]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", qualification_path, evidence_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "rewrite evidence"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "only append receipts"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="release/v0.3.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
     def test_recovery_authorization_does_not_impersonate_checked_release_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -514,7 +514,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_briefcase_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "161")
+        self.assertEqual(info["CFBundleVersion"], "162")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- prepare Stable `0.3.1` with global Sparkle build `162`
- add the focused cut packet and exact MKV audio-handling qualification evidence
- update current release-route documentation from published `v0.3.0` to the `v0.3.1` patch target
- preserve automated artifact/publication blockers while keeping operator-only presentation and hardware evidence visible but nonblocking

## User-facing patch

- genuinely audio-less MKVs produce video-only output
- missing layouts are inferred only for unambiguous mono/stereo tracks during transcoding
- ambiguous or multichannel missing-layout inputs remain fail-closed
- no audio is fabricated or synthesized

## Derived identity

- package/public version: `0.3.1`
- build: `162`
- tag/title: `v0.3.1`
- DMG: `3D-Blu-ray-to-Vision-Pro-0.3.1.dmg`
- prerelease: `false`
- GitHub Latest: `true`
- PyPI/Homebrew: enabled

## Qualification

- preparation classifier passes at exact head `d2cd692b980c829d9f60a45e1b439a1a1c3ad533` with zero blocking retests
- exact-source ad-hoc signed package, worker cancellation smoke, and preview presentation smoke passed
- real generated no-audio MKV produced one video track and zero audio tracks
- missing-layout stereo PCM transcoded to canonical AAC stereo
- missing-layout six-channel PCM failed closed as required
- native Sparkle presentation and physical hardware evidence remain visible but nonblocking

## Validation

- `uv run python -m scripts.release validate`
- `uv run python -m unittest discover -s tests -t .` (1,616 passed, 3 skipped)
- `uv run python scripts/native_app.py test` (355 passed)
- `uv run python scripts/validate_observability_migration.py`
- import and CLI smoke
- `uv build`
- clean Briefcase create/build
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- release qualification/receipt focused tests
- `actionlint -no-color`
- JetBrains inspection returned `UNKNOWN: execution_not_proven` with zero findings and retry disabled after IntelliJ lacked the worktree SDK; this is not reported as GREEN
- independent exact-head review: clean

This PR prepares reviewed metadata and evidence only. It does not dispatch Stable, approve `macos-signing`, tag, sign, or publish anything.

Refs #520
