### PR TITLE
fix(deps): allow compatible uv releases

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -60,11 +60,12 @@ bytes and target digests; a later invocation restores an interrupted prepared
 transaction or finalizes an interrupted committed transaction. A lock refresh,
 metadata failure, or detected concurrent edit fails closed.
 
-`[tool.uv].required-version` in `pyproject.toml` is the single source of truth
-for the exact uv release used locally and by `astral-sh/setup-uv`. Keep that pin
-and `uv.lock` together: changing uv may canonicalize lock data even when the
-resolved dependency graph is unchanged, and that normalization must land in a
-reviewed prerequisite change rather than during release preparation.
+`[tool.uv].required-version` in `pyproject.toml` defines the minimum supported
+uv release. `astral-sh/setup-uv` resolves the newest compatible release, while
+Dependabot can use its supported updater version. A newer uv release may
+canonicalize lock data even when the resolved dependency graph is unchanged;
+that normalization must land in a reviewed prerequisite change rather than
+during release preparation.
 
 The one-time `0.3.0rc1` build `147` to `0.3.0b3` build `148` correction used
 `scripts/release.py recover-beta3` and the exact checked-in evidence in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "==0.11.29"
+required-version = ">=0.11.31"
 default-groups = "all"
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -119,11 +119,11 @@ def skip_remote_verification(_evidence: object) -> None:
 
 
 class ReleaseMetadataTests(unittest.TestCase):
-    def test_repository_pins_uv_for_reproducible_lock_refresh(self) -> None:
+    def test_repository_requires_dependabot_compatible_uv(self) -> None:
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
             pyproject = tomllib.load(handle)
 
-        self.assertEqual(pyproject["tool"]["uv"]["required-version"], "==0.11.29")
+        self.assertEqual(pyproject["tool"]["uv"]["required-version"], ">=0.11.31")
 
     def test_repository_keeps_gui_dependency_out_of_cli_base(self) -> None:
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:


### PR DESCRIPTION
## Summary
- replace the exact uv `0.11.29` pin with a minimum supported version of `>=0.11.31`
- keep release metadata validation aligned with the new compatibility policy
- document that setup-uv selects the newest compatible release while Dependabot can use its supported updater version

## Why
The uv Dependabot updater currently runs uv `0.11.31`. The exact `==0.11.29` requirement caused every uv update job to fail with `tool_version_not_supported`, preventing automated dependency PRs.

## Validation
- `uvx --from uv==0.11.31 uv lock --check`
- `uvx --from uv==0.12.3 uv lock --check`
- `uvx --from uv==0.11.31 uv sync --locked --all-groups --python 3.12`
- `uvx --from uv==0.11.31 uv run python -m unittest tests.test_release.ReleaseMetadataTests` (20 passed)
- `uvx --from uv==0.12.3 uv run python -m unittest tests.test_release.ReleaseMetadataTests.test_repository_requires_dependabot_compatible_uv`
- `git diff --check`

## Inspection
JetBrains changed-files inspection was attempted and remained `UNKNOWN` because the IDE created checkout-local `.idea` metadata during its lifecycle. Those generated files were removed and are not part of this PR; the helper returned no source-backed finding for the changed project files.
