### PR TITLE
Add read-only qualification status controller

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -77,6 +77,7 @@
     "qualificationManifestPath": "docs/release-evidence/<tag>/qualification-manifest.json",
     "qualificationSnapshotPath": "docs/release-evidence/<tag>/qualification-record.json",
     "qualificationManifestCommand": "uv run python -m scripts.release_qualification_manifest",
+    "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationRecordPath": "docs/qualification/stable-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
@@ -131,6 +132,7 @@
       "unitSmoke": "uv run python -m unittest discover -s tests -t .",
       "releaseQualificationPolicy": "uv run python -m scripts.qualify_release_scope --validate-policy",
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
+      "releaseQualificationStatus": "uv run python -m unittest tests.test_release_qualification_controller",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -301,6 +301,22 @@ The workflow performs these ordered boundaries:
    the signed UI artifact expires before the first successful capture, the
    workflow stops explicitly because that immutable evidence cannot be
    reconstructed; it never substitutes a rebuilt or operator-authored receipt.
+   Inspect the checked result without dispatching workflows, changing refs, or
+   writing evidence by running:
+
+   ```sh
+   uv run python -m scripts.release_qualification_controller status \
+     --release-tag <tag>
+   ```
+
+   The command validates either the canonical manifest or the legacy checked
+   receipt/publication pair, then reports completed, stale, blocking, optional,
+   and operator-required cases as deterministic JSON. A present but invalid
+   manifest fails closed rather than falling back to legacy evidence. Exit `0`
+   means the status was computed with no blocking cases, exit `2` means the
+   status was computed with blocking cases, and exit `1` means validation or
+   identity resolution failed. Use `--as-of YYYY-MM-DD` when a reproducible
+   Tier 3 expiry boundary is required.
 15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -372,6 +372,37 @@ python -m scripts.qualify_release_scope \
   --require-evidence
 ```
 
+### Inspect Checked Qualification Status
+
+The maintained read-only controller reports the current checked state for one
+explicit release tag:
+
+```sh
+uv run python -m scripts.release_qualification_controller status \
+  --release-tag v0.3.1
+```
+
+It performs no GitHub calls, dispatches, commits, pushes, comments, pull-request
+updates, or git ref/index mutations. It uses only checked repository evidence
+and fails if any controlling worktree file differs from `HEAD`. It uses the
+existing fail-closed milestone validators and scope classifier. When a canonical
+manifest exists, its recorded runner revision supplies the policy and its
+evidence-index history must remain append-only from the recorded base. When no
+manifest exists, the legacy release receipt and publication record must match
+the rolling qualification candidate exactly. A present but invalid manifest
+never falls back to legacy evidence.
+
+The JSON report preserves the classifier facts for every case and adds
+overlapping groups for `completed`, `stale`, `blocking`, `optional`, and
+`operator_required`. `stale` means previously accepted or preregistered evidence
+was invalidated, expired, explicitly retired, disallowed from carry-forward, or
+bound to a different milestone receipt. `operator_required` is emitted only
+when an applicable operator-assisted case is actually due. Optional cases remain
+visible without satisfying or bypassing blockers. Exit `0` means classification
+completed without blockers, exit `2` means classification completed with
+blockers, and exit `1` means evidence or identity validation failed. The
+optional `--as-of YYYY-MM-DD` input makes expiry-sensitive reports reproducible.
+
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated
 receipts to that same idempotent branch. Optional physical and native-window

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -120,8 +120,7 @@ def _load_json(path: Path, description: str) -> Mapping[str, Any]:
         raise QualificationScopeError(f"Invalid JSON in {description} at {path}: {error}") from error
 
 
-def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
-    policy = _load_json(path, "release qualification policy")
+def validate_policy(policy: Mapping[str, Any]) -> Mapping[str, Any]:
     if policy.get("schema_version") != 1:
         raise QualificationScopeError("Release qualification policy schema_version must be 1.")
     if not isinstance(policy.get("policy_id"), str) or not policy["policy_id"]:
@@ -396,6 +395,10 @@ def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
                         f"Tier 3 qualification case {case_id!r} {field} must contain unique values."
                     )
     return policy
+
+
+def load_policy(path: Path = DEFAULT_POLICY_PATH) -> Mapping[str, Any]:
+    return validate_policy(_load_json(path, "release qualification policy"))
 
 
 def _release_blocking(case: Mapping[str, Any]) -> bool:

--- a/scripts/release_qualification_controller.py
+++ b/scripts/release_qualification_controller.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.qualify_release_scope import (
+    QualificationScopeError,
+    classify_release_scope,
+    git_changed_paths,
+    load_evidence,
+    load_policy,
+    load_qualification_overrides,
+    validate_policy,
+)
+from scripts.release import ReleaseError, parse_release_tag
+from scripts.release_milestone_context import (
+    ReleaseMilestoneContext,
+    ReleaseMilestoneContextError,
+    resolve_milestone_context,
+    resolve_milestone_manifest_context,
+)
+from scripts.release_qualification_manifest import (
+    MANIFEST_NAME,
+    ReleaseQualificationManifestError,
+    load_validated_manifest,
+    validate_manifest_evidence_history,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATUS_TYPE = "bd_to_avp.release_qualification_status"
+STATUS_SCHEMA_VERSION = 1
+STATUS_GROUPS = ("completed", "stale", "blocking", "optional", "operator_required")
+STALE_TRIGGERS = {
+    "carry_disallowed",
+    "expired",
+    "explicit_retest",
+    "invalidated",
+    "milestone_receipt_mismatch",
+}
+
+
+class ReleaseQualificationControllerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvidenceBinding:
+    context: ReleaseMilestoneContext
+    manifest: Mapping[str, Any] | None
+    mode: str
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReleaseQualificationControllerError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ReleaseQualificationControllerError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReleaseQualificationControllerError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _canonical_release_tag(value: str) -> str:
+    try:
+        version = parse_release_tag(value)
+    except ReleaseError as error:
+        raise ReleaseQualificationControllerError(f"Release tag is invalid: {error}") from error
+    if version.release_tag != value:
+        raise ReleaseQualificationControllerError(
+            f"Release tag must use its canonical public spelling {version.release_tag!r}."
+        )
+    return value
+
+
+def _read_json_at_revision(
+    repo_root: Path,
+    revision: str,
+    relative_path: str,
+    description: str,
+) -> Mapping[str, Any]:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "git show failed"
+        raise ReleaseQualificationControllerError(
+            f"Unable to read {description} from runner revision {revision}: {detail}"
+        )
+    try:
+        return _mapping(json.loads(result.stdout), description)
+    except json.JSONDecodeError as error:
+        raise ReleaseQualificationControllerError(
+            f"Invalid JSON in {description} from runner revision {revision}: {error}"
+        ) from error
+
+
+def _require_checked_file(repo_root: Path, relative_path: str, description: str) -> None:
+    path = Path(relative_path)
+    if path.is_absolute() or ".." in path.parts or relative_path.startswith("./"):
+        raise ReleaseQualificationControllerError(f"{description} must be a canonical repository-relative path.")
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseQualificationControllerError(f"{description} must be committed in the current repository HEAD.")
+    try:
+        current = (repo_root / path).read_bytes()
+    except OSError as error:
+        raise ReleaseQualificationControllerError(
+            f"Unable to read {description} at {relative_path}: {error}"
+        ) from error
+    if current != result.stdout:
+        raise ReleaseQualificationControllerError(f"{description} must match the checked content in repository HEAD.")
+
+
+def resolve_evidence_binding(repo_root: Path, release_tag: str) -> EvidenceBinding:
+    release_tag = _canonical_release_tag(release_tag)
+    release_root = repo_root / "docs" / "release-evidence" / release_tag
+    manifest_path = release_root / MANIFEST_NAME
+    if manifest_path.is_file():
+        context = resolve_milestone_manifest_context(repo_root, manifest_path)
+        manifest = load_validated_manifest(manifest_path, repo_root=repo_root)
+        mode = "manifest"
+    else:
+        receipt_path = release_root / "release-receipt.json"
+        if not receipt_path.is_file():
+            raise ReleaseQualificationControllerError(
+                f"No checked qualification manifest or release receipt exists for {release_tag}."
+            )
+        context = resolve_milestone_context(repo_root, receipt_path)
+        manifest = None
+        mode = "legacy"
+    if context.release_tag != release_tag:
+        raise ReleaseQualificationControllerError(
+            f"Resolved qualification evidence belongs to {context.release_tag}, not {release_tag}."
+        )
+    return EvidenceBinding(context=context, manifest=manifest, mode=mode)
+
+
+def _load_bound_policy(repo_root: Path, binding: EvidenceBinding) -> Mapping[str, Any]:
+    context = binding.context
+    if binding.mode == "manifest":
+        if not context.runner_sha:
+            raise ReleaseQualificationControllerError("Manifest-backed qualification status requires a runner SHA.")
+        return validate_policy(
+            _read_json_at_revision(
+                repo_root,
+                context.runner_sha,
+                context.policy_path,
+                "runner-bound release qualification policy",
+            )
+        )
+    return load_policy(repo_root / context.policy_path)
+
+
+def _policy_cases(policy: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    cases: dict[str, Mapping[str, Any]] = {}
+    for raw_case in _sequence(policy.get("cases"), "release qualification cases"):
+        case = _mapping(raw_case, "release qualification case")
+        case_id = _string(case.get("id"), "release qualification case ID")
+        cases[case_id] = case
+    return cases
+
+
+def _case_categories(
+    result: Mapping[str, Any],
+    policy_case: Mapping[str, Any],
+    blocking_case_ids: set[str],
+) -> tuple[str, ...]:
+    case_id = _string(result.get("case_id"), "qualification result case ID")
+    status = _string(result.get("status"), f"qualification result {case_id} status")
+    trigger = _string(result.get("trigger"), f"qualification result {case_id} trigger")
+    categories: list[str] = []
+    if status in {"covered", "carry"}:
+        categories.append("completed")
+    if status == "retest" and trigger in STALE_TRIGGERS:
+        categories.append("stale")
+    if case_id in blocking_case_ids:
+        categories.append("blocking")
+    if (
+        result.get("applicable") is True
+        and not bool(result.get("blocking"))
+        and (result.get("evidence_due") is True or result.get("operational_status") in {"due", "failed", "skipped"})
+    ):
+        categories.append("optional")
+    if (
+        policy_case.get("execution_mode") == "operator_assisted"
+        and result.get("evidence_due") is True
+        and result.get("applicable") is True
+    ):
+        categories.append("operator_required")
+    return tuple(category for category in STATUS_GROUPS if category in categories)
+
+
+def _overall_status(groups: Mapping[str, Sequence[str]]) -> str:
+    if groups["blocking"]:
+        return "blocked"
+    if groups["operator_required"]:
+        return "operator_required"
+    if groups["stale"] or groups["optional"]:
+        return "ready_with_optional_actions"
+    return "complete"
+
+
+def build_status(
+    repo_root: Path,
+    release_tag: str,
+    *,
+    as_of: date | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    binding = resolve_evidence_binding(repo_root, release_tag)
+    context = binding.context
+    checked_paths = {
+        context.evidence_path: "qualification evidence",
+        context.qualification_path: "qualification record",
+        context.release_receipt_path: "release receipt",
+    }
+    if binding.mode == "legacy":
+        checked_paths[context.policy_path] = "qualification policy"
+        checked_paths[f"docs/release-evidence/{context.release_tag}/publication-record.json"] = "publication record"
+    elif context.manifest_path:
+        checked_paths[context.manifest_path] = "qualification manifest"
+    for checked_path, description in checked_paths.items():
+        _require_checked_file(repo_root, checked_path, description)
+    if binding.manifest is not None:
+        canonical_evidence = _mapping(binding.manifest.get("canonical_evidence"), "manifest canonical evidence")
+        validate_manifest_evidence_history(
+            binding.manifest,
+            repo_root=repo_root,
+            base_revision=_string(canonical_evidence.get("base_sha"), "manifest evidence base SHA"),
+        )
+    policy = _load_bound_policy(repo_root, binding)
+    evidence = load_evidence(repo_root / context.evidence_path)
+    qualification_id, fresh_retest = load_qualification_overrides(
+        repo_root / context.qualification_path,
+        policy,
+    )
+    classification = classify_release_scope(
+        policy,
+        evidence,
+        candidate_sha=context.candidate_sha,
+        changed_paths=git_changed_paths(repo_root),
+        repo=repo_root,
+        qualification_id=qualification_id,
+        fresh_retest=fresh_retest,
+        release_stage=context.release_stage,
+        first_candidate_of_cycle=context.first_candidate_of_cycle,
+        workflow_phase="milestone",
+        milestone_receipt_path=repo_root / context.release_receipt_path,
+        as_of=as_of,
+    )
+
+    blocking_case_ids = set(
+        _string(value, "blocking qualification case ID")
+        for value in _sequence(classification.get("blocking_retests"), "blocking qualification cases")
+    )
+    cases_by_id = _policy_cases(policy)
+    groups: dict[str, list[str]] = {group: [] for group in STATUS_GROUPS}
+    cases: list[dict[str, Any]] = []
+    for raw_result in _sequence(classification.get("cases"), "qualification results"):
+        result = _mapping(raw_result, "qualification result")
+        case_id = _string(result.get("case_id"), "qualification result case ID")
+        policy_case = cases_by_id.get(case_id)
+        if policy_case is None:
+            raise ReleaseQualificationControllerError(
+                f"Qualification result references unknown policy case {case_id!r}."
+            )
+        categories = _case_categories(result, policy_case, blocking_case_ids)
+        for category in categories:
+            groups[category].append(case_id)
+        rendered_case = dict(result)
+        rendered_case["categories"] = list(categories)
+        rendered_case["operator_assisted"] = policy_case.get("execution_mode") == "operator_assisted"
+        cases.append(rendered_case)
+
+    frozen_groups = {group: groups[group] for group in STATUS_GROUPS}
+    return {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status_type": STATUS_TYPE,
+        "release_tag": context.release_tag,
+        "candidate_sha": context.candidate_sha,
+        "release_stage": context.release_stage,
+        "first_candidate_of_cycle": context.first_candidate_of_cycle,
+        "workflow_phase": "milestone",
+        "as_of": classification["as_of"],
+        "policy_id": classification["policy_id"],
+        "qualification_id": classification["qualification_id"],
+        "evidence_binding": {
+            "mode": binding.mode,
+            "expected_evidence_ref": f"automation/release-evidence-{context.release_tag}",
+            "evidence_path": context.evidence_path,
+            "manifest_path": context.manifest_path,
+            "manifest_sha256": context.manifest_sha256,
+            "qualification_path": context.qualification_path,
+            "release_receipt_path": context.release_receipt_path,
+            "runner_sha": context.runner_sha,
+        },
+        "overall_status": _overall_status(frozen_groups),
+        "passed": not frozen_groups["blocking"],
+        "summary": {group: len(frozen_groups[group]) for group in STATUS_GROUPS},
+        "groups": frozen_groups,
+        "cases": cases,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect and resume release qualification safely.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    status_parser = subparsers.add_parser("status", help="Inspect checked qualification state without mutation.")
+    status_parser.add_argument("--release-tag", required=True)
+    status_parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    status_parser.add_argument("--as-of", type=date.fromisoformat)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_status(
+            args.repo_root,
+            args.release_tag,
+            as_of=args.as_of,
+        )
+    except (
+        json.JSONDecodeError,
+        OSError,
+        QualificationScopeError,
+        ReleaseMilestoneContextError,
+        ReleaseQualificationControllerError,
+        ReleaseQualificationManifestError,
+    ) as error:
+        print(f"Release qualification status failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 2 if cast(bool, payload["groups"]["blocking"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -1,0 +1,387 @@
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.release_milestone_context import ReleaseMilestoneContextError
+from scripts.release_qualification_controller import (
+    EvidenceBinding,
+    ReleaseQualificationControllerError,
+    _case_categories,
+    _load_bound_policy,
+    _require_checked_file,
+    build_status,
+    main,
+    resolve_evidence_binding,
+)
+from scripts.release_milestone_context import ReleaseMilestoneContext
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+READ_ONLY_GIT_COMMANDS = {"diff", "ls-files", "merge-base", "show"}
+
+
+class ReleaseQualificationControllerTests(unittest.TestCase):
+    def test_reports_v031_legacy_evidence_without_mutation(self) -> None:
+        before_status = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        before_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        before_refs = subprocess.run(
+            ["git", "show-ref"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        original_run = subprocess.run
+        observed_commands: list[tuple[str, ...]] = []
+
+        def guarded_run(command: list[str], *args: object, **kwargs: object) -> subprocess.CompletedProcess[object]:
+            observed_commands.append(tuple(command))
+            self.assertEqual(command[0], "git")
+            self.assertIn(command[1], READ_ONLY_GIT_COMMANDS)
+            return original_run(command, *args, **kwargs)
+
+        with patch("subprocess.run", side_effect=guarded_run):
+            payload = build_status(REPO_ROOT, "v0.3.1", as_of=date(2026, 8, 10))
+
+        after_status = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        after_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        after_refs = subprocess.run(
+            ["git", "show-ref"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+        self.assertTrue(observed_commands)
+        self.assertEqual(before_status, after_status)
+        self.assertEqual(before_head, after_head)
+        self.assertEqual(before_refs, after_refs)
+        self.assertIn(payload["evidence_binding"]["mode"], {"legacy", "manifest"})
+        self.assertEqual(payload["overall_status"], "ready_with_optional_actions")
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["groups"]["blocking"], [])
+        self.assertIn("release-workflow-identity", payload["groups"]["completed"])
+        self.assertIn("clean-machine-signed-update", payload["groups"]["completed"])
+        self.assertIn("installed-ui-accessibility", payload["groups"]["completed"])
+        self.assertEqual(payload["groups"]["operator_required"], [])
+
+    def test_status_output_is_deterministic(self) -> None:
+        outputs: list[str] = []
+        for _ in range(2):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "status",
+                        "--release-tag",
+                        "v0.3.1",
+                        "--repo-root",
+                        str(REPO_ROOT),
+                        "--as-of",
+                        "2026-08-10",
+                    ]
+                )
+            self.assertEqual(exit_code, 0)
+            outputs.append(stdout.getvalue())
+
+        self.assertEqual(outputs[0], outputs[1])
+        self.assertEqual(json.loads(outputs[0])["release_tag"], "v0.3.1")
+
+    def test_present_invalid_manifest_does_not_fall_back_to_legacy(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            manifest_path = root / "docs/release-evidence/v0.3.1/qualification-manifest.json"
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            with (
+                patch(
+                    "scripts.release_qualification_controller.resolve_milestone_manifest_context",
+                    side_effect=ReleaseMilestoneContextError("invalid manifest"),
+                ),
+                patch("scripts.release_qualification_controller.resolve_milestone_context") as legacy_resolver,
+            ):
+                with self.assertRaisesRegex(ReleaseMilestoneContextError, "invalid manifest"):
+                    resolve_evidence_binding(root, "v0.3.1")
+
+        legacy_resolver.assert_not_called()
+
+    def test_absent_manifest_uses_legacy_resolver(self) -> None:
+        context = self._context()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path = root / "docs/release-evidence/v0.3.1/release-receipt.json"
+            receipt_path.parent.mkdir(parents=True)
+            receipt_path.write_text("{}\n", encoding="utf-8")
+            with patch(
+                "scripts.release_qualification_controller.resolve_milestone_context",
+                return_value=context,
+            ) as legacy_resolver:
+                binding = resolve_evidence_binding(root, "v0.3.1")
+
+        legacy_resolver.assert_called_once_with(root, receipt_path)
+        self.assertEqual(binding.mode, "legacy")
+        self.assertIsNone(binding.manifest)
+
+    def test_manifest_binding_loads_runner_policy(self) -> None:
+        context = self._context(
+            runner_sha="a" * 40, manifest_path="docs/release-evidence/v0.3.1/qualification-manifest.json"
+        )
+        manifest = {"canonical_evidence": {"base_sha": "b" * 40}}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            manifest_path = root / context.manifest_path
+            manifest_path.parent.mkdir(parents=True)
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            with (
+                patch(
+                    "scripts.release_qualification_controller.resolve_milestone_manifest_context",
+                    return_value=context,
+                ),
+                patch(
+                    "scripts.release_qualification_controller.load_validated_manifest",
+                    return_value=manifest,
+                ),
+            ):
+                binding = resolve_evidence_binding(root, "v0.3.1")
+            runner_policy = {"policy": "runner"}
+            validated_policy = {"policy": "validated"}
+            with (
+                patch(
+                    "scripts.release_qualification_controller._read_json_at_revision",
+                    return_value=runner_policy,
+                ) as read_revision,
+                patch(
+                    "scripts.release_qualification_controller.validate_policy",
+                    return_value=validated_policy,
+                ) as validate,
+            ):
+                policy = _load_bound_policy(root, binding)
+
+        self.assertEqual(binding.mode, "manifest")
+        self.assertEqual(binding.manifest, manifest)
+        self.assertEqual(policy, validated_policy)
+        read_revision.assert_called_once_with(
+            root, context.runner_sha, context.policy_path, "runner-bound release qualification policy"
+        )
+        validate.assert_called_once_with(runner_policy)
+
+    def test_manifest_status_validates_append_only_evidence_history(self) -> None:
+        context = self._context(
+            runner_sha="a" * 40,
+            manifest_path="docs/release-evidence/v0.3.1/qualification-manifest.json",
+        )
+        manifest = {"canonical_evidence": {"base_sha": "b" * 40}}
+        binding = EvidenceBinding(context=context, manifest=manifest, mode="manifest")
+        policy = {"policy_id": "policy", "cases": [{"id": "complete"}]}
+        classification = {
+            "as_of": "2026-08-10",
+            "blocking_retests": [],
+            "cases": [
+                {
+                    "applicable": True,
+                    "blocking": True,
+                    "case_id": "complete",
+                    "evidence_due": False,
+                    "operational_status": None,
+                    "status": "covered",
+                    "trigger": "exact_candidate",
+                }
+            ],
+            "policy_id": "policy",
+            "qualification_id": "qualification",
+        }
+        with (
+            patch("scripts.release_qualification_controller.resolve_evidence_binding", return_value=binding),
+            patch("scripts.release_qualification_controller._require_checked_file"),
+            patch("scripts.release_qualification_controller.validate_manifest_evidence_history") as validate_history,
+            patch("scripts.release_qualification_controller._load_bound_policy", return_value=policy),
+            patch("scripts.release_qualification_controller.load_evidence", return_value={"schema_version": 1}),
+            patch(
+                "scripts.release_qualification_controller.load_qualification_overrides",
+                return_value=("qualification", {}),
+            ),
+            patch("scripts.release_qualification_controller.classify_release_scope", return_value=classification),
+        ):
+            payload = build_status(REPO_ROOT, "v0.3.1", as_of=date(2026, 8, 10))
+
+        validate_history.assert_called_once_with(manifest, repo_root=REPO_ROOT, base_revision="b" * 40)
+        self.assertEqual(payload["evidence_binding"]["expected_evidence_ref"], "automation/release-evidence-v0.3.1")
+        self.assertEqual(payload["overall_status"], "complete")
+
+    def test_checked_file_rejects_worktree_content_that_differs_from_head(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+            path = root / "evidence.json"
+            path.write_text('{"state": "checked"}\n', encoding="utf-8")
+            subprocess.run(["git", "add", "evidence.json"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "checked"], cwd=root, check=True)
+            path.write_text('{"state": "dirty"}\n', encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseQualificationControllerError, "must match the checked content"):
+                _require_checked_file(root, "evidence.json", "qualification evidence")
+
+    def test_missing_checked_evidence_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(
+                ReleaseQualificationControllerError,
+                "No checked qualification manifest or release receipt",
+            ):
+                resolve_evidence_binding(Path(temporary_directory), "v0.3.1")
+
+    def test_noncanonical_release_tag_is_rejected_before_path_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(ReleaseQualificationControllerError, "Release tag is invalid"):
+                resolve_evidence_binding(Path(temporary_directory), "../../v0.3.1")
+
+    def test_case_categories_preserve_overlapping_status_groups(self) -> None:
+        scenarios = (
+            (
+                {
+                    "case_id": "complete",
+                    "status": "covered",
+                    "trigger": "exact_candidate",
+                    "blocking": True,
+                    "evidence_due": False,
+                    "applicable": True,
+                    "operational_status": None,
+                },
+                {},
+                set(),
+                ("completed",),
+            ),
+            (
+                {
+                    "case_id": "stale-optional",
+                    "status": "retest",
+                    "trigger": "invalidated",
+                    "blocking": False,
+                    "evidence_due": True,
+                    "applicable": True,
+                    "operational_status": "due",
+                },
+                {},
+                set(),
+                ("stale", "optional"),
+            ),
+            (
+                {
+                    "case_id": "missing-blocker",
+                    "status": "retest",
+                    "trigger": "missing_prior_evidence",
+                    "blocking": True,
+                    "evidence_due": True,
+                    "applicable": True,
+                    "operational_status": None,
+                },
+                {},
+                {"missing-blocker"},
+                ("blocking",),
+            ),
+            (
+                {
+                    "case_id": "operator",
+                    "status": "retest",
+                    "trigger": "stable_candidate",
+                    "blocking": False,
+                    "evidence_due": True,
+                    "applicable": True,
+                    "operational_status": "due",
+                },
+                {"execution_mode": "operator_assisted"},
+                set(),
+                ("optional", "operator_required"),
+            ),
+            (
+                {
+                    "case_id": "external",
+                    "status": "external",
+                    "trigger": "post_publication",
+                    "blocking": False,
+                    "evidence_due": False,
+                    "applicable": False,
+                    "operational_status": None,
+                },
+                {},
+                set(),
+                (),
+            ),
+        )
+        for result, policy_case, blockers, expected in scenarios:
+            with self.subTest(case_id=result["case_id"]):
+                self.assertEqual(_case_categories(result, policy_case, blockers), expected)
+
+    def test_main_returns_two_for_computed_blocking_state(self) -> None:
+        payload = {"groups": {"blocking": ["required-case"]}}
+        stdout = io.StringIO()
+        with patch("scripts.release_qualification_controller.build_status", return_value=payload):
+            with redirect_stdout(stdout):
+                exit_code = main(["status", "--release-tag", "v0.3.1"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(json.loads(stdout.getvalue()), payload)
+
+    def test_main_returns_one_for_validation_failure(self) -> None:
+        stderr = io.StringIO()
+        with patch(
+            "scripts.release_qualification_controller.build_status",
+            side_effect=ReleaseQualificationControllerError("conflicting identity"),
+        ):
+            with redirect_stderr(stderr):
+                exit_code = main(["status", "--release-tag", "v0.3.1"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("conflicting identity", stderr.getvalue())
+
+    @staticmethod
+    def _context(*, runner_sha: str = "", manifest_path: str = "") -> ReleaseMilestoneContext:
+        return ReleaseMilestoneContext(
+            candidate_sha="c" * 40,
+            evidence_path="docs/qualification/release-evidence-v1.json",
+            first_candidate_of_cycle=False,
+            policy_path="docs/qualification/release-qualification-policy-v1.json",
+            qualification_path="docs/qualification/stable-signed-qualification-v1.json",
+            release_receipt_path="docs/release-evidence/v0.3.1/release-receipt.json",
+            release_stage="stable",
+            release_tag="v0.3.1",
+            manifest_path=manifest_path,
+            runner_sha=runner_sha,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `scripts.release_qualification_controller status` for deterministic, read-only qualification reporting
- validate manifest-backed and legacy checked evidence without GitHub calls or git mutations
- report overlapping completed, stale, blocking, optional, and operator-required case groups
- bind manifest policy to its runner SHA, enforce append-only evidence history, and reject controlling files that differ from `HEAD`
- document the command and register its focused quality gate

## Validation

- `uv run python -m unittest discover -s tests -t .` — 1658 passed, 3 skipped
- focused release qualification tests — 85 passed
- scoped Ruff lint and format checks
- release policy and observability validation
- `uv run mypy bd_to_avp`
- `uv build`
- Opus exact-head review — READY
- Gemini exact-head review — READY
- JetBrains inspection — inconclusive because the isolated worktree lacked a configured language SDK; no trustworthy findings

Refs #526
