### PR TITLE
Add guarded qualification resume dispatch

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -78,6 +78,7 @@
     "qualificationSnapshotPath": "docs/release-evidence/<tag>/qualification-record.json",
     "qualificationManifestCommand": "uv run python -m scripts.release_qualification_manifest",
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
+    "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationRecordPath": "docs/qualification/stable-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
@@ -109,6 +110,7 @@
       ".github/workflows/prerelease.yml",
       ".github/workflows/release-engine.yml",
       ".github/workflows/release-evidence.yml",
+      ".github/workflows/milestone-qualification.yml",
       ".github/workflows/sparkle-pages.yml",
       ".github/workflows/manage-sparkle-pages.yml"
     ]
@@ -133,6 +135,7 @@
       "releaseQualificationPolicy": "uv run python -m scripts.qualify_release_scope --validate-policy",
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
       "releaseQualificationStatus": "uv run python -m unittest tests.test_release_qualification_controller",
+      "releaseQualificationResume": "uv run python -m unittest tests.test_release_qualification_resume",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -1,6 +1,6 @@
 ---
 name: Milestone Qualification
-run-name: Milestone qualification ${{ inputs.candidate_tag }}
+run-name: Milestone ${{ inputs.candidate_tag }} ${{ inputs.manifest_sha256 }}
 
 "on":
   workflow_dispatch:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -317,6 +317,49 @@ The workflow performs these ordered boundaries:
    status was computed with blocking cases, and exit `1` means validation or
    identity resolution failed. Use `--as-of YYYY-MM-DD` when a reproducible
    Tier 3 expiry boundary is required.
+
+   When blocking automated cases remain on an open canonical evidence branch,
+   run the bounded resume observer from the exact checked
+   `automation/release-evidence-<tag>` branch head:
+
+   ```sh
+   uv run python -m scripts.release_qualification_controller resume \
+     --release-tag <tag>
+   ```
+
+   The first invocation is observational. It verifies the same-repository
+   evidence PR, remote evidence head, protected `main`, manifest runner and
+   digest, docs-only branch diff, prior dispatches, job conclusion, and retained
+   artifact metadata. If dispatch is the only safe next transition, the JSON
+   response reports the exact required `main` and manifest values. Authorize
+   that one workflow dispatch by repeating the command with both values:
+
+   ```sh
+   uv run python -m scripts.release_qualification_controller resume \
+     --release-tag <tag> \
+     --expected-main-sha <full-main-sha> \
+     --expected-manifest-sha256 <manifest-sha256>
+   ```
+
+   Dispatch requires the active local GitHub identity `cbusillo`. The controller
+   writes a mode-`0600` checkpoint under the shared git directory before the
+   API call, then adopts only the exact run whose display title binds the tag
+   and full manifest digest. An unresolved prepared checkpoint prevents a
+   second dispatch after interruption. Local locking prevents concurrent
+   controller processes from dispatching the same transition. After the
+   visibility window, retrying an unresolved dispatch requires the exact
+   checkpoint self digest through `--retry-checkpoint-sha256` plus the same main
+   and manifest authorization. Failed or expired runs require the exact prior
+   run ID through `--retry-run-id`; they are never retried implicitly. If
+   protected `main` moved, rerun Release Evidence to refresh the manifest before
+   resuming.
+
+   This bounded stage does not download milestone artifacts or create commits,
+   pushes, comments, or pull requests. `artifact_available` means the exact
+   retained receipts are ready for validated reconciliation. `artifact_expired`
+   permits a new run only after explicit retry authorization; checked durable
+   receipts already accepted by `status` remain a no-op even after Actions
+   transport expires.
 15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -354,6 +354,17 @@ The workflow performs these ordered boundaries:
    protected `main` moved, rerun Release Evidence to refresh the manifest before
    resuming.
 
+   Resume exit `0` means observation completed without an operator decision,
+   exit `20` means an exact operator action or later observation is required,
+   exit `21` means an identity or concurrency safety conflict stopped the
+   transition, and exit `1` means local validation failed. Checkpoints live at
+   `<git-common-dir>/bd-to-avp/release-qualification/<tag>.json`. If later
+   evidence reconciliation advances the evidence branch while blockers remain,
+   first verify that no exact qualification run is queued or active and that the
+   recorded run no longer needs observation; only then remove the stale local
+   checkpoint and rerun the observational command. Never remove a prepared
+   checkpoint merely because its workflow run is slow to appear.
+
    This bounded stage does not download milestone artifacts or create commits,
    pushes, comments, or pull requests. `artifact_available` means the exact
    retained receipts are ready for validated reconciliation. `artifact_expired`

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -403,6 +403,47 @@ completed without blockers, exit `2` means classification completed with
 blockers, and exit `1` means evidence or identity validation failed. The
 optional `--as-of YYYY-MM-DD` input makes expiry-sensitive reports reproducible.
 
+### Resume Blocking Automated Qualification
+
+`resume` is an observation-first state machine with one bounded mutation: an
+exact Milestone Qualification workflow dispatch. It must run from the checked
+head of `automation/release-evidence-<tag>` when `status` still reports blocking
+cases. Releases whose checked durable evidence already satisfies every blocker,
+including legacy v0.3.1, return `complete` without contacting GitHub or writing a
+checkpoint.
+
+Before offering dispatch, the controller verifies the repository identity,
+remote `main`, evidence ref and SHA, exactly one same-repository open evidence
+PR, docs-only branch diff, manifest self digest, runner SHA, candidate and
+release identities, signed UI artifact, policy/checkpoint/route/controller
+digests, and existing exact workflow runs through the same active GitHub
+identity used for dispatch. The workflow display title includes
+the release tag and full manifest digest because `workflow_dispatch` returns no
+run ID. More than one active exact run, a moved ref, a mismatched checkpoint, a
+fork PR, a skipped qualification job, partial identity, or any non-documentation
+evidence-branch change fails closed.
+
+The initial command reports `dispatch_ready` and the exact values required for
+authorization. Dispatch occurs only when both `--expected-main-sha` and
+`--expected-manifest-sha256` match the preflight identity and the active local
+GitHub login is `cbusillo`. Before the API call, the controller atomically writes
+a mode-`0600` prepared checkpoint under the shared git directory. It records the
+observed run only after exactly one newer run with the expected workflow path,
+branch, head SHA, actors, tag, and manifest digest appears. A prepared checkpoint
+with no visible run blocks redispatch, and a local checkpoint lock rejects
+concurrent controller processes. Once the visibility window expires, retrying
+that unresolved dispatch requires its exact checkpoint self digest through
+`--retry-checkpoint-sha256` and repeats every remote identity check. Retrying a
+failed or expired run also requires its exact ID through `--retry-run-id`.
+
+This stage observes successful job and artifact state but deliberately does not
+download ZIPs or mutate evidence refs, commits, comments, or pull requests.
+`artifact_available` requires validated reconciliation as the next controller
+stage. Expired milestone transport may trigger an explicitly authorized fresh
+qualification run; it never reconstructs receipts. If equivalent receipts are
+already committed and accepted, `status` reports no blockers and `resume`
+returns `complete` regardless of Actions retention.
+
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated
 receipts to that same idempotent branch. Optional physical and native-window

--- a/scripts/release_qualification_controller.py
+++ b/scripts/release_qualification_controller.py
@@ -2,330 +2,39 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
-from scripts.qualify_release_scope import (
-    QualificationScopeError,
-    classify_release_scope,
-    git_changed_paths,
-    load_evidence,
-    load_policy,
-    load_qualification_overrides,
-    validate_policy,
-)
-from scripts.release import ReleaseError, parse_release_tag
-from scripts.release_milestone_context import (
-    ReleaseMilestoneContext,
-    ReleaseMilestoneContextError,
-    resolve_milestone_context,
-    resolve_milestone_manifest_context,
-)
-from scripts.release_qualification_manifest import (
-    MANIFEST_NAME,
-    ReleaseQualificationManifestError,
-    load_validated_manifest,
-    validate_manifest_evidence_history,
+from scripts.qualify_release_scope import QualificationScopeError
+from scripts.release_milestone_context import ReleaseMilestoneContextError
+from scripts.release_qualification_manifest import ReleaseQualificationManifestError
+from scripts.release_qualification_status import (
+    EvidenceBinding,
+    ReleaseQualificationControllerError,
+    _case_categories,
+    _load_bound_policy,
+    _require_checked_file,
+    build_status,
+    resolve_evidence_binding,
 )
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-STATUS_TYPE = "bd_to_avp.release_qualification_status"
-STATUS_SCHEMA_VERSION = 1
-STATUS_GROUPS = ("completed", "stale", "blocking", "optional", "operator_required")
-STALE_TRIGGERS = {
-    "carry_disallowed",
-    "expired",
-    "explicit_retest",
-    "invalidated",
-    "milestone_receipt_mismatch",
-}
-
-
-class ReleaseQualificationControllerError(RuntimeError):
-    pass
-
-
-@dataclass(frozen=True)
-class EvidenceBinding:
-    context: ReleaseMilestoneContext
-    manifest: Mapping[str, Any] | None
-    mode: str
-
-
-def _mapping(value: object, description: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
-        raise ReleaseQualificationControllerError(f"{description} must be a JSON object.")
-    return cast(Mapping[str, Any], value)
-
-
-def _sequence(value: object, description: str) -> Sequence[Any]:
-    if not isinstance(value, list):
-        raise ReleaseQualificationControllerError(f"{description} must be a JSON array.")
-    return value
-
-
-def _string(value: object, description: str) -> str:
-    if not isinstance(value, str) or not value:
-        raise ReleaseQualificationControllerError(f"{description} must be a non-empty string.")
-    return value
-
-
-def _canonical_release_tag(value: str) -> str:
-    try:
-        version = parse_release_tag(value)
-    except ReleaseError as error:
-        raise ReleaseQualificationControllerError(f"Release tag is invalid: {error}") from error
-    if version.release_tag != value:
-        raise ReleaseQualificationControllerError(
-            f"Release tag must use its canonical public spelling {version.release_tag!r}."
-        )
-    return value
-
-
-def _read_json_at_revision(
-    repo_root: Path,
-    revision: str,
-    relative_path: str,
-    description: str,
-) -> Mapping[str, Any]:
-    result = subprocess.run(
-        ["git", "show", f"{revision}:{relative_path}"],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        detail = result.stderr.strip() or "git show failed"
-        raise ReleaseQualificationControllerError(
-            f"Unable to read {description} from runner revision {revision}: {detail}"
-        )
-    try:
-        return _mapping(json.loads(result.stdout), description)
-    except json.JSONDecodeError as error:
-        raise ReleaseQualificationControllerError(
-            f"Invalid JSON in {description} from runner revision {revision}: {error}"
-        ) from error
-
-
-def _require_checked_file(repo_root: Path, relative_path: str, description: str) -> None:
-    path = Path(relative_path)
-    if path.is_absolute() or ".." in path.parts or relative_path.startswith("./"):
-        raise ReleaseQualificationControllerError(f"{description} must be a canonical repository-relative path.")
-    result = subprocess.run(
-        ["git", "show", f"HEAD:{relative_path}"],
-        cwd=repo_root,
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise ReleaseQualificationControllerError(f"{description} must be committed in the current repository HEAD.")
-    try:
-        current = (repo_root / path).read_bytes()
-    except OSError as error:
-        raise ReleaseQualificationControllerError(
-            f"Unable to read {description} at {relative_path}: {error}"
-        ) from error
-    if current != result.stdout:
-        raise ReleaseQualificationControllerError(f"{description} must match the checked content in repository HEAD.")
-
-
-def resolve_evidence_binding(repo_root: Path, release_tag: str) -> EvidenceBinding:
-    release_tag = _canonical_release_tag(release_tag)
-    release_root = repo_root / "docs" / "release-evidence" / release_tag
-    manifest_path = release_root / MANIFEST_NAME
-    if manifest_path.is_file():
-        context = resolve_milestone_manifest_context(repo_root, manifest_path)
-        manifest = load_validated_manifest(manifest_path, repo_root=repo_root)
-        mode = "manifest"
-    else:
-        receipt_path = release_root / "release-receipt.json"
-        if not receipt_path.is_file():
-            raise ReleaseQualificationControllerError(
-                f"No checked qualification manifest or release receipt exists for {release_tag}."
-            )
-        context = resolve_milestone_context(repo_root, receipt_path)
-        manifest = None
-        mode = "legacy"
-    if context.release_tag != release_tag:
-        raise ReleaseQualificationControllerError(
-            f"Resolved qualification evidence belongs to {context.release_tag}, not {release_tag}."
-        )
-    return EvidenceBinding(context=context, manifest=manifest, mode=mode)
-
-
-def _load_bound_policy(repo_root: Path, binding: EvidenceBinding) -> Mapping[str, Any]:
-    context = binding.context
-    if binding.mode == "manifest":
-        if not context.runner_sha:
-            raise ReleaseQualificationControllerError("Manifest-backed qualification status requires a runner SHA.")
-        return validate_policy(
-            _read_json_at_revision(
-                repo_root,
-                context.runner_sha,
-                context.policy_path,
-                "runner-bound release qualification policy",
-            )
-        )
-    return load_policy(repo_root / context.policy_path)
-
-
-def _policy_cases(policy: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
-    cases: dict[str, Mapping[str, Any]] = {}
-    for raw_case in _sequence(policy.get("cases"), "release qualification cases"):
-        case = _mapping(raw_case, "release qualification case")
-        case_id = _string(case.get("id"), "release qualification case ID")
-        cases[case_id] = case
-    return cases
-
-
-def _case_categories(
-    result: Mapping[str, Any],
-    policy_case: Mapping[str, Any],
-    blocking_case_ids: set[str],
-) -> tuple[str, ...]:
-    case_id = _string(result.get("case_id"), "qualification result case ID")
-    status = _string(result.get("status"), f"qualification result {case_id} status")
-    trigger = _string(result.get("trigger"), f"qualification result {case_id} trigger")
-    categories: list[str] = []
-    if status in {"covered", "carry"}:
-        categories.append("completed")
-    if status == "retest" and trigger in STALE_TRIGGERS:
-        categories.append("stale")
-    if case_id in blocking_case_ids:
-        categories.append("blocking")
-    if (
-        result.get("applicable") is True
-        and not bool(result.get("blocking"))
-        and (result.get("evidence_due") is True or result.get("operational_status") in {"due", "failed", "skipped"})
-    ):
-        categories.append("optional")
-    if (
-        policy_case.get("execution_mode") == "operator_assisted"
-        and result.get("evidence_due") is True
-        and result.get("applicable") is True
-    ):
-        categories.append("operator_required")
-    return tuple(category for category in STATUS_GROUPS if category in categories)
-
-
-def _overall_status(groups: Mapping[str, Sequence[str]]) -> str:
-    if groups["blocking"]:
-        return "blocked"
-    if groups["operator_required"]:
-        return "operator_required"
-    if groups["stale"] or groups["optional"]:
-        return "ready_with_optional_actions"
-    return "complete"
-
-
-def build_status(
-    repo_root: Path,
-    release_tag: str,
-    *,
-    as_of: date | None = None,
-) -> dict[str, Any]:
-    repo_root = repo_root.resolve()
-    binding = resolve_evidence_binding(repo_root, release_tag)
-    context = binding.context
-    checked_paths = {
-        context.evidence_path: "qualification evidence",
-        context.qualification_path: "qualification record",
-        context.release_receipt_path: "release receipt",
-    }
-    if binding.mode == "legacy":
-        checked_paths[context.policy_path] = "qualification policy"
-        checked_paths[f"docs/release-evidence/{context.release_tag}/publication-record.json"] = "publication record"
-    elif context.manifest_path:
-        checked_paths[context.manifest_path] = "qualification manifest"
-    for checked_path, description in checked_paths.items():
-        _require_checked_file(repo_root, checked_path, description)
-    if binding.manifest is not None:
-        canonical_evidence = _mapping(binding.manifest.get("canonical_evidence"), "manifest canonical evidence")
-        validate_manifest_evidence_history(
-            binding.manifest,
-            repo_root=repo_root,
-            base_revision=_string(canonical_evidence.get("base_sha"), "manifest evidence base SHA"),
-        )
-    policy = _load_bound_policy(repo_root, binding)
-    evidence = load_evidence(repo_root / context.evidence_path)
-    qualification_id, fresh_retest = load_qualification_overrides(
-        repo_root / context.qualification_path,
-        policy,
-    )
-    classification = classify_release_scope(
-        policy,
-        evidence,
-        candidate_sha=context.candidate_sha,
-        changed_paths=git_changed_paths(repo_root),
-        repo=repo_root,
-        qualification_id=qualification_id,
-        fresh_retest=fresh_retest,
-        release_stage=context.release_stage,
-        first_candidate_of_cycle=context.first_candidate_of_cycle,
-        workflow_phase="milestone",
-        milestone_receipt_path=repo_root / context.release_receipt_path,
-        as_of=as_of,
-    )
-
-    blocking_case_ids = set(
-        _string(value, "blocking qualification case ID")
-        for value in _sequence(classification.get("blocking_retests"), "blocking qualification cases")
-    )
-    cases_by_id = _policy_cases(policy)
-    groups: dict[str, list[str]] = {group: [] for group in STATUS_GROUPS}
-    cases: list[dict[str, Any]] = []
-    for raw_result in _sequence(classification.get("cases"), "qualification results"):
-        result = _mapping(raw_result, "qualification result")
-        case_id = _string(result.get("case_id"), "qualification result case ID")
-        policy_case = cases_by_id.get(case_id)
-        if policy_case is None:
-            raise ReleaseQualificationControllerError(
-                f"Qualification result references unknown policy case {case_id!r}."
-            )
-        categories = _case_categories(result, policy_case, blocking_case_ids)
-        for category in categories:
-            groups[category].append(case_id)
-        rendered_case = dict(result)
-        rendered_case["categories"] = list(categories)
-        rendered_case["operator_assisted"] = policy_case.get("execution_mode") == "operator_assisted"
-        cases.append(rendered_case)
-
-    frozen_groups = {group: groups[group] for group in STATUS_GROUPS}
-    return {
-        "schema_version": STATUS_SCHEMA_VERSION,
-        "status_type": STATUS_TYPE,
-        "release_tag": context.release_tag,
-        "candidate_sha": context.candidate_sha,
-        "release_stage": context.release_stage,
-        "first_candidate_of_cycle": context.first_candidate_of_cycle,
-        "workflow_phase": "milestone",
-        "as_of": classification["as_of"],
-        "policy_id": classification["policy_id"],
-        "qualification_id": classification["qualification_id"],
-        "evidence_binding": {
-            "mode": binding.mode,
-            "expected_evidence_ref": f"automation/release-evidence-{context.release_tag}",
-            "evidence_path": context.evidence_path,
-            "manifest_path": context.manifest_path,
-            "manifest_sha256": context.manifest_sha256,
-            "qualification_path": context.qualification_path,
-            "release_receipt_path": context.release_receipt_path,
-            "runner_sha": context.runner_sha,
-        },
-        "overall_status": _overall_status(frozen_groups),
-        "passed": not frozen_groups["blocking"],
-        "summary": {group: len(frozen_groups[group]) for group in STATUS_GROUPS},
-        "groups": frozen_groups,
-        "cases": cases,
-    }
+__all__ = [
+    "EvidenceBinding",
+    "ReleaseQualificationControllerError",
+    "_case_categories",
+    "_load_bound_policy",
+    "_require_checked_file",
+    "build_parser",
+    "build_status",
+    "main",
+    "resolve_evidence_binding",
+]
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/release_qualification_controller.py
+++ b/scripts/release_qualification_controller.py
@@ -335,11 +335,49 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser.add_argument("--release-tag", required=True)
     status_parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     status_parser.add_argument("--as-of", type=date.fromisoformat)
+    resume_parser = subparsers.add_parser(
+        "resume",
+        help="Observe qualification recovery and dispatch one exact milestone run when explicitly authorized.",
+    )
+    resume_parser.add_argument("--release-tag", required=True)
+    resume_parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    resume_parser.add_argument("--expected-main-sha")
+    resume_parser.add_argument("--expected-manifest-sha256")
+    resume_parser.add_argument("--retry-run-id", type=int)
+    resume_parser.add_argument("--retry-checkpoint-sha256")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.command == "resume":
+        from scripts.github_release_run import ReleaseRunError
+        from scripts.release_qualification_resume import (
+            EXIT_FAILED,
+            EXIT_SAFETY_ERROR,
+            QualificationResumeError,
+            QualificationResumeSafetyError,
+            resume_qualification,
+            safety_error_payload,
+        )
+
+        try:
+            result = resume_qualification(
+                args.repo_root,
+                args.release_tag,
+                expected_main_sha=args.expected_main_sha,
+                expected_manifest_sha256=args.expected_manifest_sha256,
+                retry_run_id=args.retry_run_id,
+                retry_checkpoint_sha256=args.retry_checkpoint_sha256,
+            )
+        except QualificationResumeSafetyError as error:
+            print(json.dumps(safety_error_payload(error), indent=2, sort_keys=True))
+            return EXIT_SAFETY_ERROR
+        except (json.JSONDecodeError, OSError, QualificationResumeError, ReleaseRunError) as error:
+            print(json.dumps(safety_error_payload(error, state="error"), indent=2, sort_keys=True))
+            return EXIT_FAILED
+        print(json.dumps(result.payload, indent=2, sort_keys=True))
+        return result.exit_code
     try:
         payload = build_status(
             args.repo_root,

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -21,7 +21,7 @@ from urllib.parse import quote
 from scripts.github_release_run import GhAPIClient
 from scripts.qualify_release_scope import QualificationScopeError
 from scripts.release_milestone_context import ReleaseMilestoneContextError
-from scripts.release_qualification_controller import (
+from scripts.release_qualification_status import (
     EvidenceBinding,
     ReleaseQualificationControllerError,
     build_status,

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -795,7 +795,7 @@ def _dispatch_locked(
             sleep(poll_seconds)
     return _result(
         "dispatch_visibility_pending",
-        EXIT_SUCCESS,
+        EXIT_OPERATOR_REQUIRED,
         status_payload,
         identity=identity,
         checkpoint_path=checkpoint_path,

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -1,0 +1,1117 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import time
+
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, cast
+from urllib.parse import quote
+
+from scripts.github_release_run import GhAPIClient
+from scripts.qualify_release_scope import QualificationScopeError
+from scripts.release_milestone_context import ReleaseMilestoneContextError
+from scripts.release_qualification_controller import (
+    EvidenceBinding,
+    ReleaseQualificationControllerError,
+    build_status,
+    resolve_evidence_binding,
+)
+from scripts.release_qualification_manifest import ReleaseQualificationManifestError
+
+
+REPOSITORY = "cbusillo/BD_to_AVP"
+REPOSITORY_OWNER = "cbusillo"
+MAIN_BRANCH = "main"
+WORKFLOW_FILE = "milestone-qualification.yml"
+WORKFLOW_NAME = "Milestone Qualification"
+WORKFLOW_PATH = ".github/workflows/milestone-qualification.yml"
+WORKFLOW_JOB_NAME = "Collect exact post-publication qualification receipts"
+RESUME_TYPE = "bd_to_avp.release_qualification_resume"
+CHECKPOINT_TYPE = "bd_to_avp.release_qualification_resume_checkpoint"
+SCHEMA_VERSION = 1
+EXIT_SUCCESS = 0
+EXIT_FAILED = 1
+EXIT_OPERATOR_REQUIRED = 20
+EXIT_SAFETY_ERROR = 21
+PREPARED_RETRY_AFTER_SECONDS = 600
+ACTIVE_RUN_STATUSES = {"in_progress", "pending", "queued", "requested", "waiting"}
+TERMINAL_RUN_STATUS = "completed"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9])/(?:Users|home|private|var|tmp)/[^\s\"']+")
+
+
+class QualificationResumeError(RuntimeError):
+    pass
+
+
+class QualificationResumeSafetyError(QualificationResumeError):
+    pass
+
+
+class GitHubAPI(Protocol):
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        raise NotImplementedError
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: Mapping[str, object],
+        *,
+        active_auth: bool = False,
+    ) -> object:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class ResumeIdentity:
+    release_tag: str
+    candidate_sha: str
+    release_id: int
+    manifest_sha256: str
+    runner_sha: str
+    main_sha: str
+    evidence_ref: str
+    evidence_sha: str
+    evidence_base_sha: str
+    evidence_pr_number: int
+    release_receipt_file_sha256: str
+    signed_ui_artifact_id: int
+    signed_ui_artifact_sha256: str
+    policy_sha256: str
+    policy_checkpoint_sha256: str
+    route_table_sha256: str
+    controller_runner_sha256: str
+
+    @property
+    def workflow_display_title(self) -> str:
+        return f"Milestone {self.release_tag} {self.manifest_sha256}"
+
+    def payload(self) -> dict[str, object]:
+        return asdict(self)
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(_canonical_json_bytes(self.payload())).hexdigest()
+
+
+@dataclass(frozen=True)
+class ResumeResult:
+    payload: dict[str, object]
+    exit_code: int
+
+
+Sleep = Callable[[float], None]
+Clock = Callable[[], datetime]
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise QualificationResumeError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise QualificationResumeError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise QualificationResumeError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise QualificationResumeError(f"{description} must be a positive integer.")
+    return value
+
+
+def _nonnegative_integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise QualificationResumeError(f"{description} must be a nonnegative integer.")
+    return value
+
+
+def _sha(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA_PATTERN.fullmatch(text) is None:
+        raise QualificationResumeError(f"{description} must be a full lowercase Git SHA.")
+    return text
+
+
+def _sha256(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA256_PATTERN.fullmatch(text) is None:
+        raise QualificationResumeError(f"{description} must be a lowercase SHA-256 digest.")
+    return text
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise QualificationResumeSafetyError(
+            f"{description} keys changed; missing={sorted(expected - actual)!r}, extra={sorted(actual - expected)!r}."
+        )
+
+
+def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def _git(
+    repo_root: Path,
+    arguments: Sequence[str],
+    *,
+    text: bool = True,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        capture_output=True,
+        text=text,
+        check=False,
+    )
+
+
+def _git_text(repo_root: Path, arguments: Sequence[str], description: str) -> str:
+    result = cast(subprocess.CompletedProcess[str], _git(repo_root, arguments))
+    if result.returncode != 0:
+        raise QualificationResumeError(f"Unable to read {description} from git.")
+    return result.stdout.strip()
+
+
+def _checkpoint_path(repo_root: Path, release_tag: str) -> Path:
+    common_dir = Path(_git_text(repo_root, ["rev-parse", "--git-common-dir"], "git common directory"))
+    if not common_dir.is_absolute():
+        common_dir = repo_root / common_dir
+    return common_dir.resolve() / "bd-to-avp" / "release-qualification" / f"{release_tag}.json"
+
+
+@contextmanager
+def _checkpoint_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.chmod(lock_path, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise QualificationResumeSafetyError(
+                "Another qualification resume process already owns this release checkpoint."
+            ) from error
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _load_checkpoint(path: Path) -> Mapping[str, Any] | None:
+    if not path.exists():
+        return None
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint permissions must be 0600.")
+    try:
+        checkpoint = _mapping(json.loads(path.read_text(encoding="utf-8")), "qualification resume checkpoint")
+    except OSError as error:
+        raise QualificationResumeError("Unable to read qualification resume checkpoint.") from error
+    except json.JSONDecodeError as error:
+        raise QualificationResumeSafetyError(f"Qualification resume checkpoint is invalid JSON: {error}") from error
+    if checkpoint.get("schema_version") != SCHEMA_VERSION or checkpoint.get("checkpoint_type") != CHECKPOINT_TYPE:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint schema or type is unsupported.")
+    _exact_keys(
+        checkpoint,
+        {
+            "schema_version",
+            "checkpoint_type",
+            "checkpoint_sha256",
+            "identity",
+            "identity_sha256",
+            "dispatch",
+        },
+        "qualification resume checkpoint",
+    )
+    recorded_digest = _sha256(checkpoint.get("checkpoint_sha256"), "checkpoint self digest")
+    digest_payload = dict(checkpoint)
+    digest_payload.pop("checkpoint_sha256")
+    if hashlib.sha256(_canonical_json_bytes(digest_payload)).hexdigest() != recorded_digest:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint self digest is invalid.")
+    return checkpoint
+
+
+def _write_checkpoint(path: Path, payload: Mapping[str, object]) -> None:
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(path.parent, 0o700)
+        rendered = _canonical_json_bytes(payload)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as temporary:
+                temporary_path = Path(temporary.name)
+                os.chmod(temporary_path, 0o600)
+                temporary.write(rendered)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            temporary_path.replace(path)
+            os.chmod(path, 0o600)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+    except OSError as error:
+        raise QualificationResumeError("Unable to write qualification resume checkpoint.") from error
+
+
+def _checkpoint_payload(
+    identity: ResumeIdentity,
+    *,
+    state: str,
+    high_water_run_id: int,
+    retry_of_run_id: int | None,
+    run_id: int | None = None,
+    run_attempt: int | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "identity": identity.payload(),
+        "identity_sha256": identity.digest,
+        "dispatch": {
+            "state": state,
+            "prepared_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "high_water_run_id": high_water_run_id,
+            "retry_of_run_id": retry_of_run_id,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+        },
+    }
+    payload["checkpoint_sha256"] = hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+    return payload
+
+
+def _validate_checkpoint(checkpoint: Mapping[str, Any], identity: ResumeIdentity) -> Mapping[str, Any]:
+    recorded_identity = _mapping(checkpoint.get("identity"), "checkpoint identity")
+    if recorded_identity != identity.payload() or checkpoint.get("identity_sha256") != identity.digest:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint conflicts with current release identity.")
+    dispatch = _mapping(checkpoint.get("dispatch"), "checkpoint dispatch")
+    _exact_keys(
+        dispatch,
+        {
+            "state",
+            "prepared_at",
+            "high_water_run_id",
+            "retry_of_run_id",
+            "run_id",
+            "run_attempt",
+        },
+        "checkpoint dispatch",
+    )
+    if dispatch.get("state") not in {"prepared", "observed"}:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint dispatch state is unsupported.")
+    prepared_at = _string(dispatch.get("prepared_at"), "checkpoint prepared timestamp")
+    try:
+        parsed_at = datetime.fromisoformat(prepared_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint timestamp is invalid.") from error
+    if parsed_at.tzinfo is None:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint timestamp must include a timezone.")
+    _nonnegative_integer(dispatch.get("high_water_run_id"), "checkpoint high-water run ID")
+    retry_of = dispatch.get("retry_of_run_id")
+    if retry_of is not None:
+        _integer(retry_of, "checkpoint retry run ID")
+    run_id = dispatch.get("run_id")
+    run_attempt = dispatch.get("run_attempt")
+    if dispatch.get("state") == "observed":
+        _integer(run_id, "checkpoint observed run ID")
+        _integer(run_attempt, "checkpoint observed run attempt")
+    elif run_id is not None or run_attempt is not None:
+        raise QualificationResumeSafetyError("Prepared qualification checkpoint cannot contain an observed run.")
+    return dispatch
+
+
+def _ref_endpoint(branch: str) -> str:
+    return f"repos/{REPOSITORY}/git/ref/heads/{quote(branch, safe='')}"
+
+
+def _workflow_runs_endpoint() -> str:
+    return (
+        f"repos/{REPOSITORY}/actions/workflows/{WORKFLOW_FILE}/runs"
+        f"?event=workflow_dispatch&branch={MAIN_BRANCH}&per_page=100"
+    )
+
+
+def _workflow_dispatch_endpoint() -> str:
+    return f"repos/{REPOSITORY}/actions/workflows/{WORKFLOW_FILE}/dispatches"
+
+
+def _ref_sha(client: GitHubAPI, branch: str) -> str:
+    reference = _mapping(
+        client.get_json(_ref_endpoint(branch), active_auth=True),
+        f"GitHub branch {branch}",
+    )
+    return _sha(_mapping(reference.get("object"), f"GitHub branch {branch} object").get("sha"), f"GitHub {branch} SHA")
+
+
+def _validate_repository(client: GitHubAPI) -> None:
+    repository = _mapping(
+        client.get_json(f"repos/{REPOSITORY}", active_auth=True),
+        "GitHub repository",
+    )
+    if repository.get("full_name") != REPOSITORY:
+        raise QualificationResumeSafetyError("GitHub repository identity does not match the qualification controller.")
+    owner = _mapping(repository.get("owner"), "GitHub repository owner")
+    if owner.get("login") != REPOSITORY_OWNER:
+        raise QualificationResumeSafetyError("GitHub repository owner does not match the qualification controller.")
+    _integer(repository.get("id"), "GitHub repository ID")
+
+
+def _open_evidence_pr(client: GitHubAPI, evidence_ref: str, evidence_sha: str) -> Mapping[str, Any]:
+    endpoint = (
+        f"repos/{REPOSITORY}/pulls?state=open&base={MAIN_BRANCH}"
+        f"&head={REPOSITORY_OWNER}%3A{quote(evidence_ref, safe='')}&per_page=100"
+    )
+    pulls = _sequence(client.get_json(endpoint, active_auth=True), "open evidence pull requests")
+    if len(pulls) != 1:
+        raise QualificationResumeSafetyError(
+            f"Expected exactly one open pull request for {evidence_ref}; found {len(pulls)}."
+        )
+    pull = _mapping(pulls[0], "evidence pull request")
+    head = _mapping(pull.get("head"), "evidence pull request head")
+    base = _mapping(pull.get("base"), "evidence pull request base")
+    if (
+        pull.get("state") != "open"
+        or head.get("ref") != evidence_ref
+        or head.get("sha") != evidence_sha
+        or _mapping(head.get("repo"), "evidence pull request head repository").get("full_name") != REPOSITORY
+        or base.get("ref") != MAIN_BRANCH
+        or _mapping(base.get("repo"), "evidence pull request base repository").get("full_name") != REPOSITORY
+    ):
+        raise QualificationResumeSafetyError(
+            "Evidence pull request identity conflicts with the checked evidence branch."
+        )
+    _integer(pull.get("number"), "evidence pull request number")
+    return pull
+
+
+def _require_local_evidence_checkout(repo_root: Path, identity: ResumeIdentity) -> None:
+    local_head = _sha(_git_text(repo_root, ["rev-parse", "HEAD"], "local HEAD"), "local HEAD")
+    local_branch = _git_text(repo_root, ["symbolic-ref", "--quiet", "--short", "HEAD"], "local branch")
+    if local_branch != identity.evidence_ref or local_head != identity.evidence_sha:
+        raise QualificationResumeSafetyError(
+            "Qualification resume must run from the exact checked evidence branch head."
+        )
+    ancestor = cast(
+        subprocess.CompletedProcess[str],
+        _git(repo_root, ["merge-base", "--is-ancestor", identity.main_sha, "HEAD"]),
+    )
+    if ancestor.returncode != 0:
+        raise QualificationResumeSafetyError("Evidence branch must contain the current protected main commit.")
+    changed = cast(
+        subprocess.CompletedProcess[bytes],
+        _git(repo_root, ["diff", "--name-only", "-z", f"{identity.main_sha}...HEAD"], text=False),
+    )
+    if changed.returncode != 0:
+        raise QualificationResumeError("Unable to inspect evidence branch changes against protected main.")
+    changed_paths = [item.decode("utf-8", errors="surrogateescape") for item in changed.stdout.split(b"\0") if item]
+    unexpected = sorted(path for path in changed_paths if not path.startswith("docs/"))
+    if unexpected:
+        raise QualificationResumeSafetyError(f"Evidence branch contains non-documentation changes: {unexpected!r}.")
+
+
+def _identity_from_binding(
+    binding: EvidenceBinding,
+    *,
+    main_sha: str,
+    evidence_sha: str,
+    evidence_pr_number: int,
+) -> ResumeIdentity:
+    manifest = binding.manifest
+    if manifest is None:
+        raise QualificationResumeError("Blocked qualification requires a canonical manifest before resume.")
+    candidate = _mapping(manifest.get("candidate"), "manifest candidate")
+    release = _mapping(manifest.get("release"), "manifest release")
+    canonical_evidence = _mapping(manifest.get("canonical_evidence"), "manifest canonical evidence")
+    input_digests = _mapping(manifest.get("input_digests"), "manifest input digests")
+    release_receipt = _mapping(manifest.get("release_receipt"), "manifest release receipt")
+    signed_ui = _mapping(manifest.get("signed_ui_artifact"), "manifest signed UI artifact")
+    return ResumeIdentity(
+        release_tag=_string(candidate.get("release_tag"), "manifest release tag"),
+        candidate_sha=_sha(candidate.get("source_sha"), "manifest candidate SHA"),
+        release_id=_integer(release.get("id"), "manifest release ID"),
+        manifest_sha256=_sha256(manifest.get("manifest_sha256"), "manifest self digest"),
+        runner_sha=_sha(manifest.get("runner_sha"), "manifest runner SHA"),
+        main_sha=_sha(main_sha, "protected main SHA"),
+        evidence_ref=_string(canonical_evidence.get("ref"), "manifest evidence ref"),
+        evidence_sha=_sha(evidence_sha, "evidence branch SHA"),
+        evidence_base_sha=_sha(canonical_evidence.get("base_sha"), "manifest evidence base SHA"),
+        evidence_pr_number=_integer(evidence_pr_number, "evidence pull request number"),
+        release_receipt_file_sha256=_sha256(
+            release_receipt.get("file_sha256"),
+            "manifest release receipt file digest",
+        ),
+        signed_ui_artifact_id=_integer(signed_ui.get("artifact_id"), "manifest signed UI artifact ID"),
+        signed_ui_artifact_sha256=_sha256(
+            signed_ui.get("artifact_sha256"),
+            "manifest signed UI artifact digest",
+        ),
+        policy_sha256=_sha256(input_digests.get("policy"), "manifest policy digest"),
+        policy_checkpoint_sha256=_sha256(
+            input_digests.get("policy_checkpoint"),
+            "manifest policy checkpoint digest",
+        ),
+        route_table_sha256=_sha256(input_digests.get("route_table"), "manifest route table digest"),
+        controller_runner_sha256=_sha256(
+            input_digests.get("controller_runner"),
+            "manifest controller runner digest",
+        ),
+    )
+
+
+def _workflow_runs(client: GitHubAPI, identity: ResumeIdentity) -> tuple[list[Mapping[str, Any]], int]:
+    payload = _mapping(
+        client.get_json(_workflow_runs_endpoint(), active_auth=True),
+        "Milestone Qualification workflow runs",
+    )
+    runs = [
+        _mapping(item, "Milestone Qualification workflow run")
+        for item in _sequence(payload.get("workflow_runs"), "workflow runs")
+    ]
+    high_water = max((_integer(run.get("id"), "workflow run ID") for run in runs), default=0)
+    matches = [run for run in runs if _run_matches(run, identity)]
+    return sorted(matches, key=lambda run: cast(int, run["id"]), reverse=True), high_water
+
+
+def _run_matches(run: Mapping[str, Any], identity: ResumeIdentity) -> bool:
+    actor = run.get("actor")
+    triggering_actor = run.get("triggering_actor")
+    return (
+        run.get("name") == WORKFLOW_NAME
+        and run.get("path") == WORKFLOW_PATH
+        and run.get("display_title") == identity.workflow_display_title
+        and run.get("event") == "workflow_dispatch"
+        and run.get("head_branch") == MAIN_BRANCH
+        and run.get("head_sha") == identity.runner_sha
+        and isinstance(actor, Mapping)
+        and actor.get("login") == REPOSITORY_OWNER
+        and isinstance(triggering_actor, Mapping)
+        and triggering_actor.get("login") == REPOSITORY_OWNER
+        and isinstance(run.get("id"), int)
+        and not isinstance(run.get("id"), bool)
+    )
+
+
+def _run_identity(run: Mapping[str, Any], identity: ResumeIdentity) -> dict[str, object]:
+    if not _run_matches(run, identity):
+        raise QualificationResumeSafetyError("Milestone Qualification run identity conflicts with resume inputs.")
+    status = _string(run.get("status"), "workflow run status")
+    conclusion = run.get("conclusion")
+    if conclusion is not None and not isinstance(conclusion, str):
+        raise QualificationResumeError("Workflow run conclusion must be a string or null.")
+    return {
+        "id": _integer(run.get("id"), "workflow run ID"),
+        "run_attempt": _integer(run.get("run_attempt"), "workflow run attempt"),
+        "status": status,
+        "conclusion": conclusion,
+        "url": _string(run.get("html_url"), "workflow run URL"),
+    }
+
+
+def _workflow_run(client: GitHubAPI, run_id: int, identity: ResumeIdentity) -> Mapping[str, Any]:
+    run = _mapping(
+        client.get_json(f"repos/{REPOSITORY}/actions/runs/{run_id}", active_auth=True),
+        "Milestone Qualification workflow run",
+    )
+    _run_identity(run, identity)
+    return run
+
+
+def _run_jobs_succeeded(client: GitHubAPI, run_id: int) -> bool:
+    payload = _mapping(
+        client.get_json(
+            f"repos/{REPOSITORY}/actions/runs/{run_id}/jobs?per_page=100",
+            active_auth=True,
+        ),
+        "workflow jobs",
+    )
+    jobs = [
+        _mapping(item, "workflow job")
+        for item in _sequence(payload.get("jobs"), "workflow jobs")
+        if isinstance(item, Mapping) and item.get("name") == WORKFLOW_JOB_NAME
+    ]
+    if len(jobs) != 1:
+        raise QualificationResumeSafetyError(
+            f"Expected exactly one {WORKFLOW_JOB_NAME!r} job for run {run_id}; found {len(jobs)}."
+        )
+    return jobs[0].get("status") == "completed" and jobs[0].get("conclusion") == "success"
+
+
+def _artifact_state(client: GitHubAPI, identity: ResumeIdentity, run: Mapping[str, Any]) -> dict[str, object]:
+    run_id = _integer(run.get("id"), "workflow run ID")
+    run_attempt = _integer(run.get("run_attempt"), "workflow run attempt")
+    payload = _mapping(
+        client.get_json(
+            f"repos/{REPOSITORY}/actions/runs/{run_id}/artifacts?per_page=100",
+            active_auth=True,
+        ),
+        "run artifacts",
+    )
+    expected_name = f"milestone-qualification-{identity.release_tag}-{run_attempt}"
+    matches = [
+        _mapping(item, "Milestone Qualification artifact")
+        for item in _sequence(payload.get("artifacts"), "run artifacts")
+        if isinstance(item, Mapping) and item.get("name") == expected_name
+    ]
+    if len(matches) > 1:
+        raise QualificationResumeSafetyError(
+            f"Multiple exact Milestone Qualification artifacts exist for run {run_id}."
+        )
+    if not matches:
+        return {"state": "missing", "name": expected_name, "run_id": run_id}
+    artifact = matches[0]
+    workflow_run = _mapping(artifact.get("workflow_run"), "artifact workflow run")
+    if (
+        workflow_run.get("id") != run_id
+        or workflow_run.get("head_branch") != MAIN_BRANCH
+        or workflow_run.get("head_sha") != identity.runner_sha
+    ):
+        raise QualificationResumeSafetyError("Milestone Qualification artifact workflow identity conflicts.")
+    digest = _string(artifact.get("digest"), "artifact digest")
+    if not digest.startswith("sha256:") or SHA256_PATTERN.fullmatch(digest.removeprefix("sha256:")) is None:
+        raise QualificationResumeError("Milestone Qualification artifact digest is invalid.")
+    expired = artifact.get("expired")
+    if not isinstance(expired, bool):
+        raise QualificationResumeError("Milestone Qualification artifact expired state must be boolean.")
+    return {
+        "state": "expired" if expired else "available",
+        "id": _integer(artifact.get("id"), "Milestone Qualification artifact ID"),
+        "name": expected_name,
+        "digest": digest,
+        "expired": expired,
+        "run_id": run_id,
+    }
+
+
+def _result(
+    state: str,
+    exit_code: int,
+    status_payload: Mapping[str, Any],
+    *,
+    identity: ResumeIdentity | None = None,
+    checkpoint_path: Path | None = None,
+    run: Mapping[str, object] | None = None,
+    artifact: Mapping[str, object] | None = None,
+    next_action: str,
+    mutation: Mapping[str, object] | None = None,
+) -> ResumeResult:
+    payload: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "resume_type": RESUME_TYPE,
+        "state": state,
+        "next_action": next_action,
+        "qualification_status": {
+            "release_tag": status_payload.get("release_tag"),
+            "candidate_sha": status_payload.get("candidate_sha"),
+            "overall_status": status_payload.get("overall_status"),
+            "passed": status_payload.get("passed"),
+            "summary": status_payload.get("summary"),
+            "groups": status_payload.get("groups"),
+        },
+        "identity": identity.payload() if identity is not None else None,
+        "identity_sha256": identity.digest if identity is not None else None,
+        "checkpoint": {
+            "present": checkpoint_path is not None and checkpoint_path.exists(),
+        },
+        "run": dict(run) if run is not None else None,
+        "artifact": dict(artifact) if artifact is not None else None,
+        "planned_mutation": dict(mutation) if mutation is not None else None,
+    }
+    return ResumeResult(payload=payload, exit_code=exit_code)
+
+
+def _validate_expected_mutation(
+    identity: ResumeIdentity,
+    *,
+    expected_main_sha: str | None,
+    expected_manifest_sha256: str | None,
+) -> bool:
+    if expected_main_sha is None and expected_manifest_sha256 is None:
+        return False
+    if expected_main_sha is None or expected_manifest_sha256 is None:
+        raise QualificationResumeSafetyError(
+            "Dispatch authorization requires both expected main SHA and expected manifest SHA-256."
+        )
+    if _sha(expected_main_sha, "expected main SHA") != identity.main_sha:
+        raise QualificationResumeSafetyError("Expected main SHA does not match protected main.")
+    if _sha256(expected_manifest_sha256, "expected manifest digest") != identity.manifest_sha256:
+        raise QualificationResumeSafetyError("Expected manifest digest does not match checked evidence.")
+    return True
+
+
+def _require_dispatch_actor(client: GitHubAPI) -> None:
+    user = _mapping(client.get_json("user", active_auth=True), "active GitHub user")
+    if user.get("login") != REPOSITORY_OWNER:
+        raise QualificationResumeSafetyError(
+            f"Milestone Qualification dispatch requires active GitHub identity {REPOSITORY_OWNER!r}."
+        )
+
+
+def _revalidate_remote_identity(client: GitHubAPI, identity: ResumeIdentity) -> None:
+    if _ref_sha(client, MAIN_BRANCH) != identity.main_sha:
+        raise QualificationResumeSafetyError("Protected main moved after qualification resume preflight.")
+    if _ref_sha(client, identity.evidence_ref) != identity.evidence_sha:
+        raise QualificationResumeSafetyError("Evidence branch moved after qualification resume preflight.")
+    pull = _open_evidence_pr(client, identity.evidence_ref, identity.evidence_sha)
+    if pull.get("number") != identity.evidence_pr_number:
+        raise QualificationResumeSafetyError("Evidence pull request changed after qualification resume preflight.")
+
+
+def _dispatch(
+    client: GitHubAPI,
+    identity: ResumeIdentity,
+    checkpoint_path: Path,
+    *,
+    high_water_run_id: int,
+    retry_of_run_id: int | None,
+    replace_prepared_checkpoint_sha256: str | None,
+    status_payload: Mapping[str, Any],
+    poll_attempts: int,
+    poll_seconds: float,
+    sleep: Sleep,
+) -> ResumeResult:
+    with _checkpoint_lock(checkpoint_path):
+        return _dispatch_locked(
+            client,
+            identity,
+            checkpoint_path,
+            high_water_run_id=high_water_run_id,
+            retry_of_run_id=retry_of_run_id,
+            replace_prepared_checkpoint_sha256=replace_prepared_checkpoint_sha256,
+            status_payload=status_payload,
+            poll_attempts=poll_attempts,
+            poll_seconds=poll_seconds,
+            sleep=sleep,
+        )
+
+
+def _dispatch_locked(
+    client: GitHubAPI,
+    identity: ResumeIdentity,
+    checkpoint_path: Path,
+    *,
+    high_water_run_id: int,
+    retry_of_run_id: int | None,
+    replace_prepared_checkpoint_sha256: str | None,
+    status_payload: Mapping[str, Any],
+    poll_attempts: int,
+    poll_seconds: float,
+    sleep: Sleep,
+) -> ResumeResult:
+    _require_dispatch_actor(client)
+    _revalidate_remote_identity(client, identity)
+    existing_checkpoint = _load_checkpoint(checkpoint_path)
+    if existing_checkpoint is not None:
+        existing_dispatch = _validate_checkpoint(existing_checkpoint, identity)
+        existing_state = cast(str, existing_dispatch["state"])
+        existing_run_id = cast(int | None, existing_dispatch.get("run_id"))
+        if replace_prepared_checkpoint_sha256 is not None:
+            recorded_digest = _sha256(
+                existing_checkpoint.get("checkpoint_sha256"),
+                "prepared checkpoint self digest",
+            )
+            if existing_state != "prepared" or recorded_digest != replace_prepared_checkpoint_sha256:
+                raise QualificationResumeSafetyError(
+                    "Prepared checkpoint retry does not match the serialized qualification checkpoint."
+                )
+        elif retry_of_run_id is None:
+            return _result(
+                "dispatch_visibility_pending" if existing_state == "prepared" else "running",
+                EXIT_SUCCESS,
+                status_payload,
+                identity=identity,
+                checkpoint_path=checkpoint_path,
+                next_action="A serialized dispatch checkpoint already exists; run resume again to observe it.",
+            )
+        elif existing_state != "observed" or existing_run_id != retry_of_run_id:
+            raise QualificationResumeSafetyError(
+                "Retry dispatch conflicts with the serialized qualification checkpoint."
+            )
+    prepared = _checkpoint_payload(
+        identity,
+        state="prepared",
+        high_water_run_id=high_water_run_id,
+        retry_of_run_id=retry_of_run_id,
+    )
+    _write_checkpoint(checkpoint_path, prepared)
+    dispatch_payload: dict[str, object] = {
+        "ref": MAIN_BRANCH,
+        "inputs": {
+            "candidate_tag": identity.release_tag,
+            "manifest_sha256": identity.manifest_sha256,
+        },
+    }
+    client.post_json(_workflow_dispatch_endpoint(), dispatch_payload, active_auth=True)
+    for attempt in range(max(1, poll_attempts)):
+        matches, _high_water = _workflow_runs(client, identity)
+        new_matches = [run for run in matches if cast(int, run["id"]) > high_water_run_id]
+        if len(new_matches) > 1:
+            raise QualificationResumeSafetyError("Multiple workflow runs appeared for one qualification dispatch.")
+        if len(new_matches) == 1:
+            run_payload = _run_identity(new_matches[0], identity)
+            observed = _checkpoint_payload(
+                identity,
+                state="observed",
+                high_water_run_id=high_water_run_id,
+                retry_of_run_id=retry_of_run_id,
+                run_id=cast(int, run_payload["id"]),
+                run_attempt=cast(int, run_payload["run_attempt"]),
+            )
+            _write_checkpoint(checkpoint_path, observed)
+            return _result(
+                "running",
+                EXIT_SUCCESS,
+                status_payload,
+                identity=identity,
+                checkpoint_path=checkpoint_path,
+                run=run_payload,
+                next_action="Wait for the exact Milestone Qualification run to finish, then run resume again.",
+            )
+        if attempt + 1 < max(1, poll_attempts):
+            sleep(poll_seconds)
+    return _result(
+        "dispatch_visibility_pending",
+        EXIT_SUCCESS,
+        status_payload,
+        identity=identity,
+        checkpoint_path=checkpoint_path,
+        next_action="The dispatch was accepted but its run is not visible yet; run resume again without redispatching.",
+    )
+
+
+def resume_qualification(
+    repo_root: Path,
+    release_tag: str,
+    *,
+    expected_main_sha: str | None = None,
+    expected_manifest_sha256: str | None = None,
+    retry_run_id: int | None = None,
+    retry_checkpoint_sha256: str | None = None,
+    client: GitHubAPI | None = None,
+    checkpoint_path: Path | None = None,
+    poll_attempts: int = 10,
+    poll_seconds: float = 2.0,
+    sleep: Sleep = time.sleep,
+    prepared_retry_after_seconds: int = PREPARED_RETRY_AFTER_SECONDS,
+    now: Clock = lambda: datetime.now(timezone.utc),
+) -> ResumeResult:
+    repo_root = repo_root.resolve()
+    if retry_run_id is not None:
+        retry_run_id = _integer(retry_run_id, "retry run ID")
+    if retry_checkpoint_sha256 is not None:
+        retry_checkpoint_sha256 = _sha256(retry_checkpoint_sha256, "retry checkpoint digest")
+    if prepared_retry_after_seconds < 0:
+        raise QualificationResumeError("Prepared checkpoint retry delay must be nonnegative.")
+    try:
+        status_payload = build_status(repo_root, release_tag)
+    except (
+        json.JSONDecodeError,
+        OSError,
+        QualificationScopeError,
+        ReleaseMilestoneContextError,
+        ReleaseQualificationControllerError,
+        ReleaseQualificationManifestError,
+    ) as error:
+        raise QualificationResumeError("Checked qualification status could not be resolved.") from error
+    groups = _mapping(status_payload.get("groups"), "qualification status groups")
+    blocking = _sequence(groups.get("blocking"), "blocking qualification cases")
+    if not blocking:
+        return _result(
+            "complete",
+            EXIT_SUCCESS,
+            status_payload,
+            next_action="No blocking qualification work remains; no GitHub or git mutation was performed.",
+        )
+
+    try:
+        binding = resolve_evidence_binding(repo_root, release_tag)
+    except (
+        json.JSONDecodeError,
+        OSError,
+        ReleaseMilestoneContextError,
+        ReleaseQualificationControllerError,
+        ReleaseQualificationManifestError,
+    ) as error:
+        raise QualificationResumeError("Checked qualification manifest could not be resolved.") from error
+    if binding.manifest is None:
+        return _result(
+            "manifest_missing",
+            EXIT_OPERATOR_REQUIRED,
+            status_payload,
+            next_action="Refresh Release Evidence so the blocked release has a canonical qualification manifest.",
+        )
+
+    github = client or GhAPIClient()
+    _validate_repository(github)
+    main_sha = _ref_sha(github, MAIN_BRANCH)
+    canonical_evidence = _mapping(binding.manifest.get("canonical_evidence"), "manifest canonical evidence")
+    evidence_ref = _string(canonical_evidence.get("ref"), "manifest evidence ref")
+    evidence_sha = _ref_sha(github, evidence_ref)
+    pull = _open_evidence_pr(github, evidence_ref, evidence_sha)
+    identity = _identity_from_binding(
+        binding,
+        main_sha=main_sha,
+        evidence_sha=evidence_sha,
+        evidence_pr_number=_integer(pull.get("number"), "evidence pull request number"),
+    )
+    if identity.runner_sha != identity.main_sha:
+        return _result(
+            "runner_stale",
+            EXIT_OPERATOR_REQUIRED,
+            status_payload,
+            identity=identity,
+            next_action="Rerun Release Evidence to refresh the manifest against the current protected main SHA.",
+        )
+    _require_local_evidence_checkout(repo_root, identity)
+
+    resolved_checkpoint_path = checkpoint_path or _checkpoint_path(repo_root, release_tag)
+    if resolved_checkpoint_path.exists():
+        with _checkpoint_lock(resolved_checkpoint_path):
+            checkpoint = _load_checkpoint(resolved_checkpoint_path)
+    else:
+        checkpoint = None
+    matches, high_water_run_id = _workflow_runs(github, identity)
+    active = [run for run in matches if run.get("status") in ACTIVE_RUN_STATUSES]
+    if len(active) > 1:
+        raise QualificationResumeSafetyError("Multiple active exact Milestone Qualification runs exist.")
+    if checkpoint is not None:
+        dispatch_checkpoint = _validate_checkpoint(checkpoint, identity)
+        checkpoint_state = cast(str, dispatch_checkpoint["state"])
+        checkpoint_high_water = cast(int, dispatch_checkpoint["high_water_run_id"])
+        checkpoint_digest = _sha256(
+            checkpoint.get("checkpoint_sha256"),
+            "checkpoint self digest",
+        )
+        if checkpoint_state == "prepared":
+            new_matches = [run for run in matches if cast(int, run["id"]) > checkpoint_high_water]
+            if len(new_matches) > 1:
+                raise QualificationResumeSafetyError("Multiple runs match one prepared qualification dispatch.")
+            if not new_matches:
+                if retry_checkpoint_sha256 is not None:
+                    if retry_checkpoint_sha256 != checkpoint_digest:
+                        raise QualificationResumeSafetyError(
+                            "Retry checkpoint digest does not match the prepared dispatch."
+                        )
+                    prepared_at = datetime.fromisoformat(
+                        _string(dispatch_checkpoint.get("prepared_at"), "checkpoint prepared timestamp").replace(
+                            "Z", "+00:00"
+                        )
+                    )
+                    age_seconds = (
+                        now().astimezone(timezone.utc) - prepared_at.astimezone(timezone.utc)
+                    ).total_seconds()
+                    if age_seconds < prepared_retry_after_seconds:
+                        return _result(
+                            "dispatch_visibility_pending",
+                            EXIT_OPERATOR_REQUIRED,
+                            status_payload,
+                            identity=identity,
+                            checkpoint_path=resolved_checkpoint_path,
+                            next_action=(
+                                "The prepared dispatch is still inside its visibility window; wait before retrying."
+                            ),
+                        )
+                    authorized_retry = _validate_expected_mutation(
+                        identity,
+                        expected_main_sha=expected_main_sha,
+                        expected_manifest_sha256=expected_manifest_sha256,
+                    )
+                    if not authorized_retry:
+                        raise QualificationResumeSafetyError(
+                            "Prepared dispatch retry requires exact main and manifest authorization."
+                        )
+                    return _dispatch(
+                        github,
+                        identity,
+                        resolved_checkpoint_path,
+                        high_water_run_id=high_water_run_id,
+                        retry_of_run_id=None,
+                        replace_prepared_checkpoint_sha256=checkpoint_digest,
+                        status_payload=status_payload,
+                        poll_attempts=poll_attempts,
+                        poll_seconds=poll_seconds,
+                        sleep=sleep,
+                    )
+                return _result(
+                    "dispatch_visibility_pending",
+                    EXIT_OPERATOR_REQUIRED,
+                    status_payload,
+                    identity=identity,
+                    checkpoint_path=resolved_checkpoint_path,
+                    next_action=(
+                        "A dispatch checkpoint is prepared; wait for its exact run or, after the visibility window, "
+                        f"retry with --retry-checkpoint-sha256 {checkpoint_digest}."
+                    ),
+                )
+            observed_run = _run_identity(new_matches[0], identity)
+            checkpoint = _checkpoint_payload(
+                identity,
+                state="observed",
+                high_water_run_id=checkpoint_high_water,
+                retry_of_run_id=cast(int | None, dispatch_checkpoint.get("retry_of_run_id")),
+                run_id=cast(int, observed_run["id"]),
+                run_attempt=cast(int, observed_run["run_attempt"]),
+            )
+            with _checkpoint_lock(resolved_checkpoint_path):
+                current_checkpoint = _load_checkpoint(resolved_checkpoint_path)
+                if current_checkpoint is None or current_checkpoint.get("checkpoint_sha256") != checkpoint_digest:
+                    raise QualificationResumeSafetyError(
+                        "Qualification checkpoint moved before the observed run could be recorded."
+                    )
+                _write_checkpoint(resolved_checkpoint_path, checkpoint)
+        observed_dispatch = _mapping(checkpoint.get("dispatch"), "checkpoint dispatch")
+        observed_run_id = _integer(observed_dispatch.get("run_id"), "checkpoint observed run ID")
+        selected_run = _workflow_run(github, observed_run_id, identity)
+    else:
+        terminal = [run for run in matches if run.get("status") == TERMINAL_RUN_STATUS]
+        selected_run = active[0] if active else terminal[0] if terminal else None
+
+    if active and selected_run is not None and selected_run.get("id") != active[0].get("id"):
+        raise QualificationResumeSafetyError("An active exact run conflicts with the checkpoint-observed run.")
+    if selected_run is not None and selected_run.get("status") in ACTIVE_RUN_STATUSES:
+        run_payload = _run_identity(selected_run, identity)
+        return _result(
+            "running",
+            EXIT_SUCCESS,
+            status_payload,
+            identity=identity,
+            checkpoint_path=resolved_checkpoint_path,
+            run=run_payload,
+            next_action="Wait for the exact Milestone Qualification run to finish, then run resume again.",
+        )
+
+    authorized = _validate_expected_mutation(
+        identity,
+        expected_main_sha=expected_main_sha,
+        expected_manifest_sha256=expected_manifest_sha256,
+    )
+    if selected_run is None:
+        if retry_run_id is not None:
+            raise QualificationResumeSafetyError("Retry run ID does not match any exact terminal qualification run.")
+        mutation = {
+            "operation": "dispatch",
+            "endpoint": _workflow_dispatch_endpoint(),
+            "ref": MAIN_BRANCH,
+            "candidate_tag": identity.release_tag,
+            "manifest_sha256": identity.manifest_sha256,
+        }
+        if not authorized:
+            return _result(
+                "dispatch_ready",
+                EXIT_OPERATOR_REQUIRED,
+                status_payload,
+                identity=identity,
+                checkpoint_path=resolved_checkpoint_path,
+                mutation=mutation,
+                next_action="Rerun resume with the exact expected main and manifest digests to authorize dispatch.",
+            )
+        return _dispatch(
+            github,
+            identity,
+            resolved_checkpoint_path,
+            high_water_run_id=high_water_run_id,
+            retry_of_run_id=None,
+            replace_prepared_checkpoint_sha256=None,
+            status_payload=status_payload,
+            poll_attempts=poll_attempts,
+            poll_seconds=poll_seconds,
+            sleep=sleep,
+        )
+
+    run_payload = _run_identity(selected_run, identity)
+    run_id = cast(int, run_payload["id"])
+    if run_payload["status"] != TERMINAL_RUN_STATUS:
+        raise QualificationResumeSafetyError("Selected Milestone Qualification run has an unsupported state.")
+    succeeded = run_payload["conclusion"] == "success" and _run_jobs_succeeded(github, run_id)
+    artifact = _artifact_state(github, identity, selected_run) if succeeded else None
+    if succeeded and artifact is not None and artifact["state"] == "available":
+        return _result(
+            "artifact_available",
+            EXIT_OPERATOR_REQUIRED,
+            status_payload,
+            identity=identity,
+            checkpoint_path=resolved_checkpoint_path,
+            run=run_payload,
+            artifact=artifact,
+            next_action="Validate and reconcile the exact qualification artifact into the evidence branch.",
+        )
+
+    failure_state = (
+        "artifact_expired" if succeeded and artifact is not None and artifact["state"] == "expired" else "failed"
+    )
+    if retry_run_id != run_id:
+        return _result(
+            failure_state,
+            EXIT_OPERATOR_REQUIRED,
+            status_payload,
+            identity=identity,
+            checkpoint_path=resolved_checkpoint_path,
+            run=run_payload,
+            artifact=artifact,
+            next_action=f"Rerun resume with --retry-run-id {run_id} and the exact expected main and manifest digests.",
+        )
+    if not authorized:
+        raise QualificationResumeSafetyError("Retry authorization requires exact expected main and manifest digests.")
+    return _dispatch(
+        github,
+        identity,
+        resolved_checkpoint_path,
+        high_water_run_id=high_water_run_id,
+        retry_of_run_id=run_id,
+        replace_prepared_checkpoint_sha256=None,
+        status_payload=status_payload,
+        poll_attempts=poll_attempts,
+        poll_seconds=poll_seconds,
+        sleep=sleep,
+    )
+
+
+def safety_error_payload(error: Exception, *, state: str = "conflict") -> dict[str, object]:
+    message = ABSOLUTE_PATH_PATTERN.sub("<local-path>", str(error))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "resume_type": RESUME_TYPE,
+        "state": state,
+        "error": message,
+    }
+
+
+def default_client() -> GitHubAPI:
+    return GhAPIClient()
+
+
+__all__ = [
+    "EXIT_FAILED",
+    "EXIT_OPERATOR_REQUIRED",
+    "EXIT_SAFETY_ERROR",
+    "EXIT_SUCCESS",
+    "QualificationResumeError",
+    "QualificationResumeSafetyError",
+    "ResumeIdentity",
+    "ResumeResult",
+    "resume_qualification",
+    "safety_error_payload",
+]

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -738,9 +738,10 @@ def _dispatch_locked(
                     "Prepared checkpoint retry does not match the serialized qualification checkpoint."
                 )
         elif retry_of_run_id is None:
+            checkpoint_state = "dispatch_visibility_pending" if existing_state == "prepared" else "running"
             return _result(
-                "dispatch_visibility_pending" if existing_state == "prepared" else "running",
-                EXIT_SUCCESS,
+                checkpoint_state,
+                EXIT_OPERATOR_REQUIRED if checkpoint_state == "dispatch_visibility_pending" else EXIT_SUCCESS,
                 status_payload,
                 identity=identity,
                 checkpoint_path=checkpoint_path,

--- a/scripts/release_qualification_status.py
+++ b/scripts/release_qualification_status.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.qualify_release_scope import (
+    classify_release_scope,
+    git_changed_paths,
+    load_evidence,
+    load_policy,
+    load_qualification_overrides,
+    validate_policy,
+)
+from scripts.release import ReleaseError, parse_release_tag
+from scripts.release_milestone_context import (
+    ReleaseMilestoneContext,
+    resolve_milestone_context,
+    resolve_milestone_manifest_context,
+)
+from scripts.release_qualification_manifest import (
+    MANIFEST_NAME,
+    load_validated_manifest,
+    validate_manifest_evidence_history,
+)
+
+
+STATUS_TYPE = "bd_to_avp.release_qualification_status"
+STATUS_SCHEMA_VERSION = 1
+STATUS_GROUPS = ("completed", "stale", "blocking", "optional", "operator_required")
+STALE_TRIGGERS = {
+    "carry_disallowed",
+    "expired",
+    "explicit_retest",
+    "invalidated",
+    "milestone_receipt_mismatch",
+}
+
+
+class ReleaseQualificationControllerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvidenceBinding:
+    context: ReleaseMilestoneContext
+    manifest: Mapping[str, Any] | None
+    mode: str
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReleaseQualificationControllerError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ReleaseQualificationControllerError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReleaseQualificationControllerError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _canonical_release_tag(value: str) -> str:
+    try:
+        version = parse_release_tag(value)
+    except ReleaseError as error:
+        raise ReleaseQualificationControllerError(f"Release tag is invalid: {error}") from error
+    if version.release_tag != value:
+        raise ReleaseQualificationControllerError(
+            f"Release tag must use its canonical public spelling {version.release_tag!r}."
+        )
+    return value
+
+
+def _read_json_at_revision(
+    repo_root: Path,
+    revision: str,
+    relative_path: str,
+    description: str,
+) -> Mapping[str, Any]:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "git show failed"
+        raise ReleaseQualificationControllerError(
+            f"Unable to read {description} from runner revision {revision}: {detail}"
+        )
+    try:
+        return _mapping(json.loads(result.stdout), description)
+    except json.JSONDecodeError as error:
+        raise ReleaseQualificationControllerError(
+            f"Invalid JSON in {description} from runner revision {revision}: {error}"
+        ) from error
+
+
+def _require_checked_file(repo_root: Path, relative_path: str, description: str) -> None:
+    path = Path(relative_path)
+    if path.is_absolute() or ".." in path.parts or relative_path.startswith("./"):
+        raise ReleaseQualificationControllerError(f"{description} must be a canonical repository-relative path.")
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseQualificationControllerError(f"{description} must be committed in the current repository HEAD.")
+    try:
+        current = (repo_root / path).read_bytes()
+    except OSError as error:
+        raise ReleaseQualificationControllerError(
+            f"Unable to read {description} at {relative_path}: {error}"
+        ) from error
+    if current != result.stdout:
+        raise ReleaseQualificationControllerError(f"{description} must match the checked content in repository HEAD.")
+
+
+def resolve_evidence_binding(repo_root: Path, release_tag: str) -> EvidenceBinding:
+    release_tag = _canonical_release_tag(release_tag)
+    release_root = repo_root / "docs" / "release-evidence" / release_tag
+    manifest_path = release_root / MANIFEST_NAME
+    if manifest_path.is_file():
+        context = resolve_milestone_manifest_context(repo_root, manifest_path)
+        manifest = load_validated_manifest(manifest_path, repo_root=repo_root)
+        mode = "manifest"
+    else:
+        receipt_path = release_root / "release-receipt.json"
+        if not receipt_path.is_file():
+            raise ReleaseQualificationControllerError(
+                f"No checked qualification manifest or release receipt exists for {release_tag}."
+            )
+        context = resolve_milestone_context(repo_root, receipt_path)
+        manifest = None
+        mode = "legacy"
+    if context.release_tag != release_tag:
+        raise ReleaseQualificationControllerError(
+            f"Resolved qualification evidence belongs to {context.release_tag}, not {release_tag}."
+        )
+    return EvidenceBinding(context=context, manifest=manifest, mode=mode)
+
+
+def _load_bound_policy(repo_root: Path, binding: EvidenceBinding) -> Mapping[str, Any]:
+    context = binding.context
+    if binding.mode == "manifest":
+        if not context.runner_sha:
+            raise ReleaseQualificationControllerError("Manifest-backed qualification status requires a runner SHA.")
+        return validate_policy(
+            _read_json_at_revision(
+                repo_root,
+                context.runner_sha,
+                context.policy_path,
+                "runner-bound release qualification policy",
+            )
+        )
+    return load_policy(repo_root / context.policy_path)
+
+
+def _policy_cases(policy: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    cases: dict[str, Mapping[str, Any]] = {}
+    for raw_case in _sequence(policy.get("cases"), "release qualification cases"):
+        case = _mapping(raw_case, "release qualification case")
+        case_id = _string(case.get("id"), "release qualification case ID")
+        cases[case_id] = case
+    return cases
+
+
+def _case_categories(
+    result: Mapping[str, Any],
+    policy_case: Mapping[str, Any],
+    blocking_case_ids: set[str],
+) -> tuple[str, ...]:
+    case_id = _string(result.get("case_id"), "qualification result case ID")
+    status = _string(result.get("status"), f"qualification result {case_id} status")
+    trigger = _string(result.get("trigger"), f"qualification result {case_id} trigger")
+    categories: list[str] = []
+    if status in {"covered", "carry"}:
+        categories.append("completed")
+    if status == "retest" and trigger in STALE_TRIGGERS:
+        categories.append("stale")
+    if case_id in blocking_case_ids:
+        categories.append("blocking")
+    if (
+        result.get("applicable") is True
+        and not bool(result.get("blocking"))
+        and (result.get("evidence_due") is True or result.get("operational_status") in {"due", "failed", "skipped"})
+    ):
+        categories.append("optional")
+    if (
+        policy_case.get("execution_mode") == "operator_assisted"
+        and result.get("evidence_due") is True
+        and result.get("applicable") is True
+    ):
+        categories.append("operator_required")
+    return tuple(category for category in STATUS_GROUPS if category in categories)
+
+
+def _overall_status(groups: Mapping[str, Sequence[str]]) -> str:
+    if groups["blocking"]:
+        return "blocked"
+    if groups["operator_required"]:
+        return "operator_required"
+    if groups["stale"] or groups["optional"]:
+        return "ready_with_optional_actions"
+    return "complete"
+
+
+def build_status(
+    repo_root: Path,
+    release_tag: str,
+    *,
+    as_of: date | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    binding = resolve_evidence_binding(repo_root, release_tag)
+    context = binding.context
+    checked_paths = {
+        context.evidence_path: "qualification evidence",
+        context.qualification_path: "qualification record",
+        context.release_receipt_path: "release receipt",
+    }
+    if binding.mode == "legacy":
+        checked_paths[context.policy_path] = "qualification policy"
+        checked_paths[f"docs/release-evidence/{context.release_tag}/publication-record.json"] = "publication record"
+    elif context.manifest_path:
+        checked_paths[context.manifest_path] = "qualification manifest"
+    for checked_path, description in checked_paths.items():
+        _require_checked_file(repo_root, checked_path, description)
+    if binding.manifest is not None:
+        canonical_evidence = _mapping(binding.manifest.get("canonical_evidence"), "manifest canonical evidence")
+        validate_manifest_evidence_history(
+            binding.manifest,
+            repo_root=repo_root,
+            base_revision=_string(canonical_evidence.get("base_sha"), "manifest evidence base SHA"),
+        )
+    policy = _load_bound_policy(repo_root, binding)
+    evidence = load_evidence(repo_root / context.evidence_path)
+    qualification_id, fresh_retest = load_qualification_overrides(
+        repo_root / context.qualification_path,
+        policy,
+    )
+    classification = classify_release_scope(
+        policy,
+        evidence,
+        candidate_sha=context.candidate_sha,
+        changed_paths=git_changed_paths(repo_root),
+        repo=repo_root,
+        qualification_id=qualification_id,
+        fresh_retest=fresh_retest,
+        release_stage=context.release_stage,
+        first_candidate_of_cycle=context.first_candidate_of_cycle,
+        workflow_phase="milestone",
+        milestone_receipt_path=repo_root / context.release_receipt_path,
+        as_of=as_of,
+    )
+
+    blocking_case_ids = set(
+        _string(value, "blocking qualification case ID")
+        for value in _sequence(classification.get("blocking_retests"), "blocking qualification cases")
+    )
+    cases_by_id = _policy_cases(policy)
+    groups: dict[str, list[str]] = {group: [] for group in STATUS_GROUPS}
+    cases: list[dict[str, Any]] = []
+    for raw_result in _sequence(classification.get("cases"), "qualification results"):
+        result = _mapping(raw_result, "qualification result")
+        case_id = _string(result.get("case_id"), "qualification result case ID")
+        policy_case = cases_by_id.get(case_id)
+        if policy_case is None:
+            raise ReleaseQualificationControllerError(
+                f"Qualification result references unknown policy case {case_id!r}."
+            )
+        categories = _case_categories(result, policy_case, blocking_case_ids)
+        for category in categories:
+            groups[category].append(case_id)
+        rendered_case = dict(result)
+        rendered_case["categories"] = list(categories)
+        rendered_case["operator_assisted"] = policy_case.get("execution_mode") == "operator_assisted"
+        cases.append(rendered_case)
+
+    frozen_groups = {group: groups[group] for group in STATUS_GROUPS}
+    return {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status_type": STATUS_TYPE,
+        "release_tag": context.release_tag,
+        "candidate_sha": context.candidate_sha,
+        "release_stage": context.release_stage,
+        "first_candidate_of_cycle": context.first_candidate_of_cycle,
+        "workflow_phase": "milestone",
+        "as_of": classification["as_of"],
+        "policy_id": classification["policy_id"],
+        "qualification_id": classification["qualification_id"],
+        "evidence_binding": {
+            "mode": binding.mode,
+            "expected_evidence_ref": f"automation/release-evidence-{context.release_tag}",
+            "evidence_path": context.evidence_path,
+            "manifest_path": context.manifest_path,
+            "manifest_sha256": context.manifest_sha256,
+            "qualification_path": context.qualification_path,
+            "release_receipt_path": context.release_receipt_path,
+            "runner_sha": context.runner_sha,
+        },
+        "overall_status": _overall_status(frozen_groups),
+        "passed": not frozen_groups["blocking"],
+        "summary": {group: len(frozen_groups[group]) for group in STATUS_GROUPS},
+        "groups": frozen_groups,
+        "cases": cases,
+    }

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -128,10 +128,10 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             manifest_path.write_text("{}\n", encoding="utf-8")
             with (
                 patch(
-                    "scripts.release_qualification_controller.resolve_milestone_manifest_context",
+                    "scripts.release_qualification_status.resolve_milestone_manifest_context",
                     side_effect=ReleaseMilestoneContextError("invalid manifest"),
                 ),
-                patch("scripts.release_qualification_controller.resolve_milestone_context") as legacy_resolver,
+                patch("scripts.release_qualification_status.resolve_milestone_context") as legacy_resolver,
             ):
                 with self.assertRaisesRegex(ReleaseMilestoneContextError, "invalid manifest"):
                     resolve_evidence_binding(root, "v0.3.1")
@@ -146,7 +146,7 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             receipt_path.parent.mkdir(parents=True)
             receipt_path.write_text("{}\n", encoding="utf-8")
             with patch(
-                "scripts.release_qualification_controller.resolve_milestone_context",
+                "scripts.release_qualification_status.resolve_milestone_context",
                 return_value=context,
             ) as legacy_resolver:
                 binding = resolve_evidence_binding(root, "v0.3.1")
@@ -167,11 +167,11 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             manifest_path.write_text("{}\n", encoding="utf-8")
             with (
                 patch(
-                    "scripts.release_qualification_controller.resolve_milestone_manifest_context",
+                    "scripts.release_qualification_status.resolve_milestone_manifest_context",
                     return_value=context,
                 ),
                 patch(
-                    "scripts.release_qualification_controller.load_validated_manifest",
+                    "scripts.release_qualification_status.load_validated_manifest",
                     return_value=manifest,
                 ),
             ):
@@ -180,11 +180,11 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             validated_policy = {"policy": "validated"}
             with (
                 patch(
-                    "scripts.release_qualification_controller._read_json_at_revision",
+                    "scripts.release_qualification_status._read_json_at_revision",
                     return_value=runner_policy,
                 ) as read_revision,
                 patch(
-                    "scripts.release_qualification_controller.validate_policy",
+                    "scripts.release_qualification_status.validate_policy",
                     return_value=validated_policy,
                 ) as validate,
             ):
@@ -224,16 +224,16 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             "qualification_id": "qualification",
         }
         with (
-            patch("scripts.release_qualification_controller.resolve_evidence_binding", return_value=binding),
-            patch("scripts.release_qualification_controller._require_checked_file"),
-            patch("scripts.release_qualification_controller.validate_manifest_evidence_history") as validate_history,
-            patch("scripts.release_qualification_controller._load_bound_policy", return_value=policy),
-            patch("scripts.release_qualification_controller.load_evidence", return_value={"schema_version": 1}),
+            patch("scripts.release_qualification_status.resolve_evidence_binding", return_value=binding),
+            patch("scripts.release_qualification_status._require_checked_file"),
+            patch("scripts.release_qualification_status.validate_manifest_evidence_history") as validate_history,
+            patch("scripts.release_qualification_status._load_bound_policy", return_value=policy),
+            patch("scripts.release_qualification_status.load_evidence", return_value={"schema_version": 1}),
             patch(
-                "scripts.release_qualification_controller.load_qualification_overrides",
+                "scripts.release_qualification_status.load_qualification_overrides",
                 return_value=("qualification", {}),
             ),
-            patch("scripts.release_qualification_controller.classify_release_scope", return_value=classification),
+            patch("scripts.release_qualification_status.classify_release_scope", return_value=classification),
         ):
             payload = build_status(REPO_ROOT, "v0.3.1", as_of=date(2026, 8, 10))
 

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -20,6 +20,7 @@ from scripts.release_qualification_controller import (
     main,
     resolve_evidence_binding,
 )
+from scripts.release_qualification_resume import ResumeResult
 from scripts.release_milestone_context import ReleaseMilestoneContext
 
 
@@ -366,6 +367,39 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertIn("conflicting identity", stderr.getvalue())
+
+    def test_main_delegates_resume_arguments(self) -> None:
+        result = ResumeResult(payload={"state": "dispatch_ready"}, exit_code=20)
+        stdout = io.StringIO()
+        with patch(
+            "scripts.release_qualification_resume.resume_qualification",
+            return_value=result,
+        ) as resume:
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "resume",
+                        "--release-tag",
+                        "v1.0.0",
+                        "--expected-main-sha",
+                        "a" * 40,
+                        "--expected-manifest-sha256",
+                        "b" * 64,
+                        "--retry-run-id",
+                        "123",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 20)
+        self.assertEqual(json.loads(stdout.getvalue()), result.payload)
+        resume.assert_called_once_with(
+            REPO_ROOT,
+            "v1.0.0",
+            expected_main_sha="a" * 40,
+            expected_manifest_sha256="b" * 64,
+            retry_run_id=123,
+            retry_checkpoint_sha256=None,
+        )
 
     @staticmethod
     def _context(*, runner_sha: str = "", manifest_path: str = "") -> ReleaseMilestoneContext:

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -17,6 +17,7 @@ from scripts.release_qualification_resume import (
     ResumeIdentity,
     _checkpoint_lock,
     _checkpoint_payload,
+    _dispatch,
     _write_checkpoint,
     resume_qualification,
     safety_error_payload,
@@ -344,6 +345,37 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
                 expected_manifest_sha256=MANIFEST_SHA,
             )
 
+        self.assertEqual(result.payload["state"], "dispatch_visibility_pending")
+        self.assertEqual(client.posts, [])
+
+    def test_dispatch_race_reports_prepared_checkpoint_as_operator_required(self) -> None:
+        client = self.configured_client()
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            _write_checkpoint(
+                checkpoint,
+                _checkpoint_payload(
+                    identity(),
+                    state="prepared",
+                    high_water_run_id=100,
+                    retry_of_run_id=None,
+                ),
+            )
+            result = _dispatch(
+                client,
+                identity(),
+                checkpoint,
+                high_water_run_id=100,
+                retry_of_run_id=None,
+                replace_prepared_checkpoint_sha256=None,
+                status_payload=status_payload(),
+                poll_attempts=1,
+                poll_seconds=0,
+                sleep=lambda _seconds: None,
+            )
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
         self.assertEqual(result.payload["state"], "dispatch_visibility_pending")
         self.assertEqual(client.posts, [])
 

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -324,6 +324,23 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         )
         self.assertTrue(active_auth)
 
+    def test_accepted_dispatch_without_visible_run_requires_later_observation(self) -> None:
+        client = self.configured_client()
+        client.set_sequence(RUNS_ENDPOINT, [{"workflow_runs": []}, {"workflow_runs": []}])
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            result = self.run_blocked(
+                client,
+                checkpoint,
+                expected_main_sha=MAIN_SHA,
+                expected_manifest_sha256=MANIFEST_SHA,
+            )
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "dispatch_visibility_pending")
+        self.assertEqual(len(client.posts), 1)
+
     def test_prepared_checkpoint_prevents_duplicate_dispatch(self) -> None:
         client = self.configured_client()
         client.set(RUNS_ENDPOINT, {"workflow_runs": []})

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -1,0 +1,621 @@
+import json
+import stat
+import tempfile
+import unittest
+
+from collections import defaultdict, deque
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.release_milestone_context import ReleaseMilestoneContext
+from scripts.release_qualification_controller import EvidenceBinding
+from scripts.release_qualification_resume import (
+    EXIT_OPERATOR_REQUIRED,
+    EXIT_SUCCESS,
+    QualificationResumeError,
+    QualificationResumeSafetyError,
+    ResumeIdentity,
+    _checkpoint_lock,
+    _checkpoint_payload,
+    _write_checkpoint,
+    resume_qualification,
+    safety_error_payload,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_SHA = "a" * 40
+EVIDENCE_SHA = "b" * 40
+CANDIDATE_SHA = "c" * 40
+MANIFEST_SHA = "d" * 64
+BASE_SHA = "e" * 40
+RELEASE_TAG = "v1.0.0"
+EVIDENCE_REF = f"automation/release-evidence-{RELEASE_TAG}"
+RUNS_ENDPOINT = (
+    "repos/cbusillo/BD_to_AVP/actions/workflows/milestone-qualification.yml/runs"
+    "?event=workflow_dispatch&branch=main&per_page=100"
+)
+PR_ENDPOINT = (
+    "repos/cbusillo/BD_to_AVP/pulls?state=open&base=main"
+    f"&head=cbusillo%3Aautomation%2Frelease-evidence-{RELEASE_TAG}&per_page=100"
+)
+
+
+class FakeGitHubAPI:
+    def __init__(self) -> None:
+        self.responses: dict[tuple[str, bool], object] = {}
+        self.sequences: dict[tuple[str, bool], deque[object]] = defaultdict(deque)
+        self.gets: list[tuple[str, bool]] = []
+        self.posts: list[tuple[str, MappingProxy, bool]] = []
+
+    def set(self, endpoint: str, payload: object, *, active_auth: bool = True) -> None:
+        self.responses[(endpoint, active_auth)] = payload
+
+    def set_sequence(self, endpoint: str, payloads: list[object], *, active_auth: bool = True) -> None:
+        self.sequences[(endpoint, active_auth)] = deque(payloads)
+
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        key = (endpoint, active_auth)
+        self.gets.append(key)
+        sequence = self.sequences.get(key)
+        if sequence:
+            if len(sequence) > 1:
+                return sequence.popleft()
+            return sequence[0]
+        if key not in self.responses:
+            raise AssertionError(f"Unexpected GitHub GET: {key!r}")
+        return self.responses[key]
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, object],
+        *,
+        active_auth: bool = False,
+    ) -> object:
+        self.posts.append((endpoint, MappingProxy(payload), active_auth))
+        return None
+
+
+class MappingProxy(dict[str, object]):
+    def __init__(self, payload: dict[str, object]) -> None:
+        super().__init__(json.loads(json.dumps(payload)))
+
+
+class FailOnGitHubAPI:
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        raise AssertionError(f"Complete qualification must not call GitHub: {endpoint}")
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, object],
+        *,
+        active_auth: bool = False,
+    ) -> object:
+        raise AssertionError(f"Complete qualification must not mutate GitHub: {endpoint}")
+
+
+def manifest() -> dict[str, object]:
+    return {
+        "candidate": {"release_tag": RELEASE_TAG, "source_sha": CANDIDATE_SHA},
+        "release": {"id": 123},
+        "manifest_sha256": MANIFEST_SHA,
+        "runner_sha": MAIN_SHA,
+        "canonical_evidence": {"ref": EVIDENCE_REF, "base_sha": BASE_SHA},
+        "input_digests": {
+            "policy": "1" * 64,
+            "policy_checkpoint": "2" * 64,
+            "route_table": "3" * 64,
+            "controller_runner": "4" * 64,
+        },
+        "release_receipt": {"file_sha256": "5" * 64},
+        "signed_ui_artifact": {"artifact_id": 456, "artifact_sha256": "6" * 64},
+    }
+
+
+def binding(*, runner_sha: str = MAIN_SHA) -> EvidenceBinding:
+    document = manifest()
+    document["runner_sha"] = runner_sha
+    context = ReleaseMilestoneContext(
+        candidate_sha=CANDIDATE_SHA,
+        evidence_path="docs/qualification/release-evidence-v1.json",
+        first_candidate_of_cycle=False,
+        policy_path="docs/qualification/release-qualification-policy-v1.json",
+        qualification_path=f"docs/release-evidence/{RELEASE_TAG}/qualification-record.json",
+        release_receipt_path=f"docs/release-evidence/{RELEASE_TAG}/release-receipt.json",
+        release_stage="stable",
+        release_tag=RELEASE_TAG,
+        manifest_path=f"docs/release-evidence/{RELEASE_TAG}/qualification-manifest.json",
+        manifest_sha256=MANIFEST_SHA,
+        runner_sha=runner_sha,
+    )
+    return EvidenceBinding(context=context, manifest=document, mode="manifest")
+
+
+def status_payload(*, blocking: bool = True) -> dict[str, object]:
+    blockers = ["clean-machine-signed-update"] if blocking else []
+    return {
+        "release_tag": RELEASE_TAG,
+        "candidate_sha": CANDIDATE_SHA,
+        "overall_status": "blocked" if blockers else "complete",
+        "passed": not blockers,
+        "summary": {"blocking": len(blockers)},
+        "groups": {"blocking": blockers},
+    }
+
+
+def pull_request(*, number: int = 42, evidence_sha: str = EVIDENCE_SHA) -> dict[str, object]:
+    return {
+        "number": number,
+        "state": "open",
+        "head": {
+            "ref": EVIDENCE_REF,
+            "sha": evidence_sha,
+            "repo": {"full_name": "cbusillo/BD_to_AVP"},
+        },
+        "base": {"ref": "main", "repo": {"full_name": "cbusillo/BD_to_AVP"}},
+    }
+
+
+def workflow_run(
+    run_id: int,
+    *,
+    status: str,
+    conclusion: str | None,
+    run_attempt: int = 1,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "run_attempt": run_attempt,
+        "name": "Milestone Qualification",
+        "path": ".github/workflows/milestone-qualification.yml",
+        "display_title": f"Milestone {RELEASE_TAG} {MANIFEST_SHA}",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": MAIN_SHA,
+        "actor": {"login": "cbusillo"},
+        "triggering_actor": {"login": "cbusillo"},
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": f"https://github.example/runs/{run_id}",
+    }
+
+
+def artifact(run_id: int, *, expired: bool, run_attempt: int = 1) -> dict[str, object]:
+    return {
+        "id": 9000 + run_id,
+        "name": f"milestone-qualification-{RELEASE_TAG}-{run_attempt}",
+        "digest": "sha256:" + "7" * 64,
+        "expired": expired,
+        "workflow_run": {"id": run_id, "head_branch": "main", "head_sha": MAIN_SHA},
+    }
+
+
+def identity() -> ResumeIdentity:
+    return ResumeIdentity(
+        release_tag=RELEASE_TAG,
+        candidate_sha=CANDIDATE_SHA,
+        release_id=123,
+        manifest_sha256=MANIFEST_SHA,
+        runner_sha=MAIN_SHA,
+        main_sha=MAIN_SHA,
+        evidence_ref=EVIDENCE_REF,
+        evidence_sha=EVIDENCE_SHA,
+        evidence_base_sha=BASE_SHA,
+        evidence_pr_number=42,
+        release_receipt_file_sha256="5" * 64,
+        signed_ui_artifact_id=456,
+        signed_ui_artifact_sha256="6" * 64,
+        policy_sha256="1" * 64,
+        policy_checkpoint_sha256="2" * 64,
+        route_table_sha256="3" * 64,
+        controller_runner_sha256="4" * 64,
+    )
+
+
+class ReleaseQualificationResumeTests(unittest.TestCase):
+    def configured_client(self) -> FakeGitHubAPI:
+        client = FakeGitHubAPI()
+        client.set(
+            "repos/cbusillo/BD_to_AVP",
+            {"id": 771225421, "full_name": "cbusillo/BD_to_AVP", "owner": {"login": "cbusillo"}},
+        )
+        client.set("repos/cbusillo/BD_to_AVP/git/ref/heads/main", {"object": {"sha": MAIN_SHA}})
+        client.set(
+            f"repos/cbusillo/BD_to_AVP/git/ref/heads/automation%2Frelease-evidence-{RELEASE_TAG}",
+            {"object": {"sha": EVIDENCE_SHA}},
+        )
+        client.set(PR_ENDPOINT, [pull_request()])
+        return client
+
+    def run_blocked(
+        self,
+        client: FakeGitHubAPI,
+        checkpoint_path: Path,
+        **kwargs: object,
+    ):
+        with (
+            patch("scripts.release_qualification_resume.build_status", return_value=status_payload()),
+            patch("scripts.release_qualification_resume.resolve_evidence_binding", return_value=binding()),
+            patch("scripts.release_qualification_resume._require_local_evidence_checkout"),
+        ):
+            return resume_qualification(
+                REPO_ROOT,
+                RELEASE_TAG,
+                client=client,
+                checkpoint_path=checkpoint_path,
+                poll_attempts=1,
+                sleep=lambda _seconds: None,
+                **kwargs,
+            )
+
+    def test_complete_v031_is_noop_without_github_or_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            result = resume_qualification(
+                REPO_ROOT,
+                "v0.3.1",
+                client=FailOnGitHubAPI(),
+                checkpoint_path=checkpoint,
+            )
+
+        self.assertEqual(result.exit_code, EXIT_SUCCESS)
+        self.assertEqual(result.payload["state"], "complete")
+        self.assertFalse(result.payload["checkpoint"]["present"])
+        self.assertFalse(checkpoint.exists())
+
+    def test_malformed_checked_status_is_reported_as_resume_error(self) -> None:
+        with patch(
+            "scripts.release_qualification_resume.build_status",
+            side_effect=json.JSONDecodeError("invalid", "{", 0),
+        ):
+            with self.assertRaisesRegex(QualificationResumeError, "status could not be resolved"):
+                resume_qualification(REPO_ROOT, RELEASE_TAG, client=FailOnGitHubAPI())
+
+    def test_dispatch_ready_requires_exact_confirmation(self) -> None:
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            result = self.run_blocked(client, checkpoint)
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "dispatch_ready")
+        self.assertEqual(client.posts, [])
+        self.assertTrue(client.gets)
+        self.assertTrue(all(active_auth for _endpoint, active_auth in client.gets))
+        self.assertFalse(checkpoint.exists())
+
+    def test_exact_dispatch_is_checkpointed_and_adopts_visible_run(self) -> None:
+        client = self.configured_client()
+        running = workflow_run(101, status="in_progress", conclusion=None)
+        client.set_sequence(
+            RUNS_ENDPOINT,
+            [{"workflow_runs": []}, {"workflow_runs": [running]}],
+        )
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            result = self.run_blocked(
+                client,
+                checkpoint,
+                expected_main_sha=MAIN_SHA,
+                expected_manifest_sha256=MANIFEST_SHA,
+            )
+            checkpoint_payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+            mode = stat.S_IMODE(checkpoint.stat().st_mode)
+
+        self.assertEqual(result.exit_code, EXIT_SUCCESS)
+        self.assertEqual(result.payload["state"], "running")
+        self.assertEqual(mode, 0o600)
+        self.assertEqual(checkpoint_payload["dispatch"]["state"], "observed")
+        self.assertEqual(checkpoint_payload["dispatch"]["run_id"], 101)
+        self.assertEqual(len(client.posts), 1)
+        endpoint, payload, active_auth = client.posts[0]
+        self.assertEqual(
+            endpoint,
+            "repos/cbusillo/BD_to_AVP/actions/workflows/milestone-qualification.yml/dispatches",
+        )
+        self.assertEqual(
+            payload,
+            {"ref": "main", "inputs": {"candidate_tag": RELEASE_TAG, "manifest_sha256": MANIFEST_SHA}},
+        )
+        self.assertTrue(active_auth)
+
+    def test_prepared_checkpoint_prevents_duplicate_dispatch(self) -> None:
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            _write_checkpoint(
+                checkpoint,
+                _checkpoint_payload(
+                    identity(),
+                    state="prepared",
+                    high_water_run_id=100,
+                    retry_of_run_id=None,
+                ),
+            )
+            result = self.run_blocked(
+                client,
+                checkpoint,
+                expected_main_sha=MAIN_SHA,
+                expected_manifest_sha256=MANIFEST_SHA,
+            )
+
+        self.assertEqual(result.payload["state"], "dispatch_visibility_pending")
+        self.assertEqual(client.posts, [])
+
+    def test_prepared_checkpoint_requires_exact_explicit_retry(self) -> None:
+        client = self.configured_client()
+        running = workflow_run(101, status="queued", conclusion=None)
+        client.set_sequence(
+            RUNS_ENDPOINT,
+            [{"workflow_runs": []}, {"workflow_runs": [running]}],
+        )
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            payload = _checkpoint_payload(
+                identity(),
+                state="prepared",
+                high_water_run_id=100,
+                retry_of_run_id=None,
+            )
+            _write_checkpoint(checkpoint, payload)
+            result = self.run_blocked(
+                client,
+                checkpoint,
+                expected_main_sha=MAIN_SHA,
+                expected_manifest_sha256=MANIFEST_SHA,
+                retry_checkpoint_sha256=payload["checkpoint_sha256"],
+                prepared_retry_after_seconds=0,
+            )
+
+        self.assertEqual(result.payload["state"], "running")
+        self.assertEqual(len(client.posts), 1)
+
+    def test_checkpoint_lock_rejects_concurrent_resume(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            with _checkpoint_lock(checkpoint):
+                with self.assertRaisesRegex(QualificationResumeSafetyError, "already owns"):
+                    with _checkpoint_lock(checkpoint):
+                        self.fail("Concurrent checkpoint lock unexpectedly succeeded")
+
+    def test_observed_checkpoint_reloads_exact_run_by_id(self) -> None:
+        client = self.configured_client()
+        failed = workflow_run(101, status="completed", conclusion="failure")
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", failed)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            _write_checkpoint(
+                checkpoint,
+                _checkpoint_payload(
+                    identity(),
+                    state="observed",
+                    high_water_run_id=100,
+                    retry_of_run_id=None,
+                    run_id=101,
+                    run_attempt=1,
+                ),
+            )
+            result = self.run_blocked(client, checkpoint)
+
+        self.assertEqual(result.payload["state"], "failed")
+        self.assertIn(("repos/cbusillo/BD_to_AVP/actions/runs/101", True), client.gets)
+
+    def test_checkpoint_self_digest_rejects_tampering(self) -> None:
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            _write_checkpoint(
+                checkpoint,
+                _checkpoint_payload(
+                    identity(),
+                    state="prepared",
+                    high_water_run_id=100,
+                    retry_of_run_id=None,
+                ),
+            )
+            payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+            payload["dispatch"]["high_water_run_id"] = 101
+            checkpoint.write_text(json.dumps(payload), encoding="utf-8")
+            checkpoint.chmod(0o600)
+            with self.assertRaisesRegex(QualificationResumeSafetyError, "self digest"):
+                self.run_blocked(client, checkpoint)
+
+    def test_error_payload_redacts_private_absolute_paths(self) -> None:
+        payload = safety_error_payload(QualificationResumeSafetyError("Failed at /Users/example/private/file.json"))
+
+        self.assertEqual(payload["error"], "Failed at <local-path>")
+
+    def test_runner_stale_fails_before_local_checkout_or_dispatch(self) -> None:
+        client = self.configured_client()
+        client.set("repos/cbusillo/BD_to_AVP/git/ref/heads/main", {"object": {"sha": "f" * 40}})
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            patch("scripts.release_qualification_resume.build_status", return_value=status_payload()),
+            patch(
+                "scripts.release_qualification_resume.resolve_evidence_binding",
+                return_value=binding(runner_sha=MAIN_SHA),
+            ),
+            patch("scripts.release_qualification_resume._require_local_evidence_checkout") as local_checkout,
+        ):
+            result = resume_qualification(
+                REPO_ROOT,
+                RELEASE_TAG,
+                client=client,
+                checkpoint_path=Path(temporary_directory) / "checkpoint.json",
+            )
+
+        self.assertEqual(result.payload["state"], "runner_stale")
+        local_checkout.assert_not_called()
+        self.assertEqual(client.posts, [])
+
+    def test_duplicate_open_pull_requests_fail_closed(self) -> None:
+        client = self.configured_client()
+        client.set(PR_ENDPOINT, [pull_request(number=42), pull_request(number=43)])
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(QualificationResumeSafetyError, "exactly one open pull request"):
+                self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+        self.assertEqual(client.posts, [])
+
+    def test_wrong_active_identity_fails_before_checkpoint_or_dispatch(self) -> None:
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        client.set("user", {"login": "shiny-code-bot"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            with self.assertRaisesRegex(QualificationResumeSafetyError, "active GitHub identity"):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                )
+            self.assertFalse(checkpoint.exists())
+
+        self.assertEqual(client.posts, [])
+
+    def test_failed_run_requires_exact_retry_run_id(self) -> None:
+        client = self.configured_client()
+        failed = workflow_run(101, status="completed", conclusion="failure")
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [failed]})
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "failed")
+        self.assertIn("--retry-run-id 101", result.payload["next_action"])
+        self.assertEqual(client.posts, [])
+
+    def test_exact_failed_run_retry_dispatches_new_run(self) -> None:
+        client = self.configured_client()
+        failed = workflow_run(101, status="completed", conclusion="failure")
+        running = workflow_run(102, status="queued", conclusion=None)
+        client.set_sequence(
+            RUNS_ENDPOINT,
+            [{"workflow_runs": [failed]}, {"workflow_runs": [running, failed]}],
+        )
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = self.run_blocked(
+                client,
+                Path(temporary_directory) / "checkpoint.json",
+                expected_main_sha=MAIN_SHA,
+                expected_manifest_sha256=MANIFEST_SHA,
+                retry_run_id=101,
+            )
+
+        self.assertEqual(result.payload["state"], "running")
+        self.assertEqual(result.payload["run"]["id"], 102)
+        self.assertEqual(len(client.posts), 1)
+
+    def test_successful_run_reports_available_artifact_without_download(self) -> None:
+        client = self.configured_client()
+        succeeded = workflow_run(101, status="completed", conclusion="success")
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [succeeded]})
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/jobs?per_page=100",
+            {
+                "jobs": [
+                    {
+                        "name": "Collect exact post-publication qualification receipts",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
+        )
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/artifacts?per_page=100",
+            {"artifacts": [artifact(101, expired=False)]},
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "artifact_available")
+        self.assertEqual(result.payload["artifact"]["state"], "available")
+        self.assertEqual(client.posts, [])
+
+    def test_expired_artifact_requires_exact_retry(self) -> None:
+        client = self.configured_client()
+        succeeded = workflow_run(101, status="completed", conclusion="success")
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [succeeded]})
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/jobs?per_page=100",
+            {
+                "jobs": [
+                    {
+                        "name": "Collect exact post-publication qualification receipts",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
+        )
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/artifacts?per_page=100",
+            {"artifacts": [artifact(101, expired=True)]},
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+        self.assertEqual(result.payload["state"], "artifact_expired")
+        self.assertIn("--retry-run-id 101", result.payload["next_action"])
+        self.assertEqual(client.posts, [])
+
+    def test_remote_main_move_between_preflight_and_dispatch_fails_closed(self) -> None:
+        client = self.configured_client()
+        client.set_sequence(
+            "repos/cbusillo/BD_to_AVP/git/ref/heads/main",
+            [{"object": {"sha": MAIN_SHA}}, {"object": {"sha": "f" * 40}}],
+        )
+        client.set(RUNS_ENDPOINT, {"workflow_runs": []})
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            with self.assertRaisesRegex(QualificationResumeSafetyError, "Protected main moved"):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                )
+            self.assertFalse(checkpoint.exists())
+
+        self.assertEqual(client.posts, [])
+
+    def test_multiple_active_exact_runs_fail_closed(self) -> None:
+        client = self.configured_client()
+        client.set(
+            RUNS_ENDPOINT,
+            {
+                "workflow_runs": [
+                    workflow_run(102, status="queued", conclusion=None),
+                    workflow_run(101, status="in_progress", conclusion=None),
+                ]
+            },
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(QualificationResumeSafetyError, "Multiple active exact"):
+                self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+    def test_workflow_run_name_binds_full_manifest_digest(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/milestone-qualification.yml").read_text(encoding="utf-8")
+
+        self.assertEqual(identity().workflow_display_title, f"Milestone {RELEASE_TAG} {MANIFEST_SHA}")
+        self.assertIn(
+            "run-name: Milestone ${{ inputs.candidate_tag }} ${{ inputs.manifest_sha256 }}",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an observation-first `release_qualification_controller resume` state machine
- bind workflow dispatch to exact candidate, runner, release, manifest, artifact, policy, evidence branch, and PR identities
- serialize dispatch with tamper-evident checkpoints, duplicate-run detection, explicit retry authorization, and same-principal GitHub reads/writes
- document operator exit codes, checkpoint recovery, and the artifact-reconciliation handoff

## Validation
- `uv run python -m unittest tests.test_release_qualification_resume tests.test_release_qualification_controller` (35 passed)
- `uv run python -m unittest discover -s tests -t .` (1681 passed, 3 skipped)
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run mypy bd_to_avp`
- `actionlint`
- release qualification policy and observability validators
- `uv build`
- real v0.3.1 resume no-op
- Opus and Gemini final reviews: READY

## Scope
This PR implements the guarded workflow-dispatch/observation stage. It deliberately stops at `artifact_available`; validated artifact ingestion and evidence-branch reconciliation remain the next bounded stage of #526.

Refs #526