### PR TITLE
Fix two CodeQL string-concatenation alerts

### DIFF
--- a/scripts/qualify_direct_mv_hevc_anchors.py
+++ b/scripts/qualify_direct_mv_hevc_anchors.py
@@ -1567,7 +1567,7 @@ def _render_checklist(receipt: Mapping[str, object], receipt_sha256: str) -> str
                 f"- File: `{candidate['artifact_filename']}`",
                 f"- SHA-256: `{artifact['sha256']}`",
                 "- Automatic validator: ready playback, Stereo · Screen presentation, "
-                "30-second sustained playback, and beginning/middle/end seeks.",
+                + "30-second sustained playback, and beginning/middle/end seeks.",
                 "- Wearer: picture remains visible without corruption or freezes.",
                 "- Wearer: depth is clearly three-dimensional, comfortable, and not inverted.",
                 "- Wearer: dialogue and visible mouth movement remain synchronized at beginning, middle, and end.",
@@ -1578,7 +1578,7 @@ def _render_checklist(receipt: Mapping[str, object], receipt_sha256: str) -> str
     lines.extend(
         [
             "A candidate is not physically qualified until its exported playback report and wearer observations "
-            "are bound to the exact artifact SHA above.",
+            + "are bound to the exact artifact SHA above.",
             "",
         ]
     )


### PR DESCRIPTION
## Summary
- replace implicit adjacent string literal concatenation with explicit concatenation
- preserve generated checklist output exactly
- resolve CodeQL alerts #70 and #71

## Validation
- `uv run python -m unittest tests.test_direct_mv_hevc_anchors` (23 passed)
- `uv run ruff check scripts/qualify_direct_mv_hevc_anchors.py`
- `uv run ruff format --check scripts/qualify_direct_mv_hevc_anchors.py`
- `uv run python -m py_compile scripts/qualify_direct_mv_hevc_anchors.py`
- `git diff --check`

## Inspection
- JetBrains changed `.idea` metadata during its helper-owned lifecycle, so the inspection verdict was inconclusive; those generated changes were removed and are not part of this PR.