### PR TITLE
Add persistent queue foundation

### DIFF
--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -17,6 +17,7 @@ final class ConversionQueueStore: ObservableObject {
     private let writer: ConversionQueueFileWriter?
     private let mutationLock = ConversionQueueMutationLock()
     private var nextGeneration = 0
+    private var documentRevision = 0
 
     init(
         fileURL: URL? = nil,
@@ -55,6 +56,144 @@ final class ConversionQueueStore: ObservableObject {
         document.items
     }
 
+    func moveWaitingItem(_ itemID: UUID, before targetID: UUID) async throws {
+        guard itemID != targetID else {
+            return
+        }
+        try await mutateItems { items in
+            guard let sourceIndex = items.firstIndex(where: { $0.id == itemID }),
+                  let targetIndex = items.firstIndex(where: { $0.id == targetID }),
+                  items[sourceIndex].state == .waiting,
+                  items[targetIndex].state == .waiting
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let affectedGroupIDs = Set([items[sourceIndex].groupID, items[targetIndex].groupID].compactMap { $0 })
+            let sourceRemovalRequests = Self.multiTitleSourceRemovalRequests(
+                in: items,
+                groupIDs: affectedGroupIDs
+            )
+            let item = items.remove(at: sourceIndex)
+            guard let insertionIndex = items.firstIndex(where: { $0.id == targetID }) else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            items.insert(item, at: insertionIndex)
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(
+                in: &items,
+                requests: sourceRemovalRequests
+            )
+        }
+    }
+
+    func moveWaitingItemNext(_ itemID: UUID) async throws {
+        try await mutateItems { items in
+            guard let sourceIndex = items.firstIndex(where: { $0.id == itemID }),
+                  items[sourceIndex].state == .waiting
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let groupIDs = Set(items[sourceIndex].groupID.map { [$0] } ?? [])
+            let sourceRemovalRequests = Self.multiTitleSourceRemovalRequests(in: items, groupIDs: groupIDs)
+            let item = items.remove(at: sourceIndex)
+            let insertionIndex = items.firstIndex(where: { $0.state == .waiting }) ?? min(sourceIndex, items.count)
+            items.insert(item, at: insertionIndex)
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(in: &items, requests: sourceRemovalRequests)
+        }
+    }
+
+    func removeWaitingItems(_ itemIDs: Set<UUID>) async throws -> PersistentQueueRemovalToken {
+        var removedItems: [DurableConversionQueueItem] = []
+        let revision = try await mutateItems { items in
+            let matchingItems = items.filter { itemIDs.contains($0.id) }
+            guard matchingItems.count == itemIDs.count,
+                  matchingItems.allSatisfy({ $0.state == .waiting })
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let affectedGroupIDs = Set(matchingItems.compactMap(\.groupID))
+            let sourceRemovalRequests = Self.multiTitleSourceRemovalRequests(
+                in: items,
+                groupIDs: affectedGroupIDs
+            )
+            removedItems = matchingItems
+            items.removeAll { itemIDs.contains($0.id) }
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(
+                in: &items,
+                requests: sourceRemovalRequests
+            )
+        }
+        return PersistentQueueRemovalToken(items: removedItems, revision: revision)
+    }
+
+    func restoreRemovedItems(_ token: PersistentQueueRemovalToken) async throws {
+        guard !token.isEmpty else {
+            return
+        }
+        try await mutateItems { items in
+            guard token.revision == documentRevision else {
+                throw ConversionQueueStoreError.staleRemovalToken
+            }
+            let existingIDs = Set(items.map(\.id))
+            guard token.items.allSatisfy({ !existingIDs.contains($0.id) }) else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            for item in token.items.sorted(by: { $0.ordinal < $1.ordinal }) {
+                items.insert(item, at: min(item.ordinal, items.count))
+            }
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(
+                in: &items,
+                requests: Self.multiTitleSourceRemovalRequests(
+                    in: items,
+                    groupIDs: Set(token.items.compactMap(\.groupID))
+                )
+            )
+        }
+    }
+
+    func updateWaitingItemIntent(_ itemID: UUID, intent: DurableQueueItemIntent) async throws {
+        try await mutateItems { items in
+            guard let index = items.firstIndex(where: { $0.id == itemID }),
+                  items[index].state == .waiting
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            items[index].intent = intent
+            let groupIDs = Set(items[index].groupID.map { [$0] } ?? [])
+            Self.normalizeMultiTitleSourceRemoval(
+                in: &items,
+                requests: Self.multiTitleSourceRemovalRequests(in: items, groupIDs: groupIDs)
+            )
+        }
+    }
+
+    func clearCompletedItems() async throws -> PersistentQueueRemovalToken {
+        var removedItems: [DurableConversionQueueItem] = []
+        let revision = try await mutateItems { items in
+            let terminalGroupIDs = Set(items.compactMap { item -> UUID? in
+                guard item.state == .completed, let groupID = item.groupID else {
+                    return nil
+                }
+                return items.allSatisfy { candidate in
+                    candidate.groupID != groupID
+                        || candidate.state == .completed
+                        || candidate.state == .stopped
+                } ? groupID : nil
+            })
+            removedItems = items.filter { item in
+                item.state == .completed
+                    && (item.groupID == nil || item.groupID.map(terminalGroupIDs.contains) == true)
+            }
+            let removedIDs = Set(removedItems.map(\.id))
+            items.removeAll { removedIDs.contains($0.id) }
+            Self.normalizeOrdinals(&items)
+        }
+        return PersistentQueueRemovalToken(items: removedItems, revision: revision)
+    }
+
     func replaceItems(_ items: [DurableConversionQueueItem]) async throws {
         await mutationLock.lock()
         do {
@@ -69,7 +208,8 @@ final class ConversionQueueStore: ObservableObject {
         }
     }
 
-    func mutateItems(_ mutation: (inout [DurableConversionQueueItem]) throws -> Void) async throws {
+    @discardableResult
+    func mutateItems(_ mutation: (inout [DurableConversionQueueItem]) throws -> Void) async throws -> Int {
         await mutationLock.lock()
         do {
             var items = document.items
@@ -77,22 +217,24 @@ final class ConversionQueueStore: ObservableObject {
             try validate(items)
             let compactedItems = compacted(items)
             try validate(compactedItems)
-            try await persist(ConversionQueueDocument(items: compactedItems))
+            let revision = try await persist(ConversionQueueDocument(items: compactedItems))
             await mutationLock.unlock()
+            return revision
         } catch {
             await mutationLock.unlock()
             throw error
         }
     }
 
-    private func persist(_ nextDocument: ConversionQueueDocument) async throws {
+    private func persist(_ nextDocument: ConversionQueueDocument) async throws -> Int {
         guard !writesBlocked else {
             throw ConversionQueueStoreError.recoveryRequired
         }
         guard let writer else {
             document = nextDocument
             loadErrorMessage = nil
-            return
+            documentRevision += 1
+            return documentRevision
         }
 
         let encoder = Self.encoder()
@@ -109,6 +251,8 @@ final class ConversionQueueStore: ObservableObject {
             try await writer.write(data, generation: generation)
             document = nextDocument
             loadErrorMessage = nil
+            documentRevision += 1
+            return documentRevision
         } catch let error as ConversionQueueStoreError {
             throw error
         } catch {
@@ -231,6 +375,46 @@ final class ConversionQueueStore: ObservableObject {
         return units
     }
 
+    private static func normalizeOrdinals(_ items: inout [DurableConversionQueueItem]) {
+        for index in items.indices {
+            items[index].ordinal = index
+        }
+    }
+
+    private static func multiTitleSourceRemovalRequests(
+        in items: [DurableConversionQueueItem],
+        groupIDs: Set<UUID>
+    ) -> [UUID: Bool] {
+        Dictionary(uniqueKeysWithValues: groupIDs.map { groupID in
+            let requested = items.contains { item in
+                item.groupID == groupID
+                    && item.origin == .multiTitle
+                    && item.intent.options.job.removeOriginalAfterSuccess
+            }
+            return (groupID, requested)
+        })
+    }
+
+    private static func normalizeMultiTitleSourceRemoval(
+        in items: inout [DurableConversionQueueItem],
+        requests: [UUID: Bool]
+    ) {
+        for (groupID, requested) in requests {
+            let finalWaitingItemID = items.last { item in
+                item.groupID == groupID
+                    && item.origin == .multiTitle
+                    && item.state == .waiting
+            }?.id
+            for index in items.indices where items[index].groupID == groupID
+                && items[index].origin == .multiTitle
+                && items[index].state == .waiting
+            {
+                items[index].intent.options.job.removeOriginalAfterSuccess = requested
+                    && items[index].id == finalWaitingItemID
+            }
+        }
+    }
+
     private func recoverFromUnreadableFile() {
         guard let fileURL else {
             return
@@ -343,6 +527,7 @@ private actor ConversionQueueMutationLock {
 enum ConversionQueueStoreError: LocalizedError, Equatable {
     case invalidDocument
     case recoveryRequired
+    case staleRemovalToken
     case staleWrite
     case unsupportedVersion(Int)
     case writeFailed
@@ -353,6 +538,8 @@ enum ConversionQueueStoreError: LocalizedError, Equatable {
             "The queue contains invalid data."
         case .recoveryRequired:
             "Queue changes are disabled until the original queue data can be protected."
+        case .staleRemovalToken:
+            "The queue changed after these items were removed, so Undo is no longer available."
         case .staleWrite:
             "A newer queue update was already saved."
         case let .unsupportedVersion(version):

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import SwiftUI
 
@@ -48,6 +49,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var liveObservabilityStatus = LiveObservabilityStatus.empty
     @Published private(set) var batchQueue: SourceFolderQueueState?
     @Published private(set) var queueItems: [ConversionQueueItem] = []
+    @Published private(set) var persistentQueueItems: [PersistentQueueItem] = []
+    @Published private(set) var persistentQueueProjectionError: PersistentQueueProjectionError?
+    @Published private(set) var selectedPersistentQueueItemID: UUID?
     @Published private(set) var completedBatchResults: [ConversionResult]?
     @Published private(set) var durableQueueRuntimeDiagnostic: String?
 
@@ -77,6 +81,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private var sourceFolderQueueCompletionPending = false
     private var sourceFolderRecoveryChoices: [UUID: String] = [:]
     private var batchItemDiagnosticJobIDs: [UUID: UUID] = [:]
+    private var durableQueueSubscription: AnyCancellable?
 
     init(
         clientFactory: @escaping ClientFactory = {
@@ -95,6 +100,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             ?? DiagnosticBundleBuilder(storageProbe: diagnosticStorageProbe)
         self.observabilityEventStore = observabilityEventStore
         self.durableQueueStore = durableQueueStore ?? ConversionQueueStore.inMemory()
+        durableQueueSubscription = self.durableQueueStore.$document.sink { [weak self] document in
+            self?.publishPersistentQueueProjection(items: document.items)
+        }
     }
 
     var isRunning: Bool {
@@ -160,12 +168,52 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         durableQueueStore.items
     }
 
+    var selectedPersistentQueueItem: PersistentQueueItem? {
+        guard let selectedPersistentQueueItemID else {
+            return nil
+        }
+        return persistentQueueItems.first(where: { $0.id == selectedPersistentQueueItemID })
+    }
+
     var durableQueueLoadErrorMessage: String? {
         durableQueueStore.loadErrorMessage
     }
 
     var durableQueueWritesBlocked: Bool {
         durableQueueStore.writesBlocked
+    }
+
+    func selectPersistentQueueItem(_ itemID: UUID?) {
+        selectedPersistentQueueItemID = itemID.flatMap { selectedID in
+            persistentQueueItems.contains(where: { $0.id == selectedID }) ? selectedID : nil
+        }
+    }
+
+    func movePersistentQueueItem(_ itemID: UUID, before targetID: UUID) async throws {
+        try await durableQueueStore.moveWaitingItem(itemID, before: targetID)
+    }
+
+    func movePersistentQueueItemNext(_ itemID: UUID) async throws {
+        try await durableQueueStore.moveWaitingItemNext(itemID)
+    }
+
+    func removePersistentQueueItems(_ itemIDs: Set<UUID>) async throws -> PersistentQueueRemovalToken {
+        try await durableQueueStore.removeWaitingItems(itemIDs)
+    }
+
+    func restorePersistentQueueItems(_ token: PersistentQueueRemovalToken) async throws {
+        try await durableQueueStore.restoreRemovedItems(token)
+    }
+
+    func updatePersistentQueueItem(_ itemID: UUID, draft: ConversionDraft) async throws {
+        try await durableQueueStore.updateWaitingItemIntent(
+            itemID,
+            intent: DurableQueueItemIntent(draft: draft)
+        )
+    }
+
+    func clearCompletedPersistentQueueItems() async throws -> PersistentQueueRemovalToken {
+        try await durableQueueStore.clearCompletedItems()
     }
 
     func captureDiagnosticBundle(
@@ -377,34 +425,12 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 return
             }
             do {
-                try await self.durableQueueStore.mutateItems { items in
-                    guard let sourceIndex = items.firstIndex(where: { $0.id == itemID }),
-                          let targetIndex = items.firstIndex(where: { $0.id == targetID }),
-                          items[sourceIndex].groupID == groupID,
-                          items[targetIndex].groupID == groupID,
-                          items[sourceIndex].state == .waiting,
-                          items[targetIndex].state == .waiting
-                    else {
-                        throw ConversionQueueStoreError.invalidDocument
-                    }
-                    let item = items.remove(at: sourceIndex)
-                    let insertionIndex = items.firstIndex(where: { $0.id == targetID }) ?? targetIndex
-                    items.insert(item, at: insertionIndex)
-                    let sourceRemovalRequested = items.contains { queueItem in
-                        queueItem.groupID == groupID
-                            && queueItem.intent.options.job.removeOriginalAfterSuccess
-                    }
-                    let finalWaitingItemID = items.last(where: { queueItem in
-                        queueItem.groupID == groupID && queueItem.state == .waiting
-                    })?.id
-                    for index in items.indices {
-                        items[index].ordinal = index
-                        if items[index].groupID == groupID, items[index].state == .waiting {
-                            items[index].intent.options.job.removeOriginalAfterSuccess = sourceRemovalRequested
-                                && items[index].id == finalWaitingItemID
-                        }
-                    }
+                guard self.currentTitleQueueItems.contains(where: { $0.id == itemID && $0.groupID == groupID }),
+                      self.currentTitleQueueItems.contains(where: { $0.id == targetID && $0.groupID == groupID })
+                else {
+                    throw ConversionQueueStoreError.invalidDocument
                 }
+                try await self.durableQueueStore.moveWaitingItem(itemID, before: targetID)
                 self.publishTitleQueueProjection()
             } catch {
                 self.durableQueueRuntimeDiagnostic = "Queue order could not be saved: \(error.localizedDescription)"
@@ -2011,6 +2037,31 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             return ConversionQueueItem(id: item.id, draft: draft, status: queueStatus(for: item))
         }
+    }
+
+    func publishPersistentQueueProjection(items: [DurableConversionQueueItem]) {
+        let projectedItems: [PersistentQueueItem]
+        do {
+            projectedItems = try items.map(PersistentQueueItem.init(item:))
+        } catch let error as PersistentQueueProjectionError {
+            persistentQueueItems = []
+            selectedPersistentQueueItemID = nil
+            persistentQueueProjectionError = error
+            return
+        } catch {
+            persistentQueueItems = []
+            selectedPersistentQueueItemID = nil
+            persistentQueueProjectionError = .unexpected
+            return
+        }
+        persistentQueueItems = projectedItems
+        persistentQueueProjectionError = nil
+        if let selectedPersistentQueueItemID,
+           persistentQueueItems.contains(where: { $0.id == selectedPersistentQueueItemID })
+        {
+            return
+        }
+        selectedPersistentQueueItemID = persistentQueueItems.first?.id
     }
 
     private func publishCompletedTitleQueueResults() {

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+enum PersistentQueueItemStatus: Equatable {
+    case waiting
+    case inspecting
+    case processing
+    case stopping
+    case interrupted
+    case attention(DurableQueueDecision)
+    case failed(DurableQueueFailure)
+    case completed(DurableQueueResult)
+    case stopped
+    case notStarted
+}
+
+struct PersistentQueueItem: Identifiable, Equatable {
+    let id: UUID
+    let ordinal: Int
+    let groupID: UUID?
+    let origin: DurableQueueItemOrigin
+    let draft: ConversionDraft
+    let status: PersistentQueueItemStatus
+    let attemptCount: Int
+
+    init(item: DurableConversionQueueItem) throws {
+        guard let sourceKind = ConversionSourceKind(rawValue: item.intent.source.kind) else {
+            throw PersistentQueueProjectionError.invalidSourceKind(item.intent.source.kind)
+        }
+        id = item.id
+        ordinal = item.ordinal
+        groupID = item.groupID
+        origin = item.origin
+        draft = ConversionDraft(
+            source: ConversionSource(
+                kind: sourceKind,
+                url: URL(fileURLWithPath: item.intent.source.path),
+                displayName: item.intent.source.displayName,
+                workerSourcePath: item.intent.source.workerSourcePath
+            ),
+            sourceDetails: item.inspection,
+            profile: EncodingProfile(
+                id: item.intent.profile.id,
+                name: item.intent.profile.name,
+                options: item.intent.options.encoding,
+                kind: item.intent.profile.kind,
+                systemImage: "slider.horizontal.3"
+            ),
+            destinationURL: URL(fileURLWithPath: item.intent.destinationPath),
+            options: item.intent.options,
+            selectedTitle: item.intent.selectedTitle
+        )
+        let resolvedStatus: PersistentQueueItemStatus
+        switch item.state {
+        case .waiting:
+            resolvedStatus = .waiting
+        case .inspecting:
+            resolvedStatus = .inspecting
+        case .processing:
+            resolvedStatus = .processing
+        case .stopping:
+            resolvedStatus = .stopping
+        case .interrupted:
+            resolvedStatus = .interrupted
+        case .attention:
+            guard let decision = item.decision else {
+                throw PersistentQueueProjectionError.missingDecision(item.id)
+            }
+            resolvedStatus = .attention(decision)
+        case .failed:
+            guard let failure = item.failure else {
+                throw PersistentQueueProjectionError.missingFailure(item.id)
+            }
+            resolvedStatus = .failed(failure)
+        case .completed:
+            guard let result = item.result else {
+                throw PersistentQueueProjectionError.missingResult(item.id)
+            }
+            resolvedStatus = .completed(result)
+        case .stopped:
+            resolvedStatus = .stopped
+        case .notStarted:
+            resolvedStatus = .notStarted
+        }
+        status = resolvedStatus
+        attemptCount = item.attempts.count
+    }
+
+    var displayName: String {
+        draft.selectedTitle?.name ?? draft.source.displayName
+    }
+
+    var isRestored: Bool {
+        switch status {
+        case .interrupted:
+            true
+        case let .attention(decision):
+            decision.staleAfterRestore
+        default:
+            false
+        }
+    }
+
+    var isEditable: Bool {
+        status == .waiting
+    }
+
+    var canMove: Bool {
+        status == .waiting
+    }
+
+    var canRemove: Bool {
+        status == .waiting
+    }
+
+    var canRetry: Bool {
+        switch status {
+        case .interrupted, .attention:
+            true
+        case let .failed(failure):
+            failure.retryable
+        default:
+            false
+        }
+    }
+}
+
+struct PersistentQueueRemovalToken: Equatable {
+    let items: [DurableConversionQueueItem]
+    let revision: Int
+
+    var isEmpty: Bool {
+        items.isEmpty
+    }
+}
+
+enum PersistentQueueProjectionError: Error, Equatable {
+    case invalidSourceKind(String)
+    case missingDecision(UUID)
+    case missingFailure(UUID)
+    case missingResult(UUID)
+    case unexpected
+}

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -402,6 +402,320 @@ final class ConversionQueueStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueMoveBeforeAndMoveNextPreserveDenseOrdinals() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let completed = makeItem(
+            ordinal: 0,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        let first = makeItem(ordinal: 1, sourcePath: "/tmp/first.mkv")
+        let second = makeItem(ordinal: 2, sourcePath: "/tmp/second.mkv")
+        let third = makeItem(ordinal: 3, sourcePath: "/tmp/third.mkv")
+        try await store.replaceItems([completed, first, second, third])
+
+        try await store.moveWaitingItem(third.id, before: second.id)
+        XCTAssertEqual(store.items.map(\.id), [completed.id, first.id, third.id, second.id])
+
+        try await store.moveWaitingItemNext(second.id)
+        XCTAssertEqual(store.items.map(\.id), [completed.id, second.id, first.id, third.id])
+        XCTAssertEqual(store.items.map(\.ordinal), Array(store.items.indices))
+    }
+
+    @MainActor
+    func testPersistentQueueRemovalTokenRestoresOriginalOrderAndIntents() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let items = (0 ..< 4).map { offset in
+            makeItem(ordinal: offset, sourcePath: "/tmp/source-\(offset).mkv")
+        }
+        try await store.replaceItems(items)
+
+        let token = try await store.removeWaitingItems([items[1].id, items[3].id])
+        XCTAssertEqual(store.items.map(\.id), [items[0].id, items[2].id])
+        XCTAssertEqual(store.items.map(\.ordinal), [0, 1])
+
+        try await store.restoreRemovedItems(token)
+        XCTAssertEqual(store.items, items)
+    }
+
+    @MainActor
+    func testPersistentQueueRemovalTokenRejectsRestoreAfterInterveningMutation() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let items = (0 ..< 3).map { offset in
+            makeItem(ordinal: offset, sourcePath: "/tmp/source-\(offset).mkv")
+        }
+        try await store.replaceItems(items)
+
+        let token = try await store.removeWaitingItems([items[1].id])
+        try await store.moveWaitingItemNext(items[2].id)
+
+        await XCTAssertThrowsErrorAsync(try await store.restoreRemovedItems(token)) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .staleRemovalToken)
+        }
+        XCTAssertEqual(store.items.map(\.id), [items[2].id, items[0].id])
+    }
+
+    @MainActor
+    func testPersistentQueueMutationsRejectNonWaitingItems() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let waiting = makeItem(ordinal: 0, sourcePath: "/tmp/waiting.mkv")
+        let completed = makeItem(
+            ordinal: 1,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        try await store.replaceItems([waiting, completed])
+
+        await XCTAssertThrowsErrorAsync(try await store.moveWaitingItemNext(completed.id)) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .invalidDocument)
+        }
+        await XCTAssertThrowsErrorAsync(try await store.removeWaitingItems([completed.id])) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .invalidDocument)
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await store.updateWaitingItemIntent(completed.id, intent: completed.intent)
+        ) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .invalidDocument)
+        }
+        XCTAssertEqual(store.items, [waiting, completed])
+    }
+
+    @MainActor
+    func testPersistentQueueIntentUpdateAndClearCompletedPersistCanonicalState() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let waiting = makeItem(ordinal: 0, sourcePath: "/tmp/waiting.mkv")
+        let completed = makeItem(
+            ordinal: 1,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        try await store.replaceItems([waiting, completed])
+        var updatedIntent = waiting.intent
+        updatedIntent.destinationPath = "/tmp/New Output"
+
+        try await store.updateWaitingItemIntent(waiting.id, intent: updatedIntent)
+        let token = try await store.clearCompletedItems()
+
+        XCTAssertEqual(store.items.count, 1)
+        XCTAssertEqual(store.items[0].intent.destinationPath, "/tmp/New Output")
+        XCTAssertEqual(store.items[0].ordinal, 0)
+        XCTAssertEqual(token.items, [completed])
+    }
+
+    @MainActor
+    func testClearCompletedPreservesCompletedSiblingsInActionableGroup() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let groupID = UUID()
+        let completed = makeItem(
+            ordinal: 0,
+            groupID: groupID,
+            origin: .sourceFolder,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        let failed = makeItem(
+            ordinal: 1,
+            groupID: groupID,
+            origin: .sourceFolder,
+            sourcePath: "/tmp/failed.mkv",
+            state: .failed,
+            failure: DurableQueueFailure(
+                code: "fixture_failure",
+                message: "Fixture failure",
+                details: nil,
+                retryable: true
+            )
+        )
+        let standaloneCompleted = makeItem(
+            ordinal: 2,
+            sourcePath: "/tmp/standalone.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/standalone.mov")
+        )
+        try await store.replaceItems([completed, failed, standaloneCompleted])
+
+        let token = try await store.clearCompletedItems()
+
+        XCTAssertEqual(store.items.map(\.id), [completed.id, failed.id])
+        XCTAssertEqual(store.items.map(\.ordinal), [0, 1])
+        XCTAssertEqual(token.items, [standaloneCompleted])
+    }
+
+    @MainActor
+    func testClearCompletedRemovesCompletedSiblingFromFullyTerminalGroup() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let groupID = UUID()
+        let completed = makeItem(
+            ordinal: 0,
+            groupID: groupID,
+            origin: .sourceFolder,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        let stopped = makeItem(
+            ordinal: 1,
+            groupID: groupID,
+            origin: .sourceFolder,
+            sourcePath: "/tmp/stopped.mkv",
+            state: .stopped
+        )
+        try await store.replaceItems([completed, stopped])
+
+        let token = try await store.clearCompletedItems()
+
+        XCTAssertEqual(store.items.map(\.id), [stopped.id])
+        XCTAssertEqual(store.items.map(\.ordinal), [0])
+        XCTAssertEqual(token.items, [completed])
+    }
+
+    @MainActor
+    func testClearCompletedRemovalTokenRestoresCompletedItems() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let waiting = makeItem(ordinal: 0, sourcePath: "/tmp/waiting.mkv")
+        let completed = makeItem(
+            ordinal: 1,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        try await store.replaceItems([waiting, completed])
+
+        let token = try await store.clearCompletedItems()
+        try await store.restoreRemovedItems(token)
+
+        XCTAssertEqual(store.items, [waiting, completed])
+    }
+
+    @MainActor
+    func testPersistentQueueMutationsPreserveFinalMultiTitleSourceRemoval() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let groupID = UUID()
+        var options = ConversionOptions()
+        options.job.removeOriginalAfterSuccess = true
+        let first = makeItem(
+            ordinal: 0,
+            groupID: groupID,
+            origin: .multiTitle,
+            sourcePath: "/tmp/feature.iso",
+            options: options
+        )
+        let second = makeItem(
+            ordinal: 1,
+            groupID: groupID,
+            origin: .multiTitle,
+            sourcePath: "/tmp/feature.iso",
+            options: options
+        )
+        let third = makeItem(
+            ordinal: 2,
+            groupID: groupID,
+            origin: .multiTitle,
+            sourcePath: "/tmp/feature.iso",
+            options: options
+        )
+        try await store.replaceItems([first, second, third])
+
+        try await store.moveWaitingItem(third.id, before: second.id)
+        XCTAssertEqual(
+            store.items.map { $0.intent.options.job.removeOriginalAfterSuccess },
+            [false, false, true]
+        )
+
+        let token = try await store.removeWaitingItems([second.id])
+        XCTAssertEqual(
+            store.items.map { $0.intent.options.job.removeOriginalAfterSuccess },
+            [false, true]
+        )
+
+        try await store.restoreRemovedItems(token)
+        XCTAssertEqual(
+            store.items.map { $0.intent.options.job.removeOriginalAfterSuccess },
+            [false, false, true]
+        )
+    }
+
+    @MainActor
+    func testPersistentQueueCrossGroupMovePreservesEachSourceRemovalOwner() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let firstGroupID = UUID()
+        let secondGroupID = UUID()
+        var options = ConversionOptions()
+        options.job.removeOriginalAfterSuccess = true
+        let firstGroup = (0 ..< 2).map { offset in
+            makeItem(
+                ordinal: offset,
+                groupID: firstGroupID,
+                origin: .multiTitle,
+                sourcePath: "/tmp/first.iso",
+                options: options
+            )
+        }
+        let secondGroup = (0 ..< 2).map { offset in
+            makeItem(
+                ordinal: 2 + offset,
+                groupID: secondGroupID,
+                origin: .multiTitle,
+                sourcePath: "/tmp/second.iso",
+                options: options
+            )
+        }
+        try await store.replaceItems(firstGroup + secondGroup)
+
+        try await store.moveWaitingItem(firstGroup[0].id, before: secondGroup[1].id)
+
+        for groupID in [firstGroupID, secondGroupID] {
+            let groupItems = store.items.filter { $0.groupID == groupID }
+            XCTAssertEqual(
+                groupItems.filter { $0.intent.options.job.removeOriginalAfterSuccess }.map(\.id),
+                [try XCTUnwrap(groupItems.last?.id)]
+            )
+        }
+        XCTAssertEqual(store.items.map(\.ordinal), Array(store.items.indices))
+    }
+
+    @MainActor
+    func testPersistentQueueRestoreRejectsTokenWhoseItemAlreadyExists() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let item = makeItem(ordinal: 0)
+        try await store.replaceItems([item])
+        let token = try await store.removeWaitingItems([item.id])
+        try await store.restoreRemovedItems(token)
+
+        await XCTAssertThrowsErrorAsync(try await store.restoreRemovedItems(token)) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .staleRemovalToken)
+        }
+        XCTAssertEqual(store.items, [item])
+    }
+
+    @MainActor
+    func testPersistentQueueMutationsFailClosedWhenWritesAreBlocked() async throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("queue.json")
+        let originalData = Data(#"{"items":[],"version":2}"#.utf8)
+        try originalData.write(to: fileURL)
+        let store = ConversionQueueStore(fileURL: fileURL)
+
+        await XCTAssertThrowsErrorAsync(try await store.moveWaitingItemNext(UUID())) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .invalidDocument)
+        }
+        await XCTAssertThrowsErrorAsync(try await store.removeWaitingItems([UUID()])) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .invalidDocument)
+        }
+        await XCTAssertThrowsErrorAsync(try await store.clearCompletedItems()) { error in
+            XCTAssertEqual(error as? ConversionQueueStoreError, .recoveryRequired)
+        }
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalData)
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    @MainActor
     func testCompactionDropsOldestTerminalGroupsAndRenumbersOrdinals() async throws {
         let store = ConversionQueueStore.inMemory()
         let groupIDs = (0 ..< 7).map { _ in UUID() }

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -2179,6 +2179,120 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueProjectionIncludesEveryOriginAndPreservesSelection() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(durableQueueStore: queueStore)
+        let groupID = UUID()
+        let items = [
+            makePersistentQueueFixture(ordinal: 0, origin: .singleSource, state: .waiting),
+            makePersistentQueueFixture(ordinal: 1, groupID: groupID, origin: .multiTitle, state: .processing),
+            makePersistentQueueFixture(ordinal: 2, groupID: UUID(), origin: .sourceFolder, state: .interrupted),
+        ]
+
+        try await queueStore.replaceItems(items)
+        viewModel.selectPersistentQueueItem(items[2].id)
+        try await queueStore.updateWaitingItemIntent(items[0].id, intent: items[0].intent)
+
+        XCTAssertEqual(viewModel.persistentQueueItems.map(\.id), items.map(\.id))
+        XCTAssertEqual(viewModel.persistentQueueItems.map(\.origin), [.singleSource, .multiTitle, .sourceFolder])
+        XCTAssertEqual(viewModel.selectedPersistentQueueItemID, items[2].id)
+        XCTAssertTrue(viewModel.selectedPersistentQueueItem?.isRestored == true)
+        XCTAssertEqual(viewModel.queueItems, [])
+        XCTAssertNil(viewModel.batchQueue)
+    }
+
+    @MainActor
+    func testPersistentQueueProjectionPreservesEveryDurableState() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(durableQueueStore: queueStore)
+        let states = DurableQueueItemState.allCases
+        let items = states.enumerated().map { offset, state in
+            var item = makePersistentQueueFixture(ordinal: offset, state: state)
+            if state == .attention {
+                item.decision = DurableQueueDecision(
+                    identifier: "subtitle_decision_required",
+                    prompt: "Retry without subtitles?",
+                    choices: ["retry_without_subtitles"],
+                    staleAfterRestore: true
+                )
+            }
+            if state == .failed {
+                item.failure = DurableQueueFailure(
+                    code: "fixture_failure",
+                    message: "Fixture failure",
+                    details: nil,
+                    retryable: true
+                )
+            }
+            if state == .completed {
+                item.result = DurableQueueResult(outputPath: "/tmp/completed.mov")
+            }
+            return item
+        }
+
+        try await queueStore.replaceItems(items)
+
+        XCTAssertEqual(viewModel.persistentQueueItems.count, states.count)
+        for (projected, state) in zip(viewModel.persistentQueueItems, states) {
+            switch (projected.status, state) {
+            case (.waiting, .waiting),
+                 (.inspecting, .inspecting),
+                 (.processing, .processing),
+                 (.stopping, .stopping),
+                 (.interrupted, .interrupted),
+                 (.attention, .attention),
+                 (.failed, .failed),
+                 (.completed, .completed),
+                 (.stopped, .stopped),
+                 (.notStarted, .notStarted):
+                break
+            default:
+                XCTFail("Unexpected projection \(projected.status) for state \(state)")
+            }
+        }
+        XCTAssertTrue(viewModel.persistentQueueItems.first(where: { item in
+            if case .attention = item.status {
+                return true
+            }
+            return false
+        })?.isRestored == true)
+    }
+
+    @MainActor
+    func testPersistentQueueProjectionFailsClosedForInvalidDurableItem() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(durableQueueStore: queueStore)
+        let validItem = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        var invalidItem = makePersistentQueueFixture(ordinal: 1, state: .completed)
+        invalidItem.result = nil
+
+        viewModel.publishPersistentQueueProjection(items: [validItem, invalidItem])
+
+        XCTAssertEqual(viewModel.persistentQueueItems, [])
+        XCTAssertNil(viewModel.selectedPersistentQueueItemID)
+        XCTAssertEqual(viewModel.persistentQueueProjectionError, .missingResult(invalidItem.id))
+    }
+
+    @MainActor
+    func testPersistentQueueProjectionSelectionFallsBackAfterRemoval() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(durableQueueStore: queueStore)
+        let first = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        let second = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        try await queueStore.replaceItems([first, second])
+        viewModel.selectPersistentQueueItem(second.id)
+
+        let token = try await viewModel.removePersistentQueueItems([second.id])
+
+        XCTAssertEqual(viewModel.selectedPersistentQueueItemID, first.id)
+        XCTAssertEqual(viewModel.persistentQueueItems.map(\.id), [first.id])
+
+        try await viewModel.restorePersistentQueueItems(token)
+        XCTAssertEqual(viewModel.persistentQueueItems.map(\.id), [first.id, second.id])
+        XCTAssertEqual(viewModel.selectedPersistentQueueItemID, first.id)
+    }
+
+    @MainActor
     func testDurableTitleQueuePersistsSynchronousLaunchFailure() async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -2615,6 +2729,31 @@ final class ConversionViewModelTests: XCTestCase {
                 result: DurableQueueResult(outputPath: "/tmp/history-\(offset).mov")
             )
         }
+    }
+
+    private func makePersistentQueueFixture(
+        ordinal: Int,
+        groupID: UUID? = nil,
+        origin: DurableQueueItemOrigin = .singleSource,
+        state: DurableQueueItemState,
+        id: UUID = UUID()
+    ) -> DurableConversionQueueItem {
+        let sourceURL = URL(fileURLWithPath: "/tmp/persistent-\(ordinal).mkv")
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: sourceURL),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/Output"),
+            options: ConversionOptions()
+        )
+        return DurableConversionQueueItem(
+            id: id,
+            ordinal: ordinal,
+            groupID: groupID,
+            origin: origin,
+            intent: DurableQueueItemIntent(draft: draft),
+            state: state
+        )
     }
 
     private func withTemporarySource(_ operation: @MainActor (URL) async throws -> Void) async throws {


### PR DESCRIPTION
## Summary
- add a canonical all-item projection for durable queue rows across every origin and state
- add serialized waiting-item move, move-next, remove/Undo, edit, and clear-completed store APIs
- preserve multi-title source-removal ownership and fail closed for invalid projection data or stale Undo tokens

## Scope
This is the staged **544a** foundation only. It makes no visual changes and does not adopt the new queue for runtime worker consumption. Those remain follow-ups under #544.

## Validation
- `xcodebuild -project macos/BluRayToVisionPro.xcodeproj -scheme BluRayToVisionPro -configuration Debug -sdk macosx -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO` — 418 tests passed
- `uv run python -m unittest discover -s tests -t .` — 1,762 tests passed, 3 skipped
- `git diff --check`
- independent Opus final review: approved, no blockers
- JetBrains changed-files inspection: inconclusive because IntelliJ created `.idea` metadata during helper lifecycle; generated changes were removed and are not part of this PR

Refs #544
