### PR TITLE
Plan qualification artifact reconciliation

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -136,6 +136,7 @@
       "releaseQualification": "uv run python -m unittest tests.test_qualify_release_scope",
       "releaseQualificationStatus": "uv run python -m unittest tests.test_release_qualification_controller",
       "releaseQualificationResume": "uv run python -m unittest tests.test_release_qualification_resume",
+      "releaseQualificationArtifact": "uv run python -m unittest tests.test_release_qualification_artifact",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -365,12 +365,18 @@ The workflow performs these ordered boundaries:
    checkpoint and rerun the observational command. Never remove a prepared
    checkpoint merely because its workflow run is slow to appear.
 
-   This bounded stage does not download milestone artifacts or create commits,
-   pushes, comments, or pull requests. `artifact_available` means the exact
-   retained receipts are ready for validated reconciliation. `artifact_expired`
-   permits a new run only after explicit retry authorization; checked durable
-   receipts already accepted by `status` remain a no-op even after Actions
-   transport expires.
+   After a successful run, `resume` automatically revalidates and downloads the
+   exact retained artifact through the active GitHub identity. The byte-bounded
+   ZIP is digest-checked, admitted without filesystem extraction, validated
+   against the runner-pinned policy and checked manifest, and converted into a
+   deterministic reconciliation plan. Use `--observe-only` to retain the prior
+   `artifact_available` behavior without downloading. `reconciliation_planned`
+   exits `20` with the canonical plan and its SHA-256; `reconciliation_current`
+   exits `0` when every proposed destination and evidence-index record is
+   already identical. This stage still creates no repository files, commits,
+   pushes, comments, or pull requests. `artifact_expired` permits a new run only
+   after explicit retry authorization; checked durable receipts already accepted
+   by `status` remain a no-op even after Actions transport expires.
 15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -436,13 +436,19 @@ that unresolved dispatch requires its exact checkpoint self digest through
 `--retry-checkpoint-sha256` and repeats every remote identity check. Retrying a
 failed or expired run also requires its exact ID through `--retry-run-id`.
 
-This stage observes successful job and artifact state but deliberately does not
-download ZIPs or mutate evidence refs, commits, comments, or pull requests.
-`artifact_available` requires validated reconciliation as the next controller
-stage. Expired milestone transport may trigger an explicitly authorized fresh
-qualification run; it never reconstructs receipts. If equivalent receipts are
-already committed and accepted, `status` reports no blockers and `resume`
-returns `complete` regardless of Actions retention.
+After successful job and artifact observation, `resume` automatically
+revalidates the exact artifact metadata, downloads the byte-bounded ZIP, rejects
+unsafe or unexpected members, validates its receipts against the runner-pinned
+policy and checked manifest, and emits a deterministic reconciliation plan.
+`--observe-only` stops at `artifact_available` without downloading.
+`reconciliation_planned` requires a later explicitly authorized apply stage;
+`reconciliation_current` means the checked destinations and evidence records
+are already identical. Planning deliberately does not mutate evidence refs,
+files, commits, comments, or pull requests. Expired milestone transport may
+trigger an explicitly authorized fresh qualification run; it never reconstructs
+receipts. If equivalent receipts are already committed and accepted, `status`
+reports no blockers and `resume` returns `complete` regardless of Actions
+retention.
 
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated

--- a/scripts/github_release_run.py
+++ b/scripts/github_release_run.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import selectors
 import subprocess
 import time
 
@@ -52,6 +53,16 @@ class GitHubAPI(Protocol):
         *,
         active_auth: bool = False,
     ) -> object:
+        raise NotImplementedError
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
         raise NotImplementedError
 
 
@@ -129,6 +140,102 @@ class GhAPIClient:
             ],
             active_auth=active_auth,
         )
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
+        if max_bytes <= 0:
+            raise ValueError("GitHub byte limit must be greater than zero.")
+        if timeout_seconds <= 0:
+            raise ValueError("GitHub byte request timeout must be greater than zero.")
+        command = [
+            self.executable,
+            "api",
+            "--hostname",
+            self.hostname,
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-H",
+            "X-GitHub-Api-Version: 2022-11-28",
+            endpoint,
+        ]
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=self._environment(active_auth=active_auth),
+            )
+        except OSError as error:
+            raise ReleaseRunError("GitHub CLI byte request could not start.") from error
+        if process.stdout is None:
+            process.kill()
+            process.wait()
+            raise ReleaseRunError("GitHub CLI byte request did not expose stdout.")
+        deadline = time.monotonic() + timeout_seconds
+        content = bytearray()
+        selector = selectors.DefaultSelector()
+        os.set_blocking(process.stdout.fileno(), False)
+        selector.register(process.stdout, selectors.EVENT_READ)
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    process.kill()
+                    process.wait()
+                    raise ReleaseRunError("GitHub CLI byte request timed out.")
+                events = selector.select(timeout=min(remaining, 0.25))
+                if not events:
+                    if process.poll() is not None:
+                        try:
+                            chunk = os.read(process.stdout.fileno(), max_bytes + 1 - len(content))
+                        except BlockingIOError:
+                            chunk = b""
+                        if chunk:
+                            content.extend(chunk)
+                        if len(content) > max_bytes:
+                            raise ReleaseRunError(f"GitHub CLI byte request exceeded the {max_bytes}-byte limit.")
+                        break
+                    continue
+                try:
+                    chunk = os.read(
+                        process.stdout.fileno(),
+                        min(64 * 1024, max_bytes + 1 - len(content)),
+                    )
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    break
+                content.extend(chunk)
+                if len(content) > max_bytes:
+                    process.kill()
+                    process.wait()
+                    raise ReleaseRunError(f"GitHub CLI byte request exceeded the {max_bytes}-byte limit.")
+            remaining = max(0.001, deadline - time.monotonic())
+            try:
+                returncode = process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired as error:
+                process.kill()
+                process.wait()
+                raise ReleaseRunError("GitHub CLI byte request timed out.") from error
+        finally:
+            selector.close()
+            process.stdout.close()
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+        if returncode != 0:
+            raise ReleaseRunError(f"GitHub CLI byte request failed with exit status {returncode}.")
+        if len(content) > max_bytes:
+            raise ReleaseRunError(f"GitHub CLI byte request exceeded the {max_bytes}-byte limit.")
+        if not content:
+            raise ReleaseRunError("GitHub CLI byte request returned an empty response.")
+        return bytes(content)
 
     def post_json(self, endpoint: str, payload: Mapping[str, object], *, active_auth: bool = False) -> object:
         return self._run_json(

--- a/scripts/release_qualification_artifact.py
+++ b/scripts/release_qualification_artifact.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import re
+import stat
+import subprocess
+import zipfile
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol, cast
+
+from scripts.qualify_release_scope import (
+    QualificationScopeError,
+    git_checked_reference_content,
+    validate_policy,
+)
+from scripts.release_evidence import ReleaseEvidenceError, _merge_unique_record
+from scripts.tier3_receipt import Tier3ReceiptError, load_validated_receipt_bytes
+
+
+PLAN_TYPE = "bd_to_avp.release_qualification_reconciliation_plan"
+SCHEMA_VERSION = 1
+REPOSITORY = "cbusillo/BD_to_AVP"
+EVIDENCE_INDEX_PATH = "docs/qualification/release-evidence-v1.json"
+MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
+MAX_TOTAL_UNCOMPRESSED_BYTES = 48 * 1024 * 1024
+MAX_JSON_BYTES = 2 * 1024 * 1024
+MAX_PNG_BYTES = 8 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 24
+MAX_COMPRESSION_RATIO = 200
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+ARCHIVE_PATH_PATTERN = re.compile(r"^[a-z0-9][a-z0-9./-]*$")
+CASE_IDS = ("clean-machine-signed-update", "installed-ui-accessibility")
+TOP_LEVEL_FILES = frozenset(
+    {
+        "clean-machine-signed-update.json",
+        "installed-ui-accessibility.json",
+        "qualification-run.json",
+        "signed-artifact-ui-receipt.json",
+    }
+)
+EVIDENCE_FILENAMES = {
+    "accessibility-tree": "accessibility-tree.json",
+    "cleanup": "cleanup.json",
+    "install-log": "install-log.json",
+    "package-smoke": "package-smoke.json",
+    "profile-snapshot": "profile-snapshot.json",
+    "screenshot-dark": "screenshot-dark.png",
+    "screenshot-light": "screenshot-light.png",
+    "sparkle-update": "sparkle-update.json",
+    "ui-result": "ui-result.json",
+}
+EVIDENCE_PREFIX = "clean-machine-signed-update-evidence/"
+EXPECTED_ARCHIVE_FILES = TOP_LEVEL_FILES | frozenset(
+    EVIDENCE_PREFIX + filename for filename in EVIDENCE_FILENAMES.values()
+)
+
+
+class QualificationArtifactError(RuntimeError):
+    pass
+
+
+class QualificationArtifactSafetyError(QualificationArtifactError):
+    pass
+
+
+class QualificationIdentity(Protocol):
+    release_tag: str
+    candidate_sha: str
+    manifest_sha256: str
+    runner_sha: str
+    main_sha: str
+    evidence_ref: str
+    evidence_sha: str
+    release_receipt_file_sha256: str
+    signed_ui_artifact_id: int
+    signed_ui_artifact_sha256: str
+
+    @property
+    def digest(self) -> str:
+        raise NotImplementedError
+
+
+class GitHubArtifactAPI(Protocol):
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        raise NotImplementedError
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
+        raise NotImplementedError
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise QualificationArtifactError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise QualificationArtifactError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise QualificationArtifactError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise QualificationArtifactError(f"{description} must be a positive integer.")
+    return value
+
+
+def _sha(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA_PATTERN.fullmatch(text) is None:
+        raise QualificationArtifactError(f"{description} must be a full lowercase Git SHA.")
+    return text
+
+
+def _sha256(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA256_PATTERN.fullmatch(text) is None:
+        raise QualificationArtifactError(f"{description} must be a lowercase SHA-256 digest.")
+    return text
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise QualificationArtifactSafetyError(
+            f"{description} keys changed; missing={sorted(expected - actual)!r}, extra={sorted(actual - expected)!r}."
+        )
+
+
+def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def _pretty_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _load_json_bytes(content: bytes, description: str, *, max_bytes: int = MAX_JSON_BYTES) -> Mapping[str, Any]:
+    if len(content) > max_bytes:
+        raise QualificationArtifactSafetyError(f"{description} exceeds the {max_bytes}-byte limit.")
+    try:
+        return _mapping(json.loads(content), description)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationArtifactSafetyError(f"{description} is not valid UTF-8 JSON.") from error
+
+
+def _checked_file(repo_root: Path, relative_path: str) -> bytes | None:
+    path = PurePosixPath(relative_path)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != relative_path:
+        raise QualificationArtifactSafetyError("Checked evidence path is not canonical.")
+    listing = subprocess.run(
+        ["git", "ls-tree", "--name-only", "HEAD", "--", relative_path],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if listing.returncode != 0:
+        raise QualificationArtifactError("Unable to inspect checked evidence paths.")
+    if listing.stdout.strip() != relative_path:
+        return None
+    content = subprocess.run(
+        ["git", "show", f"HEAD:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if content.returncode != 0:
+        raise QualificationArtifactError("Unable to read checked evidence content.")
+    return content.stdout
+
+
+def _json_at_revision(repo_root: Path, revision: str, relative_path: str, description: str) -> Mapping[str, Any]:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise QualificationArtifactSafetyError(f"Unable to read runner-bound {description}.")
+    return _load_json_bytes(result.stdout, f"runner-bound {description}")
+
+
+def _accepted_at(run: Mapping[str, Any]) -> str:
+    text = _string(run.get("updated_at"), "workflow run updated_at")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise QualificationArtifactError("Workflow run updated_at is invalid.") from error
+    if parsed.tzinfo is None:
+        raise QualificationArtifactError("Workflow run updated_at must include a timezone.")
+    return parsed.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _archive_entry_limit(name: str) -> int:
+    return MAX_PNG_BYTES if name.endswith(".png") else MAX_JSON_BYTES
+
+
+def _admit_archive(archive_bytes: bytes) -> dict[str, bytes]:
+    if not archive_bytes:
+        raise QualificationArtifactError("Milestone Qualification artifact download was empty.")
+    if len(archive_bytes) > MAX_ARCHIVE_BYTES:
+        raise QualificationArtifactSafetyError(
+            f"Milestone Qualification artifact exceeds the {MAX_ARCHIVE_BYTES}-byte archive limit."
+        )
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(archive_bytes))
+    except zipfile.BadZipFile as error:
+        raise QualificationArtifactSafetyError(
+            "Milestone Qualification artifact is not a valid ZIP archive."
+        ) from error
+    with archive:
+        if archive.comment:
+            raise QualificationArtifactSafetyError("Milestone Qualification artifact ZIP comment is not allowed.")
+        members = archive.infolist()
+        if len(members) > MAX_ARCHIVE_ENTRIES:
+            raise QualificationArtifactSafetyError("Milestone Qualification artifact contains too many ZIP entries.")
+        names = [member.filename for member in members]
+        if len(names) != len(set(names)):
+            raise QualificationArtifactSafetyError("Milestone Qualification artifact contains duplicate ZIP entries.")
+        admitted: dict[str, bytes] = {}
+        total_size = 0
+        for member in members:
+            name = member.filename
+            path = PurePosixPath(name.rstrip("/"))
+            if (
+                not name
+                or "\\" in name
+                or name.startswith("/")
+                or "//" in name
+                or any(part in {"", ".", ".."} for part in path.parts)
+                or ARCHIVE_PATH_PATTERN.fullmatch(name) is None
+            ):
+                raise QualificationArtifactSafetyError("Milestone Qualification artifact contains an unsafe ZIP path.")
+            mode = (member.external_attr >> 16) & 0o177777
+            file_type = stat.S_IFMT(mode)
+            if stat.S_ISLNK(mode) or file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                raise QualificationArtifactSafetyError(
+                    "Milestone Qualification artifact contains a non-regular ZIP entry."
+                )
+            if member.flag_bits & 0x1:
+                raise QualificationArtifactSafetyError(
+                    "Milestone Qualification artifact contains an encrypted ZIP entry."
+                )
+            if member.compress_type not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}:
+                raise QualificationArtifactSafetyError(
+                    "Milestone Qualification artifact uses an unsupported compression type."
+                )
+            if member.is_dir():
+                if member.file_size:
+                    raise QualificationArtifactSafetyError(
+                        "Milestone Qualification artifact directory entry contains data."
+                    )
+                if name != EVIDENCE_PREFIX:
+                    raise QualificationArtifactSafetyError(
+                        "Milestone Qualification artifact contains an unexpected directory entry."
+                    )
+                continue
+            if name not in EXPECTED_ARCHIVE_FILES:
+                raise QualificationArtifactSafetyError(
+                    f"Milestone Qualification artifact contains unexpected file {name!r}."
+                )
+            limit = _archive_entry_limit(name)
+            if member.file_size > limit:
+                raise QualificationArtifactSafetyError(
+                    f"Milestone Qualification artifact entry {name!r} exceeds its size limit."
+                )
+            if member.file_size / max(member.compress_size, 1) > MAX_COMPRESSION_RATIO:
+                raise QualificationArtifactSafetyError(
+                    f"Milestone Qualification artifact entry {name!r} exceeds the compression-ratio limit."
+                )
+            total_size += member.file_size
+            if total_size > MAX_TOTAL_UNCOMPRESSED_BYTES:
+                raise QualificationArtifactSafetyError(
+                    "Milestone Qualification artifact exceeds the total uncompressed size limit."
+                )
+            try:
+                with archive.open(member) as source:
+                    content = source.read(limit + 1)
+            except (RuntimeError, zipfile.BadZipFile) as error:
+                raise QualificationArtifactSafetyError(
+                    f"Unable to read Milestone Qualification artifact entry {name!r}."
+                ) from error
+            if len(content) != member.file_size or len(content) > limit:
+                raise QualificationArtifactSafetyError(
+                    f"Milestone Qualification artifact entry {name!r} size changed during admission."
+                )
+            admitted[name] = content
+        missing = sorted(EXPECTED_ARCHIVE_FILES - set(admitted))
+        if missing:
+            raise QualificationArtifactSafetyError(
+                f"Milestone Qualification artifact is missing required files: {missing!r}."
+            )
+        return admitted
+
+
+def _validate_qualification_run(
+    payload: Mapping[str, Any],
+    *,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    receipt_digests: Mapping[str, str],
+) -> None:
+    _exact_keys(
+        payload,
+        {
+            "candidate_tag",
+            "evidence_ref",
+            "evidence_sha",
+            "manifest_sha256",
+            "prior_tag",
+            "route",
+            "signed_ui_artifact",
+            "tier3_receipts",
+        },
+        "qualification-run.json",
+    )
+    prior = _mapping(manifest.get("prior"), "manifest prior")
+    release = _mapping(manifest.get("release"), "manifest release")
+    if payload.get("candidate_tag") != identity.release_tag:
+        raise QualificationArtifactSafetyError("Qualification artifact release tag conflicts with resume identity.")
+    if payload.get("evidence_ref") != identity.evidence_ref or payload.get("evidence_sha") != identity.evidence_sha:
+        raise QualificationArtifactSafetyError("Qualification artifact evidence branch identity conflicts.")
+    if payload.get("manifest_sha256") != identity.manifest_sha256:
+        raise QualificationArtifactSafetyError("Qualification artifact manifest digest conflicts.")
+    if payload.get("prior_tag") != prior.get("release_tag") or payload.get("route") != release.get("sparkle_route"):
+        raise QualificationArtifactSafetyError("Qualification artifact release route identity conflicts.")
+    signed_ui = _mapping(payload.get("signed_ui_artifact"), "qualification-run signed UI artifact")
+    _exact_keys(signed_ui, {"digest", "id", "receipt_sha256"}, "qualification-run signed UI artifact")
+    if signed_ui.get("id") != identity.signed_ui_artifact_id:
+        raise QualificationArtifactSafetyError("Qualification artifact signed UI artifact ID conflicts.")
+    if signed_ui.get("digest") != f"sha256:{identity.signed_ui_artifact_sha256}":
+        raise QualificationArtifactSafetyError("Qualification artifact signed UI artifact digest conflicts.")
+    manifest_signed_ui = _mapping(manifest.get("signed_ui_artifact"), "manifest signed UI artifact")
+    if signed_ui.get("receipt_sha256") != manifest_signed_ui.get("receipt_sha256"):
+        raise QualificationArtifactSafetyError("Qualification artifact signed UI receipt digest conflicts.")
+    raw_receipts = _sequence(payload.get("tier3_receipts"), "qualification-run Tier 3 receipts")
+    if len(raw_receipts) != len(CASE_IDS):
+        raise QualificationArtifactSafetyError("Qualification artifact Tier 3 receipt set changed.")
+    observed: dict[str, str] = {}
+    for index, raw_receipt in enumerate(raw_receipts):
+        receipt = _mapping(raw_receipt, f"qualification-run Tier 3 receipt {index}")
+        _exact_keys(receipt, {"case_id", "receipt_sha256"}, f"qualification-run Tier 3 receipt {index}")
+        case_id = _string(receipt.get("case_id"), f"qualification-run Tier 3 receipt {index} case ID")
+        if case_id in observed:
+            raise QualificationArtifactSafetyError("Qualification artifact repeats a Tier 3 case ID.")
+        observed[case_id] = _sha256(
+            receipt.get("receipt_sha256"),
+            f"qualification-run Tier 3 receipt {index} digest",
+        )
+    if observed != dict(receipt_digests):
+        raise QualificationArtifactSafetyError("Qualification artifact Tier 3 receipt digests conflict.")
+    _integer(run.get("id"), "workflow run ID")
+    _integer(run.get("run_attempt"), "workflow run attempt")
+
+
+def _validate_receipts(
+    entries: Mapping[str, bytes],
+    *,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    manifest: Mapping[str, Any],
+) -> tuple[list[dict[str, object]], dict[str, Mapping[str, Any]], dict[str, str]]:
+    paths = _mapping(manifest.get("paths"), "manifest paths")
+    policy_path = _string(paths.get("policy"), "manifest policy path")
+    try:
+        policy = validate_policy(
+            _json_at_revision(repo_root, identity.runner_sha, policy_path, "release qualification policy")
+        )
+    except QualificationScopeError as error:
+        raise QualificationArtifactSafetyError(str(error)) from error
+    policy_id = _string(policy.get("policy_id"), "release qualification policy ID")
+    cases = {
+        _string(case.get("id"), "qualification case ID"): case
+        for case in (
+            _mapping(item, "release qualification case")
+            for item in _sequence(policy.get("cases"), "release qualification cases")
+        )
+    }
+    reference_content = git_checked_reference_content(repo_root)
+    validated: dict[str, Mapping[str, Any]] = {}
+    digests: dict[str, str] = {}
+    summaries: list[dict[str, object]] = []
+    for case_id in CASE_IDS:
+        case = cases.get(case_id)
+        if case is None:
+            raise QualificationArtifactSafetyError(f"Runner policy is missing qualification case {case_id!r}.")
+        content = entries[f"{case_id}.json"]
+        if content != _pretty_json_bytes(_load_json_bytes(content, f"{case_id} receipt")):
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} is not canonical JSON.")
+        try:
+            receipt = load_validated_receipt_bytes(
+                content,
+                policy_id=policy_id,
+                case=case,
+                reference_content=reference_content,
+            )
+        except (QualificationScopeError, Tier3ReceiptError) as error:
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} is invalid: {error}") from error
+        result = _mapping(receipt.get("result"), f"{case_id} result")
+        if result.get("status") != "passed":
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} did not pass.")
+        release_identity = _mapping(receipt.get("release_identity"), f"{case_id} release identity")
+        release_receipt = _mapping(release_identity.get("release_receipt"), f"{case_id} release receipt")
+        if release_identity.get("source_sha") != identity.candidate_sha:
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} source SHA conflicts.")
+        if release_identity.get("release_tag") != identity.release_tag:
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} release tag conflicts.")
+        if release_receipt.get("file_sha256") != identity.release_receipt_file_sha256:
+            raise QualificationArtifactSafetyError(f"Qualification receipt {case_id!r} release receipt conflicts.")
+        receipt_digest = _sha256(receipt.get("receipt_sha256"), f"{case_id} receipt self digest")
+        evidence_summaries: list[dict[str, str]] = []
+        for raw_evidence in _sequence(receipt.get("evidence"), f"{case_id} evidence"):
+            evidence = _mapping(raw_evidence, f"{case_id} evidence record")
+            evidence_summaries.append(
+                {
+                    "kind": _string(evidence.get("kind"), f"{case_id} evidence kind"),
+                    "sha256": _sha256(evidence.get("sha256"), f"{case_id} evidence digest"),
+                }
+            )
+        timestamps = _mapping(receipt.get("timestamps"), f"{case_id} timestamps")
+        validated[case_id] = receipt
+        digests[case_id] = receipt_digest
+        summaries.append(
+            {
+                "case_id": case_id,
+                "completed_at": _string(timestamps.get("completed_at"), f"{case_id} completed_at"),
+                "evidence_digests": sorted(evidence_summaries, key=lambda item: item["kind"]),
+                "receipt_sha256": receipt_digest,
+            }
+        )
+    return summaries, validated, digests
+
+
+def _validate_evidence_files(entries: Mapping[str, bytes], receipts: Mapping[str, Mapping[str, Any]]) -> None:
+    referenced: dict[str, str] = {}
+    for case_id in CASE_IDS:
+        for raw_evidence in _sequence(receipts[case_id].get("evidence"), f"{case_id} evidence"):
+            evidence = _mapping(raw_evidence, f"{case_id} evidence record")
+            kind = _string(evidence.get("kind"), f"{case_id} evidence kind")
+            digest = _sha256(evidence.get("sha256"), f"{case_id} evidence digest")
+            if kind in referenced and referenced[kind] != digest:
+                raise QualificationArtifactSafetyError("Qualification receipts disagree about an evidence digest.")
+            referenced[kind] = digest
+    if set(referenced) != set(EVIDENCE_FILENAMES):
+        raise QualificationArtifactSafetyError("Qualification artifact evidence set changed.")
+    for kind, filename in EVIDENCE_FILENAMES.items():
+        observed = hashlib.sha256(entries[EVIDENCE_PREFIX + filename]).hexdigest()
+        if observed != referenced[kind]:
+            raise QualificationArtifactSafetyError(f"Qualification artifact evidence digest conflicts for {kind!r}.")
+    clean_cleanup = _mapping(receipts["clean-machine-signed-update"].get("cleanup"), "clean-machine cleanup")
+    if clean_cleanup.get("evidence_sha256") != referenced["cleanup"]:
+        raise QualificationArtifactSafetyError("Clean-machine cleanup evidence digest conflicts.")
+
+
+def _plan_file_operation(repo_root: Path, path: str, content: bytes) -> dict[str, object]:
+    existing = _checked_file(repo_root, path)
+    if existing is None:
+        state = "create"
+    elif existing == content:
+        state = "identical"
+    else:
+        raise QualificationArtifactSafetyError(f"Checked qualification receipt {path!r} conflicts.")
+    return {
+        "kind": "write_file",
+        "path": path,
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "size_bytes": len(content),
+        "state": state,
+    }
+
+
+def _plan_index_operations(
+    repo_root: Path,
+    *,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    receipt_contents: Mapping[str, bytes],
+) -> list[dict[str, object]]:
+    index_content = _checked_file(repo_root, EVIDENCE_INDEX_PATH)
+    if index_content is None:
+        raise QualificationArtifactSafetyError("Checked release qualification evidence index is missing.")
+    index = dict(_load_json_bytes(index_content, "release qualification evidence index"))
+    if index.get("schema_version") != 1:
+        raise QualificationArtifactSafetyError("Release qualification evidence index schema version changed.")
+    receipts = [
+        dict(_mapping(item, "release qualification evidence record"))
+        for item in _sequence(index.get("receipts"), "release qualification evidence records")
+    ]
+    accepted_at = _accepted_at(run)
+    run_id = _integer(run.get("id"), "workflow run ID")
+    operations: list[dict[str, object]] = []
+    for case_id in CASE_IDS:
+        destination = f"docs/qualification/{identity.release_tag}-{case_id}-v1.json"
+        content = receipt_contents[case_id]
+        record: dict[str, object] = {
+            "accepted_at": accepted_at,
+            "case_id": case_id,
+            "receipt_id": f"{identity.release_tag}:{case_id}:{run_id}",
+            "reference": destination,
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "source": "tier3_automation_receipt",
+            "source_sha": identity.candidate_sha,
+            "status": "accepted",
+        }
+        before = len(receipts)
+        try:
+            _merge_unique_record(receipts, record, "receipt_id")
+        except ReleaseEvidenceError as error:
+            raise QualificationArtifactSafetyError(str(error)) from error
+        operations.append(
+            {
+                "kind": "append_evidence_record",
+                "path": EVIDENCE_INDEX_PATH,
+                "receipt_id": record["receipt_id"],
+                "record": record,
+                "state": "append" if len(receipts) > before else "present",
+            }
+        )
+    return operations
+
+
+def plan_reconciliation(
+    *,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    archive_bytes: bytes,
+) -> dict[str, object]:
+    repo_root = repo_root.resolve()
+    entries = _admit_archive(archive_bytes)
+    receipt_summaries, receipts, receipt_digests = _validate_receipts(
+        entries,
+        repo_root=repo_root,
+        identity=identity,
+        manifest=manifest,
+    )
+    qualification_run = _load_json_bytes(entries["qualification-run.json"], "qualification-run.json")
+    _validate_qualification_run(
+        qualification_run,
+        identity=identity,
+        run=run,
+        manifest=manifest,
+        receipt_digests=receipt_digests,
+    )
+    _validate_evidence_files(entries, receipts)
+    manifest_signed_ui = _mapping(manifest.get("signed_ui_artifact"), "manifest signed UI artifact")
+    signed_ui_path = _string(manifest_signed_ui.get("receipt_path"), "manifest signed UI receipt path")
+    signed_ui_content = entries["signed-artifact-ui-receipt.json"]
+    if hashlib.sha256(signed_ui_content).hexdigest() != manifest_signed_ui.get("receipt_file_sha256"):
+        raise QualificationArtifactSafetyError("Qualification artifact signed UI receipt file digest conflicts.")
+    checked_signed_ui = _checked_file(repo_root, signed_ui_path)
+    if checked_signed_ui is None or checked_signed_ui != signed_ui_content:
+        raise QualificationArtifactSafetyError(
+            "Qualification artifact signed UI receipt conflicts with checked evidence."
+        )
+    operations: list[dict[str, object]] = []
+    receipt_contents = {case_id: entries[f"{case_id}.json"] for case_id in CASE_IDS}
+    for case_id in CASE_IDS:
+        operations.append(
+            _plan_file_operation(
+                repo_root,
+                f"docs/qualification/{identity.release_tag}-{case_id}-v1.json",
+                receipt_contents[case_id],
+            )
+        )
+    operations.append(
+        {
+            "kind": "verify_file",
+            "path": signed_ui_path,
+            "sha256": hashlib.sha256(signed_ui_content).hexdigest(),
+            "size_bytes": len(signed_ui_content),
+            "state": "identical",
+        }
+    )
+    operations.extend(
+        _plan_index_operations(
+            repo_root,
+            identity=identity,
+            run=run,
+            receipt_contents=receipt_contents,
+        )
+    )
+    sorted_operations = sorted(
+        operations,
+        key=lambda item: (
+            cast(str, item["kind"]),
+            cast(str, item["path"]),
+            cast(str, item.get("receipt_id", "")),
+        ),
+    )
+    artifact_digest = _string(artifact.get("digest"), "Milestone Qualification artifact digest")
+    if not artifact_digest.startswith("sha256:"):
+        raise QualificationArtifactError("Milestone Qualification artifact digest is invalid.")
+    plan: dict[str, object] = {
+        "artifact": {
+            "id": _integer(artifact.get("id"), "Milestone Qualification artifact ID"),
+            "name": _string(artifact.get("name"), "Milestone Qualification artifact name"),
+            "run_attempt": _integer(run.get("run_attempt"), "workflow run attempt"),
+            "run_id": _integer(run.get("id"), "workflow run ID"),
+            "sha256": _sha256(artifact_digest.removeprefix("sha256:"), "Milestone Qualification artifact digest"),
+        },
+        "candidate_sha": _sha(identity.candidate_sha, "candidate SHA"),
+        "cases": sorted(receipt_summaries, key=lambda item: cast(str, item["case_id"])),
+        "evidence_ref": identity.evidence_ref,
+        "evidence_sha": _sha(identity.evidence_sha, "evidence SHA"),
+        "identity_sha256": _sha256(identity.digest, "resume identity digest"),
+        "main_sha": _sha(identity.main_sha, "main SHA"),
+        "manifest_sha256": _sha256(identity.manifest_sha256, "manifest digest"),
+        "operations": sorted_operations,
+        "plan_type": PLAN_TYPE,
+        "release_tag": identity.release_tag,
+        "requires_changes": any(item["state"] in {"append", "create"} for item in sorted_operations),
+        "schema_version": SCHEMA_VERSION,
+    }
+    plan["plan_sha256"] = hashlib.sha256(_canonical_json_bytes(plan)).hexdigest()
+    return plan
+
+
+def download_and_plan_reconciliation(
+    *,
+    client: GitHubArtifactAPI,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> dict[str, object]:
+    artifact_id = _integer(artifact.get("id"), "Milestone Qualification artifact ID")
+    run_id = _integer(run.get("id"), "workflow run ID")
+    run_attempt = _integer(run.get("run_attempt"), "workflow run attempt")
+    expected_name = f"milestone-qualification-{identity.release_tag}-{run_attempt}"
+    metadata = _mapping(
+        client.get_json(f"repos/{REPOSITORY}/actions/artifacts/{artifact_id}", active_auth=True),
+        "Milestone Qualification artifact metadata",
+    )
+    workflow_run = _mapping(metadata.get("workflow_run"), "Milestone Qualification artifact workflow run")
+    if (
+        metadata.get("id") != artifact_id
+        or metadata.get("name") != expected_name
+        or metadata.get("digest") != artifact.get("digest")
+        or metadata.get("expired") is not False
+        or workflow_run.get("id") != run_id
+        or workflow_run.get("head_branch") != "main"
+        or workflow_run.get("head_sha") != identity.runner_sha
+    ):
+        raise QualificationArtifactSafetyError("Milestone Qualification artifact metadata changed before download.")
+    size_in_bytes = _integer(metadata.get("size_in_bytes"), "Milestone Qualification artifact size")
+    if size_in_bytes > MAX_ARCHIVE_BYTES:
+        raise QualificationArtifactSafetyError(
+            f"Milestone Qualification artifact exceeds the {MAX_ARCHIVE_BYTES}-byte archive limit."
+        )
+    archive_bytes = client.get_bytes(
+        f"repos/{REPOSITORY}/actions/artifacts/{artifact_id}/zip",
+        active_auth=True,
+        max_bytes=MAX_ARCHIVE_BYTES,
+        timeout_seconds=300.0,
+    )
+    expected_digest = _string(artifact.get("digest"), "Milestone Qualification artifact digest")
+    if hashlib.sha256(archive_bytes).hexdigest() != expected_digest.removeprefix("sha256:"):
+        raise QualificationArtifactSafetyError("Milestone Qualification artifact archive digest conflicts.")
+    return plan_reconciliation(
+        repo_root=repo_root,
+        identity=identity,
+        run=run,
+        artifact=artifact,
+        manifest=manifest,
+        archive_bytes=archive_bytes,
+    )
+
+
+__all__ = [
+    "MAX_ARCHIVE_BYTES",
+    "PLAN_TYPE",
+    "QualificationArtifactError",
+    "QualificationArtifactSafetyError",
+    "download_and_plan_reconciliation",
+    "plan_reconciliation",
+]

--- a/scripts/release_qualification_controller.py
+++ b/scripts/release_qualification_controller.py
@@ -54,6 +54,7 @@ def build_parser() -> argparse.ArgumentParser:
     resume_parser.add_argument("--expected-manifest-sha256")
     resume_parser.add_argument("--retry-run-id", type=int)
     resume_parser.add_argument("--retry-checkpoint-sha256")
+    resume_parser.add_argument("--observe-only", action="store_true")
     return parser
 
 
@@ -78,6 +79,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 expected_manifest_sha256=args.expected_manifest_sha256,
                 retry_run_id=args.retry_run_id,
                 retry_checkpoint_sha256=args.retry_checkpoint_sha256,
+                observe_only=args.observe_only,
             )
         except QualificationResumeSafetyError as error:
             print(json.dumps(safety_error_payload(error), indent=2, sort_keys=True))

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -21,6 +21,11 @@ from urllib.parse import quote
 from scripts.github_release_run import GhAPIClient
 from scripts.qualify_release_scope import QualificationScopeError
 from scripts.release_milestone_context import ReleaseMilestoneContextError
+from scripts.release_qualification_artifact import (
+    QualificationArtifactError,
+    QualificationArtifactSafetyError,
+    download_and_plan_reconciliation,
+)
 from scripts.release_qualification_status import (
     EvidenceBinding,
     ReleaseQualificationControllerError,
@@ -71,6 +76,16 @@ class GitHubAPI(Protocol):
         *,
         active_auth: bool = False,
     ) -> object:
+        raise NotImplementedError
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
         raise NotImplementedError
 
 
@@ -615,6 +630,7 @@ def _result(
     checkpoint_path: Path | None = None,
     run: Mapping[str, object] | None = None,
     artifact: Mapping[str, object] | None = None,
+    reconciliation_plan: Mapping[str, object] | None = None,
     next_action: str,
     mutation: Mapping[str, object] | None = None,
 ) -> ResumeResult:
@@ -638,6 +654,7 @@ def _result(
         },
         "run": dict(run) if run is not None else None,
         "artifact": dict(artifact) if artifact is not None else None,
+        "reconciliation_plan": dict(reconciliation_plan) if reconciliation_plan is not None else None,
         "planned_mutation": dict(mutation) if mutation is not None else None,
     }
     return ResumeResult(payload=payload, exit_code=exit_code)
@@ -811,6 +828,7 @@ def resume_qualification(
     expected_manifest_sha256: str | None = None,
     retry_run_id: int | None = None,
     retry_checkpoint_sha256: str | None = None,
+    observe_only: bool = False,
     client: GitHubAPI | None = None,
     checkpoint_path: Path | None = None,
     poll_attempts: int = 10,
@@ -1049,15 +1067,47 @@ def resume_qualification(
     succeeded = run_payload["conclusion"] == "success" and _run_jobs_succeeded(github, run_id)
     artifact = _artifact_state(github, identity, selected_run) if succeeded else None
     if succeeded and artifact is not None and artifact["state"] == "available":
+        run_payload = _run_identity(selected_run, identity)
+        if observe_only:
+            return _result(
+                "artifact_available",
+                EXIT_OPERATOR_REQUIRED,
+                status_payload,
+                identity=identity,
+                checkpoint_path=resolved_checkpoint_path,
+                run=run_payload,
+                artifact=artifact,
+                next_action="Validate and reconcile the exact qualification artifact into the evidence branch.",
+            )
+        try:
+            plan = download_and_plan_reconciliation(
+                client=github,
+                repo_root=repo_root,
+                identity=identity,
+                run=selected_run,
+                artifact=artifact,
+                manifest=cast(Mapping[str, Any], binding.manifest),
+            )
+        except QualificationArtifactSafetyError as error:
+            raise QualificationResumeSafetyError(str(error)) from error
+        except QualificationArtifactError as error:
+            raise QualificationResumeError(str(error)) from error
+        _revalidate_remote_identity(github, identity)
+        requires_changes = plan.get("requires_changes") is True
         return _result(
-            "artifact_available",
-            EXIT_OPERATOR_REQUIRED,
+            "reconciliation_planned" if requires_changes else "reconciliation_current",
+            EXIT_OPERATOR_REQUIRED if requires_changes else EXIT_SUCCESS,
             status_payload,
             identity=identity,
             checkpoint_path=resolved_checkpoint_path,
             run=run_payload,
             artifact=artifact,
-            next_action="Validate and reconcile the exact qualification artifact into the evidence branch.",
+            reconciliation_plan=plan,
+            next_action=(
+                "Review the exact reconciliation plan; the write-capable apply stage is not implemented yet."
+                if requires_changes
+                else "All planned qualification evidence is already present and identical."
+            ),
         )
 
     failure_state = (

--- a/tests/test_github_release_run.py
+++ b/tests/test_github_release_run.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import subprocess
+import tempfile
 import unittest
 
 from collections import defaultdict, deque
@@ -839,6 +840,13 @@ class GitHubReleaseRunContractTests(unittest.TestCase):
 
 
 class GhAPIClientTests(unittest.TestCase):
+    @staticmethod
+    def executable(root: Path, body: str) -> Path:
+        path = root / "fake-gh"
+        path.write_text(f"#!/bin/sh\nset -eu\n{body}\n", encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
     @patch("scripts.github_release_run.subprocess.run")
     def test_active_auth_scrubs_token_and_repo_overrides(self, run: Any) -> None:
         run.return_value = subprocess.CompletedProcess(
@@ -904,6 +912,44 @@ class GhAPIClientTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ReleaseRunError, "timed out"):
             client.get_json("user", active_auth=True)
+
+    def test_binary_download_uses_bounded_bytes_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = self.executable(Path(temporary_directory), "printf archive")
+            client = GhAPIClient(executable=str(executable))
+
+            content = client.get_bytes(
+                "repos/cbusillo/BD_to_AVP/actions/artifacts/123/zip",
+                active_auth=True,
+                max_bytes=1024,
+                timeout_seconds=5,
+            )
+
+        self.assertEqual(content, b"archive")
+
+    def test_binary_download_stops_at_size_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = self.executable(Path(temporary_directory), "while :; do printf oversized; done")
+            client = GhAPIClient(executable=str(executable))
+
+            with self.assertRaisesRegex(ReleaseRunError, "exceeded the 4-byte limit"):
+                client.get_bytes(
+                    "repos/cbusillo/BD_to_AVP/actions/artifacts/123/zip",
+                    max_bytes=4,
+                    timeout_seconds=5,
+                )
+
+    def test_binary_download_timeout_kills_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = self.executable(Path(temporary_directory), "sleep 5; printf late")
+            client = GhAPIClient(executable=str(executable))
+
+            with self.assertRaisesRegex(ReleaseRunError, "timed out"):
+                client.get_bytes(
+                    "repos/cbusillo/BD_to_AVP/actions/artifacts/123/zip",
+                    max_bytes=1024,
+                    timeout_seconds=0.05,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_release_qualification_artifact.py
+++ b/tests/test_release_qualification_artifact.py
@@ -1,0 +1,496 @@
+import hashlib
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+import zipfile
+
+from pathlib import Path
+
+from scripts.release_qualification_artifact import (
+    MAX_ARCHIVE_BYTES,
+    QualificationArtifactSafetyError,
+    download_and_plan_reconciliation,
+    plan_reconciliation,
+)
+from scripts.release_qualification_resume import ResumeIdentity
+from scripts.tier3_receipt import receipt_sha256
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_TAG = "v0.3.1"
+RUN_ID = 31330296987
+ARTIFACT_ID = 9001
+
+
+class FakeArtifactAPI:
+    def __init__(self, metadata: dict[str, object], archive: bytes) -> None:
+        self.metadata = metadata
+        self.archive = archive
+        self.gets: list[tuple[str, bool]] = []
+        self.byte_gets: list[tuple[str, bool, int, float]] = []
+
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        self.gets.append((endpoint, active_auth))
+        return self.metadata
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
+        self.byte_gets.append((endpoint, active_auth, max_bytes, timeout_seconds))
+        return self.archive
+
+
+class ReleaseQualificationArtifactTests(unittest.TestCase):
+    def fixture(
+        self,
+        root: Path,
+    ) -> tuple[ResumeIdentity, dict[str, object], dict[str, object], dict[str, object], dict[str, bytes], bytes]:
+        policy_path = root / "docs/qualification/release-qualification-policy-v1.json"
+        index_path = root / "docs/qualification/release-evidence-v1.json"
+        release_receipt_path = root / f"docs/release-evidence/{RELEASE_TAG}/release-receipt.json"
+        signed_ui_path = root / f"docs/release-evidence/{RELEASE_TAG}/signed-artifact-ui-receipt.json"
+        policy_path.parent.mkdir(parents=True)
+        release_receipt_path.parent.mkdir(parents=True)
+        policy_path.write_bytes((REPO_ROOT / "docs/qualification/release-qualification-policy-v1.json").read_bytes())
+        release_receipt_content = (REPO_ROOT / f"docs/release-evidence/{RELEASE_TAG}/release-receipt.json").read_bytes()
+        release_receipt_path.write_bytes(release_receipt_content)
+        signed_ui_content = (
+            REPO_ROOT / f"docs/qualification/{RELEASE_TAG}-profile-save-action-accessibility-v1.json"
+        ).read_bytes()
+        signed_ui_path.write_bytes(signed_ui_content)
+        index_path.write_text('{"receipts":[],"schema_version":1}\n', encoding="utf-8")
+
+        evidence_contents = {
+            "accessibility-tree": b'{"kind":"accessibility-tree"}\n',
+            "cleanup": b'{"kind":"cleanup"}\n',
+            "install-log": b'{"kind":"install-log"}\n',
+            "package-smoke": b'{"kind":"package-smoke"}\n',
+            "profile-snapshot": b'{"kind":"profile-snapshot"}\n',
+            "screenshot-dark": b"\x89PNG\r\n\x1a\ndark",
+            "screenshot-light": b"\x89PNG\r\n\x1a\nlight",
+            "sparkle-update": b'{"kind":"sparkle-update"}\n',
+            "ui-result": b'{"kind":"ui-result"}\n',
+        }
+        receipt_documents: dict[str, dict[str, object]] = {}
+        receipt_contents: dict[str, bytes] = {}
+        for case_id in ("clean-machine-signed-update", "installed-ui-accessibility"):
+            document = json.loads((REPO_ROOT / f"docs/qualification/{RELEASE_TAG}-{case_id}-v1.json").read_bytes())
+            for evidence in document["evidence"]:
+                evidence["sha256"] = hashlib.sha256(evidence_contents[evidence["kind"]]).hexdigest()
+            if case_id == "clean-machine-signed-update":
+                document["cleanup"]["evidence_sha256"] = hashlib.sha256(evidence_contents["cleanup"]).hexdigest()
+            document["receipt_sha256"] = receipt_sha256(document)
+            content = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode()
+            receipt_documents[case_id] = document
+            receipt_contents[case_id] = content
+
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "fixture"], cwd=root, check=True)
+        runner_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        release_receipt = json.loads(release_receipt_content)
+        signed_ui_receipt = json.loads(signed_ui_content)
+        identity = ResumeIdentity(
+            release_tag=RELEASE_TAG,
+            candidate_sha=release_receipt["source_sha"],
+            release_id=release_receipt["release"]["id"],
+            manifest_sha256="d" * 64,
+            runner_sha=runner_sha,
+            main_sha=runner_sha,
+            evidence_ref=f"automation/release-evidence-{RELEASE_TAG}",
+            evidence_sha=runner_sha,
+            evidence_base_sha=runner_sha,
+            evidence_pr_number=42,
+            release_receipt_file_sha256=hashlib.sha256(release_receipt_content).hexdigest(),
+            signed_ui_artifact_id=456,
+            signed_ui_artifact_sha256="6" * 64,
+            policy_sha256="1" * 64,
+            policy_checkpoint_sha256="2" * 64,
+            route_table_sha256="3" * 64,
+            controller_runner_sha256="4" * 64,
+        )
+        manifest: dict[str, object] = {
+            "paths": {"policy": "docs/qualification/release-qualification-policy-v1.json"},
+            "prior": {"release_tag": "v0.3.0"},
+            "release": {"sparkle_route": "stable"},
+            "signed_ui_artifact": {
+                "artifact_id": identity.signed_ui_artifact_id,
+                "artifact_sha256": identity.signed_ui_artifact_sha256,
+                "receipt_file_sha256": hashlib.sha256(signed_ui_content).hexdigest(),
+                "receipt_path": f"docs/release-evidence/{RELEASE_TAG}/signed-artifact-ui-receipt.json",
+                "receipt_sha256": signed_ui_receipt["receipt_sha256"],
+            },
+        }
+        run: dict[str, object] = {
+            "id": RUN_ID,
+            "run_attempt": 1,
+            "updated_at": "2026-08-09T19:05:28Z",
+        }
+        qualification_run = {
+            "candidate_tag": RELEASE_TAG,
+            "evidence_ref": identity.evidence_ref,
+            "evidence_sha": identity.evidence_sha,
+            "manifest_sha256": identity.manifest_sha256,
+            "prior_tag": "v0.3.0",
+            "route": "stable",
+            "signed_ui_artifact": {
+                "digest": f"sha256:{identity.signed_ui_artifact_sha256}",
+                "id": identity.signed_ui_artifact_id,
+                "receipt_sha256": signed_ui_receipt["receipt_sha256"],
+            },
+            "tier3_receipts": [
+                {
+                    "case_id": case_id,
+                    "receipt_sha256": receipt_documents[case_id]["receipt_sha256"],
+                }
+                for case_id in ("clean-machine-signed-update", "installed-ui-accessibility")
+            ],
+        }
+        entries = {
+            "clean-machine-signed-update.json": receipt_contents["clean-machine-signed-update"],
+            "installed-ui-accessibility.json": receipt_contents["installed-ui-accessibility"],
+            "qualification-run.json": (json.dumps(qualification_run, indent=2) + "\n").encode(),
+            "signed-artifact-ui-receipt.json": signed_ui_content,
+        }
+        evidence_filenames = {
+            "accessibility-tree": "accessibility-tree.json",
+            "cleanup": "cleanup.json",
+            "install-log": "install-log.json",
+            "package-smoke": "package-smoke.json",
+            "profile-snapshot": "profile-snapshot.json",
+            "screenshot-dark": "screenshot-dark.png",
+            "screenshot-light": "screenshot-light.png",
+            "sparkle-update": "sparkle-update.json",
+            "ui-result": "ui-result.json",
+        }
+        entries.update(
+            {
+                f"clean-machine-signed-update-evidence/{filename}": evidence_contents[kind]
+                for kind, filename in evidence_filenames.items()
+            }
+        )
+        archive = self.archive(entries)
+        artifact: dict[str, object] = {
+            "digest": "sha256:" + hashlib.sha256(archive).hexdigest(),
+            "id": ARTIFACT_ID,
+            "name": f"milestone-qualification-{RELEASE_TAG}-1",
+            "run_id": RUN_ID,
+            "state": "available",
+        }
+        return identity, manifest, run, artifact, entries, archive
+
+    @staticmethod
+    def archive(entries: dict[str, bytes]) -> bytes:
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+            for name, content in sorted(entries.items()):
+                archive.writestr(name, content)
+        return output.getvalue()
+
+    def test_valid_archive_produces_deterministic_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+
+            first = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            second = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first["requires_changes"])
+        self.assertEqual(len(first["plan_sha256"]), 64)
+        self.assertEqual(
+            [operation["state"] for operation in first["operations"]],
+            ["append", "append", "identical", "create", "create"],
+        )
+        self.assertNotIn("/Users/", json.dumps(first))
+
+    def test_existing_identical_evidence_is_current(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, archive = self.fixture(root)
+            plan = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            index_path = root / "docs/qualification/release-evidence-v1.json"
+            index = json.loads(index_path.read_bytes())
+            for operation in plan["operations"]:
+                if operation["kind"] == "write_file":
+                    path = root / operation["path"]
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    case_id = next(
+                        case_id
+                        for case_id in ("clean-machine-signed-update", "installed-ui-accessibility")
+                        if path.name == f"{RELEASE_TAG}-{case_id}-v1.json"
+                    )
+                    path.write_bytes(entries[f"{case_id}.json"])
+                if operation["kind"] == "append_evidence_record":
+                    index["receipts"].append(operation["record"])
+            index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "reconciled"], cwd=root, check=True)
+
+            current = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+
+        self.assertFalse(current["requires_changes"])
+        self.assertEqual(
+            [operation["state"] for operation in current["operations"]],
+            ["present", "present", "identical", "identical", "identical"],
+        )
+
+    def test_unsafe_archive_path_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            entries["../escape.json"] = b"{}\n"
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "unsafe ZIP path"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=self.archive(entries),
+                )
+
+    def test_qualification_run_identity_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            qualification_run = json.loads(entries["qualification-run.json"])
+            qualification_run["manifest_sha256"] = "0" * 64
+            entries["qualification-run.json"] = (json.dumps(qualification_run, indent=2) + "\n").encode()
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "manifest digest conflicts"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=self.archive(entries),
+                )
+
+    def test_evidence_digest_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            entries["clean-machine-signed-update-evidence/cleanup.json"] += b"changed"
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "evidence digest conflicts"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=self.archive(entries),
+                )
+
+    def test_missing_or_unexpected_archive_file_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            scenarios = {
+                "missing": {name: content for name, content in entries.items() if name != "qualification-run.json"},
+                "unexpected": {**entries, "unexpected.json": b"{}\n"},
+            }
+
+            for scenario, archive_entries in scenarios.items():
+                with self.subTest(scenario=scenario):
+                    with self.assertRaises(QualificationArtifactSafetyError):
+                        plan_reconciliation(
+                            repo_root=root,
+                            identity=identity,
+                            run=run,
+                            artifact=artifact,
+                            manifest=manifest,
+                            archive_bytes=self.archive(archive_entries),
+                        )
+
+    def test_unexpected_empty_directory_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            output = io.BytesIO()
+            with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+                for name, content in sorted(entries.items()):
+                    archive.writestr(name, content)
+                archive.writestr("unexpected/", b"")
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "unexpected directory"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=output.getvalue(),
+                )
+
+    def test_noncanonical_receipt_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, _archive = self.fixture(root)
+            receipt = json.loads(entries["clean-machine-signed-update.json"])
+            entries["clean-machine-signed-update.json"] = json.dumps(receipt).encode()
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "not canonical JSON"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=self.archive(entries),
+                )
+
+    def test_conflicting_checked_receipt_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            conflict = root / f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-v1.json"
+            conflict.write_text("{}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "conflict"], cwd=root, check=True)
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "conflicts"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=archive,
+                )
+
+    def test_download_revalidates_metadata_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            metadata = {
+                "digest": artifact["digest"],
+                "expired": False,
+                "id": ARTIFACT_ID,
+                "name": artifact["name"],
+                "size_in_bytes": len(archive),
+                "workflow_run": {"head_branch": "main", "head_sha": identity.runner_sha, "id": RUN_ID},
+            }
+            client = FakeArtifactAPI(metadata, archive)
+
+            plan = download_and_plan_reconciliation(
+                client=client,
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+            )
+
+        self.assertTrue(plan["requires_changes"])
+        self.assertEqual(
+            client.byte_gets,
+            [
+                (
+                    f"repos/cbusillo/BD_to_AVP/actions/artifacts/{ARTIFACT_ID}/zip",
+                    True,
+                    MAX_ARCHIVE_BYTES,
+                    300.0,
+                )
+            ],
+        )
+
+    def test_expired_metadata_race_fails_before_download(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            metadata = {
+                "digest": artifact["digest"],
+                "expired": True,
+                "id": ARTIFACT_ID,
+                "name": artifact["name"],
+                "size_in_bytes": len(archive),
+                "workflow_run": {"head_branch": "main", "head_sha": identity.runner_sha, "id": RUN_ID},
+            }
+            client = FakeArtifactAPI(metadata, archive)
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "metadata changed"):
+                download_and_plan_reconciliation(
+                    client=client,
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                )
+
+        self.assertEqual(client.byte_gets, [])
+
+    def test_download_digest_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            metadata = {
+                "digest": artifact["digest"],
+                "expired": False,
+                "id": ARTIFACT_ID,
+                "name": artifact["name"],
+                "size_in_bytes": len(archive),
+                "workflow_run": {"head_branch": "main", "head_sha": identity.runner_sha, "id": RUN_ID},
+            }
+            client = FakeArtifactAPI(metadata, archive + b"changed")
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "archive digest conflicts"):
+                download_and_plan_reconciliation(
+                    client=client,
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -387,6 +387,7 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
                         "b" * 64,
                         "--retry-run-id",
                         "123",
+                        "--observe-only",
                     ]
                 )
 
@@ -399,6 +400,7 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             expected_manifest_sha256="b" * 64,
             retry_run_id=123,
             retry_checkpoint_sha256=None,
+            observe_only=True,
         )
 
     @staticmethod

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -46,7 +46,9 @@ class FakeGitHubAPI:
     def __init__(self) -> None:
         self.responses: dict[tuple[str, bool], object] = {}
         self.sequences: dict[tuple[str, bool], deque[object]] = defaultdict(deque)
+        self.byte_responses: dict[tuple[str, bool], bytes] = {}
         self.gets: list[tuple[str, bool]] = []
+        self.byte_gets: list[tuple[str, bool, int, float]] = []
         self.posts: list[tuple[str, MappingProxy, bool]] = []
 
     def set(self, endpoint: str, payload: object, *, active_auth: bool = True) -> None:
@@ -77,6 +79,20 @@ class FakeGitHubAPI:
         self.posts.append((endpoint, MappingProxy(payload), active_auth))
         return None
 
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
+        self.byte_gets.append((endpoint, active_auth, max_bytes, timeout_seconds))
+        key = (endpoint, active_auth)
+        if key not in self.byte_responses:
+            raise AssertionError(f"Unexpected GitHub byte GET: {key!r}")
+        return self.byte_responses[key]
+
 
 class MappingProxy(dict[str, object]):
     def __init__(self, payload: dict[str, object]) -> None:
@@ -95,6 +111,16 @@ class FailOnGitHubAPI:
         active_auth: bool = False,
     ) -> object:
         raise AssertionError(f"Complete qualification must not mutate GitHub: {endpoint}")
+
+    def get_bytes(
+        self,
+        endpoint: str,
+        *,
+        active_auth: bool = False,
+        max_bytes: int,
+        timeout_seconds: float,
+    ) -> bytes:
+        raise AssertionError(f"Complete qualification must not download GitHub content: {endpoint}")
 
 
 def manifest() -> dict[str, object]:
@@ -179,6 +205,7 @@ def workflow_run(
         "triggering_actor": {"login": "cbusillo"},
         "status": status,
         "conclusion": conclusion,
+        "updated_at": "2026-08-10T12:00:00Z",
         "html_url": f"https://github.example/runs/{run_id}",
     }
 
@@ -189,6 +216,7 @@ def artifact(run_id: int, *, expired: bool, run_attempt: int = 1) -> dict[str, o
         "name": f"milestone-qualification-{RELEASE_TAG}-{run_attempt}",
         "digest": "sha256:" + "7" * 64,
         "expired": expired,
+        "size_in_bytes": 1024,
         "workflow_run": {"id": run_id, "head_branch": "main", "head_sha": MAIN_SHA},
     }
 
@@ -586,12 +614,54 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
             {"artifacts": [artifact(101, expired=False)]},
         )
         with tempfile.TemporaryDirectory() as temporary_directory:
-            result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+            result = self.run_blocked(
+                client,
+                Path(temporary_directory) / "checkpoint.json",
+                observe_only=True,
+            )
 
         self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
         self.assertEqual(result.payload["state"], "artifact_available")
         self.assertEqual(result.payload["artifact"]["state"], "available")
+        self.assertEqual(client.byte_gets, [])
         self.assertEqual(client.posts, [])
+
+    def test_successful_run_builds_read_only_reconciliation_plan(self) -> None:
+        client = self.configured_client()
+        succeeded = workflow_run(101, status="completed", conclusion="success")
+        available_artifact = artifact(101, expired=False)
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [succeeded]})
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/jobs?per_page=100",
+            {
+                "jobs": [
+                    {
+                        "name": "Collect exact post-publication qualification receipts",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
+        )
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/artifacts?per_page=100",
+            {"artifacts": [available_artifact]},
+        )
+        plan = {"plan_sha256": "8" * 64, "requires_changes": True}
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            patch(
+                "scripts.release_qualification_resume.download_and_plan_reconciliation",
+                return_value=plan,
+            ) as planner,
+        ):
+            result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "reconciliation_planned")
+        self.assertEqual(result.payload["reconciliation_plan"], plan)
+        self.assertEqual(client.posts, [])
+        planner.assert_called_once()
 
     def test_expired_artifact_requires_exact_retry(self) -> None:
         client = self.configured_client()


### PR DESCRIPTION
## Summary
- admit the exact Milestone Qualification artifact with bounded streaming and fail-closed ZIP validation
- validate workflow, manifest, signed UI, Tier 3 receipt, and evidence identities before producing a deterministic read-only reconciliation plan
- extend `resume` with automatic planning plus `--observe-only`, without adding write-capable evidence mutation
- document the planner contract and register its focused quality gate

## Validation
- `uv run python -m unittest tests.test_github_release_run tests.test_release_qualification_artifact tests.test_release_qualification_resume tests.test_release_qualification_controller` (85 passed)
- `uv run python -m unittest discover -s tests -t .` (1697 passed, 3 skipped)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python scripts/validate_observability_migration.py`
- `actionlint`
- `uv build`
- JetBrains changed-file inspection attempted twice; inconclusive because the exact worktree lacks a configured Python SDK. IDE-created files were removed.

## Reviews
- Opus exact-head review: READY
- Gemini 3.1 Pro exact-head review: READY

Refs #526
Refs #517