### PR TITLE
Fix post-publication evidence test state

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -179,7 +179,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `162`", cut_packet)
         self.assertIn("#520", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertTrue(any(state in cut_packet for state in ("Prepared metadata; publication pending.",)))
+        receipt_exists = (REPO_ROOT / "docs" / "release-evidence" / "v0.3.1" / "release-receipt.json").exists()
+        expected_state = "Published and immutable." if receipt_exists else "Prepared metadata; publication pending."
+        self.assertIn(expected_state, cut_packet)
         self.assertIn("post-publication", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)


### PR DESCRIPTION
The canonical v0.3.1 evidence PR transitions the cut packet from prepared to published state. Make the release metadata test derive the expected state from the checked immutable receipt so the same invariant covers both preparation and post-publication evidence.

Validation:
- `uv run python -m unittest tests.test_release.ReleaseMetadataTests.test_repository_is_prepared_for_stable`
- resource-sampler regression passed 10/10 repeated runs
- `uv run ruff format --check tests/test_release.py`
- `uv run ruff check tests/test_release.py`
- `git diff --check`

Refs #520 and unblocks #523.