### PR TITLE
fix(deps): restore Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,20 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+
+  - package-ecosystem: npm
+    directory: "/support-diagnostics"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      all-version-updates:
+        patterns:
+          - "*"
+      all-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ bd-to-avp-worker = "bd_to_avp.worker.__main__:main"
 dev = [
     "black>=26.5.1,<27",
     "briefcase==0.4.4",
+    "gitpython>=3.1.58,<4",
     "mypy>=2.1.0,<3",
     "pyside6>=6.7.1,<6.10",
     "ruff>=0.15.20,<0.16",
@@ -57,7 +58,6 @@ dev = [
 [tool.uv]
 required-version = "==0.11.29"
 default-groups = "all"
-constraint-dependencies = ["gitpython>=3.1.55,<4"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["bd_to_avp"]

--- a/support-diagnostics/package-lock.json
+++ b/support-diagnostics/package-lock.json
@@ -11,7 +11,7 @@
         "@types/node": "26.1.1",
         "typescript": "7.0.2",
         "vitest": "4.1.10",
-        "wrangler": "4.115.0"
+        "wrangler": "4.122.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
-      "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
       "cpu": [
         "x64"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
-      "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
-      "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
-      "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
-      "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
       "cpu": [
         "x64"
       ],
@@ -1571,9 +1571,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -2547,30 +2547,27 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260722.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.1.tgz",
-      "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
+      "version": "5.20260811.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.0-alpha.tgz",
+      "integrity": "sha512-sypXsD5fjY88fZNedPqnwrwR1dwfnfbfW7MfvMyIfPJdtRiCCOpUnjWGeFVYYZ+0fQVICye6Juu+vZgzTEx8XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260722.1",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2887,9 +2884,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3099,9 +3096,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
-      "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3112,17 +3109,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260722.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
-        "@cloudflare/workerd-linux-64": "1.20260722.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260722.1",
-        "@cloudflare/workerd-windows-64": "1.20260722.1"
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.115.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.115.0.tgz",
-      "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
+      "version": "4.122.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.122.0.tgz",
+      "integrity": "sha512-qkskzgQ76Y1qvVe5JARgvc3RISq6BC2rPoxQhFoKH1dKIwQc3GDFttQ/7m2OfeQ+tmQRzynv2dy/DXnxFCj2Lw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -3130,10 +3127,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260722.1",
+        "miniflare": "5.20260811.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260722.1"
+        "workerd": "1.20260811.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -3147,7 +3144,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260722.1"
+        "@cloudflare/workers-types": "^5.20260811.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/support-diagnostics/package.json
+++ b/support-diagnostics/package.json
@@ -14,6 +14,6 @@
     "@types/node": "26.1.1",
     "typescript": "7.0.2",
     "vitest": "4.1.10",
-    "wrangler": "4.115.0"
+    "wrangler": "4.122.0"
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
-[manifest]
-constraints = [{ name = "gitpython", specifier = ">=3.1.55,<4" }]
-
 [[package]]
 name = "anyio"
 version = "4.14.1"
@@ -116,6 +113,7 @@ gui = [
 dev = [
     { name = "black" },
     { name = "briefcase" },
+    { name = "gitpython" },
     { name = "mypy" },
     { name = "pyside6" },
     { name = "ruff" },
@@ -144,6 +142,7 @@ provides-extras = ["gui"]
 dev = [
     { name = "black", specifier = ">=26.5.1,<27" },
     { name = "briefcase", specifier = "==0.4.4" },
+    { name = "gitpython", specifier = ">=3.1.58,<4" },
     { name = "mypy", specifier = ">=2.1.0,<3" },
     { name = "pyside6", specifier = ">=6.7.1,<6.10" },
     { name = "ruff", specifier = ">=0.15.20,<0.16" },
@@ -385,14 +384,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Dependabot npm coverage for `/support-diagnostics`
- make GitPython a direct development dependency and update it to 3.1.59
- update Wrangler to 4.122.0, bringing undici to patched 7.29.0
- refresh the npm lockfile, including patched nanoid 3.3.18

## Why
Dependabot security updates were enabled but could not produce fixes:
- uv reported GitPython as `update_not_possible` while it remained only a constrained transitive dependency
- the support diagnostics npm workspace was not configured for version updates, so Dependabot could not update Wrangler to unlock the patched undici version

## Validation
- `uv lock --check`
- `uv sync --locked --all-groups --python 3.12`
- `uv run python -c "import git; assert git.__version__ == '3.1.59'"`
- `uv run python -m unittest discover -s tests -t .` (1,762 passed, 3 skipped)
- `npm ci`
- `npm run check` (23 passed)
- `npm run deploy:dry-run`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`

## Inspection
JetBrains changed-files inspection was attempted twice internally and remained `UNKNOWN` because the IDE reported a stale project snapshot after project-model changes. It returned no actionable findings and its retry policy prohibited another attempt.
