### PR TITLE
Harden native Sparkle qualification state machine

### DIFF
--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -149,8 +149,10 @@ entries. Only a passed receipt may be indexed as accepted release evidence.
 The maintained clean-machine, Sparkle, and installed UI/accessibility collector is documented in
 [`docs/tier3-clean-machine.md`](tier3-clean-machine.md). It uses an isolated
 synthetic home in a runner-owned disposable location, reuses the installed-app
-package smoke, verifies a real-feed update from an exact prior signed release,
-and emits checked `clean-machine-signed-update` and
+package smoke, revalidates the exact prior signed app immediately before an
+identifier-scoped bounded updater state machine, permits one clean retry only
+for classified pre-press environmental startup failures, verifies the final
+candidate identity, and emits checked `clean-machine-signed-update` and
 `installed-ui-accessibility` receipts.
 
 Physical drive, protected-media conversion, and Vision Pro playback evidence

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -124,17 +124,24 @@ The runner performs this bounded sequence:
    synthetic home.
 3. Run the installed-app XCUITest lane against the exact prior app, verifying
    Sparkle controls and the source-bound release-notes URL without installing.
-4. Launch the prior app again, invoke `Check for Updates…`, click Sparkle's
-   bounded install/relaunch action, and wait for the exact candidate bundle,
-   build, and signed app tree to relaunch.
-5. Verify the selected route, unrelated preference, and byte-for-byte profile
+4. Revalidate the exact prior bundle and signed app tree immediately before
+   updater interaction, invoke `Check for Updates…`, and drive Sparkle through
+   an explicit bounded state machine. Identifier-scoped observations distinguish
+   downloading, staged install, install-and-relaunch, install-on-quit,
+   cancellation, terminal failure, and unknown states.
+5. Durably record each selected action inside the owned qualification root
+   before pressing it. Install-on-quit explicitly terminates the prior app,
+   waits for the exact candidate on disk, and launches that candidate; staged
+   installs remain bounded until Sparkle exposes the final action or relaunches.
+6. Verify the final candidate bundle, build, signed app tree, and running app,
+   then verify the selected route, unrelated preference, and byte-for-byte profile
    library are preserved.
-6. Run the candidate installed-app XCUITest lane. It verifies main-window
+7. Run the candidate installed-app XCUITest lane. It verifies main-window
    readiness, profile-save accessibility and success, updater settings, the
    public releases link, and cropped light/dark app-window screenshots.
-7. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
+8. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
    and delete the qualification root with raw XCTest and build output.
-8. Emit normalized public-safe evidence and validated receipts for both policy
+9. Emit normalized public-safe evidence and validated receipts for both policy
    cases with `cleanup.status = disposed`.
 
 Every mount, subprocess, network request, GUI wait, update wait, and cleanup
@@ -143,6 +150,27 @@ root and is deleted; public evidence records only its SHA-256 digest. Raw AX
 trees, XCTest logs, `.xcresult` bundles, local paths, and full-screen captures
 are deleted. Retained screenshots contain only the app window. A failed run
 does not emit either accepted receipt.
+
+The updater state machine prefers the Sparkle `SUUpdateAlert` window and
+`SPUUserUpdateChoiceInstall` action identifiers. A title fallback is permitted
+only inside the single owned updater window and is recorded in evidence. The
+selected action, state, exact prior/candidate identities, attempt number, and
+transition history are atomically written and synced before an asynchronous
+press. That journal remains disposable; normalized `sparkle-update.json`
+retains bounded public-safe action, window-match, state, attempt, route, and
+candidate-version fields plus the journal and intent SHA-256 digests. It never
+retains window text, local paths, usernames, hostnames, or raw AX output.
+
+One clean retry is allowed only for a classified pre-press application-start,
+update-menu, or update-window timeout. The first attempt must fully dispose its
+owned root and app process before retry. Cancellation, updater-reported failure,
+unknown UI, identity mismatch, preference/profile drift, action-limit failure,
+and every failure after a press are terminal. No other implicit retry occurs.
+
+Native Sparkle-window presentation sampling remains visible operational
+evidence but is nonblocking. The state-machine result, exact release-note source,
+and installed accessibility semantics remain the automated blocking contract;
+missing or failed manual presentation capture does not alter the runner result.
 
 If the cleanup ownership marker is missing or changed, the runner refuses to
 delete the qualification root because it can no longer prove ownership. It

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import enum
 import hashlib
 import json
 import os
@@ -64,6 +65,16 @@ SPARKLE_INSTALL_ACTIONS = (
     "Install and Relaunch",
     "Install on Quit",
 )
+MAX_UPDATE_ACTIONS = 2
+MAX_UPDATE_TRANSITIONS = 32
+UPDATE_POLL_SECONDS = 0.5
+RETRYABLE_UPDATE_FAILURES = frozenset(
+    {
+        "application-process-timeout",
+        "update-menu-timeout",
+        "update-window-timeout",
+    }
+)
 ROUTE_CHANNELS: dict[str, set[str | None]] = {
     "stable": {None},
     "rc": {None, "rc"},
@@ -86,6 +97,43 @@ SYSTEM_TOOL_PATHS = {
 
 class CleanMachineError(RuntimeError):
     pass
+
+
+class SparkleUpdateFailure(CleanMachineError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        state: SparkleUpdateState,
+        action_pressed: bool,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.state = state
+        self.action_pressed = action_pressed
+
+    @property
+    def retryable(self) -> bool:
+        return not self.action_pressed and self.reason_code in RETRYABLE_UPDATE_FAILURES
+
+
+class SparkleUpdateState(str, enum.Enum):
+    WAITING_FOR_WINDOW = "waiting-for-window"
+    DOWNLOADING = "downloading"
+    STAGED_INSTALL = "staged-install"
+    READY_INSTALL_RELAUNCH = "ready-install-relaunch"
+    READY_INSTALL_ON_QUIT = "ready-install-on-quit"
+    INSTALLING = "installing"
+    CANCELLED = "cancelled"
+    TERMINAL_FAILURE = "terminal-failure"
+    UNKNOWN = "unknown"
+
+
+class SparkleUpdateOutcome(str, enum.Enum):
+    INSTALL_AND_RELAUNCH = "install-and-relaunch"
+    INSTALL_ON_QUIT = "install-on-quit"
+    STAGED = "staged"
 
 
 @dataclass(frozen=True)
@@ -156,8 +204,24 @@ class QualificationConfig:
 
 
 @dataclass(frozen=True)
+class UpdateObservation:
+    state: SparkleUpdateState
+    window_match: str
+    action_identifier: str
+    action_title: str
+
+
+@dataclass(frozen=True)
 class UpdateInteraction:
     clicked_button: str
+    outcome: SparkleUpdateOutcome
+    action_identifier: str
+    window_match: str
+    states_observed: tuple[str, ...]
+    intent_checkpoint_sha256: str
+    journal_sha256: str
+    attempt: int
+    retry_reason_code: str | None
 
 
 class QualificationOperations(Protocol):
@@ -179,7 +243,16 @@ class QualificationOperations(Protocol):
     def read_preference(self, synthetic_home: Path, key: str) -> str:
         raise NotImplementedError
 
-    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+    def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
+        raise NotImplementedError
+
+    def open_updater(self, app_path: Path, synthetic_home: Path) -> None:
+        raise NotImplementedError
+
+    def observe_updater(self) -> UpdateObservation:
+        raise NotImplementedError
+
+    def press_updater_action(self, observation: UpdateObservation) -> None:
         raise NotImplementedError
 
     def collect_ui_evidence(
@@ -194,7 +267,7 @@ class QualificationOperations(Protocol):
     ) -> None:
         raise NotImplementedError
 
-    def app_running(self) -> bool:
+    def app_running(self, app_path: Path | None = None) -> bool:
         raise NotImplementedError
 
     def quit_app(self) -> None:
@@ -251,8 +324,97 @@ def _write_json(path: Path, value: Mapping[str, Any]) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
 
 
+def _write_durable_json(path: Path, value: Mapping[str, Any]) -> str:
+    content = _canonical_json_bytes(value)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    file_descriptor = os.open(temporary_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        destination = os.fdopen(file_descriptor, "wb")
+        file_descriptor = -1
+        with destination:
+            destination.write(content)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.replace(temporary_path, path)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        temporary_path.unlink(missing_ok=True)
+    return hashlib.sha256(content).hexdigest()
+
+
 def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_update_observation(output: str) -> UpdateObservation:
+    fields = output.rstrip("\n").split("\t")
+    if len(fields) != 4:
+        raise SparkleUpdateFailure(
+            "Sparkle updater observation returned an invalid field count.",
+            reason_code="updater-observation-invalid",
+            state=SparkleUpdateState.UNKNOWN,
+            action_pressed=False,
+        )
+    state_value, window_match, action_identifier, action_title = fields
+    try:
+        state = SparkleUpdateState(state_value)
+    except ValueError as error:
+        raise SparkleUpdateFailure(
+            f"Sparkle updater observation returned an unknown state: {state_value!r}.",
+            reason_code="updater-state-unknown",
+            state=SparkleUpdateState.UNKNOWN,
+            action_pressed=False,
+        ) from error
+    if window_match not in {"none", "identifier", "button-identifier", "owned-dialog"}:
+        raise SparkleUpdateFailure(
+            f"Sparkle updater observation returned an unsupported window match: {window_match!r}.",
+            reason_code="updater-observation-invalid",
+            state=SparkleUpdateState.UNKNOWN,
+            action_pressed=False,
+        )
+    for value, description in (
+        (action_identifier, "action identifier"),
+        (action_title, "action title"),
+    ):
+        if len(value) > 200 or any(character in value for character in ("\r", "\n", "\t")):
+            raise SparkleUpdateFailure(
+                f"Sparkle updater observation returned an invalid {description}.",
+                reason_code="updater-observation-invalid",
+                state=SparkleUpdateState.UNKNOWN,
+                action_pressed=False,
+            )
+    return UpdateObservation(
+        state=state,
+        window_match=window_match,
+        action_identifier=action_identifier,
+        action_title=action_title,
+    )
+
+
+def _sparkle_script_failure(error: CleanMachineError, *, action_pressed: bool) -> SparkleUpdateFailure:
+    message = str(error)
+    markers = {
+        "Timed out waiting for the application process.": "application-process-timeout",
+        "Timed out waiting for Check for Updates.": "update-menu-timeout",
+        "Updater state changed before the guarded press.": "updater-state-changed",
+    }
+    reason_code = next((code for marker, code in markers.items() if marker in message), "updater-script-failure")
+    state = SparkleUpdateState.UNKNOWN
+    if reason_code in {"application-process-timeout", "update-menu-timeout"}:
+        state = SparkleUpdateState.WAITING_FOR_WINDOW
+    return SparkleUpdateFailure(
+        message,
+        reason_code=reason_code,
+        state=state,
+        action_pressed=action_pressed,
+    )
 
 
 def _relative_checked_path(repo: Path, path: Path, description: str) -> str:
@@ -779,7 +941,7 @@ class MacOSOperations:
         )
         return result.stdout.strip()
 
-    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+    def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
         env = self._synthetic_env(synthetic_home)
         self._run(
             [
@@ -794,12 +956,45 @@ class MacOSOperations:
             ],
             env=env,
         )
-        result = self._run(
-            ["osascript", "-", BUNDLE_IDENTIFIER],
-            timeout=GUI_TIMEOUT_SECONDS,
-            input_text=self._updater_script(),
-        )
-        return UpdateInteraction(clicked_button=result.stdout.strip())
+
+    def open_updater(self, app_path: Path, synthetic_home: Path) -> None:
+        self.launch_app(app_path, synthetic_home)
+        try:
+            self._run(
+                ["osascript", "-", BUNDLE_IDENTIFIER],
+                timeout=COMMAND_TIMEOUT_SECONDS * 3,
+                input_text=self._updater_open_script(),
+            )
+        except CleanMachineError as error:
+            raise _sparkle_script_failure(error, action_pressed=False) from error
+
+    def observe_updater(self) -> UpdateObservation:
+        try:
+            result = self._run(
+                ["osascript", "-", BUNDLE_IDENTIFIER],
+                timeout=COMMAND_TIMEOUT_SECONDS,
+                input_text=self._updater_observe_script(),
+            )
+        except CleanMachineError as error:
+            raise _sparkle_script_failure(error, action_pressed=False) from error
+        return _parse_update_observation(result.stdout)
+
+    def press_updater_action(self, observation: UpdateObservation) -> None:
+        try:
+            self._run(
+                [
+                    "osascript",
+                    "-",
+                    BUNDLE_IDENTIFIER,
+                    observation.window_match,
+                    observation.action_identifier,
+                    observation.action_title,
+                ],
+                timeout=COMMAND_TIMEOUT_SECONDS,
+                input_text=self._updater_press_script(),
+            )
+        except CleanMachineError as error:
+            raise _sparkle_script_failure(error, action_pressed=False) from error
 
     def collect_ui_evidence(
         self,
@@ -920,10 +1115,10 @@ class MacOSOperations:
                 raise CleanMachineError("Installed UI candidate release-link evidence is not source-bound.")
 
     @staticmethod
-    def app_running() -> bool:
+    def app_running(app_path: Path | None = None) -> bool:
         script = (
-            'tell application "System Events" to return exists '
-            f'(first application process whose bundle identifier is "{BUNDLE_IDENTIFIER}")'
+            'tell application "System Events" to return unix id of every '
+            f'application process whose bundle identifier is "{BUNDLE_IDENTIFIER}"'
         )
         result = subprocess.run(
             ["osascript", "-e", script],
@@ -931,7 +1126,38 @@ class MacOSOperations:
             text=True,
             timeout=COMMAND_TIMEOUT_SECONDS,
         )
-        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+        if result.returncode != 0:
+            return False
+        output = result.stdout.strip()
+        if not output:
+            return False
+        try:
+            process_ids = tuple(int(value.strip()) for value in output.split(",") if value.strip())
+        except ValueError:
+            return False
+        if app_path is None:
+            return bool(process_ids)
+        if len(process_ids) != 1:
+            return False
+        try:
+            info = _mapping(
+                plistlib.loads((app_path / "Contents" / "Info.plist").read_bytes()),
+                "installed app Info.plist",
+            )
+            executable_name = _string(info.get("CFBundleExecutable"), "installed app executable name")
+        except (OSError, plistlib.InvalidFileException, CleanMachineError):
+            return False
+        executable_path = (app_path / "Contents" / "MacOS" / executable_name).resolve()
+        process = subprocess.run(
+            ["/bin/ps", "-p", str(process_ids[0]), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        command = process.stdout.strip()
+        return process.returncode == 0 and (
+            command == str(executable_path) or command.startswith(f"{executable_path} ")
+        )
 
     def quit_app(self) -> None:
         script = f'''tell application "System Events"
@@ -973,17 +1199,21 @@ end tell'''
             raise CleanMachineError("Production app did not terminate during cleanup.")
 
     @staticmethod
-    def _updater_script() -> str:
+    def _updater_open_script() -> str:
         return """on run argv
     set targetBundleID to item 1 of argv
     set processDeadline to (current date) + 60
     tell application "System Events"
         repeat
-            if exists (first application process whose bundle identifier is targetBundleID) then exit repeat
+            set processMatches to every application process whose bundle identifier is targetBundleID
+            if (count of processMatches) is 1 then exit repeat
+            if (count of processMatches) > 1 then
+                error "Multiple application processes matched the qualification bundle identifier."
+            end if
             if (current date) > processDeadline then error "Timed out waiting for the application process."
             delay 0.5
         end repeat
-        set targetProcess to first application process whose bundle identifier is targetBundleID
+        set targetProcess to item 1 of processMatches
         tell targetProcess
             set frontmost to true
             set menuDeadline to (current date) + 60
@@ -993,66 +1223,187 @@ end tell'''
             end repeat
             click menu item "Check for Updates…" of menu 1 of menu bar item "Help" of menu bar 1
         end tell
-        set installStarted to false
-        set updateDeadline to (current date) + (15 * 60)
-        repeat
-            if exists (first application process whose bundle identifier is targetBundleID) then
-                set targetProcess to first application process whose bundle identifier is targetBundleID
-                tell targetProcess
-                    repeat with targetWindow in windows
-                        set identifiedButton to missing value
-                        repeat with targetButton in buttons of targetWindow
-                            try
-                                set buttonIdentifier to value of attribute "AXIdentifier" of targetButton
-                                if buttonIdentifier is "SPUUserUpdateChoiceInstall" then
-                                    set identifiedButton to targetButton
-                                    exit repeat
-                                end if
-                            end try
-                        end repeat
-                        set selectedButton to missing value
-                        set selectedTitle to ""
-                        set selectedByIdentifier to false
-                        if identifiedButton is not missing value then
-                            if enabled of identifiedButton then
-                                set selectedButton to identifiedButton
-                                set selectedTitle to name of identifiedButton as text
-                                set selectedByIdentifier to true
-                            end if
-                        else
-                            repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Install on Quit"}
-                                if exists button (buttonTitle as text) of targetWindow then
-                                    set titledButton to button (buttonTitle as text) of targetWindow
-                                    if enabled of titledButton then
-                                        set selectedButton to titledButton
-                                        set selectedTitle to buttonTitle as text
-                                        exit repeat
-                                    end if
-                                end if
-                            end repeat
-                        end if
-                        if selectedButton is not missing value then
-                            if selectedTitle is "Install Update" then
-                                if installStarted is false then
-                                    perform action "AXPress" of selectedButton
-                                    set installStarted to true
-                                    delay 1
-                                end if
-                                exit repeat
-                            else
-                                perform action "AXPress" of selectedButton
-                                if selectedByIdentifier then return "SPUUserUpdateChoiceInstall"
-                                return selectedTitle
-                            end if
-                        end if
-                    end repeat
-                end tell
-            else if installStarted then
-                return "Install Update"
+    end tell
+end run"""
+
+    @staticmethod
+    def _updater_observe_script() -> str:
+        return """on run argv
+    set targetBundleID to item 1 of argv
+    tell application "System Events"
+        set processMatches to every application process whose bundle identifier is targetBundleID
+        if (count of processMatches) is 0 then
+            return "waiting-for-window" & tab & "none" & tab & "" & tab & ""
+        end if
+        if (count of processMatches) > 1 then
+            return "unknown" & tab & "none" & tab & "" & tab & ""
+        end if
+        set targetProcess to item 1 of processMatches
+        tell targetProcess
+            set identifiedWindows to {}
+            repeat with candidateWindow in windows
+                try
+                    if (value of attribute "AXIdentifier" of candidateWindow) is "SUUpdateAlert" then
+                        set end of identifiedWindows to candidateWindow
+                    end if
+                end try
+            end repeat
+            if (count of identifiedWindows) > 1 then
+                return "unknown" & tab & "identifier" & tab & "" & tab & ""
             end if
-            if (current date) > updateDeadline then error "Timed out waiting for a Sparkle install button."
-            delay 0.5
-        end repeat
+
+            set targetWindow to missing value
+            set windowMatch to "none"
+            if (count of identifiedWindows) is 1 then
+                set targetWindow to item 1 of identifiedWindows
+                set windowMatch to "identifier"
+            else
+                set fallbackWindows to {}
+                repeat with candidateWindow in windows
+                    repeat with candidateButton in buttons of candidateWindow
+                        try
+                            set candidateIdentifier to value of attribute "AXIdentifier" of candidateButton
+                            if candidateIdentifier is "SPUUserUpdateChoiceInstall" then
+                                set end of fallbackWindows to candidateWindow
+                                exit repeat
+                            end if
+                        end try
+                    end repeat
+                end repeat
+                if (count of fallbackWindows) > 1 then
+                    return "unknown" & tab & "button-identifier" & tab & "" & tab & ""
+                else if (count of fallbackWindows) is 1 then
+                    set targetWindow to item 1 of fallbackWindows
+                    set windowMatch to "button-identifier"
+                end if
+            end if
+
+            if targetWindow is missing value then
+                repeat with candidateWindow in windows
+                    try
+                        set windowSubrole to value of attribute "AXSubrole" of candidateWindow
+                        if windowSubrole is "AXDialog" or windowSubrole is "AXSystemDialog" then
+                            return "terminal-failure" & tab & "owned-dialog" & tab & "" & tab & ""
+                        end if
+                    end try
+                end repeat
+                return "waiting-for-window" & tab & "none" & tab & "" & tab & ""
+            end if
+
+            set selectedButton to missing value
+            set selectedIdentifier to ""
+            repeat with candidateButton in buttons of targetWindow
+                try
+                    set buttonIdentifier to value of attribute "AXIdentifier" of candidateButton
+                    if buttonIdentifier is "SPUUserUpdateChoiceInstall" then
+                        set selectedButton to candidateButton
+                        set selectedIdentifier to buttonIdentifier
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            if selectedButton is missing value then
+                repeat with buttonTitle in {"Install and Relaunch", "Install Update", "Install on Quit"}
+                    if exists button (buttonTitle as text) of targetWindow then
+                        set selectedButton to button (buttonTitle as text) of targetWindow
+                        exit repeat
+                    end if
+                end repeat
+            end if
+
+            if selectedButton is missing value then
+                if exists progress indicator 1 of targetWindow then
+                    return "downloading" & tab & windowMatch & tab & "" & tab & ""
+                end if
+                return "terminal-failure" & tab & windowMatch & tab & "" & tab & ""
+            end if
+
+            set selectedTitle to name of selectedButton as text
+            if not (enabled of selectedButton) then
+                return "downloading" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+            end if
+            if selectedTitle is "Install Update" then
+                return "staged-install" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+            else if selectedTitle is "Install on Quit" then
+                return "ready-install-on-quit" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+            else if selectedTitle is "Install and Relaunch" then
+                return "ready-install-relaunch" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+            end if
+            return "unknown" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+        end tell
+    end tell
+end run"""
+
+    @staticmethod
+    def _updater_press_script() -> str:
+        return """on run argv
+    set targetBundleID to item 1 of argv
+    set expectedWindowMatch to item 2 of argv
+    set expectedIdentifier to item 3 of argv
+    set expectedTitle to item 4 of argv
+    tell application "System Events"
+        set processMatches to every application process whose bundle identifier is targetBundleID
+        if (count of processMatches) is not 1 then
+            error "Updater state changed before the guarded press."
+        end if
+        set targetProcess to item 1 of processMatches
+        tell targetProcess
+            set targetWindow to missing value
+            set actualWindowMatch to "none"
+            repeat with candidateWindow in windows
+                try
+                    if (value of attribute "AXIdentifier" of candidateWindow) is "SUUpdateAlert" then
+                        if targetWindow is not missing value then
+                            error "Updater state changed before the guarded press."
+                        end if
+                        set targetWindow to candidateWindow
+                        set actualWindowMatch to "identifier"
+                    end if
+                end try
+            end repeat
+            if targetWindow is missing value then
+                repeat with candidateWindow in windows
+                    repeat with candidateButton in buttons of candidateWindow
+                        try
+                            set candidateIdentifier to value of attribute "AXIdentifier" of candidateButton
+                            if candidateIdentifier is "SPUUserUpdateChoiceInstall" then
+                                if targetWindow is not missing value then
+                                    error "Updater state changed before the guarded press."
+                                end if
+                                set targetWindow to candidateWindow
+                                set actualWindowMatch to "button-identifier"
+                                exit repeat
+                            end if
+                        end try
+                    end repeat
+                end repeat
+            end if
+            if targetWindow is missing value or actualWindowMatch is not expectedWindowMatch then
+                error "Updater state changed before the guarded press."
+            end if
+
+            set selectedButton to missing value
+            if expectedIdentifier is not "" then
+                repeat with candidateButton in buttons of targetWindow
+                    try
+                        if (value of attribute "AXIdentifier" of candidateButton) is expectedIdentifier then
+                            if selectedButton is not missing value then
+                                error "Updater state changed before the guarded press."
+                            end if
+                            set selectedButton to candidateButton
+                        end if
+                    end try
+                end repeat
+            else if exists button expectedTitle of targetWindow then
+                set selectedButton to button expectedTitle of targetWindow
+            end if
+            if selectedButton is missing value then error "Updater state changed before the guarded press."
+            if (name of selectedButton as text) is not expectedTitle then
+                error "Updater state changed before the guarded press."
+            end if
+            if not (enabled of selectedButton) then error "Updater state changed before the guarded press."
+            perform action "AXPress" of selectedButton
+        end tell
     end tell
 end run"""
 
@@ -1171,6 +1522,235 @@ def preflight_report(
     }
 
 
+def _perform_sparkle_update(
+    *,
+    app_path: Path,
+    synthetic_home: Path,
+    prior: ReleaseArtifact,
+    candidate: ReleaseArtifact,
+    operations: QualificationOperations,
+    checkpoint_path: Path,
+    run_id: str,
+    attempt: int,
+    retry_reason_code: str | None,
+) -> UpdateInteraction:
+    prior_identity = verify_installed_app(app_path, prior)
+    journal: dict[str, Any] = {
+        "attempt": attempt,
+        "candidate": {
+            "build_version": candidate.build_version,
+            "package_version": candidate.package_version,
+            "release_tag": candidate.release_tag,
+            "signed_app_tree_sha256": candidate.signed_app_tree_sha256,
+        },
+        "prior": {
+            "build_version": prior_identity.build_version,
+            "package_version": prior_identity.package_version,
+            "release_tag": prior.release_tag,
+            "signed_app_tree_sha256": prior.signed_app_tree_sha256,
+        },
+        "retry_reason_code": retry_reason_code,
+        "run_id": run_id,
+        "schema_version": 1,
+        "transitions": [],
+    }
+    journal_sha256 = _write_durable_json(checkpoint_path, journal)
+    operations.open_updater(app_path, synthetic_home)
+
+    deadline = time.monotonic() + GUI_TIMEOUT_SECONDS
+    states_observed: list[str] = []
+    last_recorded_state: SparkleUpdateState | None = None
+    saw_owned_window = False
+    staged_pressed = False
+    action_count = 0
+    last_pressed: UpdateObservation | None = None
+    intent_checkpoint_sha256 = ""
+
+    def record_transition(phase: str, observation: UpdateObservation) -> str:
+        transitions = cast(list[dict[str, Any]], journal["transitions"])
+        if len(transitions) >= MAX_UPDATE_TRANSITIONS:
+            raise SparkleUpdateFailure(
+                "Sparkle updater exceeded the bounded transition count.",
+                reason_code="updater-transition-limit",
+                state=observation.state,
+                action_pressed=action_count > 0,
+            )
+        transitions.append(
+            {
+                "action_identifier": observation.action_identifier or None,
+                "action_title": observation.action_title or None,
+                "phase": phase,
+                "sequence": len(transitions) + 1,
+                "state": observation.state.value,
+                "timestamp": _utc_timestamp(),
+                "window_match": observation.window_match,
+            }
+        )
+        return _write_durable_json(checkpoint_path, journal)
+
+    while time.monotonic() < deadline:
+        observation = operations.observe_updater()
+        state = observation.state
+        if state != last_recorded_state:
+            states_observed.append(state.value)
+            journal_sha256 = record_transition("observed", observation)
+            last_recorded_state = state
+
+        if observation.window_match in {"identifier", "button-identifier"}:
+            saw_owned_window = True
+
+        if state == SparkleUpdateState.WAITING_FOR_WINDOW:
+            if staged_pressed and not operations.app_running():
+                if last_pressed is None:
+                    raise AssertionError("staged Sparkle update lost its pressed action")
+                return UpdateInteraction(
+                    clicked_button=last_pressed.action_title,
+                    outcome=SparkleUpdateOutcome.STAGED,
+                    action_identifier=last_pressed.action_identifier,
+                    window_match=last_pressed.window_match,
+                    states_observed=tuple(states_observed),
+                    intent_checkpoint_sha256=intent_checkpoint_sha256,
+                    journal_sha256=journal_sha256,
+                    attempt=attempt,
+                    retry_reason_code=retry_reason_code,
+                )
+            if saw_owned_window and action_count == 0:
+                cancelled = UpdateObservation(
+                    state=SparkleUpdateState.CANCELLED,
+                    window_match="none",
+                    action_identifier="",
+                    action_title="",
+                )
+                states_observed.append(cancelled.state.value)
+                record_transition("terminal", cancelled)
+                raise SparkleUpdateFailure(
+                    "Sparkle update window closed before an install action was selected.",
+                    reason_code="updater-cancelled",
+                    state=cancelled.state,
+                    action_pressed=False,
+                )
+            time.sleep(UPDATE_POLL_SECONDS)
+            continue
+
+        if state in {SparkleUpdateState.DOWNLOADING, SparkleUpdateState.INSTALLING}:
+            time.sleep(UPDATE_POLL_SECONDS)
+            continue
+        if state == SparkleUpdateState.STAGED_INSTALL and staged_pressed:
+            time.sleep(UPDATE_POLL_SECONDS)
+            continue
+
+        if state == SparkleUpdateState.TERMINAL_FAILURE:
+            raise SparkleUpdateFailure(
+                "Sparkle presented a terminal updater failure before the candidate was installed.",
+                reason_code="updater-reported-failure",
+                state=state,
+                action_pressed=action_count > 0,
+            )
+        if state == SparkleUpdateState.CANCELLED:
+            raise SparkleUpdateFailure(
+                "Sparkle update was cancelled before the candidate was installed.",
+                reason_code="updater-cancelled",
+                state=state,
+                action_pressed=action_count > 0,
+            )
+        if state == SparkleUpdateState.UNKNOWN:
+            action_detail = (
+                f" unsupported install action: {observation.action_title!r}." if observation.action_title else ""
+            )
+            raise SparkleUpdateFailure(
+                f"Sparkle updater entered an unknown state; no action was taken.{action_detail}",
+                reason_code="updater-state-unknown",
+                state=state,
+                action_pressed=action_count > 0,
+            )
+
+        outcomes = {
+            SparkleUpdateState.STAGED_INSTALL: SparkleUpdateOutcome.STAGED,
+            SparkleUpdateState.READY_INSTALL_RELAUNCH: SparkleUpdateOutcome.INSTALL_AND_RELAUNCH,
+            SparkleUpdateState.READY_INSTALL_ON_QUIT: SparkleUpdateOutcome.INSTALL_ON_QUIT,
+        }
+        try:
+            outcome = outcomes[state]
+        except KeyError as error:
+            raise SparkleUpdateFailure(
+                f"Sparkle updater state is not actionable: {state.value}.",
+                reason_code="updater-state-unknown",
+                state=SparkleUpdateState.UNKNOWN,
+                action_pressed=action_count > 0,
+            ) from error
+        if observation.action_title not in {"Install and Relaunch", "Install Update", "Install on Quit"}:
+            raise SparkleUpdateFailure(
+                f"Sparkle updater exposed an unsupported action title: {observation.action_title!r}.",
+                reason_code="updater-action-unknown",
+                state=SparkleUpdateState.UNKNOWN,
+                action_pressed=action_count > 0,
+            )
+        if observation.action_identifier not in {"", SPARKLE_INSTALL_IDENTIFIER}:
+            raise SparkleUpdateFailure(
+                f"Sparkle updater exposed an unsupported action identifier: {observation.action_identifier!r}.",
+                reason_code="updater-action-unknown",
+                state=SparkleUpdateState.UNKNOWN,
+                action_pressed=action_count > 0,
+            )
+        if action_count >= MAX_UPDATE_ACTIONS:
+            raise SparkleUpdateFailure(
+                "Sparkle updater exceeded the bounded install-action count.",
+                reason_code="updater-action-limit",
+                state=state,
+                action_pressed=True,
+            )
+
+        intent_checkpoint_sha256 = record_transition("intent", observation)
+        try:
+            operations.press_updater_action(observation)
+        except SparkleUpdateFailure as error:
+            if error.reason_code != "updater-state-changed":
+                raise
+            record_transition("intent-invalidated", observation)
+            raise SparkleUpdateFailure(
+                "Sparkle updater changed after intent was durably recorded; no action was pressed.",
+                reason_code="updater-state-changed",
+                state=observation.state,
+                action_pressed=False,
+            ) from error
+        journal_sha256 = record_transition("pressed", observation)
+        action_count += 1
+        last_pressed = observation
+
+        if outcome == SparkleUpdateOutcome.STAGED:
+            staged_pressed = True
+            last_recorded_state = SparkleUpdateState.INSTALLING
+            states_observed.append(SparkleUpdateState.INSTALLING.value)
+            installing = UpdateObservation(
+                state=SparkleUpdateState.INSTALLING,
+                window_match=observation.window_match,
+                action_identifier=observation.action_identifier,
+                action_title=observation.action_title,
+            )
+            journal_sha256 = record_transition("derived", installing)
+            time.sleep(UPDATE_POLL_SECONDS)
+            continue
+
+        return UpdateInteraction(
+            clicked_button=observation.action_title,
+            outcome=outcome,
+            action_identifier=observation.action_identifier,
+            window_match=observation.window_match,
+            states_observed=tuple(states_observed),
+            intent_checkpoint_sha256=intent_checkpoint_sha256,
+            journal_sha256=journal_sha256,
+            attempt=attempt,
+            retry_reason_code=retry_reason_code,
+        )
+
+    raise SparkleUpdateFailure(
+        "Sparkle updater did not reach a bounded install state before timeout.",
+        reason_code="update-window-timeout",
+        state=last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW,
+        action_pressed=action_count > 0,
+    )
+
+
 def _wait_for_candidate(
     app_path: Path,
     candidate: ReleaseArtifact,
@@ -1185,11 +1765,31 @@ def _wait_for_candidate(
             except CleanMachineError as error:
                 last_error = error
             else:
-                if operations.app_running():
+                if operations.app_running(app_path):
                     return identity
         time.sleep(1)
     detail = f" Last identity error: {last_error}" if last_error is not None else ""
     raise CleanMachineError(f"Sparkle did not install and relaunch the exact candidate before timeout.{detail}")
+
+
+def _wait_for_candidate_on_disk(app_path: Path, candidate: ReleaseArtifact) -> BundleIdentity:
+    deadline = time.monotonic() + UPDATE_TIMEOUT_SECONDS
+    last_error: CleanMachineError | None = None
+    previous_identity: BundleIdentity | None = None
+    while time.monotonic() < deadline:
+        if app_path.exists():
+            try:
+                identity = verify_installed_app(app_path, candidate)
+            except CleanMachineError as error:
+                last_error = error
+                previous_identity = None
+            else:
+                if identity == previous_identity:
+                    return identity
+                previous_identity = identity
+        time.sleep(1)
+    detail = f" Last identity error: {last_error}" if last_error is not None else ""
+    raise CleanMachineError(f"Sparkle did not install the exact candidate before timeout.{detail}")
 
 
 def _seed_profile(synthetic_home: Path) -> tuple[Path, str]:
@@ -1462,7 +2062,11 @@ def _build_checked_receipt(
 
 
 def _run_qualification(
-    config: QualificationConfig, operations: QualificationOperations
+    config: QualificationConfig,
+    operations: QualificationOperations,
+    *,
+    attempt: int = 1,
+    retry_reason_code: str | None = None,
 ) -> Mapping[str, Mapping[str, Any]]:
     if config.output_receipt is None or config.ui_output_receipt is None or config.evidence_directory is None:
         raise CleanMachineError("Run mode requires both output receipts and the evidence directory path.")
@@ -1516,7 +2120,21 @@ def _run_qualification(
         if operations.app_running():
             raise CleanMachineError("Installed UI updater inspection left the production app running.")
 
-        interaction = operations.perform_update(app_path, synthetic_home)
+        interaction = _perform_sparkle_update(
+            app_path=app_path,
+            synthetic_home=synthetic_home,
+            prior=prior,
+            candidate=candidate,
+            operations=operations,
+            checkpoint_path=qualification_root / ".bd-to-avp-sparkle-update.json",
+            run_id=marker["run_id"],
+            attempt=attempt,
+            retry_reason_code=retry_reason_code,
+        )
+        if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT:
+            operations.quit_app()
+            _wait_for_candidate_on_disk(app_path, candidate)
+            operations.launch_app(app_path, synthetic_home)
         candidate_identity = _wait_for_candidate(app_path, candidate, operations)
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
         sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
@@ -1567,6 +2185,8 @@ def _run_qualification(
         update_digest = _write_json(
             evidence_directory / "sparkle-update.json",
             {
+                "action_identifier": interaction.action_identifier or None,
+                "attempt": interaction.attempt,
                 "button": interaction.clicked_button,
                 "candidate": {
                     "build_version": candidate_identity.build_version,
@@ -1574,8 +2194,14 @@ def _run_qualification(
                     "signed_app_tree_sha256": candidate.signed_app_tree_sha256,
                 },
                 "feed_sha256": feed.feed_sha256,
+                "intent_checkpoint_sha256": interaction.intent_checkpoint_sha256,
+                "journal_sha256": interaction.journal_sha256,
+                "outcome": interaction.outcome.value,
+                "retry_reason_code": interaction.retry_reason_code,
                 "route": config.route,
+                "states_observed": list(interaction.states_observed),
                 "status": "passed",
+                "window_match": interaction.window_match,
             },
         )
         profile_digest = _write_json(
@@ -1673,16 +2299,34 @@ def _run_qualification(
 def run_qualification(
     config: QualificationConfig, operations: QualificationOperations
 ) -> Mapping[str, Mapping[str, Any]]:
-    try:
-        return _run_qualification(config, operations)
-    except BaseException:
+    def remove_partial_outputs() -> None:
         if config.output_receipt is not None and config.output_receipt.exists():
             config.output_receipt.unlink()
         if config.ui_output_receipt is not None and config.ui_output_receipt.exists():
             config.ui_output_receipt.unlink()
         if config.evidence_directory is not None and config.evidence_directory.exists():
             shutil.rmtree(config.evidence_directory)
-        raise
+
+    retry_reason_code: str | None = None
+    for attempt in (1, 2):
+        try:
+            return _run_qualification(
+                config,
+                operations,
+                attempt=attempt,
+                retry_reason_code=retry_reason_code,
+            )
+        except SparkleUpdateFailure as error:
+            remove_partial_outputs()
+            clean_retry_environment = not config.qualification_root.resolve().exists() and not operations.app_running()
+            if attempt == 1 and error.retryable and clean_retry_environment:
+                retry_reason_code = error.reason_code
+                continue
+            raise
+        except BaseException:
+            remove_partial_outputs()
+            raise
+    raise AssertionError("bounded Sparkle qualification retry loop exhausted")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -27,8 +27,10 @@ from scripts.tier3_clean_machine import (
     QualificationOperations,
     RELEASES_URL,
     ReleaseArtifact,
+    SparkleUpdateFailure,
+    SparkleUpdateState,
     SPARKLE_INSTALL_ACTIONS,
-    UpdateInteraction,
+    UpdateObservation,
     file_sha256,
     parse_feed_candidate,
     preflight_report,
@@ -52,6 +54,15 @@ class FakeOperations(QualificationOperations):
         *,
         macos_version: str = "26.0",
         update_failure: bool = False,
+        retryable_failures: int = 0,
+        post_press_failure: bool = False,
+        terminal_failure: bool = False,
+        cancelled: bool = False,
+        tamper_prior_before_update: bool = False,
+        wrong_running_path: bool = False,
+        staged_repeats_after_press: int = 0,
+        press_state_changed: bool = False,
+        oscillate_non_actionable: bool = False,
         sentinel_failure: bool = False,
         tamper_marker: bool = False,
         install_action: str = "Install and Relaunch",
@@ -60,12 +71,31 @@ class FakeOperations(QualificationOperations):
         self.feed_bytes = feed_bytes
         self.macos_version = macos_version
         self.update_failure = update_failure
+        self.retryable_failures = retryable_failures
+        self.post_press_failure = post_press_failure
+        self.terminal_failure = terminal_failure
+        self.cancelled = cancelled
+        self.tamper_prior_before_update = tamper_prior_before_update
+        self.wrong_running_path = wrong_running_path
+        self.staged_repeats_after_press = staged_repeats_after_press
+        self.press_state_changed = press_state_changed
+        self.oscillate_non_actionable = oscillate_non_actionable
         self.sentinel_failure = sentinel_failure
         self.tamper_marker = tamper_marker
         self.install_action = install_action
         self.preferences: dict[str, str] = {}
         self.running = False
         self.candidate_source = app_sources[candidate_dmg.resolve()]
+        self.pressed_actions: list[UpdateObservation] = []
+        self.update_attempts = 0
+        self.intent_seen_before_press = False
+        self.current_app_path: Path | None = None
+        self.current_synthetic_home: Path | None = None
+        self.launch_calls = 0
+        self.quit_calls = 0
+        self.running_app_path: Path | None = None
+        self.post_staged_observations = 0
+        self.observation_calls = 0
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
         return EnvironmentFacts(
@@ -101,16 +131,141 @@ class FakeOperations(QualificationOperations):
     def read_preference(self, synthetic_home: Path, key: str) -> str:
         return self.preferences[key]
 
-    def perform_update(self, app_path: Path, synthetic_home: Path) -> UpdateInteraction:
+    def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
+        self.launch_calls += 1
+        self.running = True
+        self.running_app_path = app_path
+
+    def open_updater(self, app_path: Path, synthetic_home: Path) -> None:
+        self.launch_app(app_path, synthetic_home)
+        self.current_app_path = app_path
+        self.current_synthetic_home = synthetic_home
+        self.update_attempts += 1
+        if self.retryable_failures > 0:
+            self.retryable_failures -= 1
+            raise SparkleUpdateFailure(
+                "simulated application process timeout",
+                reason_code="application-process-timeout",
+                state=SparkleUpdateState.WAITING_FOR_WINDOW,
+                action_pressed=False,
+            )
         if self.update_failure:
-            raise CleanMachineError("simulated Sparkle failure")
+            raise SparkleUpdateFailure(
+                "simulated Sparkle failure",
+                reason_code="updater-script-failure",
+                state=SparkleUpdateState.UNKNOWN,
+                action_pressed=False,
+            )
+
+    def observe_updater(self) -> UpdateObservation:
+        self.observation_calls += 1
+        if self.oscillate_non_actionable:
+            state = SparkleUpdateState.DOWNLOADING if self.observation_calls % 2 else SparkleUpdateState.INSTALLING
+            return UpdateObservation(
+                state=state,
+                window_match="identifier",
+                action_identifier="SPUUserUpdateChoiceInstall",
+                action_title="Install Update",
+            )
+        if self.post_press_failure and self.pressed_actions:
+            raise SparkleUpdateFailure(
+                "simulated post-press failure",
+                reason_code="updater-script-failure",
+                state=SparkleUpdateState.INSTALLING,
+                action_pressed=True,
+            )
+        if self.terminal_failure:
+            return UpdateObservation(
+                state=SparkleUpdateState.TERMINAL_FAILURE,
+                window_match="owned-dialog",
+                action_identifier="",
+                action_title="",
+            )
+        if self.cancelled:
+            return UpdateObservation(
+                state=SparkleUpdateState.CANCELLED,
+                window_match="none",
+                action_identifier="",
+                action_title="",
+            )
+        action_states = {
+            "Install and Relaunch": (
+                SparkleUpdateState.READY_INSTALL_RELAUNCH,
+                "",
+                "Install and Relaunch",
+            ),
+            "Install on Quit": (
+                SparkleUpdateState.READY_INSTALL_ON_QUIT,
+                "",
+                "Install on Quit",
+            ),
+            "SPUUserUpdateChoiceInstall": (
+                SparkleUpdateState.READY_INSTALL_RELAUNCH,
+                "SPUUserUpdateChoiceInstall",
+                "Install and Relaunch",
+            ),
+        }
+        if self.install_action == "Install Update":
+            staged_observation = UpdateObservation(
+                state=SparkleUpdateState.STAGED_INSTALL,
+                window_match="identifier",
+                action_identifier="SPUUserUpdateChoiceInstall",
+                action_title="Install Update",
+            )
+            if not self.pressed_actions:
+                observation = staged_observation
+            elif self.post_staged_observations < self.staged_repeats_after_press:
+                self.post_staged_observations += 1
+                observation = staged_observation
+            else:
+                observation = UpdateObservation(
+                    state=SparkleUpdateState.READY_INSTALL_RELAUNCH,
+                    window_match="identifier",
+                    action_identifier="SPUUserUpdateChoiceInstall",
+                    action_title="Install and Relaunch",
+                )
+        elif self.install_action in action_states:
+            state, identifier, title = action_states[self.install_action]
+            observation = UpdateObservation(
+                state=state,
+                window_match="identifier" if identifier else "button-identifier",
+                action_identifier=identifier,
+                action_title=title,
+            )
+        else:
+            observation = UpdateObservation(
+                state=SparkleUpdateState.UNKNOWN,
+                window_match="identifier",
+                action_identifier="",
+                action_title=self.install_action,
+            )
+        return observation
+
+    def press_updater_action(self, observation: UpdateObservation) -> None:
+        if self.current_app_path is None or self.current_synthetic_home is None:
+            raise AssertionError("fake updater was pressed before it was opened")
+        checkpoint_path = self.current_synthetic_home.parent / ".bd-to-avp-sparkle-update.json"
+        checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        transitions = checkpoint["transitions"]
+        self.intent_seen_before_press = bool(transitions and transitions[-1]["phase"] == "intent")
+        if self.press_state_changed:
+            raise SparkleUpdateFailure(
+                "simulated updater state change",
+                reason_code="updater-state-changed",
+                state=observation.state,
+                action_pressed=False,
+            )
+        self.pressed_actions.append(observation)
+        if observation.state == SparkleUpdateState.STAGED_INSTALL:
+            return
         if self.tamper_marker:
-            marker_path = synthetic_home.parent / ".bd-to-avp-tier3-owned.json"
+            marker_path = self.current_synthetic_home.parent / ".bd-to-avp-tier3-owned.json"
             marker_path.write_text('{"owner":"changed"}\n', encoding="utf-8")
+        app_path = self.current_app_path
         shutil.rmtree(app_path)
         shutil.copytree(self.candidate_source, app_path, symlinks=True)
         self.running = True
-        return UpdateInteraction(clicked_button=self.install_action)
+        self.running_app_path = self.candidate_source if self.wrong_running_path else app_path
 
     def collect_ui_evidence(
         self,
@@ -122,6 +277,8 @@ class FakeOperations(QualificationOperations):
         output_directory: Path,
         release_notes_url: str,
     ) -> None:
+        if phase == "updater" and self.tamper_prior_before_update:
+            (app_path / "tampered-before-updater").write_text("changed\n", encoding="utf-8")
         del repo, app_path, synthetic_home
         output_directory.mkdir(parents=True, exist_ok=True)
         if phase == "updater":
@@ -204,11 +361,15 @@ class FakeOperations(QualificationOperations):
         (output_directory / "screenshot-light.png").write_bytes(screenshot)
         (output_directory / "screenshot-dark.png").write_bytes(screenshot)
 
-    def app_running(self) -> bool:
-        return self.running
+    def app_running(self, app_path: Path | None = None) -> bool:
+        if not self.running:
+            return False
+        return app_path is None or self.running_app_path == app_path
 
     def quit_app(self) -> None:
+        self.quit_calls += 1
         self.running = False
+        self.running_app_path = None
 
 
 class Tier3CleanMachineTests(unittest.TestCase):
@@ -655,6 +816,16 @@ class Tier3CleanMachineTests(unittest.TestCase):
                 self.assertEqual(receipt["result"]["status"], "passed")
                 self.assertEqual(receipt["cleanup"]["status"], "disposed")
                 self.assertEqual(receipt["release_identity"]["source_sha"], CANDIDATE_SHA)
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(update_evidence["attempt"], 1)
+            self.assertEqual(update_evidence["outcome"], "install-and-relaunch")
+            self.assertEqual(update_evidence["window_match"], "button-identifier")
+            self.assertIn("ready-install-relaunch", update_evidence["states_observed"])
+            self.assertRegex(update_evidence["intent_checkpoint_sha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(update_evidence["journal_sha256"], r"^[0-9a-f]{64}$")
+            self.assertTrue(operations.intent_seen_before_press)
             self.assertFalse(operations.app_running())
 
     def test_run_accepts_supported_sparkle_install_actions(self) -> None:
@@ -699,6 +870,164 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertFalse(operations.app_running())
             self.assertFalse(config.output_receipt.exists())
             self.assertFalse(config.ui_output_receipt.exists())
+            self.assertFalse(config.evidence_directory.exists())
+            self.assertEqual(operations.update_attempts, 1)
+
+    def test_run_install_on_quit_installs_then_launches_exact_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install on Quit"
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(update_evidence["outcome"], "install-on-quit")
+            self.assertIn("ready-install-on-quit", update_evidence["states_observed"])
+            self.assertEqual(operations.launch_calls, 2)
+            self.assertTrue(operations.intent_seen_before_press)
+
+    def test_run_records_staged_install_before_final_relaunch_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                [observation.state for observation in operations.pressed_actions],
+                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
+            )
+            self.assertEqual(update_evidence["outcome"], "install-and-relaunch")
+            self.assertEqual(
+                update_evidence["states_observed"],
+                ["staged-install", "installing", "ready-install-relaunch"],
+            )
+
+    def test_run_does_not_press_a_repeated_staged_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_repeats_after_press = 2
+
+            run_qualification(config, operations)
+
+            self.assertEqual(
+                [observation.state for observation in operations.pressed_actions],
+                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
+            )
+
+    def test_run_retries_one_clean_attempt_for_pre_press_environmental_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.retryable_failures = 1
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(operations.update_attempts, 2)
+            self.assertEqual(update_evidence["attempt"], 2)
+            self.assertEqual(update_evidence["retry_reason_code"], "application-process-timeout")
+
+    def test_run_does_not_retry_after_an_action_was_pressed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.post_press_failure = True
+
+            with self.assertRaisesRegex(CleanMachineError, "simulated post-press failure"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_fails_closed_when_updater_changes_after_intent_recording(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.press_state_changed = True
+
+            with self.assertRaisesRegex(CleanMachineError, "changed after intent"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertTrue(operations.intent_seen_before_press)
+            self.assertFalse(operations.pressed_actions)
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_classifies_terminal_failure_without_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.terminal_failure = True
+
+            with self.assertRaisesRegex(CleanMachineError, "terminal updater failure"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertFalse(operations.pressed_actions)
+
+    def test_run_classifies_cancellation_without_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.cancelled = True
+
+            with self.assertRaisesRegex(CleanMachineError, "was cancelled"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertFalse(operations.pressed_actions)
+
+    def test_run_bounds_non_actionable_state_transitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.oscillate_non_actionable = True
+
+            with patch("scripts.tier3_clean_machine.UPDATE_POLL_SECONDS", 0):
+                with self.assertRaisesRegex(CleanMachineError, "bounded transition count"):
+                    run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertFalse(operations.pressed_actions)
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_revalidates_prior_identity_immediately_before_updater_interaction(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.tamper_prior_before_update = True
+
+            with self.assertRaisesRegex(CleanMachineError, "exact signed release receipt"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 0)
+            self.assertFalse(operations.pressed_actions)
+
+    def test_run_rejects_candidate_process_from_a_different_app_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.wrong_running_path = True
+
+            with patch("scripts.tier3_clean_machine.UPDATE_TIMEOUT_SECONDS", 0.01):
+                with self.assertRaisesRegex(CleanMachineError, "did not install and relaunch"):
+                    run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
             self.assertFalse(config.evidence_directory.exists())
 
     def test_preflight_rejects_wrong_macos_major(self) -> None:
@@ -805,30 +1134,39 @@ class Tier3CleanMachineTests(unittest.TestCase):
 
     @unittest.skipUnless(platform.system() == "Darwin", "AppleScript compilation requires macOS")
     def test_updater_applescript_compiles(self) -> None:
+        operations = MacOSOperations()
+        scripts = {
+            "open": operations._updater_open_script(),
+            "observe": operations._updater_observe_script(),
+            "press": operations._updater_press_script(),
+        }
         with tempfile.TemporaryDirectory() as temporary_directory:
-            source = Path(temporary_directory) / "updater.applescript"
-            output = Path(temporary_directory) / "updater.scpt"
-            source.write_text(MacOSOperations()._updater_script(), encoding="utf-8")
-            result = subprocess.run(
-                ["osacompile", "-o", str(output), str(source)],
-                capture_output=True,
-                text=True,
-            )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
+            root = Path(temporary_directory)
+            for name, script in scripts.items():
+                with self.subTest(name=name):
+                    source = root / f"{name}.applescript"
+                    output = root / f"{name}.scpt"
+                    source.write_text(script, encoding="utf-8")
+                    result = subprocess.run(
+                        ["osacompile", "-o", str(output), str(source)],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_updater_waits_for_identified_enabled_install_button(self) -> None:
-        script = MacOSOperations()._updater_script()
+        observe_script = MacOSOperations()._updater_observe_script()
+        press_script = MacOSOperations()._updater_press_script()
 
-        self.assertIn('attribute "AXIdentifier"', script)
-        self.assertIn('"SPUUserUpdateChoiceInstall"', script)
-        self.assertIn("enabled of identifiedButton", script)
-        self.assertIn("enabled of titledButton", script)
-        self.assertIn('if selectedTitle is "Install Update"', script)
-        self.assertIn('perform action "AXPress" of selectedButton', script)
-        self.assertIn("set installStarted to true", script)
-        self.assertIn('"Install on Quit"', script)
-        self.assertIn('return "SPUUserUpdateChoiceInstall"', script)
+        self.assertIn('attribute "AXIdentifier"', observe_script)
+        self.assertIn('"SUUpdateAlert"', observe_script)
+        self.assertIn('"SPUUserUpdateChoiceInstall"', observe_script)
+        self.assertIn("enabled of selectedButton", observe_script)
+        self.assertIn('selectedTitle is "Install Update"', observe_script)
+        self.assertIn('selectedTitle is "Install on Quit"', observe_script)
+        self.assertIn('"ready-install-relaunch"', observe_script)
+        self.assertIn('perform action "AXPress" of selectedButton', press_script)
+        self.assertIn("actualWindowMatch is not expectedWindowMatch", press_script)
 
     @unittest.skipUnless(platform.system() == "Darwin", "DMG mount integration requires macOS")
     def test_synthetic_dmg_mount_and_detach(self) -> None:


### PR DESCRIPTION
## Summary

- replace the monolithic Sparkle interaction with an explicit bounded updater state machine
- revalidate the exact prior app before interaction and the exact candidate bundle, signed app tree, and running executable path after installation
- prefer `SUUpdateAlert` / `SPUUserUpdateChoiceInstall` accessibility identifiers with a single owned-window fallback and guarded sample-to-press validation
- atomically persist and fsync the selected action before each asynchronous press
- handle staged install, install-and-relaunch, and install-on-quit explicitly while failing closed on cancellation, terminal failure, unknown state, excessive transitions, and races
- permit one clean retry only for classified pre-press environmental startup timeouts
- retain the existing Tier 3 receipt schema and evidence filenames while enriching `sparkle-update.json` with bounded public-safe state metadata

## Validation

- `uv run python -m unittest tests.test_tier3_clean_machine` — 30 passed
- `uv run python -m unittest discover -s tests -t .` — 1,731 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 355 passed
- native package/build and bundled-tool verification passed
- Ruff format/lint, mypy, policy validation, observability validation, Actionlint, import smoke, and `uv build` passed
- Opus and Gemini final exact-head reviews: READY
- JetBrains inspection: UNKNOWN because the helper mutated IDE metadata; helper-created changes were removed and no IDE files are included

## Qualification Impact

This intentionally changes paths that invalidate existing clean-machine and installed-UI receipts. The next milestone candidate requires a fresh Tier 3 qualification run using the hardened state machine. Manual native-window presentation remains visible and nonblocking.

Closes #527
