### PR TITLE
Apply qualification reconciliation plans safely

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -137,6 +137,7 @@
       "releaseQualificationStatus": "uv run python -m unittest tests.test_release_qualification_controller",
       "releaseQualificationResume": "uv run python -m unittest tests.test_release_qualification_resume",
       "releaseQualificationArtifact": "uv run python -m unittest tests.test_release_qualification_artifact",
+      "releaseQualificationApply": "uv run python -m unittest tests.test_release_qualification_apply",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -373,10 +373,40 @@ The workflow performs these ordered boundaries:
    `artifact_available` behavior without downloading. `reconciliation_planned`
    exits `20` with the canonical plan and its SHA-256; `reconciliation_current`
    exits `0` when every proposed destination and evidence-index record is
-   already identical. This stage still creates no repository files, commits,
-   pushes, comments, or pull requests. `artifact_expired` permits a new run only
-   after explicit retry authorization; checked durable receipts already accepted
-   by `status` remain a no-op even after Actions transport expires.
+   already identical. Planning creates no repository files, commits, pushes,
+   comments, or pull requests.
+
+   Apply an exact reviewed plan by echoing its digest:
+
+   ```sh
+   uv run python -m scripts.release_qualification_controller resume \
+     --release-tag <tag> \
+     --apply-plan-sha256 <plan-sha256>
+   ```
+
+   Apply requires the active GitHub identity `cbusillo`, the exact canonical
+   evidence worktree and pull request, an unchanged protected `main`, no active
+   exact Milestone Qualification run, and a clean worktree. Before changing
+   files it freezes the authorized plan and exact target bytes in a mode-`0600`,
+   self-digested apply checkpoint adjacent to the dispatch checkpoint. It then
+   uses per-file atomic replacement plus resumable verification for only the
+   planned qualification receipts and append-only evidence index, creates one
+   commit containing the plan and run identities,
+   performs a non-force fast-forward push, and posts one marker-bound pull-request
+   comment. Every transition is adopted rather than duplicated after an
+   interruption, including a commit or push whose response was lost. Reruns must
+   repeat the exact `--apply-plan-sha256`; `reconciliation_apply_pending` reports
+   that requirement and `reconciliation_applied` exits `0` after the commit,
+   push, and comment are all durable.
+
+   The apply checkpoint is
+   `<git-common-dir>/bd-to-avp/release-qualification/<tag>.apply.json` and shares
+   the dispatch checkpoint lock. Never delete it while an apply transition is
+   incomplete; the controller removes it only after the pushed commit and exact
+   marker comment are revalidated as durable. `artifact_expired` permits a new run only after explicit retry
+   authorization when no validated apply checkpoint or equivalent durable state
+   exists; checked receipts already accepted by `status` remain a no-op after
+   Actions transport expires.
 15. The separate `cbusillo/homebrew-tap` repository checks the latest stable
    GitHub Release on a schedule and by manual dispatch. Homebrew opens a formula
    update pull request when the version changes; tap CI must pass formula audit,

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -441,14 +441,29 @@ revalidates the exact artifact metadata, downloads the byte-bounded ZIP, rejects
 unsafe or unexpected members, validates its receipts against the runner-pinned
 policy and checked manifest, and emits a deterministic reconciliation plan.
 `--observe-only` stops at `artifact_available` without downloading.
-`reconciliation_planned` requires a later explicitly authorized apply stage;
+`reconciliation_planned` requires an explicit rerun with
+`--apply-plan-sha256 <plan-sha256>`;
 `reconciliation_current` means the checked destinations and evidence records
 are already identical. Planning deliberately does not mutate evidence refs,
-files, commits, comments, or pull requests. Expired milestone transport may
-trigger an explicitly authorized fresh qualification run; it never reconstructs
-receipts. If equivalent receipts are already committed and accepted, `status`
-reports no blockers and `resume` returns `complete` regardless of Actions
-retention.
+files, commits, comments, or pull requests.
+
+Apply freezes the full authorized plan and exact target file bytes in a separate
+mode-`0600`, self-digested checkpoint while sharing the per-release dispatch
+lock. Before every mutation it revalidates protected `main`, the canonical
+evidence ref and same-repository pull request, the active `cbusillo` identity,
+and the absence of an active exact Milestone Qualification run. It writes only
+the planned qualification receipts and append-only evidence index, creates one
+identity-bound commit, performs a non-force fast-forward push, and posts one
+marker-bound pull-request comment. Prepared, files-written, committed, pushed,
+and commented states are adopted after interruption rather than repeated.
+Conflicting local content, unrelated worktree changes, moved refs, changed pull
+requests, duplicate markers, or a non-fast-forward push fail closed.
+
+Expired milestone transport may trigger an explicitly authorized fresh
+qualification run only when no validated apply checkpoint or equivalent durable
+commit exists; it never reconstructs receipts. If equivalent receipts are
+already committed and accepted, `status` reports no blockers and `resume`
+returns `complete` regardless of Actions retention.
 
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated

--- a/scripts/release_qualification_apply.py
+++ b/scripts/release_qualification_apply.py
@@ -1,0 +1,1008 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol, cast
+
+from scripts.release_qualification_artifact import ReconciliationBundle
+
+
+REPOSITORY = "cbusillo/BD_to_AVP"
+REPOSITORY_OWNER = "cbusillo"
+HTTPS_REPOSITORY_URL = "https://github.com/cbusillo/BD_to_AVP.git"
+APPLY_CHECKPOINT_TYPE = "bd_to_avp.release_qualification_apply_checkpoint"
+APPLY_SCHEMA_VERSION = 1
+COMMENT_PAGE_SIZE = 100
+MAX_COMMENT_PAGES = 20
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+APPLY_STATES = {"prepared", "files_written", "committed", "pushed", "commented"}
+
+
+class QualificationApplyError(RuntimeError):
+    pass
+
+
+class QualificationApplySafetyError(QualificationApplyError):
+    pass
+
+
+class QualificationIdentity(Protocol):
+    release_tag: str
+    evidence_ref: str
+    evidence_sha: str
+    evidence_pr_number: int
+
+    def payload(self) -> dict[str, object]:
+        raise NotImplementedError
+
+
+class GitHubApplyAPI(Protocol):
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        raise NotImplementedError
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: Mapping[str, object],
+        *,
+        active_auth: bool = False,
+    ) -> object:
+        raise NotImplementedError
+
+
+RevalidateRemote = Callable[[str], None]
+EnsureNoActiveRuns = Callable[[], None]
+RequireActor = Callable[[], tuple[str, int]]
+RemoteEvidenceSHA = Callable[[], str]
+
+
+@dataclass(frozen=True)
+class ApplyOutcome:
+    state: str
+    plan: dict[str, object]
+    commit_sha: str
+    comment_id: int
+
+
+def _mapping(value: object, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise QualificationApplyError(f"{description} must be a JSON object.")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: object, description: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise QualificationApplyError(f"{description} must be a JSON array.")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise QualificationApplyError(f"{description} must be a non-empty string.")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise QualificationApplyError(f"{description} must be a positive integer.")
+    return value
+
+
+def _sha(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA_PATTERN.fullmatch(text) is None:
+        raise QualificationApplyError(f"{description} must be a full lowercase Git SHA.")
+    return text
+
+
+def _sha256(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA256_PATTERN.fullmatch(text) is None:
+        raise QualificationApplyError(f"{description} must be a lowercase SHA-256 digest.")
+    return text
+
+
+def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], description: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise QualificationApplySafetyError(
+            f"{description} keys changed; missing={sorted(expected - actual)!r}, extra={sorted(actual - expected)!r}."
+        )
+
+
+def reconciliation_checkpoint_path(dispatch_checkpoint_path: Path) -> Path:
+    return dispatch_checkpoint_path.with_name(dispatch_checkpoint_path.stem + ".apply.json")
+
+
+def _run_git(
+    repo_root: Path,
+    arguments: Sequence[str],
+    *,
+    text: bool = True,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        capture_output=True,
+        text=text,
+        env=env,
+        check=False,
+    )
+
+
+def _git_text(repo_root: Path, arguments: Sequence[str], description: str) -> str:
+    result = cast(subprocess.CompletedProcess[str], _run_git(repo_root, arguments))
+    if result.returncode != 0:
+        raise QualificationApplyError(f"Unable to read {description} from git.")
+    return result.stdout.strip()
+
+
+def _git_bytes(repo_root: Path, arguments: Sequence[str], description: str) -> bytes:
+    result = cast(subprocess.CompletedProcess[bytes], _run_git(repo_root, arguments, text=False))
+    if result.returncode != 0:
+        raise QualificationApplyError(f"Unable to read {description} from git.")
+    return result.stdout
+
+
+def _checked_content(repo_root: Path, revision: str, path: str) -> bytes | None:
+    result = cast(
+        subprocess.CompletedProcess[bytes],
+        _run_git(repo_root, ["show", f"{revision}:{path}"], text=False),
+    )
+    if result.returncode == 0:
+        return result.stdout
+    missing = cast(
+        subprocess.CompletedProcess[str],
+        _run_git(repo_root, ["cat-file", "-e", f"{revision}:{path}"]),
+    )
+    if missing.returncode != 0:
+        return None
+    raise QualificationApplyError(f"Unable to read checked reconciliation path {path!r}.")
+
+
+def _write_atomic(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        temporary_path.replace(path)
+    except OSError as error:
+        raise QualificationApplyError(f"Unable to write reconciliation path {path.name!r}.") from error
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _write_checkpoint(path: Path, checkpoint: Mapping[str, object]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+            os.chmod(temporary_path, 0o600)
+            temporary.write(_canonical_json_bytes(checkpoint))
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        temporary_path.replace(path)
+        os.chmod(path, 0o600)
+    except OSError as error:
+        raise QualificationApplyError("Unable to write qualification apply checkpoint.") from error
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _checkpoint_payload(
+    identity: QualificationIdentity,
+    bundle: ReconciliationBundle,
+    *,
+    state: str,
+    commit_sha: str | None = None,
+    comment_id: int | None = None,
+) -> dict[str, object]:
+    if state not in APPLY_STATES:
+        raise QualificationApplyError("Qualification apply checkpoint state is unsupported.")
+    plan = dict(bundle.plan)
+    files = [
+        {
+            "path": file.path,
+            "sha256": hashlib.sha256(file.content).hexdigest(),
+            "size_bytes": len(file.content),
+            "content_base64": base64.b64encode(file.content).decode("ascii"),
+        }
+        for file in bundle.files
+    ]
+    payload: dict[str, object] = {
+        "schema_version": APPLY_SCHEMA_VERSION,
+        "checkpoint_type": APPLY_CHECKPOINT_TYPE,
+        "identity": identity.payload(),
+        "plan": plan,
+        "plan_sha256": _sha256(plan.get("plan_sha256"), "reconciliation plan digest"),
+        "files": files,
+        "progress": {
+            "state": state,
+            "commit_sha": commit_sha,
+            "comment_id": comment_id,
+        },
+    }
+    payload["checkpoint_sha256"] = hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+    return payload
+
+
+def _replace_progress(
+    path: Path,
+    checkpoint: Mapping[str, Any],
+    *,
+    state: str,
+    commit_sha: str | None,
+    comment_id: int | None,
+) -> dict[str, object]:
+    payload = dict(checkpoint)
+    payload["progress"] = {
+        "state": state,
+        "commit_sha": commit_sha,
+        "comment_id": comment_id,
+    }
+    payload.pop("checkpoint_sha256", None)
+    payload["checkpoint_sha256"] = hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+    _write_checkpoint(path, payload)
+    return payload
+
+
+def load_reconciliation_checkpoint(path: Path) -> Mapping[str, Any] | None:
+    if not path.exists():
+        return None
+    if path.stat().st_mode & 0o077:
+        raise QualificationApplySafetyError("Qualification apply checkpoint permissions must be 0600.")
+    try:
+        checkpoint = _mapping(json.loads(path.read_text(encoding="utf-8")), "qualification apply checkpoint")
+    except OSError as error:
+        raise QualificationApplyError("Unable to read qualification apply checkpoint.") from error
+    except json.JSONDecodeError as error:
+        raise QualificationApplySafetyError("Qualification apply checkpoint is invalid JSON.") from error
+    _exact_keys(
+        checkpoint,
+        {
+            "schema_version",
+            "checkpoint_type",
+            "checkpoint_sha256",
+            "identity",
+            "plan",
+            "plan_sha256",
+            "files",
+            "progress",
+        },
+        "qualification apply checkpoint",
+    )
+    if (
+        checkpoint.get("schema_version") != APPLY_SCHEMA_VERSION
+        or checkpoint.get("checkpoint_type") != APPLY_CHECKPOINT_TYPE
+    ):
+        raise QualificationApplySafetyError("Qualification apply checkpoint schema or type is unsupported.")
+    recorded_digest = _sha256(checkpoint.get("checkpoint_sha256"), "qualification apply checkpoint self digest")
+    digest_payload = dict(checkpoint)
+    digest_payload.pop("checkpoint_sha256")
+    if hashlib.sha256(_canonical_json_bytes(digest_payload)).hexdigest() != recorded_digest:
+        raise QualificationApplySafetyError("Qualification apply checkpoint self digest is invalid.")
+    plan = _mapping(checkpoint.get("plan"), "qualification apply plan")
+    plan_digest = _sha256(checkpoint.get("plan_sha256"), "qualification apply plan digest")
+    if plan.get("plan_sha256") != plan_digest:
+        raise QualificationApplySafetyError("Qualification apply checkpoint plan digest conflicts.")
+    plan_digest_payload = dict(plan)
+    plan_digest_payload.pop("plan_sha256", None)
+    if hashlib.sha256(_canonical_json_bytes(plan_digest_payload)).hexdigest() != plan_digest:
+        raise QualificationApplySafetyError("Qualification apply checkpoint plan self digest is invalid.")
+    _validated_checkpoint_files(checkpoint)
+    progress = _mapping(checkpoint.get("progress"), "qualification apply progress")
+    _exact_keys(progress, {"state", "commit_sha", "comment_id"}, "qualification apply progress")
+    state = _string(progress.get("state"), "qualification apply state")
+    if state not in APPLY_STATES:
+        raise QualificationApplySafetyError("Qualification apply checkpoint state is unsupported.")
+    commit_sha = progress.get("commit_sha")
+    comment_id = progress.get("comment_id")
+    if state in {"committed", "pushed", "commented"}:
+        _sha(commit_sha, "qualification apply commit SHA")
+    elif commit_sha is not None:
+        raise QualificationApplySafetyError("Qualification apply checkpoint records a premature commit SHA.")
+    if state == "commented":
+        _integer(comment_id, "qualification apply comment ID")
+    elif comment_id is not None:
+        raise QualificationApplySafetyError("Qualification apply checkpoint records a premature comment ID.")
+    return checkpoint
+
+
+def _validated_checkpoint_files(checkpoint: Mapping[str, Any]) -> dict[str, bytes]:
+    plan = _mapping(checkpoint.get("plan"), "qualification apply plan")
+    planned_files = {
+        _string(item.get("path"), "planned reconciliation file path"): item
+        for item in (
+            _mapping(value, "planned reconciliation file")
+            for value in _sequence(plan.get("files"), "planned reconciliation files")
+        )
+    }
+    files: dict[str, bytes] = {}
+    for raw_file in _sequence(checkpoint.get("files"), "qualification apply files"):
+        file = _mapping(raw_file, "qualification apply file")
+        _exact_keys(file, {"path", "sha256", "size_bytes", "content_base64"}, "qualification apply file")
+        path = _validated_path(file.get("path"))
+        if path in files:
+            raise QualificationApplySafetyError("Qualification apply checkpoint repeats a file path.")
+        try:
+            content = base64.b64decode(
+                _string(file.get("content_base64"), "qualification apply file content"), validate=True
+            )
+        except ValueError as error:
+            raise QualificationApplySafetyError("Qualification apply checkpoint contains invalid base64.") from error
+        digest = _sha256(file.get("sha256"), "qualification apply file digest")
+        size = _integer(file.get("size_bytes"), "qualification apply file size")
+        if len(content) != size or hashlib.sha256(content).hexdigest() != digest:
+            raise QualificationApplySafetyError(
+                "Qualification apply checkpoint file content conflicts with its digest."
+            )
+        planned = planned_files.get(path)
+        if planned is None or planned.get("sha256") != digest or planned.get("size_bytes") != size:
+            raise QualificationApplySafetyError(
+                "Qualification apply checkpoint file conflicts with the authorized plan."
+            )
+        files[path] = content
+    if set(files) != set(planned_files):
+        raise QualificationApplySafetyError(
+            "Qualification apply checkpoint file set conflicts with the authorized plan."
+        )
+    return files
+
+
+def _validated_path(value: object) -> str:
+    text = _string(value, "qualification apply file path")
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or path.as_posix() != text
+        or not text.startswith("docs/qualification/")
+    ):
+        raise QualificationApplySafetyError("Qualification apply file path is outside the qualification evidence tree.")
+    return text
+
+
+def _validate_identity(checkpoint: Mapping[str, Any], identity: QualificationIdentity) -> tuple[str, str | None]:
+    recorded = dict(_mapping(checkpoint.get("identity"), "qualification apply identity"))
+    current = identity.payload()
+    base_evidence_sha = _sha(recorded.get("evidence_sha"), "qualification apply base evidence SHA")
+    progress = _mapping(checkpoint.get("progress"), "qualification apply progress")
+    commit_sha = progress.get("commit_sha")
+    for key, value in recorded.items():
+        if key != "evidence_sha" and current.get(key) != value:
+            raise QualificationApplySafetyError(
+                "Qualification apply checkpoint conflicts with current release identity."
+            )
+    current_evidence_sha = _sha(current.get("evidence_sha"), "current evidence SHA")
+    allowed = {base_evidence_sha}
+    if commit_sha is not None:
+        allowed.add(_sha(commit_sha, "qualification apply commit SHA"))
+    if current_evidence_sha not in allowed:
+        raise QualificationApplySafetyError("Qualification apply evidence branch moved to an unrelated commit.")
+    return base_evidence_sha, cast(str | None, commit_sha)
+
+
+def _changed_paths(repo_root: Path) -> set[str]:
+    paths: set[str] = set()
+    for arguments in (
+        ["diff", "--name-only", "-z"],
+        ["diff", "--cached", "--name-only", "-z"],
+        ["ls-files", "--others", "--exclude-standard", "-z"],
+    ):
+        output = _git_bytes(repo_root, arguments, "qualification apply worktree changes")
+        paths.update(item.decode("utf-8", errors="surrogateescape") for item in output.split(b"\0") if item)
+    return paths
+
+
+def _validate_origin(repo_root: Path) -> None:
+    origin = _git_text(repo_root, ["remote", "get-url", "origin"], "origin URL")
+    accepted = {
+        "https://github.com/cbusillo/BD_to_AVP",
+        "https://github.com/cbusillo/BD_to_AVP.git",
+        "git@github.com:cbusillo/BD_to_AVP.git",
+        "ssh://git@github.com/cbusillo/BD_to_AVP.git",
+    }
+    if origin not in accepted:
+        raise QualificationApplySafetyError("Qualification apply origin does not match cbusillo/BD_to_AVP.")
+
+
+def _validate_local_branch(repo_root: Path, identity: QualificationIdentity, allowed_heads: set[str]) -> str:
+    branch = _git_text(repo_root, ["symbolic-ref", "--quiet", "--short", "HEAD"], "local branch")
+    if branch != identity.evidence_ref:
+        raise QualificationApplySafetyError("Qualification apply must run from the canonical evidence branch.")
+    head = _sha(_git_text(repo_root, ["rev-parse", "HEAD"], "local HEAD"), "local HEAD")
+    if head not in allowed_heads:
+        raise QualificationApplySafetyError("Qualification apply local HEAD is not an authorized transition commit.")
+    _validate_origin(repo_root)
+    return head
+
+
+def _validate_and_write_files(repo_root: Path, base_sha: str, files: Mapping[str, bytes]) -> None:
+    unexpected = sorted(_changed_paths(repo_root) - set(files))
+    if unexpected:
+        raise QualificationApplySafetyError(f"Qualification apply worktree contains unrelated changes: {unexpected!r}.")
+    for path, desired in files.items():
+        base = _checked_content(repo_root, base_sha, path)
+        local_path = repo_root / path
+        current = local_path.read_bytes() if local_path.exists() else None
+        if current not in {base, desired}:
+            raise QualificationApplySafetyError(
+                f"Qualification apply path {path!r} contains conflicting local content."
+            )
+    for path, desired in files.items():
+        _write_atomic(repo_root / path, desired)
+    for path, desired in files.items():
+        if (repo_root / path).read_bytes() != desired:
+            raise QualificationApplySafetyError(f"Qualification apply path {path!r} changed after writing.")
+    expected_changed = {
+        path for path, desired in files.items() if _checked_content(repo_root, base_sha, path) != desired
+    }
+    if _changed_paths(repo_root) != expected_changed:
+        raise QualificationApplySafetyError("Qualification apply worktree diff does not match the authorized plan.")
+
+
+def _commit_message(plan: Mapping[str, Any]) -> str:
+    artifact = _mapping(plan.get("artifact"), "reconciliation plan artifact")
+    return (
+        f"Record qualification evidence for {_string(plan.get('release_tag'), 'release tag')}\n\n"
+        f"Qualification-Plan-SHA256: {_sha256(plan.get('plan_sha256'), 'plan digest')}\n"
+        f"Qualification-Run-ID: {_integer(artifact.get('run_id'), 'qualification run ID')}\n"
+    )
+
+
+def _commit_message_bytes(repo_root: Path, commit_sha: str) -> bytes:
+    commit_object = _git_bytes(
+        repo_root,
+        ["cat-file", "commit", commit_sha],
+        "qualification apply commit object",
+    )
+    _headers, separator, message = commit_object.partition(b"\n\n")
+    if not separator:
+        raise QualificationApplySafetyError("Qualification apply commit object has no message payload.")
+    return message
+
+
+def _validate_commit(
+    repo_root: Path,
+    *,
+    commit_sha: str,
+    base_sha: str,
+    plan: Mapping[str, Any],
+    files: Mapping[str, bytes],
+    actor_login: str,
+    actor_id: int,
+) -> None:
+    if _git_text(repo_root, ["rev-parse", f"{commit_sha}^"], "qualification apply commit parent") != base_sha:
+        raise QualificationApplySafetyError(
+            "Qualification apply commit parent conflicts with the authorized evidence head."
+        )
+    changed = set(
+        item.decode("utf-8", errors="surrogateescape")
+        for item in _git_bytes(
+            repo_root,
+            ["diff-tree", "--no-commit-id", "--name-only", "-r", "-z", commit_sha],
+            "qualification apply commit paths",
+        ).split(b"\0")
+        if item
+    )
+    expected_changed = {
+        path for path, desired in files.items() if _checked_content(repo_root, base_sha, path) != desired
+    }
+    if changed != expected_changed:
+        raise QualificationApplySafetyError("Qualification apply commit paths conflict with the authorized plan.")
+    for path, desired in files.items():
+        if _checked_content(repo_root, commit_sha, path) != desired:
+            raise QualificationApplySafetyError(f"Qualification apply commit content conflicts for {path!r}.")
+    if _commit_message_bytes(repo_root, commit_sha) != _commit_message(plan).encode():
+        raise QualificationApplySafetyError("Qualification apply commit message conflicts with the authorized plan.")
+    expected_email = f"{actor_id}+{actor_login}@users.noreply.github.com"
+    if _git_text(repo_root, ["show", "-s", "--format=%an", commit_sha], "qualification apply author") != actor_login:
+        raise QualificationApplySafetyError(
+            "Qualification apply commit author conflicts with the active GitHub identity."
+        )
+    if (
+        _git_text(repo_root, ["show", "-s", "--format=%ae", commit_sha], "qualification apply author email")
+        != expected_email
+    ):
+        raise QualificationApplySafetyError(
+            "Qualification apply commit email conflicts with the active GitHub identity."
+        )
+    if _git_text(repo_root, ["show", "-s", "--format=%cn", commit_sha], "qualification apply committer") != actor_login:
+        raise QualificationApplySafetyError(
+            "Qualification apply commit committer conflicts with the active GitHub identity."
+        )
+    if (
+        _git_text(repo_root, ["show", "-s", "--format=%ce", commit_sha], "qualification apply committer email")
+        != expected_email
+    ):
+        raise QualificationApplySafetyError(
+            "Qualification apply commit committer email conflicts with the active GitHub identity."
+        )
+
+
+def _create_or_adopt_commit(
+    repo_root: Path,
+    *,
+    base_sha: str,
+    plan: Mapping[str, Any],
+    files: Mapping[str, bytes],
+    actor_login: str,
+    actor_id: int,
+) -> str:
+    head = _sha(_git_text(repo_root, ["rev-parse", "HEAD"], "local HEAD"), "local HEAD")
+    if head != base_sha:
+        _validate_commit(
+            repo_root,
+            commit_sha=head,
+            base_sha=base_sha,
+            plan=plan,
+            files=files,
+            actor_login=actor_login,
+            actor_id=actor_id,
+        )
+        return head
+    paths = sorted(files)
+    add = cast(subprocess.CompletedProcess[str], _run_git(repo_root, ["add", "--", *paths]))
+    if add.returncode != 0:
+        raise QualificationApplyError("Unable to stage qualification reconciliation files.")
+    expected_email = f"{actor_id}+{actor_login}@users.noreply.github.com"
+    commit = cast(
+        subprocess.CompletedProcess[str],
+        _run_git(
+            repo_root,
+            [
+                "-c",
+                f"user.name={actor_login}",
+                "-c",
+                f"user.email={expected_email}",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                _commit_message(plan).rstrip("\n"),
+                "--",
+                *paths,
+            ],
+        ),
+    )
+    if commit.returncode != 0:
+        raise QualificationApplyError("Unable to commit qualification reconciliation files.")
+    commit_sha = _sha(_git_text(repo_root, ["rev-parse", "HEAD"], "qualification apply commit"), "commit SHA")
+    _validate_commit(
+        repo_root,
+        commit_sha=commit_sha,
+        base_sha=base_sha,
+        plan=plan,
+        files=files,
+        actor_login=actor_login,
+        actor_id=actor_id,
+    )
+    if _changed_paths(repo_root):
+        raise QualificationApplySafetyError("Qualification apply worktree changed during commit creation.")
+    return commit_sha
+
+
+def _authenticated_git_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    for name in (
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "CODEX_GITHUB_TOKEN",
+        "GH_ENTERPRISE_TOKEN",
+        "GITHUB_ENTERPRISE_TOKEN",
+        "GH_HOST",
+        "GH_REPO",
+    ):
+        environment.pop(name, None)
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    return environment
+
+
+def _push_commit(repo_root: Path, evidence_ref: str, commit_sha: str) -> None:
+    push = cast(
+        subprocess.CompletedProcess[str],
+        _run_git(
+            repo_root,
+            [
+                "-c",
+                "credential.helper=",
+                "-c",
+                "credential.helper=!gh auth git-credential",
+                "push",
+                HTTPS_REPOSITORY_URL,
+                f"{commit_sha}:refs/heads/{evidence_ref}",
+            ],
+            env=_authenticated_git_environment(),
+        ),
+    )
+    if push.returncode != 0:
+        raise QualificationApplyError("Unable to push the qualification reconciliation commit.")
+
+
+def _comment_marker(plan_sha256: str) -> str:
+    return f"<!-- bd-to-avp-qualification-reconciliation:{plan_sha256} -->"
+
+
+def _comment_body(plan: Mapping[str, Any], commit_sha: str) -> str:
+    artifact = _mapping(plan.get("artifact"), "reconciliation plan artifact")
+    plan_sha256 = _sha256(plan.get("plan_sha256"), "reconciliation plan digest")
+    return (
+        f"{_comment_marker(plan_sha256)}\n"
+        f"Qualification evidence for `{_string(plan.get('release_tag'), 'release tag')}` was reconciled from the exact "
+        "Milestone Qualification artifact.\n\n"
+        f"- Plan SHA-256: `{plan_sha256}`\n"
+        f"- Evidence commit: `{commit_sha}`\n"
+        f"- Milestone Qualification run: `{_integer(artifact.get('run_id'), 'qualification run ID')}` "
+        f"attempt `{_integer(artifact.get('run_attempt'), 'qualification run attempt')}`\n"
+    )
+
+
+def _matching_comment(
+    client: GitHubApplyAPI,
+    *,
+    pr_number: int,
+    plan: Mapping[str, Any],
+    commit_sha: str,
+    actor_login: str,
+    actor_id: int,
+) -> Mapping[str, Any] | None:
+    expected_body = _comment_body(plan, commit_sha)
+    marker = _comment_marker(_sha256(plan.get("plan_sha256"), "reconciliation plan digest"))
+    matches: list[Mapping[str, Any]] = []
+    for page in range(1, MAX_COMMENT_PAGES + 1):
+        payload = _sequence(
+            client.get_json(
+                f"repos/{REPOSITORY}/issues/{pr_number}/comments?per_page={COMMENT_PAGE_SIZE}&page={page}",
+                active_auth=True,
+            ),
+            "evidence pull request comments",
+        )
+        comments = [_mapping(item, "evidence pull request comment") for item in payload]
+        matches.extend(comment for comment in comments if marker in str(comment.get("body", "")))
+        if len(comments) < COMMENT_PAGE_SIZE:
+            break
+        if page == MAX_COMMENT_PAGES:
+            raise QualificationApplySafetyError("Evidence pull request comment history exceeds the adoption limit.")
+    if len(matches) > 1:
+        raise QualificationApplySafetyError("Multiple qualification reconciliation comments match one plan.")
+    if not matches:
+        return None
+    comment = matches[0]
+    _validate_comment(comment, expected_body=expected_body, actor_login=actor_login, actor_id=actor_id)
+    return comment
+
+
+def _validate_comment(
+    comment: Mapping[str, Any],
+    *,
+    expected_body: str,
+    actor_login: str,
+    actor_id: int,
+) -> int:
+    user = _mapping(comment.get("user"), "qualification reconciliation comment user")
+    if comment.get("body") != expected_body or user.get("login") != actor_login or user.get("id") != actor_id:
+        raise QualificationApplySafetyError("Qualification reconciliation comment conflicts with the plan.")
+    return _integer(comment.get("id"), "qualification reconciliation comment ID")
+
+
+def _post_or_adopt_comment(
+    client: GitHubApplyAPI,
+    *,
+    pr_number: int,
+    plan: Mapping[str, Any],
+    commit_sha: str,
+    actor_login: str,
+    actor_id: int,
+) -> int:
+    existing = _matching_comment(
+        client,
+        pr_number=pr_number,
+        plan=plan,
+        commit_sha=commit_sha,
+        actor_login=actor_login,
+        actor_id=actor_id,
+    )
+    if existing is not None:
+        return _integer(existing.get("id"), "qualification reconciliation comment ID")
+    body = _comment_body(plan, commit_sha)
+    comment = _mapping(
+        client.post_json(
+            f"repos/{REPOSITORY}/issues/{pr_number}/comments",
+            {"body": body},
+            active_auth=True,
+        ),
+        "qualification reconciliation comment",
+    )
+    return _validate_comment(comment, expected_body=body, actor_login=actor_login, actor_id=actor_id)
+
+
+def _comment_by_id(
+    client: GitHubApplyAPI,
+    *,
+    comment_id: int,
+    plan: Mapping[str, Any],
+    commit_sha: str,
+    actor_login: str,
+    actor_id: int,
+) -> Mapping[str, Any]:
+    comment = _mapping(
+        client.get_json(
+            f"repos/{REPOSITORY}/issues/comments/{comment_id}",
+            active_auth=True,
+        ),
+        "qualification reconciliation comment",
+    )
+    _validate_comment(
+        comment,
+        expected_body=_comment_body(plan, commit_sha),
+        actor_login=actor_login,
+        actor_id=actor_id,
+    )
+    return comment
+
+
+def reconciliation_checkpoint_summary(path: Path) -> dict[str, object] | None:
+    checkpoint = load_reconciliation_checkpoint(path)
+    if checkpoint is None:
+        return None
+    progress = _mapping(checkpoint.get("progress"), "qualification apply progress")
+    return {
+        "present": True,
+        "plan_sha256": checkpoint.get("plan_sha256"),
+        "state": progress.get("state"),
+        "commit_sha": progress.get("commit_sha"),
+        "comment_id": progress.get("comment_id"),
+    }
+
+
+def start_reconciliation_apply(
+    *,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    bundle: ReconciliationBundle,
+    expected_plan_sha256: str,
+    client: GitHubApplyAPI,
+    checkpoint_path: Path,
+    revalidate_remote: RevalidateRemote,
+    ensure_no_active_runs: EnsureNoActiveRuns,
+    require_actor: RequireActor,
+    remote_evidence_sha: RemoteEvidenceSHA,
+) -> ApplyOutcome:
+    expected_plan_sha256 = _sha256(expected_plan_sha256, "authorized reconciliation plan digest")
+    if bundle.plan.get("plan_sha256") != expected_plan_sha256:
+        raise QualificationApplySafetyError("Authorized reconciliation plan digest does not match the current plan.")
+    if bundle.plan.get("requires_changes") is not True:
+        raise QualificationApplySafetyError("Qualification reconciliation plan does not require mutation.")
+    existing = load_reconciliation_checkpoint(checkpoint_path)
+    if existing is None:
+        ensure_no_active_runs()
+        revalidate_remote(identity.evidence_sha)
+        _validate_local_branch(repo_root, identity, {identity.evidence_sha})
+        if _changed_paths(repo_root):
+            raise QualificationApplySafetyError("Qualification apply requires a clean evidence worktree.")
+        checkpoint = _checkpoint_payload(identity, bundle, state="prepared")
+        _write_checkpoint(checkpoint_path, checkpoint)
+    return continue_reconciliation_apply(
+        repo_root=repo_root,
+        identity=identity,
+        expected_plan_sha256=expected_plan_sha256,
+        client=client,
+        checkpoint_path=checkpoint_path,
+        revalidate_remote=revalidate_remote,
+        ensure_no_active_runs=ensure_no_active_runs,
+        require_actor=require_actor,
+        remote_evidence_sha=remote_evidence_sha,
+    )
+
+
+def continue_reconciliation_apply(
+    *,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    expected_plan_sha256: str,
+    client: GitHubApplyAPI,
+    checkpoint_path: Path,
+    revalidate_remote: RevalidateRemote,
+    ensure_no_active_runs: EnsureNoActiveRuns,
+    require_actor: RequireActor,
+    remote_evidence_sha: RemoteEvidenceSHA,
+) -> ApplyOutcome:
+    checkpoint = load_reconciliation_checkpoint(checkpoint_path)
+    if checkpoint is None:
+        raise QualificationApplySafetyError("Qualification apply checkpoint is missing.")
+    expected_plan_sha256 = _sha256(expected_plan_sha256, "authorized reconciliation plan digest")
+    if checkpoint.get("plan_sha256") != expected_plan_sha256:
+        raise QualificationApplySafetyError(
+            "Authorized reconciliation plan digest conflicts with the apply checkpoint."
+        )
+    base_sha, checkpoint_commit_sha = _validate_identity(checkpoint, identity)
+    plan = dict(_mapping(checkpoint.get("plan"), "qualification apply plan"))
+    files = _validated_checkpoint_files(checkpoint)
+    progress = _mapping(checkpoint.get("progress"), "qualification apply progress")
+    state = _string(progress.get("state"), "qualification apply state")
+    actor_login, actor_id = require_actor()
+    allowed_heads = {base_sha}
+    if checkpoint_commit_sha is not None:
+        allowed_heads.add(checkpoint_commit_sha)
+    if state == "files_written" and checkpoint_commit_sha is None:
+        allowed_heads.add(_sha(_git_text(repo_root, ["rev-parse", "HEAD"], "local HEAD"), "local HEAD"))
+    _validate_local_branch(repo_root, identity, allowed_heads)
+    if state in {"committed", "pushed", "commented"} and _changed_paths(repo_root):
+        raise QualificationApplySafetyError(
+            "Qualification apply worktree changed after the reconciliation commit was created."
+        )
+
+    if state == "prepared":
+        ensure_no_active_runs()
+        revalidate_remote(base_sha)
+        _validate_and_write_files(repo_root, base_sha, files)
+        checkpoint = _replace_progress(
+            checkpoint_path,
+            checkpoint,
+            state="files_written",
+            commit_sha=None,
+            comment_id=None,
+        )
+        state = "files_written"
+
+    if state == "files_written":
+        ensure_no_active_runs()
+        revalidate_remote(base_sha)
+        local_head = _sha(_git_text(repo_root, ["rev-parse", "HEAD"], "local HEAD"), "local HEAD")
+        if local_head == base_sha:
+            _validate_and_write_files(repo_root, base_sha, files)
+        elif _changed_paths(repo_root):
+            raise QualificationApplySafetyError(
+                "Qualification apply worktree changed after the reconciliation commit was created."
+            )
+        commit_sha = _create_or_adopt_commit(
+            repo_root,
+            base_sha=base_sha,
+            plan=plan,
+            files=files,
+            actor_login=actor_login,
+            actor_id=actor_id,
+        )
+        checkpoint = _replace_progress(
+            checkpoint_path,
+            checkpoint,
+            state="committed",
+            commit_sha=commit_sha,
+            comment_id=None,
+        )
+        state = "committed"
+    else:
+        commit_sha = _sha(
+            _mapping(checkpoint.get("progress"), "qualification apply progress").get("commit_sha"),
+            "qualification apply commit SHA",
+        )
+
+    if state == "committed":
+        _validate_commit(
+            repo_root,
+            commit_sha=commit_sha,
+            base_sha=base_sha,
+            plan=plan,
+            files=files,
+            actor_login=actor_login,
+            actor_id=actor_id,
+        )
+        ensure_no_active_runs()
+        remote_sha = _sha(remote_evidence_sha(), "remote evidence SHA")
+        if remote_sha == commit_sha:
+            revalidate_remote(commit_sha)
+        elif remote_sha == base_sha:
+            revalidate_remote(base_sha)
+            try:
+                _push_commit(repo_root, identity.evidence_ref, commit_sha)
+            except QualificationApplyError as error:
+                observed_after_error = _sha(remote_evidence_sha(), "remote evidence SHA")
+                if observed_after_error != commit_sha:
+                    if observed_after_error != base_sha:
+                        raise QualificationApplySafetyError(
+                            "Evidence branch moved while the reconciliation commit was being pushed."
+                        ) from error
+                    raise
+            if _sha(remote_evidence_sha(), "remote evidence SHA") != commit_sha:
+                raise QualificationApplySafetyError("Evidence branch did not advance to the reconciliation commit.")
+            revalidate_remote(commit_sha)
+        else:
+            raise QualificationApplySafetyError(
+                "Evidence branch moved before the reconciliation commit could be pushed."
+            )
+        checkpoint = _replace_progress(
+            checkpoint_path,
+            checkpoint,
+            state="pushed",
+            commit_sha=commit_sha,
+            comment_id=None,
+        )
+        state = "pushed"
+
+    if state == "pushed":
+        ensure_no_active_runs()
+        if _sha(remote_evidence_sha(), "remote evidence SHA") != commit_sha:
+            raise QualificationApplySafetyError("Evidence branch moved after the reconciliation commit was pushed.")
+        revalidate_remote(commit_sha)
+        comment_id = _post_or_adopt_comment(
+            client,
+            pr_number=identity.evidence_pr_number,
+            plan=plan,
+            commit_sha=commit_sha,
+            actor_login=actor_login,
+            actor_id=actor_id,
+        )
+        checkpoint = _replace_progress(
+            checkpoint_path,
+            checkpoint,
+            state="commented",
+            commit_sha=commit_sha,
+            comment_id=comment_id,
+        )
+        state = "commented"
+    else:
+        comment_id = _integer(
+            _mapping(checkpoint.get("progress"), "qualification apply progress").get("comment_id"),
+            "qualification apply comment ID",
+        )
+
+    if state != "commented":
+        raise QualificationApplySafetyError("Qualification apply stopped in an unsupported state.")
+    if _sha(remote_evidence_sha(), "remote evidence SHA") != commit_sha:
+        raise QualificationApplySafetyError("Evidence branch moved after qualification reconciliation completed.")
+    revalidate_remote(commit_sha)
+    adopted = _comment_by_id(
+        client,
+        comment_id=comment_id,
+        plan=plan,
+        commit_sha=commit_sha,
+        actor_login=actor_login,
+        actor_id=actor_id,
+    )
+    if _integer(adopted.get("id"), "qualification reconciliation comment ID") != comment_id:
+        raise QualificationApplySafetyError("Qualification reconciliation comment is no longer durable.")
+    try:
+        checkpoint_path.unlink()
+    except OSError as error:
+        raise QualificationApplyError("Unable to remove completed qualification apply checkpoint.") from error
+    return ApplyOutcome(
+        state="reconciliation_applied",
+        plan=plan,
+        commit_sha=commit_sha,
+        comment_id=comment_id,
+    )
+
+
+__all__ = [
+    "ApplyOutcome",
+    "QualificationApplyError",
+    "QualificationApplySafetyError",
+    "continue_reconciliation_apply",
+    "load_reconciliation_checkpoint",
+    "reconciliation_checkpoint_path",
+    "reconciliation_checkpoint_summary",
+    "start_reconciliation_apply",
+]

--- a/scripts/release_qualification_apply.py
+++ b/scripts/release_qualification_apply.py
@@ -17,7 +17,6 @@ from scripts.release_qualification_artifact import ReconciliationBundle
 
 
 REPOSITORY = "cbusillo/BD_to_AVP"
-REPOSITORY_OWNER = "cbusillo"
 HTTPS_REPOSITORY_URL = "https://github.com/cbusillo/BD_to_AVP.git"
 APPLY_CHECKPOINT_TYPE = "bd_to_avp.release_qualification_apply_checkpoint"
 APPLY_SCHEMA_VERSION = 1
@@ -955,7 +954,7 @@ def continue_reconciliation_apply(
             actor_login=actor_login,
             actor_id=actor_id,
         )
-        checkpoint = _replace_progress(
+        _replace_progress(
             checkpoint_path,
             checkpoint,
             state="commented",

--- a/scripts/release_qualification_artifact.py
+++ b/scripts/release_qualification_artifact.py
@@ -9,6 +9,7 @@ import subprocess
 import zipfile
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, cast
@@ -67,6 +68,18 @@ class QualificationArtifactError(RuntimeError):
 
 class QualificationArtifactSafetyError(QualificationArtifactError):
     pass
+
+
+@dataclass(frozen=True)
+class ReconciliationFile:
+    path: str
+    content: bytes
+
+
+@dataclass(frozen=True)
+class ReconciliationBundle:
+    plan: dict[str, object]
+    files: tuple[ReconciliationFile, ...]
 
 
 class QualificationIdentity(Protocol):
@@ -202,15 +215,19 @@ def _json_at_revision(repo_root: Path, revision: str, relative_path: str, descri
     return _load_json_bytes(result.stdout, f"runner-bound {description}")
 
 
-def _accepted_at(run: Mapping[str, Any]) -> str:
-    text = _string(run.get("updated_at"), "workflow run updated_at")
+def _parse_timestamp(value: object, description: str) -> datetime:
+    text = _string(value, description)
     try:
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
     except ValueError as error:
-        raise QualificationArtifactError("Workflow run updated_at is invalid.") from error
+        raise QualificationArtifactError(f"{description} is invalid.") from error
     if parsed.tzinfo is None:
-        raise QualificationArtifactError("Workflow run updated_at must include a timezone.")
-    return parsed.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        raise QualificationArtifactError(f"{description} must include a timezone.")
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def _archive_entry_limit(name: str) -> int:
@@ -498,7 +515,8 @@ def _plan_index_operations(
     identity: QualificationIdentity,
     run: Mapping[str, Any],
     receipt_contents: Mapping[str, bytes],
-) -> list[dict[str, object]]:
+    accepted_at: str,
+) -> tuple[list[dict[str, object]], bytes]:
     index_content = _checked_file(repo_root, EVIDENCE_INDEX_PATH)
     if index_content is None:
         raise QualificationArtifactSafetyError("Checked release qualification evidence index is missing.")
@@ -509,7 +527,6 @@ def _plan_index_operations(
         dict(_mapping(item, "release qualification evidence record"))
         for item in _sequence(index.get("receipts"), "release qualification evidence records")
     ]
-    accepted_at = _accepted_at(run)
     run_id = _integer(run.get("id"), "workflow run ID")
     operations: list[dict[str, object]] = []
     for case_id in CASE_IDS:
@@ -539,10 +556,11 @@ def _plan_index_operations(
                 "state": "append" if len(receipts) > before else "present",
             }
         )
-    return operations
+    index["receipts"] = receipts
+    return operations, _pretty_json_bytes(index)
 
 
-def plan_reconciliation(
+def plan_reconciliation_bundle(
     *,
     repo_root: Path,
     identity: QualificationIdentity,
@@ -550,7 +568,7 @@ def plan_reconciliation(
     artifact: Mapping[str, Any],
     manifest: Mapping[str, Any],
     archive_bytes: bytes,
-) -> dict[str, object]:
+) -> ReconciliationBundle:
     repo_root = repo_root.resolve()
     entries = _admit_archive(archive_bytes)
     receipt_summaries, receipts, receipt_digests = _validate_receipts(
@@ -558,6 +576,12 @@ def plan_reconciliation(
         repo_root=repo_root,
         identity=identity,
         manifest=manifest,
+    )
+    accepted_at = _format_timestamp(
+        max(
+            _parse_timestamp(summary["completed_at"], f"{summary['case_id']} receipt completed_at")
+            for summary in receipt_summaries
+        )
     )
     qualification_run = _load_json_bytes(entries["qualification-run.json"], "qualification-run.json")
     _validate_qualification_run(
@@ -597,14 +621,14 @@ def plan_reconciliation(
             "state": "identical",
         }
     )
-    operations.extend(
-        _plan_index_operations(
-            repo_root,
-            identity=identity,
-            run=run,
-            receipt_contents=receipt_contents,
-        )
+    index_operations, index_content = _plan_index_operations(
+        repo_root,
+        identity=identity,
+        run=run,
+        receipt_contents=receipt_contents,
+        accepted_at=accepted_at,
     )
+    operations.extend(index_operations)
     sorted_operations = sorted(
         operations,
         key=lambda item: (
@@ -616,6 +640,21 @@ def plan_reconciliation(
     artifact_digest = _string(artifact.get("digest"), "Milestone Qualification artifact digest")
     if not artifact_digest.startswith("sha256:"):
         raise QualificationArtifactError("Milestone Qualification artifact digest is invalid.")
+    materialized_files = {
+        **{
+            f"docs/qualification/{identity.release_tag}-{case_id}-v1.json": receipt_contents[case_id]
+            for case_id in CASE_IDS
+        },
+        EVIDENCE_INDEX_PATH: index_content,
+    }
+    file_states = {
+        cast(str, operation["path"]): cast(str, operation["state"])
+        for operation in sorted_operations
+        if operation["kind"] == "write_file"
+    }
+    file_states[EVIDENCE_INDEX_PATH] = (
+        "append" if any(operation["state"] == "append" for operation in index_operations) else "identical"
+    )
     plan: dict[str, object] = {
         "artifact": {
             "id": _integer(artifact.get("id"), "Milestone Qualification artifact ID"),
@@ -628,6 +667,15 @@ def plan_reconciliation(
         "cases": sorted(receipt_summaries, key=lambda item: cast(str, item["case_id"])),
         "evidence_ref": identity.evidence_ref,
         "evidence_sha": _sha(identity.evidence_sha, "evidence SHA"),
+        "files": [
+            {
+                "path": path,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size_bytes": len(content),
+                "state": file_states[path],
+            }
+            for path, content in sorted(materialized_files.items())
+        ],
         "identity_sha256": _sha256(identity.digest, "resume identity digest"),
         "main_sha": _sha(identity.main_sha, "main SHA"),
         "manifest_sha256": _sha256(identity.manifest_sha256, "manifest digest"),
@@ -638,10 +686,34 @@ def plan_reconciliation(
         "schema_version": SCHEMA_VERSION,
     }
     plan["plan_sha256"] = hashlib.sha256(_canonical_json_bytes(plan)).hexdigest()
-    return plan
+    return ReconciliationBundle(
+        plan=plan,
+        files=tuple(
+            ReconciliationFile(path=path, content=content) for path, content in sorted(materialized_files.items())
+        ),
+    )
 
 
-def download_and_plan_reconciliation(
+def plan_reconciliation(
+    *,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    archive_bytes: bytes,
+) -> dict[str, object]:
+    return plan_reconciliation_bundle(
+        repo_root=repo_root,
+        identity=identity,
+        run=run,
+        artifact=artifact,
+        manifest=manifest,
+        archive_bytes=archive_bytes,
+    ).plan
+
+
+def download_reconciliation_bundle(
     *,
     client: GitHubArtifactAPI,
     repo_root: Path,
@@ -649,7 +721,7 @@ def download_and_plan_reconciliation(
     run: Mapping[str, Any],
     artifact: Mapping[str, Any],
     manifest: Mapping[str, Any],
-) -> dict[str, object]:
+) -> ReconciliationBundle:
     artifact_id = _integer(artifact.get("id"), "Milestone Qualification artifact ID")
     run_id = _integer(run.get("id"), "workflow run ID")
     run_attempt = _integer(run.get("run_attempt"), "workflow run attempt")
@@ -683,7 +755,7 @@ def download_and_plan_reconciliation(
     expected_digest = _string(artifact.get("digest"), "Milestone Qualification artifact digest")
     if hashlib.sha256(archive_bytes).hexdigest() != expected_digest.removeprefix("sha256:"):
         raise QualificationArtifactSafetyError("Milestone Qualification artifact archive digest conflicts.")
-    return plan_reconciliation(
+    return plan_reconciliation_bundle(
         repo_root=repo_root,
         identity=identity,
         run=run,
@@ -693,11 +765,34 @@ def download_and_plan_reconciliation(
     )
 
 
+def download_and_plan_reconciliation(
+    *,
+    client: GitHubArtifactAPI,
+    repo_root: Path,
+    identity: QualificationIdentity,
+    run: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> dict[str, object]:
+    return download_reconciliation_bundle(
+        client=client,
+        repo_root=repo_root,
+        identity=identity,
+        run=run,
+        artifact=artifact,
+        manifest=manifest,
+    ).plan
+
+
 __all__ = [
     "MAX_ARCHIVE_BYTES",
     "PLAN_TYPE",
     "QualificationArtifactError",
     "QualificationArtifactSafetyError",
+    "ReconciliationBundle",
+    "ReconciliationFile",
     "download_and_plan_reconciliation",
+    "download_reconciliation_bundle",
     "plan_reconciliation",
+    "plan_reconciliation_bundle",
 ]

--- a/scripts/release_qualification_controller.py
+++ b/scripts/release_qualification_controller.py
@@ -54,6 +54,7 @@ def build_parser() -> argparse.ArgumentParser:
     resume_parser.add_argument("--expected-manifest-sha256")
     resume_parser.add_argument("--retry-run-id", type=int)
     resume_parser.add_argument("--retry-checkpoint-sha256")
+    resume_parser.add_argument("--apply-plan-sha256")
     resume_parser.add_argument("--observe-only", action="store_true")
     return parser
 
@@ -79,6 +80,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 expected_manifest_sha256=args.expected_manifest_sha256,
                 retry_run_id=args.retry_run_id,
                 retry_checkpoint_sha256=args.retry_checkpoint_sha256,
+                apply_plan_sha256=args.apply_plan_sha256,
                 observe_only=args.observe_only,
             )
         except QualificationResumeSafetyError as error:

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -24,7 +24,15 @@ from scripts.release_milestone_context import ReleaseMilestoneContextError
 from scripts.release_qualification_artifact import (
     QualificationArtifactError,
     QualificationArtifactSafetyError,
-    download_and_plan_reconciliation,
+    download_reconciliation_bundle,
+)
+from scripts.release_qualification_apply import (
+    QualificationApplyError,
+    QualificationApplySafetyError,
+    continue_reconciliation_apply,
+    reconciliation_checkpoint_path,
+    reconciliation_checkpoint_summary,
+    start_reconciliation_apply,
 )
 from scripts.release_qualification_status import (
     EvidenceBinding,
@@ -50,6 +58,7 @@ EXIT_FAILED = 1
 EXIT_OPERATOR_REQUIRED = 20
 EXIT_SAFETY_ERROR = 21
 PREPARED_RETRY_AFTER_SECONDS = 600
+MAX_WORKFLOW_RUN_PAGES = 20
 ACTIVE_RUN_STATUSES = {"in_progress", "pending", "queued", "requested", "waiting"}
 TERMINAL_RUN_STATUS = "completed"
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -363,11 +372,12 @@ def _ref_endpoint(branch: str) -> str:
     return f"repos/{REPOSITORY}/git/ref/heads/{quote(branch, safe='')}"
 
 
-def _workflow_runs_endpoint() -> str:
-    return (
+def _workflow_runs_endpoint(page: int = 1) -> str:
+    endpoint = (
         f"repos/{REPOSITORY}/actions/workflows/{WORKFLOW_FILE}/runs"
         f"?event=workflow_dispatch&branch={MAIN_BRANCH}&per_page=100"
     )
+    return endpoint if page == 1 else f"{endpoint}&page={page}"
 
 
 def _workflow_dispatch_endpoint() -> str:
@@ -498,14 +508,23 @@ def _identity_from_binding(
 
 
 def _workflow_runs(client: GitHubAPI, identity: ResumeIdentity) -> tuple[list[Mapping[str, Any]], int]:
-    payload = _mapping(
-        client.get_json(_workflow_runs_endpoint(), active_auth=True),
-        "Milestone Qualification workflow runs",
-    )
-    runs = [
-        _mapping(item, "Milestone Qualification workflow run")
-        for item in _sequence(payload.get("workflow_runs"), "workflow runs")
-    ]
+    runs: list[Mapping[str, Any]] = []
+    for page in range(1, MAX_WORKFLOW_RUN_PAGES + 1):
+        payload = _mapping(
+            client.get_json(_workflow_runs_endpoint(page), active_auth=True),
+            "Milestone Qualification workflow runs",
+        )
+        page_runs = [
+            _mapping(item, "Milestone Qualification workflow run")
+            for item in _sequence(payload.get("workflow_runs"), "workflow runs")
+        ]
+        runs.extend(page_runs)
+        if len(page_runs) < 100:
+            break
+        if page == MAX_WORKFLOW_RUN_PAGES:
+            raise QualificationResumeSafetyError(
+                "Milestone Qualification workflow history exceeds the bounded identity scan."
+            )
     high_water = max((_integer(run.get("id"), "workflow run ID") for run in runs), default=0)
     matches = [run for run in runs if _run_matches(run, identity)]
     return sorted(matches, key=lambda run: cast(int, run["id"]), reverse=True), high_water
@@ -628,9 +647,11 @@ def _result(
     *,
     identity: ResumeIdentity | None = None,
     checkpoint_path: Path | None = None,
+    apply_checkpoint_path: Path | None = None,
     run: Mapping[str, object] | None = None,
     artifact: Mapping[str, object] | None = None,
     reconciliation_plan: Mapping[str, object] | None = None,
+    reconciliation_result: Mapping[str, object] | None = None,
     next_action: str,
     mutation: Mapping[str, object] | None = None,
 ) -> ResumeResult:
@@ -652,12 +673,25 @@ def _result(
         "checkpoint": {
             "present": checkpoint_path is not None and checkpoint_path.exists(),
         },
+        "apply_checkpoint": _apply_checkpoint_summary(apply_checkpoint_path)
+        if apply_checkpoint_path is not None
+        else None,
         "run": dict(run) if run is not None else None,
         "artifact": dict(artifact) if artifact is not None else None,
         "reconciliation_plan": dict(reconciliation_plan) if reconciliation_plan is not None else None,
+        "reconciliation_result": dict(reconciliation_result) if reconciliation_result is not None else None,
         "planned_mutation": dict(mutation) if mutation is not None else None,
     }
     return ResumeResult(payload=payload, exit_code=exit_code)
+
+
+def _apply_checkpoint_summary(path: Path) -> dict[str, object] | None:
+    try:
+        return reconciliation_checkpoint_summary(path)
+    except QualificationApplySafetyError as error:
+        raise QualificationResumeSafetyError(str(error)) from error
+    except QualificationApplyError as error:
+        raise QualificationResumeError(str(error)) from error
 
 
 def _validate_expected_mutation(
@@ -679,6 +713,15 @@ def _validate_expected_mutation(
     return True
 
 
+def _require_mutation_actor(client: GitHubAPI) -> tuple[str, int]:
+    user = _mapping(client.get_json("user", active_auth=True), "active GitHub user")
+    if user.get("login") != REPOSITORY_OWNER:
+        raise QualificationResumeSafetyError(
+            f"Qualification mutation requires active GitHub identity {REPOSITORY_OWNER!r}."
+        )
+    return REPOSITORY_OWNER, _integer(user.get("id"), "active GitHub user ID")
+
+
 def _require_dispatch_actor(client: GitHubAPI) -> None:
     user = _mapping(client.get_json("user", active_auth=True), "active GitHub user")
     if user.get("login") != REPOSITORY_OWNER:
@@ -687,14 +730,47 @@ def _require_dispatch_actor(client: GitHubAPI) -> None:
         )
 
 
-def _revalidate_remote_identity(client: GitHubAPI, identity: ResumeIdentity) -> None:
+def _revalidate_remote_identity(
+    client: GitHubAPI,
+    identity: ResumeIdentity,
+    *,
+    expected_evidence_sha: str | None = None,
+) -> None:
     if _ref_sha(client, MAIN_BRANCH) != identity.main_sha:
         raise QualificationResumeSafetyError("Protected main moved after qualification resume preflight.")
-    if _ref_sha(client, identity.evidence_ref) != identity.evidence_sha:
+    evidence_sha = (
+        identity.evidence_sha
+        if expected_evidence_sha is None
+        else _sha(
+            expected_evidence_sha,
+            "expected evidence SHA",
+        )
+    )
+    if _ref_sha(client, identity.evidence_ref) != evidence_sha:
         raise QualificationResumeSafetyError("Evidence branch moved after qualification resume preflight.")
-    pull = _open_evidence_pr(client, identity.evidence_ref, identity.evidence_sha)
+    pull_attempts = 5 if evidence_sha != identity.evidence_sha else 1
+    pull: Mapping[str, Any] | None = None
+    for attempt in range(pull_attempts):
+        try:
+            pull = _open_evidence_pr(client, identity.evidence_ref, evidence_sha)
+            break
+        except QualificationResumeSafetyError:
+            if attempt + 1 == pull_attempts:
+                raise
+            time.sleep(1.0)
+    if pull is None:
+        raise QualificationResumeSafetyError("Evidence pull request identity could not be revalidated.")
     if pull.get("number") != identity.evidence_pr_number:
         raise QualificationResumeSafetyError("Evidence pull request changed after qualification resume preflight.")
+
+
+def _require_no_active_exact_runs(client: GitHubAPI, identity: ResumeIdentity) -> None:
+    matches, _high_water = _workflow_runs(client, identity)
+    active = [run for run in matches if run.get("status") in ACTIVE_RUN_STATUSES]
+    if active:
+        raise QualificationResumeSafetyError(
+            "An exact Milestone Qualification run is active; evidence mutation must wait for it to finish."
+        )
 
 
 def _dispatch(
@@ -828,6 +904,7 @@ def resume_qualification(
     expected_manifest_sha256: str | None = None,
     retry_run_id: int | None = None,
     retry_checkpoint_sha256: str | None = None,
+    apply_plan_sha256: str | None = None,
     observe_only: bool = False,
     client: GitHubAPI | None = None,
     checkpoint_path: Path | None = None,
@@ -838,10 +915,16 @@ def resume_qualification(
     now: Clock = lambda: datetime.now(timezone.utc),
 ) -> ResumeResult:
     repo_root = repo_root.resolve()
+    resolved_checkpoint_path = checkpoint_path or _checkpoint_path(repo_root, release_tag)
+    resolved_apply_checkpoint_path = reconciliation_checkpoint_path(resolved_checkpoint_path)
     if retry_run_id is not None:
         retry_run_id = _integer(retry_run_id, "retry run ID")
     if retry_checkpoint_sha256 is not None:
         retry_checkpoint_sha256 = _sha256(retry_checkpoint_sha256, "retry checkpoint digest")
+    if apply_plan_sha256 is not None:
+        apply_plan_sha256 = _sha256(apply_plan_sha256, "authorized reconciliation plan digest")
+    if observe_only and apply_plan_sha256 is not None:
+        raise QualificationResumeSafetyError("Observe-only mode cannot authorize reconciliation apply.")
     if prepared_retry_after_seconds < 0:
         raise QualificationResumeError("Prepared checkpoint retry delay must be nonnegative.")
     try:
@@ -857,7 +940,7 @@ def resume_qualification(
         raise QualificationResumeError("Checked qualification status could not be resolved.") from error
     groups = _mapping(status_payload.get("groups"), "qualification status groups")
     blocking = _sequence(groups.get("blocking"), "blocking qualification cases")
-    if not blocking:
+    if not blocking and not resolved_apply_checkpoint_path.exists():
         return _result(
             "complete",
             EXIT_SUCCESS,
@@ -904,9 +987,64 @@ def resume_qualification(
             identity=identity,
             next_action="Rerun Release Evidence to refresh the manifest against the current protected main SHA.",
         )
+    if resolved_apply_checkpoint_path.exists():
+        apply_summary = _apply_checkpoint_summary(resolved_apply_checkpoint_path)
+        if apply_summary is None:
+            raise QualificationResumeSafetyError("Qualification apply checkpoint disappeared during preflight.")
+        if apply_plan_sha256 is None and apply_summary.get("state") == "commented":
+            apply_plan_sha256 = _sha256(
+                apply_summary.get("plan_sha256"),
+                "completed reconciliation plan digest",
+            )
+        if apply_plan_sha256 is None:
+            return _result(
+                "reconciliation_apply_pending",
+                EXIT_OPERATOR_REQUIRED,
+                status_payload,
+                identity=identity,
+                checkpoint_path=resolved_checkpoint_path,
+                apply_checkpoint_path=resolved_apply_checkpoint_path,
+                next_action="Rerun resume with the exact apply checkpoint plan SHA-256 to continue reconciliation.",
+            )
+        try:
+            with _checkpoint_lock(resolved_checkpoint_path):
+                outcome = continue_reconciliation_apply(
+                    repo_root=repo_root,
+                    identity=identity,
+                    expected_plan_sha256=apply_plan_sha256,
+                    client=github,
+                    checkpoint_path=resolved_apply_checkpoint_path,
+                    revalidate_remote=lambda evidence_sha: _revalidate_remote_identity(
+                        github,
+                        identity,
+                        expected_evidence_sha=evidence_sha,
+                    ),
+                    ensure_no_active_runs=lambda: _require_no_active_exact_runs(github, identity),
+                    require_actor=lambda: _require_mutation_actor(github),
+                    remote_evidence_sha=lambda: _ref_sha(github, identity.evidence_ref),
+                )
+        except QualificationApplySafetyError as error:
+            raise QualificationResumeSafetyError(str(error)) from error
+        except QualificationApplyError as error:
+            raise QualificationResumeError(str(error)) from error
+        return _result(
+            outcome.state,
+            EXIT_SUCCESS,
+            status_payload,
+            identity=identity,
+            checkpoint_path=resolved_checkpoint_path,
+            apply_checkpoint_path=resolved_apply_checkpoint_path,
+            reconciliation_plan=outcome.plan,
+            reconciliation_result={
+                "commit_sha": outcome.commit_sha,
+                "comment_id": outcome.comment_id,
+            },
+            next_action=(
+                "Qualification evidence was committed, pushed, and recorded on the canonical evidence pull request."
+            ),
+        )
     _require_local_evidence_checkout(repo_root, identity)
 
-    resolved_checkpoint_path = checkpoint_path or _checkpoint_path(repo_root, release_tag)
     if resolved_checkpoint_path.exists():
         with _checkpoint_lock(resolved_checkpoint_path):
             checkpoint = _load_checkpoint(resolved_checkpoint_path)
@@ -1080,7 +1218,7 @@ def resume_qualification(
                 next_action="Validate and reconcile the exact qualification artifact into the evidence branch.",
             )
         try:
-            plan = download_and_plan_reconciliation(
+            bundle = download_reconciliation_bundle(
                 client=github,
                 repo_root=repo_root,
                 identity=identity,
@@ -1092,24 +1230,89 @@ def resume_qualification(
             raise QualificationResumeSafetyError(str(error)) from error
         except QualificationArtifactError as error:
             raise QualificationResumeError(str(error)) from error
+        plan = bundle.plan
         _revalidate_remote_identity(github, identity)
         requires_changes = plan.get("requires_changes") is True
+        if apply_plan_sha256 is not None:
+            if plan.get("plan_sha256") != apply_plan_sha256:
+                raise QualificationResumeSafetyError(
+                    "Authorized reconciliation plan digest does not match the current exact artifact plan."
+                )
+            if not requires_changes:
+                return _result(
+                    "reconciliation_current",
+                    EXIT_SUCCESS,
+                    status_payload,
+                    identity=identity,
+                    checkpoint_path=resolved_checkpoint_path,
+                    apply_checkpoint_path=resolved_apply_checkpoint_path,
+                    run=run_payload,
+                    artifact=artifact,
+                    reconciliation_plan=plan,
+                    next_action="All planned qualification evidence is already present and identical.",
+                )
+            try:
+                with _checkpoint_lock(resolved_checkpoint_path):
+                    outcome = start_reconciliation_apply(
+                        repo_root=repo_root,
+                        identity=identity,
+                        bundle=bundle,
+                        expected_plan_sha256=apply_plan_sha256,
+                        client=github,
+                        checkpoint_path=resolved_apply_checkpoint_path,
+                        revalidate_remote=lambda evidence_sha: _revalidate_remote_identity(
+                            github,
+                            identity,
+                            expected_evidence_sha=evidence_sha,
+                        ),
+                        ensure_no_active_runs=lambda: _require_no_active_exact_runs(github, identity),
+                        require_actor=lambda: _require_mutation_actor(github),
+                        remote_evidence_sha=lambda: _ref_sha(github, identity.evidence_ref),
+                    )
+            except QualificationApplySafetyError as error:
+                raise QualificationResumeSafetyError(str(error)) from error
+            except QualificationApplyError as error:
+                raise QualificationResumeError(str(error)) from error
+            return _result(
+                outcome.state,
+                EXIT_SUCCESS,
+                status_payload,
+                identity=identity,
+                checkpoint_path=resolved_checkpoint_path,
+                apply_checkpoint_path=resolved_apply_checkpoint_path,
+                run=run_payload,
+                artifact=artifact,
+                reconciliation_plan=outcome.plan,
+                reconciliation_result={
+                    "commit_sha": outcome.commit_sha,
+                    "comment_id": outcome.comment_id,
+                },
+                next_action=(
+                    "Qualification evidence was committed, pushed, and recorded on the canonical evidence pull request."
+                ),
+            )
         return _result(
             "reconciliation_planned" if requires_changes else "reconciliation_current",
             EXIT_OPERATOR_REQUIRED if requires_changes else EXIT_SUCCESS,
             status_payload,
             identity=identity,
             checkpoint_path=resolved_checkpoint_path,
+            apply_checkpoint_path=resolved_apply_checkpoint_path,
             run=run_payload,
             artifact=artifact,
             reconciliation_plan=plan,
             next_action=(
-                "Review the exact reconciliation plan; the write-capable apply stage is not implemented yet."
+                "Review the exact reconciliation plan, then rerun resume with --apply-plan-sha256 set to its digest."
                 if requires_changes
                 else "All planned qualification evidence is already present and identical."
             ),
         )
 
+    if apply_plan_sha256 is not None:
+        raise QualificationResumeSafetyError(
+            "Reconciliation apply requires the exact successful retained qualification artifact "
+            "or an existing apply checkpoint."
+        )
     failure_state = (
         "artifact_expired" if succeeded and artifact is not None and artifact["state"] == "expired" else "failed"
     )

--- a/tests/test_release_qualification_apply.py
+++ b/tests/test_release_qualification_apply.py
@@ -1,0 +1,512 @@
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.release_qualification_apply import (
+    QualificationApplyError,
+    QualificationApplySafetyError,
+    _commit_message,
+    _push_commit,
+    _replace_progress,
+    _validate_commit,
+    continue_reconciliation_apply,
+    load_reconciliation_checkpoint,
+    start_reconciliation_apply,
+)
+from scripts.release_qualification_artifact import ReconciliationBundle, ReconciliationFile
+from scripts.release_qualification_resume import ResumeIdentity
+
+
+RELEASE_TAG = "v1.0.0"
+EVIDENCE_REF = f"automation/release-evidence-{RELEASE_TAG}"
+ACTOR_ID = 1_875_516
+
+
+class FakeGitHubAPI:
+    def __init__(self) -> None:
+        self.comments: list[dict[str, object]] = []
+        self.gets: list[str] = []
+        self.posts: list[tuple[str, dict[str, object]]] = []
+        self.fail_post_after_store = False
+
+    def get_json(self, endpoint: str, *, active_auth: bool = False) -> object:
+        self.gets.append(endpoint)
+        if "/issues/comments/" in endpoint:
+            comment_id = int(endpoint.rsplit("/", 1)[1])
+            return next(comment for comment in self.comments if comment["id"] == comment_id)
+        if "/comments?" not in endpoint:
+            raise AssertionError(f"Unexpected GitHub GET: {endpoint}")
+        page = int(endpoint.rsplit("page=", 1)[1])
+        start = (page - 1) * 100
+        return self.comments[start : start + 100]
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, object],
+        *,
+        active_auth: bool = False,
+    ) -> object:
+        self.posts.append((endpoint, dict(payload)))
+        comment = {
+            "id": len(self.comments) + 1,
+            "body": payload["body"],
+            "user": {"id": ACTOR_ID, "login": "cbusillo"},
+        }
+        self.comments.append(comment)
+        if self.fail_post_after_store:
+            self.fail_post_after_store = False
+            raise QualificationApplyError("simulated lost comment response")
+        return comment
+
+
+class ApplyFixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.remote = root.parent / "remote.git"
+        subprocess.run(["git", "init", "-q", "--bare", self.remote], check=True)
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "switch", "-qc", EVIDENCE_REF], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "Fixture"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=root, check=True)
+        index_path = root / "docs/qualification/release-evidence-v1.json"
+        index_path.parent.mkdir(parents=True)
+        index_path.write_text('{"receipts":[],"schema_version":1}\n', encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "fixture"], cwd=root, check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(self.remote)], cwd=root, check=True)
+        subprocess.run(["git", "push", "-qu", "origin", EVIDENCE_REF], cwd=root, check=True)
+        self.base_sha = self.git("rev-parse", "HEAD")
+        self.identity = ResumeIdentity(
+            release_tag=RELEASE_TAG,
+            candidate_sha="c" * 40,
+            release_id=123,
+            manifest_sha256="d" * 64,
+            runner_sha="a" * 40,
+            main_sha="a" * 40,
+            evidence_ref=EVIDENCE_REF,
+            evidence_sha=self.base_sha,
+            evidence_base_sha="e" * 40,
+            evidence_pr_number=42,
+            release_receipt_file_sha256="5" * 64,
+            signed_ui_artifact_id=456,
+            signed_ui_artifact_sha256="6" * 64,
+            policy_sha256="1" * 64,
+            policy_checkpoint_sha256="2" * 64,
+            route_table_sha256="3" * 64,
+            controller_runner_sha256="4" * 64,
+        )
+        receipt_path = f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-v1.json"
+        index_path_text = "docs/qualification/release-evidence-v1.json"
+        receipt_content = b'{"receipt_sha256":"' + b"7" * 64 + b'"}\n'
+        index_content = (
+            json.dumps(
+                {
+                    "receipts": [
+                        {
+                            "accepted_at": "2026-08-10T21:48:28Z",
+                            "case_id": "clean-machine-signed-update",
+                            "receipt_id": f"{RELEASE_TAG}:clean-machine-signed-update:9001",
+                            "reference": receipt_path,
+                            "sha256": hashlib.sha256(receipt_content).hexdigest(),
+                            "source": "tier3_automation_receipt",
+                            "source_sha": "c" * 40,
+                            "status": "accepted",
+                        }
+                    ],
+                    "schema_version": 1,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode()
+        self.files = (
+            ReconciliationFile(path=receipt_path, content=receipt_content),
+            ReconciliationFile(path=index_path_text, content=index_content),
+        )
+        plan: dict[str, object] = {
+            "artifact": {"run_attempt": 1, "run_id": 9001},
+            "evidence_sha": self.base_sha,
+            "files": [
+                {
+                    "path": file.path,
+                    "sha256": hashlib.sha256(file.content).hexdigest(),
+                    "size_bytes": len(file.content),
+                    "state": "append" if file.path == index_path_text else "create",
+                }
+                for file in self.files
+            ],
+            "operations": [],
+            "plan_type": "bd_to_avp.release_qualification_reconciliation_plan",
+            "release_tag": RELEASE_TAG,
+            "requires_changes": True,
+            "schema_version": 1,
+        }
+        plan["plan_sha256"] = hashlib.sha256(
+            (json.dumps(plan, separators=(",", ":"), sort_keys=True) + "\n").encode()
+        ).hexdigest()
+        self.bundle = ReconciliationBundle(plan=plan, files=self.files)
+        self.checkpoint = root.parent / "apply.json"
+        self.client = FakeGitHubAPI()
+        self.revalidations: list[str] = []
+        self.active_checks = 0
+
+    def git(self, *arguments: str) -> str:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    def remote_sha(self) -> str:
+        output = subprocess.run(
+            ["git", "ls-remote", self.remote, f"refs/heads/{EVIDENCE_REF}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        return output.split()[0]
+
+    def revalidate(self, expected: str) -> None:
+        self.revalidations.append(expected)
+        if self.remote_sha() != expected:
+            raise QualificationApplySafetyError("simulated remote identity conflict")
+
+    def ensure_no_active(self) -> None:
+        self.active_checks += 1
+
+    @staticmethod
+    def require_actor() -> tuple[str, int]:
+        return "cbusillo", ACTOR_ID
+
+    def start(self):
+        with (
+            patch("scripts.release_qualification_apply._validate_origin"),
+            patch("scripts.release_qualification_apply.HTTPS_REPOSITORY_URL", str(self.remote)),
+        ):
+            return start_reconciliation_apply(
+                repo_root=self.root,
+                identity=self.identity,
+                bundle=self.bundle,
+                expected_plan_sha256=self.bundle.plan["plan_sha256"],
+                client=self.client,
+                checkpoint_path=self.checkpoint,
+                revalidate_remote=self.revalidate,
+                ensure_no_active_runs=self.ensure_no_active,
+                require_actor=self.require_actor,
+                remote_evidence_sha=self.remote_sha,
+            )
+
+    def continue_apply(self):
+        with (
+            patch("scripts.release_qualification_apply._validate_origin"),
+            patch("scripts.release_qualification_apply.HTTPS_REPOSITORY_URL", str(self.remote)),
+        ):
+            return continue_reconciliation_apply(
+                repo_root=self.root,
+                identity=self.identity,
+                expected_plan_sha256=self.bundle.plan["plan_sha256"],
+                client=self.client,
+                checkpoint_path=self.checkpoint,
+                revalidate_remote=self.revalidate,
+                ensure_no_active_runs=self.ensure_no_active,
+                require_actor=self.require_actor,
+                remote_evidence_sha=self.remote_sha,
+            )
+
+
+class ReleaseQualificationApplyTests(unittest.TestCase):
+    def test_apply_writes_commits_pushes_and_comments_once(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+
+            outcome = fixture.start()
+            checkpoint = load_reconciliation_checkpoint(fixture.checkpoint)
+
+            self.assertEqual(outcome.state, "reconciliation_applied")
+            self.assertEqual(fixture.remote_sha(), outcome.commit_sha)
+            self.assertEqual(len(fixture.client.comments), 1)
+            self.assertIsNone(checkpoint)
+            self.assertFalse(fixture.checkpoint.exists())
+            self.assertGreaterEqual(fixture.active_checks, 3)
+
+    def test_push_response_loss_adopts_remote_commit_without_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+
+            def push_then_fail(repo_root: Path, evidence_ref: str, commit_sha: str) -> None:
+                subprocess.run(
+                    ["git", "push", "origin", f"{commit_sha}:refs/heads/{evidence_ref}"],
+                    cwd=repo_root,
+                    check=True,
+                    capture_output=True,
+                )
+                raise QualificationApplyError("simulated lost push response")
+
+            with (
+                patch("scripts.release_qualification_apply._validate_origin"),
+                patch(
+                    "scripts.release_qualification_apply._push_commit",
+                    side_effect=push_then_fail,
+                ),
+            ):
+                outcome = fixture.start()
+            checkpoint = load_reconciliation_checkpoint(fixture.checkpoint)
+            self.assertIsNone(checkpoint)
+            self.assertNotEqual(fixture.remote_sha(), fixture.base_sha)
+            self.assertEqual(outcome.commit_sha, fixture.remote_sha())
+            self.assertEqual(len(fixture.client.comments), 1)
+
+    def test_push_race_to_unrelated_commit_is_safety_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+
+            def move_remote_then_fail(repo_root: Path, evidence_ref: str, _commit_sha: str) -> None:
+                tree_sha = fixture.git("rev-parse", f"{fixture.base_sha}^{{tree}}")
+                sibling_sha = subprocess.run(
+                    ["git", "commit-tree", tree_sha, "-p", fixture.base_sha, "-m", "unrelated"],
+                    cwd=repo_root,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.strip()
+                subprocess.run(
+                    ["git", "push", "origin", f"{sibling_sha}:refs/heads/{evidence_ref}"],
+                    cwd=repo_root,
+                    check=True,
+                    capture_output=True,
+                )
+                raise QualificationApplyError("simulated non-fast-forward race")
+
+            with (
+                patch("scripts.release_qualification_apply._validate_origin"),
+                patch(
+                    "scripts.release_qualification_apply._push_commit",
+                    side_effect=move_remote_then_fail,
+                ),
+            ):
+                with self.assertRaisesRegex(QualificationApplySafetyError, "moved while"):
+                    fixture.start()
+
+    def test_comment_response_loss_adopts_marker_without_duplicate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            fixture.client.fail_post_after_store = True
+
+            with self.assertRaisesRegex(QualificationApplyError, "lost comment response"):
+                fixture.start()
+            checkpoint = load_reconciliation_checkpoint(fixture.checkpoint)
+            self.assertEqual(checkpoint["progress"]["state"], "pushed")
+            self.assertEqual(stat.S_IMODE(fixture.checkpoint.stat().st_mode), 0o600)
+            self.assertEqual(len(fixture.client.comments), 1)
+
+            outcome = fixture.continue_apply()
+
+            self.assertEqual(outcome.state, "reconciliation_applied")
+            self.assertEqual(len(fixture.client.comments), 1)
+
+    def test_comment_marker_with_wrong_actor_id_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            fixture.client.fail_post_after_store = True
+            with self.assertRaises(QualificationApplyError):
+                fixture.start()
+            fixture.client.comments[0]["user"] = {"id": 99, "login": "cbusillo"}
+
+            with self.assertRaisesRegex(QualificationApplySafetyError, "comment conflicts"):
+                fixture.continue_apply()
+
+    def test_commit_created_before_checkpoint_update_is_adopted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+
+            def fail_committed_transition(path, checkpoint, *, state, commit_sha, comment_id):
+                if state == "committed":
+                    raise QualificationApplyError("simulated checkpoint write interruption")
+                return _replace_progress(
+                    path,
+                    checkpoint,
+                    state=state,
+                    commit_sha=commit_sha,
+                    comment_id=comment_id,
+                )
+
+            with (
+                patch("scripts.release_qualification_apply._validate_origin"),
+                patch(
+                    "scripts.release_qualification_apply._replace_progress",
+                    side_effect=fail_committed_transition,
+                ),
+            ):
+                with self.assertRaisesRegex(QualificationApplyError, "checkpoint write interruption"):
+                    fixture.start()
+            checkpoint = load_reconciliation_checkpoint(fixture.checkpoint)
+            self.assertEqual(checkpoint["progress"]["state"], "files_written")
+            self.assertNotEqual(fixture.git("rev-parse", "HEAD"), fixture.base_sha)
+
+            outcome = fixture.continue_apply()
+
+            self.assertEqual(outcome.state, "reconciliation_applied")
+
+    def test_active_run_blocks_before_checkpoint_or_write(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+
+            def active() -> None:
+                raise QualificationApplySafetyError("active run")
+
+            with patch("scripts.release_qualification_apply._validate_origin"):
+                with self.assertRaisesRegex(QualificationApplySafetyError, "active run"):
+                    start_reconciliation_apply(
+                        repo_root=root,
+                        identity=fixture.identity,
+                        bundle=fixture.bundle,
+                        expected_plan_sha256=fixture.bundle.plan["plan_sha256"],
+                        client=fixture.client,
+                        checkpoint_path=fixture.checkpoint,
+                        revalidate_remote=fixture.revalidate,
+                        ensure_no_active_runs=active,
+                        require_actor=fixture.require_actor,
+                        remote_evidence_sha=fixture.remote_sha,
+                    )
+
+            self.assertFalse(fixture.checkpoint.exists())
+            self.assertEqual(fixture.git("status", "--short"), "")
+
+    def test_unrelated_worktree_change_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            (root / "unrelated.txt").write_text("conflict", encoding="utf-8")
+
+            with self.assertRaisesRegex(QualificationApplySafetyError, "clean evidence worktree"):
+                fixture.start()
+
+            self.assertFalse(fixture.checkpoint.exists())
+
+    def test_checkpoint_tampering_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            fixture.client.fail_post_after_store = True
+            with self.assertRaises(QualificationApplyError):
+                fixture.start()
+            payload = json.loads(fixture.checkpoint.read_text(encoding="utf-8"))
+            payload["plan_sha256"] = "0" * 64
+            fixture.checkpoint.write_text(json.dumps(payload), encoding="utf-8")
+            fixture.checkpoint.chmod(0o600)
+
+            with self.assertRaisesRegex(QualificationApplySafetyError, "self digest"):
+                fixture.continue_apply()
+
+    def test_commit_message_bytes_must_match_exactly(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            for file in fixture.files:
+                path = root / file.path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(file.content)
+            subprocess.run(["git", "add", "--", *(file.path for file in fixture.files)], cwd=root, check=True)
+            tree_sha = fixture.git("write-tree")
+            environment = dict(os.environ)
+            expected_email = f"{ACTOR_ID}+cbusillo@users.noreply.github.com"
+            environment.update(
+                {
+                    "GIT_AUTHOR_NAME": "cbusillo",
+                    "GIT_AUTHOR_EMAIL": expected_email,
+                    "GIT_COMMITTER_NAME": "cbusillo",
+                    "GIT_COMMITTER_EMAIL": expected_email,
+                }
+            )
+            malformed_message = _commit_message(fixture.bundle.plan) + "\n"
+            commit_sha = subprocess.run(
+                ["git", "commit-tree", tree_sha, "-p", fixture.base_sha],
+                cwd=root,
+                input=malformed_message,
+                capture_output=True,
+                text=True,
+                env=environment,
+                check=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(QualificationApplySafetyError, "commit message conflicts"):
+                _validate_commit(
+                    root,
+                    commit_sha=commit_sha,
+                    base_sha=fixture.base_sha,
+                    plan=fixture.bundle.plan,
+                    files={file.path: file.content for file in fixture.files},
+                    actor_login="cbusillo",
+                    actor_id=ACTOR_ID,
+                )
+
+    def test_push_uses_active_gh_credential_without_token_environment(self) -> None:
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            patch("scripts.release_qualification_apply._run_git", return_value=completed) as run_git,
+            patch.dict(os.environ, {"GH_TOKEN": "wrong-token", "GITHUB_TOKEN": "wrong-token"}),
+        ):
+            _push_commit(Path("/tmp/repo"), EVIDENCE_REF, "9" * 40)
+
+        arguments = run_git.call_args.args[1]
+        environment = run_git.call_args.kwargs["env"]
+        self.assertIn("credential.helper=!gh auth git-credential", arguments)
+        self.assertIn("https://github.com/cbusillo/BD_to_AVP.git", arguments)
+        self.assertNotIn("GH_TOKEN", environment)
+        self.assertNotIn("GITHUB_TOKEN", environment)
+
+    def test_comment_marker_on_second_page_is_adopted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "work"
+            root.mkdir()
+            fixture = ApplyFixture(root)
+            fixture.client.comments = [
+                {
+                    "id": index + 1,
+                    "body": f"comment {index}",
+                    "user": {"id": 99, "login": "someone"},
+                }
+                for index in range(100)
+            ]
+            fixture.client.fail_post_after_store = True
+            with self.assertRaises(QualificationApplyError):
+                fixture.start()
+            stored = fixture.client.comments[-1]
+            fixture.client.comments = [*fixture.client.comments[:100], stored]
+
+            outcome = fixture.continue_apply()
+
+            self.assertEqual(outcome.comment_id, stored["id"])
+            self.assertTrue(any("page=2" in endpoint for endpoint in fixture.client.gets))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_qualification_artifact.py
+++ b/tests/test_release_qualification_artifact.py
@@ -13,6 +13,7 @@ from scripts.release_qualification_artifact import (
     QualificationArtifactSafetyError,
     download_and_plan_reconciliation,
     plan_reconciliation,
+    plan_reconciliation_bundle,
 )
 from scripts.release_qualification_resume import ResumeIdentity
 from scripts.tier3_receipt import receipt_sha256
@@ -232,6 +233,63 @@ class ReleaseQualificationArtifactTests(unittest.TestCase):
             ["append", "append", "identical", "create", "create"],
         )
         self.assertNotIn("/Users/", json.dumps(first))
+
+    def test_bundle_binds_exact_materialized_file_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, archive = self.fixture(root)
+
+            bundle = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+
+        files = {file.path: file.content for file in bundle.files}
+        self.assertEqual(
+            files[f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-v1.json"],
+            entries["clean-machine-signed-update.json"],
+        )
+        self.assertEqual(
+            files[f"docs/qualification/{RELEASE_TAG}-installed-ui-accessibility-v1.json"],
+            entries["installed-ui-accessibility.json"],
+        )
+        self.assertEqual(
+            {item["path"] for item in bundle.plan["files"]},
+            set(files),
+        )
+        for summary in bundle.plan["files"]:
+            content = files[summary["path"]]
+            self.assertEqual(summary["sha256"], hashlib.sha256(content).hexdigest())
+            self.assertEqual(summary["size_bytes"], len(content))
+
+    def test_plan_is_stable_when_workflow_updated_at_drifts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            first = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            run["updated_at"] = "2026-08-20T12:00:00Z"
+
+            second = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+
+        self.assertEqual(first, second)
 
     def test_existing_identical_evidence_is_current(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -16,11 +16,12 @@ from scripts.release_qualification_controller import (
     _case_categories,
     _load_bound_policy,
     _require_checked_file,
+    build_parser,
     build_status,
     main,
     resolve_evidence_binding,
 )
-from scripts.release_qualification_resume import ResumeResult
+from scripts.release_qualification_resume import QualificationResumeSafetyError, ResumeResult
 from scripts.release_milestone_context import ReleaseMilestoneContext
 
 
@@ -29,6 +30,25 @@ READ_ONLY_GIT_COMMANDS = {"diff", "ls-files", "merge-base", "show"}
 
 
 class ReleaseQualificationControllerTests(unittest.TestCase):
+    def test_resume_parser_accepts_apply_plan_digest(self) -> None:
+        args = build_parser().parse_args(["resume", "--release-tag", "v1.0.0", "--apply-plan-sha256", "c" * 64])
+
+        self.assertEqual(args.apply_plan_sha256, "c" * 64)
+
+    def test_resume_safety_error_is_json_and_path_scrubbed(self) -> None:
+        stdout = io.StringIO()
+        with patch(
+            "scripts.release_qualification_resume.resume_qualification",
+            side_effect=QualificationResumeSafetyError("Invalid /Users/example/private/apply.json"),
+        ):
+            with redirect_stdout(stdout):
+                exit_code = main(["resume", "--release-tag", "v1.0.0"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 21)
+        self.assertEqual(payload["state"], "conflict")
+        self.assertNotIn("/Users/", json.dumps(payload))
+
     def test_reports_v031_legacy_evidence_without_mutation(self) -> None:
         before_status = subprocess.run(
             ["git", "status", "--porcelain=v1", "--untracked-files=all"],
@@ -400,6 +420,7 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             expected_manifest_sha256="b" * 64,
             retry_run_id=123,
             retry_checkpoint_sha256=None,
+            apply_plan_sha256=None,
             observe_only=True,
         )
 

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts.release_milestone_context import ReleaseMilestoneContext
+from scripts.release_qualification_apply import ApplyOutcome
+from scripts.release_qualification_artifact import ReconciliationBundle
 from scripts.release_qualification_controller import EvidenceBinding
 from scripts.release_qualification_resume import (
     EXIT_OPERATOR_REQUIRED,
@@ -18,6 +20,8 @@ from scripts.release_qualification_resume import (
     _checkpoint_lock,
     _checkpoint_payload,
     _dispatch,
+    _require_no_active_exact_runs,
+    _revalidate_remote_identity,
     _write_checkpoint,
     resume_qualification,
     safety_error_payload,
@@ -36,6 +40,7 @@ RUNS_ENDPOINT = (
     "repos/cbusillo/BD_to_AVP/actions/workflows/milestone-qualification.yml/runs"
     "?event=workflow_dispatch&branch=main&per_page=100"
 )
+RUNS_ENDPOINT_PAGE_2 = RUNS_ENDPOINT + "&page=2"
 PR_ENDPOINT = (
     "repos/cbusillo/BD_to_AVP/pulls?state=open&base=main"
     f"&head=cbusillo%3Aautomation%2Frelease-evidence-{RELEASE_TAG}&per_page=100"
@@ -315,6 +320,44 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         self.assertTrue(client.gets)
         self.assertTrue(all(active_auth for _endpoint, active_auth in client.gets))
         self.assertFalse(checkpoint.exists())
+
+    def test_active_exact_run_on_second_page_blocks_apply(self) -> None:
+        client = FakeGitHubAPI()
+        client.set(
+            RUNS_ENDPOINT,
+            {"workflow_runs": [{"id": 1_000 + index} for index in range(100)]},
+        )
+        client.set(
+            RUNS_ENDPOINT_PAGE_2,
+            {"workflow_runs": [workflow_run(101, status="in_progress", conclusion=None)]},
+        )
+
+        with self.assertRaisesRegex(QualificationResumeSafetyError, "is active"):
+            _require_no_active_exact_runs(client, identity())
+
+    def test_remote_identity_retries_transient_pull_request_head_lag(self) -> None:
+        client = self.configured_client()
+        pushed_sha = "9" * 40
+        client.set(
+            f"repos/cbusillo/BD_to_AVP/git/ref/heads/automation%2Frelease-evidence-{RELEASE_TAG}",
+            {"object": {"sha": pushed_sha}},
+        )
+        client.set_sequence(
+            PR_ENDPOINT,
+            [
+                [pull_request(evidence_sha=EVIDENCE_SHA)],
+                [pull_request(evidence_sha=pushed_sha)],
+            ],
+        )
+
+        with patch("scripts.release_qualification_resume.time.sleep") as sleep:
+            _revalidate_remote_identity(
+                client,
+                identity(),
+                expected_evidence_sha=pushed_sha,
+            )
+
+        sleep.assert_called_once_with(1.0)
 
     def test_exact_dispatch_is_checkpointed_and_adopts_visible_run(self) -> None:
         client = self.configured_client()
@@ -648,11 +691,12 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
             {"artifacts": [available_artifact]},
         )
         plan = {"plan_sha256": "8" * 64, "requires_changes": True}
+        bundle = ReconciliationBundle(plan=plan, files=())
         with (
             tempfile.TemporaryDirectory() as temporary_directory,
             patch(
-                "scripts.release_qualification_resume.download_and_plan_reconciliation",
-                return_value=plan,
+                "scripts.release_qualification_resume.download_reconciliation_bundle",
+                return_value=bundle,
             ) as planner,
         ):
             result = self.run_blocked(client, Path(temporary_directory) / "checkpoint.json")
@@ -662,6 +706,181 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         self.assertEqual(result.payload["reconciliation_plan"], plan)
         self.assertEqual(client.posts, [])
         planner.assert_called_once()
+
+    def test_successful_run_applies_exact_authorized_plan(self) -> None:
+        client = self.configured_client()
+        succeeded = workflow_run(101, status="completed", conclusion="success")
+        available_artifact = artifact(101, expired=False)
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [succeeded]})
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/jobs?per_page=100",
+            {
+                "jobs": [
+                    {
+                        "name": "Collect exact post-publication qualification receipts",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
+        )
+        client.set(
+            "repos/cbusillo/BD_to_AVP/actions/runs/101/artifacts?per_page=100",
+            {"artifacts": [available_artifact]},
+        )
+        plan = {"plan_sha256": "8" * 64, "requires_changes": True}
+        bundle = ReconciliationBundle(plan=plan, files=())
+        outcome = ApplyOutcome(
+            state="reconciliation_applied",
+            plan=plan,
+            commit_sha="9" * 40,
+            comment_id=77,
+        )
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            patch(
+                "scripts.release_qualification_resume.download_reconciliation_bundle",
+                return_value=bundle,
+            ),
+            patch(
+                "scripts.release_qualification_resume.start_reconciliation_apply",
+                return_value=outcome,
+            ) as apply,
+        ):
+            result = self.run_blocked(
+                client,
+                Path(temporary_directory) / "checkpoint.json",
+                apply_plan_sha256="8" * 64,
+            )
+
+        self.assertEqual(result.exit_code, EXIT_SUCCESS)
+        self.assertEqual(result.payload["state"], "reconciliation_applied")
+        self.assertEqual(result.payload["reconciliation_result"]["commit_sha"], "9" * 40)
+        self.assertEqual(result.payload["reconciliation_result"]["comment_id"], 77)
+        apply.assert_called_once()
+
+    def test_apply_checkpoint_continues_before_complete_early_return(self) -> None:
+        client = self.configured_client()
+        plan = {"plan_sha256": "8" * 64, "requires_changes": True}
+        outcome = ApplyOutcome(
+            state="reconciliation_applied",
+            plan=plan,
+            commit_sha="9" * 40,
+            comment_id=77,
+        )
+        complete_status = status_payload()
+        complete_status["groups"] = {"blocking": []}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            apply_checkpoint = checkpoint.with_name("checkpoint.apply.json")
+            apply_checkpoint.write_text("{}", encoding="utf-8")
+            with (
+                patch("scripts.release_qualification_resume.build_status", return_value=complete_status),
+                patch("scripts.release_qualification_resume.resolve_evidence_binding", return_value=binding()),
+                patch(
+                    "scripts.release_qualification_resume.continue_reconciliation_apply",
+                    return_value=outcome,
+                ) as continuation,
+                patch(
+                    "scripts.release_qualification_resume.reconciliation_checkpoint_summary",
+                    return_value={"present": True, "state": "commented", "plan_sha256": "8" * 64},
+                ),
+            ):
+                result = resume_qualification(
+                    REPO_ROOT,
+                    RELEASE_TAG,
+                    client=client,
+                    checkpoint_path=checkpoint,
+                    apply_plan_sha256="8" * 64,
+                )
+
+        self.assertEqual(result.payload["state"], "reconciliation_applied")
+        continuation.assert_called_once()
+
+    def test_apply_checkpoint_requires_exact_plan_echo(self) -> None:
+        client = self.configured_client()
+        complete_status = status_payload()
+        complete_status["groups"] = {"blocking": []}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            apply_checkpoint = checkpoint.with_name("checkpoint.apply.json")
+            apply_checkpoint.write_text("{}", encoding="utf-8")
+            with (
+                patch("scripts.release_qualification_resume.build_status", return_value=complete_status),
+                patch("scripts.release_qualification_resume.resolve_evidence_binding", return_value=binding()),
+                patch(
+                    "scripts.release_qualification_resume.reconciliation_checkpoint_summary",
+                    return_value={"present": True, "state": "pushed", "plan_sha256": "8" * 64},
+                ),
+            ):
+                result = resume_qualification(
+                    REPO_ROOT,
+                    RELEASE_TAG,
+                    client=client,
+                    checkpoint_path=checkpoint,
+                )
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "reconciliation_apply_pending")
+
+    def test_corrupt_apply_checkpoint_is_translated_to_resume_safety_error(self) -> None:
+        client = self.configured_client()
+        complete_status = status_payload()
+        complete_status["groups"] = {"blocking": []}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            apply_checkpoint = checkpoint.with_name("checkpoint.apply.json")
+            apply_checkpoint.write_text('{"unexpected":true}\n', encoding="utf-8")
+            apply_checkpoint.chmod(0o600)
+            with (
+                patch("scripts.release_qualification_resume.build_status", return_value=complete_status),
+                patch("scripts.release_qualification_resume.resolve_evidence_binding", return_value=binding()),
+            ):
+                with self.assertRaisesRegex(QualificationResumeSafetyError, "keys changed"):
+                    resume_qualification(
+                        REPO_ROOT,
+                        RELEASE_TAG,
+                        client=client,
+                        checkpoint_path=checkpoint,
+                    )
+
+    def test_completed_apply_checkpoint_revalidates_without_plan_echo(self) -> None:
+        client = self.configured_client()
+        plan = {"plan_sha256": "8" * 64, "requires_changes": True}
+        outcome = ApplyOutcome(
+            state="reconciliation_applied",
+            plan=plan,
+            commit_sha="9" * 40,
+            comment_id=77,
+        )
+        complete_status = status_payload()
+        complete_status["groups"] = {"blocking": []}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            apply_checkpoint = checkpoint.with_name("checkpoint.apply.json")
+            apply_checkpoint.write_text("{}", encoding="utf-8")
+            with (
+                patch("scripts.release_qualification_resume.build_status", return_value=complete_status),
+                patch("scripts.release_qualification_resume.resolve_evidence_binding", return_value=binding()),
+                patch(
+                    "scripts.release_qualification_resume.continue_reconciliation_apply",
+                    return_value=outcome,
+                ) as continuation,
+                patch(
+                    "scripts.release_qualification_resume.reconciliation_checkpoint_summary",
+                    return_value={"present": True, "state": "commented", "plan_sha256": "8" * 64},
+                ),
+            ):
+                result = resume_qualification(
+                    REPO_ROOT,
+                    RELEASE_TAG,
+                    client=client,
+                    checkpoint_path=checkpoint,
+                )
+
+        self.assertEqual(result.exit_code, EXIT_SUCCESS)
+        self.assertEqual(result.payload["state"], "reconciliation_applied")
+        continuation.assert_called_once()
 
     def test_expired_artifact_requires_exact_retry(self) -> None:
         client = self.configured_client()


### PR DESCRIPTION
## Summary
- add exact `--apply-plan-sha256` authorization to the one-command qualification resume flow
- freeze the reviewed plan and exact target bytes in a tamper-evident mode-0600 checkpoint sharing the dispatch lock
- recover idempotently across prepared, files-written, committed, pushed, and commented transitions
- create one exact identity-bound commit, push through the active `gh` identity without force, and post one marker-bound comment on the existing evidence PR
- fail closed on active exact runs, moved refs/PRs, conflicting worktree content, duplicate comments, and push races

## Validation
- `uv run python -m unittest tests.test_release_qualification_artifact tests.test_release_qualification_apply tests.test_release_qualification_resume tests.test_release_qualification_controller` (71 passed)
- `uv run python -m unittest discover -s tests -t .` (1720 passed, 3 skipped)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run python scripts/validate_observability_migration.py`
- `actionlint`
- `uv build`
- JetBrains changed-file inspection attempted; inconclusive because the helper mutated IDE metadata. Generated IDE changes were removed.

## Reviews
- Opus exact-head review: READY
- Gemini 3.1 Pro exact-head review: READY

Refs #526
Refs #517