### PR TITLE
Implement repetition-first conversion setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ but this feature does not establish the cause of the output-size report in
 issue #202 and does not claim to fix any separately reported media-specific
 stall. Those observations remain separate diagnostic work.
 
+The native app keeps conversion setup centered on the selected source,
+Profile, destination, and estimated result. Use **Edit…** for per-conversion
+changes, then either apply them to the current conversion, update a custom
+Profile, or save a new Profile. If a source and Profile require a choice before
+they can run together, resolve it inline or use **Add to Queue for Review**;
+the queue preserves those decisions for each source and will not start while
+any item still needs attention. Remembered choices are scoped to the matching
+source and Profile and can be forgotten from the resolution prompt.
+
 ## Terminal Usage
 
 Navigate to the tool's directory in your terminal and execute the command with the required and optional parameters:

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -84,7 +84,7 @@ struct BluRayToVisionProApp: App {
                 resolutionMemoryStore: resolutionMemoryStore,
                 capabilities: capabilities
             )
-                .frame(minWidth: 1_080, minHeight: 680)
+                .frame(minWidth: 820, minHeight: 680)
                 .background(
                     WindowAccessor { window in
                         appDelegate.attach(window: window, workCoordinator: workCoordinator)

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -4,6 +4,21 @@ enum AppWindowID {
     static let settings = "settings"
 }
 
+struct ConversionSourceSelectionAction {
+    let perform: () -> Void
+}
+
+private struct ConversionSourceSelectionActionKey: FocusedValueKey {
+    typealias Value = ConversionSourceSelectionAction
+}
+
+extension FocusedValues {
+    var conversionSourceSelectionAction: ConversionSourceSelectionAction? {
+        get { self[ConversionSourceSelectionActionKey.self] }
+        set { self[ConversionSourceSelectionActionKey.self] = newValue }
+    }
+}
+
 @main
 struct BluRayToVisionProApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -82,14 +97,7 @@ struct BluRayToVisionProApp: App {
         .commands {
             SettingsWindowCommands()
             UpdateCommands(updater: updater)
-
-            CommandGroup(replacing: .newItem) {
-                Button("Add Source…") {
-                    chooseSource()
-                }
-                .keyboardShortcut("o")
-                .disabled(!viewModel.canSelectSource || previewViewModel.hasActiveWorker)
-            }
+            SourceCommands()
         }
 
         Window("Settings", id: AppWindowID.settings) {
@@ -103,15 +111,19 @@ struct BluRayToVisionProApp: App {
         .windowResizability(.contentMinSize)
     }
 
-    @MainActor
-    private func chooseSource() {
-        guard viewModel.canSelectSource, !previewViewModel.hasActiveWorker else {
-            return
+}
+
+private struct SourceCommands: Commands {
+    @FocusedValue(\.conversionSourceSelectionAction) private var sourceSelectionAction
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {
+            Button("Add Source…") {
+                sourceSelectionAction?.perform()
+            }
+            .keyboardShortcut("o")
+            .disabled(sourceSelectionAction == nil)
         }
-        guard let sourceURL = SourcePicker.chooseExistingSource() else {
-            return
-        }
-        viewModel.selectSource(sourceURL)
     }
 }
 

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -27,7 +27,8 @@ struct BluRayToVisionProApp: App {
     @StateObject private var diagnosticReportViewModel: DiagnosticReportViewModel
     @StateObject private var updater: UpdateController
     @StateObject private var settings = AppSettings()
-    @StateObject private var profileStore = ProfileStore()
+    @StateObject private var profileStore: ProfileStore
+    @StateObject private var resolutionMemoryStore: ResolutionMemoryStore
     @StateObject private var durableQueueStore: ConversionQueueStore
 
     private let capabilities = AppCapabilities.current
@@ -37,6 +38,8 @@ struct BluRayToVisionProApp: App {
 
     init() {
         let observabilityEventStore = ObservabilityEventStore.automatic()
+        let resolutionMemoryStore = ResolutionMemoryStore()
+        let profileStore = ProfileStore(resolutionMemoryStore: resolutionMemoryStore)
         let durableQueueStore = ConversionQueueStore()
         let viewModel = ConversionViewModel(
             observabilityEventStore: observabilityEventStore,
@@ -62,6 +65,8 @@ struct BluRayToVisionProApp: App {
         _diagnosticReportViewModel = StateObject(wrappedValue: diagnosticReportViewModel)
         _updater = StateObject(wrappedValue: UpdateController(installPostponer: workCoordinator))
         _durableQueueStore = StateObject(wrappedValue: durableQueueStore)
+        _profileStore = StateObject(wrappedValue: profileStore)
+        _resolutionMemoryStore = StateObject(wrappedValue: resolutionMemoryStore)
         self.workCoordinator = workCoordinator
         self.observabilityEventStore = observabilityEventStore
         suppressDefaultLaunch = AppDelegate.isAutomationSmoke(arguments: ProcessInfo.processInfo.arguments)
@@ -76,6 +81,7 @@ struct BluRayToVisionProApp: App {
                 diagnosticReportViewModel: diagnosticReportViewModel,
                 settings: settings,
                 profileStore: profileStore,
+                resolutionMemoryStore: resolutionMemoryStore,
                 capabilities: capabilities
             )
                 .frame(minWidth: 1_080, minHeight: 680)

--- a/macos/BluRayToVisionPro/Feature/AppSettings.swift
+++ b/macos/BluRayToVisionPro/Feature/AppSettings.swift
@@ -11,6 +11,7 @@ final class AppSettings: ObservableObject {
         static let showTechnicalDetails = "native.showTechnicalDetails"
         static let keepIntermediateFiles = "native.keepIntermediateFiles"
         static let useSoftwareEncoder = "native.useSoftwareEncoder"
+        static let standardMovieRenameNoticeAcknowledged = "native.standardMovieRenameNoticeAcknowledged"
     }
 
     private let defaults: UserDefaults
@@ -53,6 +54,8 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(useSoftwareEncoder, forKey: Key.useSoftwareEncoder) }
     }
 
+    @Published private(set) var hasAcknowledgedStandardMovieRenameNotice: Bool
+
     init(
         defaults: UserDefaults = .standard,
         homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -72,6 +75,9 @@ final class AppSettings: ObservableObject {
             legacyKeepStageFiles: defaults.object(forKey: Key.keepIntermediateFiles) as? Bool ?? false
         )
         useSoftwareEncoder = defaults.object(forKey: Key.useSoftwareEncoder) as? Bool ?? false
+        hasAcknowledgedStandardMovieRenameNotice = defaults.bool(
+            forKey: Key.standardMovieRenameNoticeAcknowledged
+        )
     }
 
     func resetAdvancedSettings() {
@@ -82,5 +88,10 @@ final class AppSettings: ObservableObject {
 
     func resetDestination() {
         destinationURL = fallbackDestinationURL
+    }
+
+    func acknowledgeStandardMovieRenameNotice() {
+        hasAcknowledgedStandardMovieRenameNotice = true
+        defaults.set(true, forKey: Key.standardMovieRenameNoticeAcknowledged)
     }
 }

--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -170,6 +170,28 @@ final class ConversionQueueStore: ObservableObject {
         }
     }
 
+    func resolveWaitingItems(
+        _ itemIDs: Set<UUID>,
+        intents: [UUID: DurableQueueItemIntent],
+        trace: DurableQueueResolutionTrace
+    ) async throws {
+        guard itemIDs == Set(intents.keys), !itemIDs.isEmpty else {
+            throw ConversionQueueStoreError.invalidDocument
+        }
+        try await mutateItems { items in
+            for index in items.indices where itemIDs.contains(items[index].id) {
+                guard items[index].state == .waiting, let intent = intents[items[index].id] else {
+                    throw ConversionQueueStoreError.invalidDocument
+                }
+                items[index].intent = intent
+                items[index].resolutionTrace = trace
+            }
+            guard Set(items.filter { itemIDs.contains($0.id) }.map(\.id)) == itemIDs else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+        }
+    }
+
     func clearCompletedItems() async throws -> PersistentQueueRemovalToken {
         var removedItems: [DurableConversionQueueItem] = []
         let revision = try await mutateItems { items in
@@ -278,9 +300,6 @@ final class ConversionQueueStore: ObservableObject {
                 writesBlocked = true
                 loadErrorMessage = "Queue data version \(version) is newer than this app. Queue changes are disabled to protect it."
                 return
-            }
-            guard version == ConversionQueueDocument.currentVersion else {
-                throw ConversionQueueStoreError.unsupportedVersion(version)
             }
             let loadedDocument = try Self.decoder().decode(ConversionQueueDocument.self, from: data)
             try validate(loadedDocument.items)

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -354,7 +354,13 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     func startConversionQueue(drafts: [ConversionDraft]) {
-        guard !hasActiveWork, let firstDraft = drafts.first
+        guard !hasActiveWork,
+              !drafts.isEmpty,
+              drafts.allSatisfy({ draft in
+                  if case .failure = RouteQualityEngine.validate(draft.options) { return false }
+                  return true
+              }),
+              let firstDraft = drafts.first
         else {
             return
         }

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -354,33 +354,59 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     func startConversionQueue(drafts: [ConversionDraft]) {
+        startConversionQueue(
+            entries: drafts.map { QueueStartEntry(id: UUID(), draft: $0, resolutionTrace: nil) }
+        )
+    }
+
+    func startConversionQueue(admissionItems: [SetupQueueAdmissionItem]) {
+        let entries = admissionItems.compactMap { item -> QueueStartEntry? in
+            guard item.state == .waiting, let draft = item.currentDraft else {
+                return nil
+            }
+            return QueueStartEntry(id: item.id, draft: draft, resolutionTrace: item.resolutionTrace)
+        }
+        guard entries.count == admissionItems.count else {
+            return
+        }
+        startConversionQueue(entries: entries)
+    }
+
+    private struct QueueStartEntry {
+        let id: UUID
+        let draft: ConversionDraft
+        let resolutionTrace: DurableQueueResolutionTrace?
+    }
+
+    private func startConversionQueue(entries: [QueueStartEntry]) {
         guard !hasActiveWork,
-              !drafts.isEmpty,
-              drafts.allSatisfy({ draft in
-                  if case .failure = RouteQualityEngine.validate(draft.options) { return false }
+              !entries.isEmpty,
+              entries.allSatisfy({ entry in
+                  if case .failure = RouteQualityEngine.validate(entry.draft.options) { return false }
                   return true
               }),
-              let firstDraft = drafts.first
+              let firstEntry = entries.first
         else {
             return
         }
-        if drafts.count == 1 {
-            startConversion(draft: firstDraft)
+        if entries.count == 1 {
+            startConversion(draft: firstEntry.draft)
             return
         }
         let groupID = UUID()
-        let removeOriginalAfterFinalSuccess = drafts.contains { $0.options.job.removeOriginalAfterSuccess }
-        let normalizedDrafts = drafts.enumerated().map { offset, draft in
-            var options = draft.options
-            options.job.removeOriginalAfterSuccess = removeOriginalAfterFinalSuccess && offset == drafts.count - 1
-            return ConversionDraft(
-                source: draft.source,
-                sourceDetails: draft.sourceDetails,
-                profile: draft.profile,
-                destinationURL: draft.destinationURL,
+        let removeOriginalAfterFinalSuccess = entries.contains { $0.draft.options.job.removeOriginalAfterSuccess }
+        let normalizedEntries = entries.enumerated().map { offset, entry in
+            var options = entry.draft.options
+            options.job.removeOriginalAfterSuccess = removeOriginalAfterFinalSuccess && offset == entries.count - 1
+            let draft = ConversionDraft(
+                source: entry.draft.source,
+                sourceDetails: entry.draft.sourceDetails,
+                profile: entry.draft.profile,
+                destinationURL: entry.draft.destinationURL,
                 options: options,
-                selectedTitle: draft.selectedTitle
+                selectedTitle: entry.draft.selectedTitle
             )
+            return QueueStartEntry(id: entry.id, draft: draft, resolutionTrace: entry.resolutionTrace)
         }
         activeQueueItemID = nil
         titleQueueGroupID = groupID
@@ -394,13 +420,17 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             do {
                 try await self.durableQueueStore.mutateItems { items in
                     let startingOrdinal = items.count
-                    items.append(contentsOf: normalizedDrafts.enumerated().map { offset, draft in
+                    items.append(contentsOf: normalizedEntries.enumerated().map { offset, entry in
                         DurableConversionQueueItem(
+                            id: entry.id,
                             ordinal: startingOrdinal + offset,
                             groupID: groupID,
-                            origin: .multiTitle,
-                            intent: DurableQueueItemIntent(draft: draft),
-                            inspection: draft.sourceDetails
+                            origin: entry.draft.source.kind == .sourceFolder
+                                ? .sourceFolder
+                                : (entry.draft.selectedTitle == nil ? .singleSource : .multiTitle),
+                            intent: DurableQueueItemIntent(draft: entry.draft),
+                            inspection: entry.draft.sourceDetails,
+                            resolutionTrace: entry.resolutionTrace
                         )
                     })
                 }

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -54,6 +54,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var selectedPersistentQueueItemID: UUID?
     @Published private(set) var completedBatchResults: [ConversionResult]?
     @Published private(set) var durableQueueRuntimeDiagnostic: String?
+    @Published private(set) var setupQueueStartFailureItemIDs: Set<UUID> = []
 
     private let clientFactory: ClientFactory
     private let diagnosticClock: () -> Date
@@ -70,6 +71,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private var pendingBatchContinuation: Task<Void, Never>?
     private var actionsWaitingForIdle: [() -> Void] = []
     private var activeQueueItemID: UUID?
+    private var activeSetupQueueItemIDs: Set<UUID> = []
     private var titleQueueGroupID: UUID?
     private var titleQueueStopRequested = false
     private var pendingTitleQueueTransition: Task<Void, Never>?
@@ -354,12 +356,14 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     func startConversionQueue(drafts: [ConversionDraft]) {
-        startConversionQueue(
-            entries: drafts.map { QueueStartEntry(id: UUID(), draft: $0, resolutionTrace: nil) }
+        _ = startConversionQueue(
+            entries: drafts.map { QueueStartEntry(id: UUID(), draft: $0, resolutionTrace: nil) },
+            preserveSingleEntry: false
         )
     }
 
-    func startConversionQueue(admissionItems: [SetupQueueAdmissionItem]) {
+    @discardableResult
+    func startConversionQueue(admissionItems: [SetupQueueAdmissionItem]) -> Bool {
         let entries = admissionItems.compactMap { item -> QueueStartEntry? in
             guard item.state == .waiting, let draft = item.currentDraft else {
                 return nil
@@ -367,9 +371,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return QueueStartEntry(id: item.id, draft: draft, resolutionTrace: item.resolutionTrace)
         }
         guard entries.count == admissionItems.count else {
-            return
+            return false
         }
-        startConversionQueue(entries: entries)
+        return startConversionQueue(entries: entries, preserveSingleEntry: true)
     }
 
     private struct QueueStartEntry {
@@ -378,8 +382,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         let resolutionTrace: DurableQueueResolutionTrace?
     }
 
-    private func startConversionQueue(entries: [QueueStartEntry]) {
+    private func startConversionQueue(entries: [QueueStartEntry], preserveSingleEntry: Bool) -> Bool {
         guard !hasActiveWork,
+              !durableQueueStore.writesBlocked,
               !entries.isEmpty,
               entries.allSatisfy({ entry in
                   if case .failure = RouteQualityEngine.validate(entry.draft.options) { return false }
@@ -387,11 +392,15 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
               }),
               let firstEntry = entries.first
         else {
-            return
+            return false
         }
-        if entries.count == 1 {
+        if entries.count == 1, !preserveSingleEntry {
             startConversion(draft: firstEntry.draft)
-            return
+            return true
+        }
+        if preserveSingleEntry {
+            activeSetupQueueItemIDs = Set(entries.map(\.id))
+            setupQueueStartFailureItemIDs = []
         }
         let groupID = UUID()
         let removeOriginalAfterFinalSuccess = entries.contains { $0.draft.options.job.removeOriginalAfterSuccess }
@@ -445,6 +454,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 self.failClosedTitleQueuePersistence(error)
             }
         }
+        return true
     }
 
     func moveWaitingQueueItem(_ itemID: UUID, before targetID: UUID) -> Bool {
@@ -512,6 +522,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             handleSynchronousRunFailure(mode)
             return false
         }
+        if case .titleQueueConversion = mode, let inspection = draft.sourceDetails {
+            state.prepareQueuedConversion(sourceURL: draft.source.url, inspection: inspection)
+        }
         let job = WorkerJobSpec(draft: draft, jobID: jobID)
         do {
             try state.begin(jobID: job.jobID, operationKind: .conversion)
@@ -570,6 +583,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         for draft: ConversionDraft,
         mode: ActiveRunMode
     ) -> Bool {
+        if case .titleQueueConversion = mode {
+            return draft.sourceDetails != nil
+        }
         guard state.sourceURL == draft.source.url, state.result != nil else {
             return false
         }
@@ -577,8 +593,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         case let .batchConversion(itemID):
             return batchQueue?.activeItemID == itemID
                 && batchQueue?.activeItem?.source == draft.source
-        case .singleConversion, .titleQueueConversion:
+        case .singleConversion:
             return source == draft.source
+        case .titleQueueConversion:
+            return false
         case .singleInspection, .batchInspection:
             return false
         }
@@ -1706,7 +1724,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return []
         }
         return durableQueueStore.items
-            .filter { $0.groupID == titleQueueGroupID && $0.origin == .multiTitle }
+            .filter { $0.groupID == titleQueueGroupID && $0.origin != .sourceFolder }
             .sorted { $0.ordinal < $1.ordinal }
     }
 
@@ -1858,6 +1876,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
         } catch {
             durableQueueRuntimeDiagnostic = "Queue state could not be saved after the conversion finished: \(error.localizedDescription)"
+            publishSetupQueueStartFailure()
             activeQueueItemID = nil
             publishCompletedTitleQueueResults()
             titleQueueGroupID = nil
@@ -2108,6 +2127,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return result
         }
         completedBatchResults = results.isEmpty ? nil : results
+        activeSetupQueueItemIDs = []
     }
 
     private func queueStatus(for item: DurableConversionQueueItem) -> ConversionQueueItemStatus {
@@ -2134,10 +2154,18 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     private func failClosedTitleQueuePersistence(_ error: Error) {
         durableQueueRuntimeDiagnostic = "Queue changes are unavailable: \(error.localizedDescription)"
+        publishSetupQueueStartFailure()
         activeQueueItemID = nil
         titleQueueGroupID = nil
         state.failTransport(message: durableQueueRuntimeDiagnostic ?? "Queue changes are unavailable.", retryable: false)
         runDeferredActionsIfIdle()
+    }
+
+    private func publishSetupQueueStartFailure() {
+        if !activeSetupQueueItemIDs.isEmpty {
+            setupQueueStartFailureItemIDs = activeSetupQueueItemIDs
+            activeSetupQueueItemIDs = []
+        }
     }
 
     private func resetQueue() {
@@ -2150,6 +2178,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         sourceFolderQueueCompletionPending = false
         sourceFolderRecoveryChoices.removeAll()
         durableQueueRuntimeDiagnostic = nil
+        activeSetupQueueItemIDs = []
+        setupQueueStartFailureItemIDs = []
         completedBatchResults = nil
     }
 

--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -13,6 +13,7 @@ final class ProfileStore: ObservableObject {
     private let fileURL: URL
     private let idGenerator: () -> UUID
     private let dataWriter: (Data, URL) throws -> Void
+    private let resolutionMemoryStore: ResolutionMemoryStore?
     private var writesBlocked = false
 
     init(
@@ -21,12 +22,14 @@ final class ProfileStore: ObservableObject {
         idGenerator: @escaping () -> UUID = UUID.init,
         dataWriter: @escaping (Data, URL) throws -> Void = { data, url in
             try data.write(to: url, options: .atomic)
-        }
+        },
+        resolutionMemoryStore: ResolutionMemoryStore? = nil
     ) {
         self.fileManager = fileManager
         self.fileURL = fileURL ?? Self.defaultFileURL(fileManager: fileManager)
         self.idGenerator = idGenerator
         self.dataWriter = dataWriter
+        self.resolutionMemoryStore = resolutionMemoryStore
         loadProfiles()
     }
 
@@ -118,6 +121,7 @@ final class ProfileStore: ObservableObject {
         }
         let updatedProfiles = customProfiles.filter { $0.id != identifier }
         try persist(updatedProfiles)
+        try resolutionMemoryStore?.removeProfileMemories(profileID: identifier)
         customProfiles = updatedProfiles
     }
 

--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -120,8 +120,16 @@ final class ProfileStore: ObservableObject {
             throw ProfileStoreError.builtInProfileIsReadOnly
         }
         let updatedProfiles = customProfiles.filter { $0.id != identifier }
-        try persist(updatedProfiles)
+        let originalMemoryEntries = resolutionMemoryStore?.entries
         try resolutionMemoryStore?.removeProfileMemories(profileID: identifier)
+        do {
+            try persist(updatedProfiles)
+        } catch {
+            if let originalMemoryEntries {
+                try? resolutionMemoryStore?.replaceEntriesForTransaction(originalMemoryEntries)
+            }
+            throw error
+        }
         customProfiles = updatedProfiles
     }
 

--- a/macos/BluRayToVisionPro/Feature/ProfileStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ProfileStore.swift
@@ -7,6 +7,7 @@ final class ProfileStore: ObservableObject {
 
     @Published private(set) var customProfiles: [EncodingProfile] = []
     @Published private(set) var loadErrorMessage: String?
+    @Published private(set) var migrationNoticeMessage: String?
 
     private let fileManager: FileManager
     private let fileURL: URL
@@ -54,7 +55,7 @@ final class ProfileStore: ObservableObject {
     func createProfile(
         name: String,
         options: EncodingOptions,
-        jobDefaults: ProfileJobDefaults? = nil
+        pipelineDefaults: ProfilePipelineDefaults? = nil
     ) throws -> String {
         let normalizedName = try validatedName(name)
         let normalizedOptions = try normalizedQualityOptions(options)
@@ -62,7 +63,7 @@ final class ProfileStore: ObservableObject {
             id: "custom.\(idGenerator().uuidString.lowercased())",
             name: normalizedName,
             options: normalizedOptions,
-            jobDefaults: jobDefaults,
+            pipelineDefaults: pipelineDefaults,
             kind: .custom,
             systemImage: "slider.horizontal.3"
         )
@@ -78,7 +79,7 @@ final class ProfileStore: ObservableObject {
         return try createProfile(
             name: suggestedDuplicateName(for: source.name),
             options: source.options,
-            jobDefaults: source.jobDefaults
+            pipelineDefaults: source.pipelineDefaults
         )
     }
 
@@ -90,14 +91,14 @@ final class ProfileStore: ObservableObject {
         guard let profile = customProfiles.first(where: { $0.id == identifier }) else {
             throw ProfileStoreError.builtInProfileIsReadOnly
         }
-        try updateProfile(identifier, name: name, options: options, jobDefaults: profile.jobDefaults)
+        try updateProfile(identifier, name: name, options: options, pipelineDefaults: profile.pipelineDefaults)
     }
 
     func updateProfile(
         _ identifier: String,
         name: String,
         options: EncodingOptions,
-        jobDefaults: ProfileJobDefaults?
+        pipelineDefaults: ProfilePipelineDefaults?
     ) throws {
         guard let index = customProfiles.firstIndex(where: { $0.id == identifier }) else {
             throw ProfileStoreError.builtInProfileIsReadOnly
@@ -106,7 +107,7 @@ final class ProfileStore: ObservableObject {
         var updatedProfiles = customProfiles
         updatedProfiles[index].name = normalizedName
         updatedProfiles[index].options = try normalizedQualityOptions(options)
-        updatedProfiles[index].jobDefaults = jobDefaults
+        updatedProfiles[index].pipelineDefaults = pipelineDefaults
         try persist(updatedProfiles)
         customProfiles = updatedProfiles
     }
@@ -174,6 +175,7 @@ final class ProfileStore: ObservableObject {
             let version = try decoder.decode(ProfileDocumentVersion.self, from: data).version
             let storedProfiles: [StoredProfile]
             let needsMigration: Bool
+            var affectedLegacyProfileIDs = Set<UUID>()
             switch version {
             case 1:
                 let legacyDocument = try decoder.decode(LegacyProfileDocumentV1.self, from: data)
@@ -189,7 +191,23 @@ final class ProfileStore: ObservableObject {
                 needsMigration = true
             case 4:
                 decoder.userInfo[.requiresVideoQualityIntent] = false
-                storedProfiles = try decoder.decode(ProfileDocument.self, from: data).profiles
+                let legacyDocument = try decoder.decode(LegacyProfileDocumentV4V5.self, from: data)
+                storedProfiles = legacyDocument.profiles.map { $0.migrated() }
+                affectedLegacyProfileIDs = Set(
+                    legacyDocument.profiles
+                        .filter(\.containsUnsafeRunDefaults)
+                        .map(\.id)
+                )
+                needsMigration = true
+            case 5:
+                decoder.userInfo[.requiresVideoQualityIntent] = true
+                let legacyDocument = try decoder.decode(LegacyProfileDocumentV4V5.self, from: data)
+                storedProfiles = legacyDocument.profiles.map { $0.migrated() }
+                affectedLegacyProfileIDs = Set(
+                    legacyDocument.profiles
+                        .filter(\.containsUnsafeRunDefaults)
+                        .map(\.id)
+                )
                 needsMigration = true
             case ProfileDocument.currentVersion:
                 decoder.userInfo[.requiresVideoQualityIntent] = true
@@ -203,17 +221,20 @@ final class ProfileStore: ObservableObject {
                 normalizedProfile.options = try normalizedQualityOptions(profile.options)
                 return normalizedProfile
             }
+            let migrationNotice = migrationNotice(for: loadedProfiles, affectedIDs: affectedLegacyProfileIDs)
             if needsMigration {
                 do {
                     try persist(loadedProfiles)
                 } catch {
                     writesBlocked = true
                     customProfiles = loadedProfiles
+                    migrationNoticeMessage = migrationNotice
                     loadErrorMessage = "Custom profiles were loaded but could not be upgraded. Profile changes are disabled to protect the original library."
                     return
                 }
             }
             customProfiles = loadedProfiles
+            migrationNoticeMessage = migrationNotice
         } catch let error as ProfileStoreError {
             if case let .unsupportedVersion(version) = error {
                 writesBlocked = true
@@ -253,7 +274,7 @@ final class ProfileStore: ObservableObject {
                 id: identifier,
                 name: normalizedName,
                 options: storedProfile.options,
-                jobDefaults: storedProfile.jobDefaults,
+                pipelineDefaults: storedProfile.pipelineDefaults,
                 kind: .custom,
                 systemImage: "slider.horizontal.3"
             )
@@ -276,7 +297,7 @@ final class ProfileStore: ObservableObject {
                 id: identifier,
                 name: profile.name,
                 options: profile.options,
-                jobDefaults: profile.jobDefaults
+                pipelineDefaults: profile.pipelineDefaults
             )
         }
         let document = ProfileDocument(version: ProfileDocument.currentVersion, profiles: storedProfiles)
@@ -285,6 +306,21 @@ final class ProfileStore: ObservableObject {
         let data = try encoder.encode(document)
         try dataWriter(data, fileURL)
         loadErrorMessage = nil
+    }
+
+    private func migrationNotice(for profiles: [EncodingProfile], affectedIDs: Set<UUID>) -> String? {
+        let affectedNames = profiles.compactMap { profile -> String? in
+            guard let identifier = UUID(uuidString: profile.id.replacingOccurrences(of: "custom.", with: "")),
+                  affectedIDs.contains(identifier)
+            else {
+                return nil
+            }
+            return profile.name
+        }
+        guard !affectedNames.isEmpty else {
+            return nil
+        }
+        return "Unsafe saved run defaults were reset for \(affectedNames.joined(separator: ", ")). Restart, overwrite, source removal, error recovery, and command output now apply per conversion."
     }
 
     private func preserveUnreadableFile() -> URL? {
@@ -340,7 +376,7 @@ enum ProfileStoreError: LocalizedError, Equatable {
 }
 
 private struct ProfileDocument: Codable {
-    static let currentVersion = 5
+    static let currentVersion = 6
 
     let version: Int
     let profiles: [StoredProfile]
@@ -354,19 +390,66 @@ private struct StoredProfile: Codable {
     let id: UUID
     let name: String
     let options: EncodingOptions
-    let jobDefaults: ProfileJobDefaults?
+    let pipelineDefaults: ProfilePipelineDefaults?
 
     init(
         id: UUID,
         name: String,
         options: EncodingOptions,
-        jobDefaults: ProfileJobDefaults? = nil
+        pipelineDefaults: ProfilePipelineDefaults? = nil
     ) {
         self.id = id
         self.name = name
         self.options = options
-        self.jobDefaults = jobDefaults
+        self.pipelineDefaults = pipelineDefaults
     }
+}
+
+private struct LegacyProfileDocumentV4V5: Decodable {
+    let version: Int
+    let profiles: [LegacyStoredProfileV4V5]
+}
+
+private struct LegacyStoredProfileV4V5: Decodable {
+    let id: UUID
+    let name: String
+    let options: EncodingOptions
+    let jobDefaults: LegacyProfileJobDefaults?
+
+    var containsUnsafeRunDefaults: Bool {
+        guard let jobDefaults else {
+            return false
+        }
+        return jobDefaults.startStage != .createMKV
+            || jobDefaults.overwriteExisting
+            || jobDefaults.removeOriginalAfterSuccess
+            || jobDefaults.continueOnError
+            || jobDefaults.outputCommands
+    }
+
+    func migrated() -> StoredProfile {
+        StoredProfile(
+            id: id,
+            name: name,
+            options: options,
+            pipelineDefaults: jobDefaults.map {
+                ProfilePipelineDefaults(
+                    intermediatePolicy: $0.intermediatePolicy,
+                    softwareEncoder: $0.softwareEncoder
+                )
+            }
+        )
+    }
+}
+
+private struct LegacyProfileJobDefaults: Decodable {
+    let startStage: ConversionStage
+    let intermediatePolicy: IntermediatePolicy
+    let overwriteExisting: Bool
+    let removeOriginalAfterSuccess: Bool
+    let continueOnError: Bool
+    let softwareEncoder: Bool
+    let outputCommands: Bool
 }
 
 private struct LegacyProfileDocumentV3: Decodable {

--- a/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
@@ -170,6 +170,16 @@ final class ResolutionMemoryStore: ObservableObject {
         entries = updated
     }
 
+    func replaceEntriesForTransaction(_ updatedEntries: [ResolutionMemoryEntry]) throws {
+        guard Set(updatedEntries.map(\.id)).count == updatedEntries.count,
+              updatedEntries.allSatisfy({ !$0.conflictID.isEmpty && !$0.resolutionID.isEmpty })
+        else {
+            throw ResolutionMemoryStoreError.invalidDocument
+        }
+        try persist(updatedEntries)
+        entries = updatedEntries
+    }
+
     private func load(from fileURL: URL) {
         guard fileManager.fileExists(atPath: fileURL.path) else { return }
         do {

--- a/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
@@ -1,0 +1,242 @@
+import Foundation
+import SwiftUI
+
+enum ResolutionMemoryScope: Codable, Equatable, Hashable, Identifiable {
+    case profile(String)
+    case sourceKind(ConversionSourceKind)
+    case global
+
+    var id: String {
+        switch self {
+        case let .profile(identifier): "profile:\(identifier)"
+        case let .sourceKind(kind): "source:\(kind.rawValue)"
+        case .global: "global"
+        }
+    }
+
+    var precedence: Int {
+        switch self {
+        case .profile: 3
+        case .sourceKind: 2
+        case .global: 1
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind, profileID, sourceKind }
+    private enum Kind: String, Codable { case profile, sourceKind, global }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(Kind.self, forKey: .kind) {
+        case .profile:
+            self = .profile(try values.decode(String.self, forKey: .profileID))
+        case .sourceKind:
+            self = .sourceKind(try values.decode(ConversionSourceKind.self, forKey: .sourceKind))
+        case .global:
+            self = .global
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .profile(identifier):
+            try values.encode(Kind.profile, forKey: .kind)
+            try values.encode(identifier, forKey: .profileID)
+        case let .sourceKind(sourceKind):
+            try values.encode(Kind.sourceKind, forKey: .kind)
+            try values.encode(sourceKind, forKey: .sourceKind)
+        case .global:
+            try values.encode(Kind.global, forKey: .kind)
+        }
+    }
+}
+
+struct ResolutionMemoryEntry: Codable, Equatable, Identifiable {
+    let conflictID: String
+    let resolutionID: String
+    let scope: ResolutionMemoryScope
+    let mappingVersion: Int
+
+    var id: String { "\(conflictID)|\(scope.id)" }
+}
+
+struct ResolutionMemorySuggestion: Equatable {
+    let entry: ResolutionMemoryEntry
+    let isStale: Bool
+
+    var staleExplanation: String? {
+        isStale ? "Quality options changed after an update. Choose a current option before applying this suggestion." : nil
+    }
+}
+
+struct ResolutionMemoryDocument: Codable, Equatable {
+    static let currentVersion = 1
+
+    let version: Int
+    var entries: [ResolutionMemoryEntry]
+
+    init(version: Int = currentVersion, entries: [ResolutionMemoryEntry] = []) {
+        self.version = version
+        self.entries = entries
+    }
+}
+
+@MainActor
+final class ResolutionMemoryStore: ObservableObject {
+    @Published private(set) var entries: [ResolutionMemoryEntry]
+    @Published private(set) var loadErrorMessage: String?
+    @Published private(set) var writesBlocked = false
+
+    private let fileURL: URL?
+    private let fileManager: FileManager
+    private let dataReader: (URL) throws -> Data
+    private let dataWriter: (Data, URL) throws -> Void
+
+    init(
+        fileURL: URL? = nil,
+        fileManager: FileManager = .default,
+        dataReader: @escaping (URL) throws -> Data = { try Data(contentsOf: $0) },
+        dataWriter: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: .atomic)
+        },
+        inMemory: Bool = false
+    ) {
+        self.fileManager = fileManager
+        self.dataReader = dataReader
+        self.dataWriter = dataWriter
+        self.fileURL = inMemory ? nil : fileURL ?? Self.defaultFileURL(fileManager: fileManager)
+        entries = []
+        if let fileURL = self.fileURL {
+            load(from: fileURL)
+        }
+    }
+
+    static func inMemory() -> ResolutionMemoryStore {
+        ResolutionMemoryStore(inMemory: true)
+    }
+
+    func suggestion(
+        conflictID: String,
+        profileID: String,
+        sourceKind: ConversionSourceKind,
+        mappingVersion: Int
+    ) -> ResolutionMemorySuggestion? {
+        let applicableScopes: Set<ResolutionMemoryScope> = [
+            .profile(profileID), .sourceKind(sourceKind), .global,
+        ]
+        guard let entry = entries
+            .filter({ $0.conflictID == conflictID && applicableScopes.contains($0.scope) })
+            .max(by: { $0.scope.precedence < $1.scope.precedence })
+        else {
+            return nil
+        }
+        return ResolutionMemorySuggestion(entry: entry, isStale: entry.mappingVersion != mappingVersion)
+    }
+
+    func store(
+        resolutionID: String,
+        for conflictID: String,
+        scope: ResolutionMemoryScope,
+        mappingVersion: Int
+    ) throws {
+        guard !resolutionID.isEmpty, !conflictID.isEmpty else {
+            throw ResolutionMemoryStoreError.invalidDocument
+        }
+        var updated = entries.filter { !($0.conflictID == conflictID && $0.scope == scope) }
+        updated.append(
+            ResolutionMemoryEntry(
+                conflictID: conflictID,
+                resolutionID: resolutionID,
+                scope: scope,
+                mappingVersion: mappingVersion
+            )
+        )
+        try persist(updated)
+        entries = updated
+    }
+
+    func forget(conflictID: String, scope: ResolutionMemoryScope) throws {
+        let updated = entries.filter { !($0.conflictID == conflictID && $0.scope == scope) }
+        guard updated.count != entries.count else { return }
+        try persist(updated)
+        entries = updated
+    }
+
+    func removeProfileMemories(profileID: String) throws {
+        let updated = entries.filter { $0.scope != .profile(profileID) }
+        guard updated.count != entries.count else { return }
+        try persist(updated)
+        entries = updated
+    }
+
+    private func load(from fileURL: URL) {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        do {
+            let data = try dataReader(fileURL)
+            let document = try JSONDecoder().decode(ResolutionMemoryDocument.self, from: data)
+            guard document.version <= ResolutionMemoryDocument.currentVersion else {
+                writesBlocked = true
+                loadErrorMessage = "Resolution suggestions are newer than this app. Changes are disabled to protect them."
+                return
+            }
+            guard document.version == ResolutionMemoryDocument.currentVersion,
+                  Set(document.entries.map(\.id)).count == document.entries.count,
+                  document.entries.allSatisfy({ !$0.conflictID.isEmpty && !$0.resolutionID.isEmpty })
+            else {
+                throw ResolutionMemoryStoreError.invalidDocument
+            }
+            entries = document.entries
+        } catch {
+            recoverFromUnreadableFile()
+        }
+    }
+
+    private func persist(_ entries: [ResolutionMemoryEntry]) throws {
+        guard !writesBlocked else { throw ResolutionMemoryStoreError.recoveryRequired }
+        guard let fileURL else { return }
+        try fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try dataWriter(encoder.encode(ResolutionMemoryDocument(entries: entries)), fileURL)
+        loadErrorMessage = nil
+    }
+
+    private func recoverFromUnreadableFile() {
+        guard let fileURL else { return }
+        var recoveryURL = fileURL.appendingPathExtension("corrupt")
+        var suffix = 2
+        while fileManager.fileExists(atPath: recoveryURL.path) {
+            recoveryURL = fileURL.appendingPathExtension("corrupt-\(suffix)")
+            suffix += 1
+        }
+        do {
+            try fileManager.moveItem(at: fileURL, to: recoveryURL)
+            loadErrorMessage = "Resolution suggestions could not be loaded. The original file was preserved as \(recoveryURL.lastPathComponent)."
+        } catch {
+            writesBlocked = true
+            loadErrorMessage = "Resolution suggestions could not be loaded or preserved. Changes are disabled to protect the original file."
+        }
+        entries = []
+    }
+
+    private static func defaultFileURL(fileManager: FileManager) -> URL {
+        let applicationSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+        return applicationSupportURL
+            .appendingPathComponent("3D Blu-ray to Vision Pro", isDirectory: true)
+            .appendingPathComponent("resolution-memory.json")
+    }
+}
+
+enum ResolutionMemoryStoreError: LocalizedError, Equatable {
+    case invalidDocument
+    case recoveryRequired
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDocument: "Resolution suggestion data is invalid."
+        case .recoveryRequired: "Resolution suggestion changes are disabled until the original data is protected."
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ResolutionMemoryStore.swift
@@ -57,6 +57,7 @@ struct ResolutionMemoryEntry: Codable, Equatable, Identifiable {
     let resolutionID: String
     let scope: ResolutionMemoryScope
     let mappingVersion: Int
+    let storedAt: Date
 
     var id: String { "\(conflictID)|\(scope.id)" }
 }
@@ -71,7 +72,7 @@ struct ResolutionMemorySuggestion: Equatable {
 }
 
 struct ResolutionMemoryDocument: Codable, Equatable {
-    static let currentVersion = 1
+    static let currentVersion = 2
 
     let version: Int
     var entries: [ResolutionMemoryEntry]
@@ -80,10 +81,45 @@ struct ResolutionMemoryDocument: Codable, Equatable {
         self.version = version
         self.entries = entries
     }
+
+    private enum CodingKeys: String, CodingKey { case version, entries }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        version = try values.decode(Int.self, forKey: .version)
+        if version == 1 {
+            entries = try values.decode([LegacyResolutionMemoryEntry].self, forKey: .entries).map {
+                ResolutionMemoryEntry(
+                    conflictID: $0.conflictID,
+                    resolutionID: $0.resolutionID,
+                    scope: $0.scope,
+                    mappingVersion: $0.mappingVersion,
+                    storedAt: .distantPast
+                )
+            }
+        } else {
+            entries = try values.decode([ResolutionMemoryEntry].self, forKey: .entries)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(version, forKey: .version)
+        try values.encode(entries, forKey: .entries)
+    }
+}
+
+private struct LegacyResolutionMemoryEntry: Decodable {
+    let conflictID: String
+    let resolutionID: String
+    let scope: ResolutionMemoryScope
+    let mappingVersion: Int
 }
 
 @MainActor
 final class ResolutionMemoryStore: ObservableObject {
+    static let suggestionLifetime: TimeInterval = 14 * 24 * 60 * 60
+
     @Published private(set) var entries: [ResolutionMemoryEntry]
     @Published private(set) var loadErrorMessage: String?
     @Published private(set) var writesBlocked = false
@@ -92,6 +128,7 @@ final class ResolutionMemoryStore: ObservableObject {
     private let fileManager: FileManager
     private let dataReader: (URL) throws -> Data
     private let dataWriter: (Data, URL) throws -> Void
+    private let now: () -> Date
 
     init(
         fileURL: URL? = nil,
@@ -100,11 +137,13 @@ final class ResolutionMemoryStore: ObservableObject {
         dataWriter: @escaping (Data, URL) throws -> Void = { data, url in
             try data.write(to: url, options: .atomic)
         },
+        now: @escaping () -> Date = Date.init,
         inMemory: Bool = false
     ) {
         self.fileManager = fileManager
         self.dataReader = dataReader
         self.dataWriter = dataWriter
+        self.now = now
         self.fileURL = inMemory ? nil : fileURL ?? Self.defaultFileURL(fileManager: fileManager)
         entries = []
         if let fileURL = self.fileURL {
@@ -112,8 +151,8 @@ final class ResolutionMemoryStore: ObservableObject {
         }
     }
 
-    static func inMemory() -> ResolutionMemoryStore {
-        ResolutionMemoryStore(inMemory: true)
+    static func inMemory(now: @escaping () -> Date = Date.init) -> ResolutionMemoryStore {
+        ResolutionMemoryStore(now: now, inMemory: true)
     }
 
     func suggestion(
@@ -126,7 +165,11 @@ final class ResolutionMemoryStore: ObservableObject {
             .profile(profileID), .sourceKind(sourceKind), .global,
         ]
         guard let entry = entries
-            .filter({ $0.conflictID == conflictID && applicableScopes.contains($0.scope) })
+            .filter({
+                $0.conflictID == conflictID
+                    && applicableScopes.contains($0.scope)
+                    && !isExpired($0)
+            })
             .max(by: { $0.scope.precedence < $1.scope.precedence })
         else {
             return nil
@@ -143,13 +186,16 @@ final class ResolutionMemoryStore: ObservableObject {
         guard !resolutionID.isEmpty, !conflictID.isEmpty else {
             throw ResolutionMemoryStoreError.invalidDocument
         }
-        var updated = entries.filter { !($0.conflictID == conflictID && $0.scope == scope) }
+        var updated = entries.filter {
+            !isExpired($0) && !($0.conflictID == conflictID && $0.scope == scope)
+        }
         updated.append(
             ResolutionMemoryEntry(
                 conflictID: conflictID,
                 resolutionID: resolutionID,
                 scope: scope,
-                mappingVersion: mappingVersion
+                mappingVersion: mappingVersion,
+                storedAt: now()
             )
         )
         try persist(updated)
@@ -190,13 +236,33 @@ final class ResolutionMemoryStore: ObservableObject {
                 loadErrorMessage = "Resolution suggestions are newer than this app. Changes are disabled to protect them."
                 return
             }
-            guard document.version == ResolutionMemoryDocument.currentVersion,
+            guard document.version >= 1,
+                  document.version <= ResolutionMemoryDocument.currentVersion,
                   Set(document.entries.map(\.id)).count == document.entries.count,
                   document.entries.allSatisfy({ !$0.conflictID.isEmpty && !$0.resolutionID.isEmpty })
             else {
                 throw ResolutionMemoryStoreError.invalidDocument
             }
-            entries = document.entries
+            let loadedEntries = document.version == 1
+                ? document.entries.map {
+                    ResolutionMemoryEntry(
+                        conflictID: $0.conflictID,
+                        resolutionID: $0.resolutionID,
+                        scope: $0.scope,
+                        mappingVersion: $0.mappingVersion,
+                        storedAt: now()
+                    )
+                }
+                : document.entries
+            entries = loadedEntries.filter { !isExpired($0) }
+            if document.version != ResolutionMemoryDocument.currentVersion || entries.count != loadedEntries.count {
+                do {
+                    try persist(entries)
+                } catch {
+                    writesBlocked = true
+                    loadErrorMessage = "Resolution suggestions were loaded safely, but their migration could not be saved. Changes are disabled until the file is writable."
+                }
+            }
         } catch {
             recoverFromUnreadableFile()
         }
@@ -210,6 +276,10 @@ final class ResolutionMemoryStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try dataWriter(encoder.encode(ResolutionMemoryDocument(entries: entries)), fileURL)
         loadErrorMessage = nil
+    }
+
+    private func isExpired(_ entry: ResolutionMemoryEntry) -> Bool {
+        now().timeIntervalSince(entry.storedAt) > Self.suggestionLifetime
     }
 
     private func recoverFromUnreadableFile() {

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -31,6 +31,7 @@ struct SetupEditSheet: View {
     let initialOptions: ConversionOptions
     let profiles: [EncodingProfile]
     @ObservedObject var profileStore: ProfileStore
+    @ObservedObject var resolutionMemoryStore: ResolutionMemoryStore
     let applyToConversion: (String, ConversionOptions) -> Void
 
     @State private var session: SetupEditSession
@@ -47,12 +48,14 @@ struct SetupEditSheet: View {
         initialOptions: ConversionOptions,
         profiles: [EncodingProfile],
         profileStore: ProfileStore,
+        resolutionMemoryStore: ResolutionMemoryStore,
         applyToConversion: @escaping (String, ConversionOptions) -> Void
     ) {
         self.initialProfile = initialProfile
         self.initialOptions = initialOptions
         self.profiles = profiles
         self.profileStore = profileStore
+        self.resolutionMemoryStore = resolutionMemoryStore
         self.applyToConversion = applyToConversion
         _session = State(initialValue: SetupEditSession(profile: initialProfile, options: initialOptions))
     }
@@ -130,6 +133,7 @@ struct SetupEditSheet: View {
                 isLocked: false,
                 sourceKind: nil,
                 routeQualityState: routeQualityState,
+                resolutionMemoryStore: resolutionMemoryStore,
                 isReady: false,
                 openEditor: {},
                 saveSelectedProfile: updateProfile,

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -1,0 +1,330 @@
+import SwiftUI
+
+struct StandardMovieRenameNoticeView: View {
+    @ObservedObject var settings: AppSettings
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Label(StandardMovieRenameNotice.message, systemImage: "info.circle")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            Button("Got it") {
+                settings.acknowledgeStandardMovieRenameNotice()
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("standard-movie-rename-notice-dismiss")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.quaternary.opacity(0.45))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("standard-movie-rename-notice")
+    }
+}
+
+struct SetupEditSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let initialProfile: EncodingProfile
+    let initialOptions: ConversionOptions
+    let profiles: [EncodingProfile]
+    @ObservedObject var profileStore: ProfileStore
+    let applyToConversion: (String, ConversionOptions) -> Void
+
+    @State private var session: SetupEditSession
+    @State private var selectedTab = ConversionSetupTab.video
+    @State private var pendingProfileID: String?
+    @State private var isShowingDiscardConfirmation = false
+    @State private var isShowingSaveAsNew = false
+    @State private var newProfileName = ""
+    @State private var errorMessage: String?
+    @StateObject private var routeQualityState = RouteQualityResolutionState()
+
+    init(
+        initialProfile: EncodingProfile,
+        initialOptions: ConversionOptions,
+        profiles: [EncodingProfile],
+        profileStore: ProfileStore,
+        applyToConversion: @escaping (String, ConversionOptions) -> Void
+    ) {
+        self.initialProfile = initialProfile
+        self.initialOptions = initialOptions
+        self.profiles = profiles
+        self.profileStore = profileStore
+        self.applyToConversion = applyToConversion
+        _session = State(initialValue: SetupEditSession(profile: initialProfile, options: initialOptions))
+    }
+
+    private var selectedProfile: EncodingProfile {
+        profiles.first(where: { $0.id == session.profileID }) ?? initialProfile
+    }
+
+    private var nameBinding: Binding<String> {
+        Binding(
+            get: { session.profileName },
+            set: { session.updateName($0) }
+        )
+    }
+
+    private var optionsBinding: Binding<ConversionOptions> {
+        Binding(
+            get: { session.draftOptions },
+            set: { session.updateOptions($0) }
+        )
+    }
+
+    private var selectedProfileBinding: Binding<String> {
+        Binding(
+            get: { session.profileID },
+            set: { requestProfileChange($0) }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Edit Conversion Settings")
+                            .font(.title2.weight(.semibold))
+                        Text("Based on \(initialProfile.name)")
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if session.isDirty {
+                        Text("Unsaved changes")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Text(ProfilePersistenceCopy.summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if selectedProfile.isCustom {
+                    TextField("Profile name", text: nameBinding)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("edit-profile-name-field")
+                } else {
+                    Label("\(selectedProfile.name) is built in and read-only. Use Save as New Profile… to keep changes as a custom Profile.", systemImage: "lock")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 18)
+            .padding(.bottom, 12)
+
+            ConversionSetupView(
+                selectedProfileID: selectedProfileBinding,
+                selectedTab: $selectedTab,
+                options: optionsBinding,
+                profiles: profiles,
+                selectedProfile: selectedProfile,
+                profileModified: session.isDirty,
+                isLocked: false,
+                sourceKind: nil,
+                routeQualityState: routeQualityState,
+                isReady: false,
+                openEditor: {},
+                saveSelectedProfile: updateProfile,
+                saveAsNewProfile: beginSaveAsNew,
+                resetProfile: discardChanges
+            )
+
+            Divider()
+            HStack(spacing: 10) {
+                Button("Cancel") {
+                    dismiss()
+                }
+                    .accessibilityIdentifier("setup-editor-cancel")
+
+                Spacer()
+
+                if session.canUpdateProfile {
+                    Button("Update Profile", action: updateProfile)
+                        .accessibilityIdentifier("setup-editor-update-profile")
+                }
+
+                Button("Save as New Profile…", action: beginSaveAsNew)
+                    .accessibilityIdentifier("setup-editor-save-as-new")
+
+                Button("Apply to This Conversion", action: apply)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("setup-editor-apply")
+            }
+            .padding(16)
+        }
+        .frame(minWidth: 760, idealWidth: 980, minHeight: 620, idealHeight: 760)
+        .onExitCommand(perform: requestDismissal)
+        .alert(
+            "Discard Unsaved Changes?",
+            isPresented: $isShowingDiscardConfirmation
+        ) {
+            Button(pendingProfileID == nil ? "Discard Changes" : "Discard and Load", role: .destructive) {
+                confirmDiscard()
+            }
+            Button("Cancel", role: .cancel) {
+                pendingProfileID = nil
+            }
+        } message: {
+            Text("Your unsaved settings will be discarded.")
+        }
+        .sheet(isPresented: $isShowingSaveAsNew) {
+            ProfileNameSheet(name: $newProfileName) {
+                saveAsNewProfile()
+            }
+        }
+        .alert(
+            "Profile Could Not Be Saved",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "The profile could not be saved.")
+        }
+    }
+
+    private func requestDismissal() {
+        if session.isDirty {
+            isShowingDiscardConfirmation = true
+        } else {
+            dismiss()
+        }
+    }
+
+    private func requestProfileChange(_ identifier: String) {
+        guard identifier != session.profileID else {
+            return
+        }
+        guard let profile = profiles.first(where: { $0.id == identifier }) else {
+            return
+        }
+        if session.isDirty {
+            pendingProfileID = profile.id
+            isShowingDiscardConfirmation = true
+            return
+        }
+        load(profile)
+    }
+
+    private func loadPendingProfile() {
+        guard let identifier = pendingProfileID,
+              let profile = profiles.first(where: { $0.id == identifier })
+        else {
+            pendingProfileID = nil
+            return
+        }
+        load(profile)
+        pendingProfileID = nil
+    }
+
+    private func confirmDiscard() {
+        if pendingProfileID == nil {
+            discardChanges()
+            dismiss()
+        } else {
+            loadPendingProfile()
+        }
+    }
+
+    private func load(_ profile: EncodingProfile) {
+        var loadedOptions = session.draftOptions
+        loadedOptions.encoding = profile.options
+        loadedOptions.job.applyProfilePipelineDefaults(
+            profile.pipelineDefaults ?? loadedOptions.job.profilePipelineDefaults
+        )
+        routeQualityState.reset()
+        session.load(profile: profile, options: loadedOptions)
+    }
+
+    private func discardChanges() {
+        routeQualityState.reset()
+        session.discard()
+    }
+
+    private func apply() {
+        applyToConversion(session.profileID, session.draftOptions)
+        dismiss()
+    }
+
+    private func updateProfile() {
+        guard session.canUpdateProfile else {
+            return
+        }
+        do {
+            let values = session.profileWriteValues()
+            try profileStore.updateProfile(
+                session.profileID,
+                name: values.name,
+                options: values.options,
+                pipelineDefaults: values.pipelineDefaults
+            )
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func beginSaveAsNew() {
+        newProfileName = profileStore.suggestedDuplicateName(for: selectedProfile.name)
+        isShowingSaveAsNew = true
+    }
+
+    private func saveAsNewProfile() {
+        do {
+            let values = session.profileWriteValues()
+            let identifier = try profileStore.createProfile(
+                name: newProfileName,
+                options: values.options,
+                pipelineDefaults: values.pipelineDefaults
+            )
+            isShowingSaveAsNew = false
+            applyToConversion(identifier, session.draftOptions)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct ProfileNameSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var name: String
+    let save: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Save as New Profile")
+                .font(.title2.weight(.semibold))
+            Text(ProfilePersistenceCopy.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            TextField("Profile name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("setup-editor-new-profile-name")
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                Button("Save", action: save)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 440)
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -30,10 +30,12 @@ struct SetupEditSheet: View {
     let initialProfile: EncodingProfile
     let initialOptions: ConversionOptions
     let fallbackPipelineDefaults: ProfilePipelineDefaults
+    let sourceKind: ConversionSourceKind?
     let profiles: [EncodingProfile]
     @ObservedObject var profileStore: ProfileStore
     @ObservedObject var resolutionMemoryStore: ResolutionMemoryStore
     let applyToConversion: (String, ConversionOptions) -> Void
+    let queueConflictForReview: ((String, RouteQualityConflict) -> Void)?
 
     @State private var session: SetupEditSession
     @State private var selectedTab = ConversionSetupTab.video
@@ -48,18 +50,22 @@ struct SetupEditSheet: View {
         initialProfile: EncodingProfile,
         initialOptions: ConversionOptions,
         fallbackPipelineDefaults: ProfilePipelineDefaults,
+        sourceKind: ConversionSourceKind?,
         profiles: [EncodingProfile],
         profileStore: ProfileStore,
         resolutionMemoryStore: ResolutionMemoryStore,
-        applyToConversion: @escaping (String, ConversionOptions) -> Void
+        applyToConversion: @escaping (String, ConversionOptions) -> Void,
+        queueConflictForReview: ((String, RouteQualityConflict) -> Void)? = nil
     ) {
         self.initialProfile = initialProfile
         self.initialOptions = initialOptions
         self.fallbackPipelineDefaults = fallbackPipelineDefaults
+        self.sourceKind = sourceKind
         self.profiles = profiles
         self.profileStore = profileStore
         self.resolutionMemoryStore = resolutionMemoryStore
         self.applyToConversion = applyToConversion
+        self.queueConflictForReview = queueConflictForReview
         _session = State(initialValue: SetupEditSession(profile: initialProfile, options: initialOptions))
     }
 
@@ -134,14 +140,15 @@ struct SetupEditSheet: View {
                 selectedProfile: selectedProfile,
                 profileModified: session.isDirty,
                 isLocked: false,
-                sourceKind: nil,
+                sourceKind: sourceKind,
                 routeQualityState: routeQualityState,
                 resolutionMemoryStore: resolutionMemoryStore,
                 isReady: false,
                 openEditor: {},
                 saveSelectedProfile: updateProfile,
                 saveAsNewProfile: beginSaveAsNew,
-                resetProfile: discardChanges
+                resetProfile: discardChanges,
+                queueConflictForReview: queueConflictForReview == nil ? nil : enqueueHeldConflict
             )
 
             Divider()
@@ -171,7 +178,7 @@ struct SetupEditSheet: View {
             }
             .padding(16)
         }
-        .frame(minWidth: 760, idealWidth: 980, minHeight: 620, idealHeight: 760)
+        .frame(minWidth: 640, idealWidth: 720, minHeight: 620, idealHeight: 760)
         .onExitCommand(perform: requestDismissal)
         .alert(
             "Discard Unsaved Changes?",
@@ -264,6 +271,12 @@ struct SetupEditSheet: View {
 
     private func apply() {
         applyToConversion(session.profileID, session.draftOptions)
+        dismiss()
+    }
+
+    private func enqueueHeldConflict(_ conflict: RouteQualityConflict) {
+        guard let queueConflictForReview else { return }
+        queueConflictForReview(session.profileID, conflict)
         dismiss()
     }
 

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -29,6 +29,7 @@ struct SetupEditSheet: View {
 
     let initialProfile: EncodingProfile
     let initialOptions: ConversionOptions
+    let fallbackPipelineDefaults: ProfilePipelineDefaults
     let profiles: [EncodingProfile]
     @ObservedObject var profileStore: ProfileStore
     @ObservedObject var resolutionMemoryStore: ResolutionMemoryStore
@@ -46,6 +47,7 @@ struct SetupEditSheet: View {
     init(
         initialProfile: EncodingProfile,
         initialOptions: ConversionOptions,
+        fallbackPipelineDefaults: ProfilePipelineDefaults,
         profiles: [EncodingProfile],
         profileStore: ProfileStore,
         resolutionMemoryStore: ResolutionMemoryStore,
@@ -53,6 +55,7 @@ struct SetupEditSheet: View {
     ) {
         self.initialProfile = initialProfile
         self.initialOptions = initialOptions
+        self.fallbackPipelineDefaults = fallbackPipelineDefaults
         self.profiles = profiles
         self.profileStore = profileStore
         self.resolutionMemoryStore = resolutionMemoryStore
@@ -92,7 +95,7 @@ struct SetupEditSheet: View {
                     VStack(alignment: .leading, spacing: 3) {
                         Text("Edit Conversion Settings")
                             .font(.title2.weight(.semibold))
-                        Text("Based on \(initialProfile.name)")
+                        Text("Based on \(selectedProfile.name)")
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
@@ -144,7 +147,7 @@ struct SetupEditSheet: View {
             Divider()
             HStack(spacing: 10) {
                 Button("Cancel") {
-                    dismiss()
+                    requestDismissal()
                 }
                     .accessibilityIdentifier("setup-editor-cancel")
 
@@ -153,15 +156,18 @@ struct SetupEditSheet: View {
                 if session.canUpdateProfile {
                     Button("Update Profile", action: updateProfile)
                         .accessibilityIdentifier("setup-editor-update-profile")
+                        .disabled(routeQualityState.blockReason != nil)
                 }
 
                 Button("Save as New Profile…", action: beginSaveAsNew)
                     .accessibilityIdentifier("setup-editor-save-as-new")
+                    .disabled(routeQualityState.blockReason != nil)
 
                 Button("Apply to This Conversion", action: apply)
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
                     .accessibilityIdentifier("setup-editor-apply")
+                    .disabled(routeQualityState.blockReason != nil)
             }
             .padding(16)
         }
@@ -245,7 +251,7 @@ struct SetupEditSheet: View {
         var loadedOptions = session.draftOptions
         loadedOptions.encoding = profile.options
         loadedOptions.job.applyProfilePipelineDefaults(
-            profile.pipelineDefaults ?? loadedOptions.job.profilePipelineDefaults
+            profile.pipelineDefaults ?? fallbackPipelineDefaults
         )
         routeQualityState.reset()
         session.load(profile: profile, options: loadedOptions)
@@ -273,6 +279,7 @@ struct SetupEditSheet: View {
                 options: values.options,
                 pipelineDefaults: values.pipelineDefaults
             )
+            applyToConversion(session.profileID, session.draftOptions)
             dismiss()
         } catch {
             errorMessage = error.localizedDescription

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -671,7 +671,6 @@ struct SourceScopedResetSummary: Equatable {
         case removeOriginal = "delete source after success"
         case recovery = "recovery choices"
         case titleSelection = "title selection"
-        case exactOverrides = "source-derived exact overrides"
     }
 
     let choices: [Choice]
@@ -729,14 +728,6 @@ private enum SourceScopedResetPolicy {
             titleSelection = .main
             choices.append(.titleSelection)
         }
-        if !options.encoding.frameRateOverride.isEmpty
-            || !options.encoding.resolutionOverride.isEmpty
-        {
-            options.encoding.frameRateOverride = ""
-            options.encoding.resolutionOverride = ""
-            choices.append(.exactOverrides)
-        }
-
         return SourceScopedResetSummary(choices: choices)
     }
 }

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -671,6 +671,7 @@ struct SourceScopedResetSummary: Equatable {
         case removeOriginal = "delete source after success"
         case recovery = "recovery choices"
         case titleSelection = "title selection"
+        case exactOverrides = "source-derived exact overrides"
     }
 
     let choices: [Choice]
@@ -728,6 +729,14 @@ private enum SourceScopedResetPolicy {
             titleSelection = .main
             choices.append(.titleSelection)
         }
+        if !options.encoding.frameRateOverride.isEmpty
+            || !options.encoding.resolutionOverride.isEmpty
+        {
+            options.encoding.frameRateOverride = ""
+            options.encoding.resolutionOverride = ""
+            choices.append(.exactOverrides)
+        }
+
         return SourceScopedResetSummary(choices: choices)
     }
 }

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -602,37 +602,22 @@ struct JobOptions: Codable, Equatable {
     }
 }
 
-struct ProfileJobDefaults: Codable, Equatable {
-    var startStage = ConversionStage.createMKV
+struct ProfilePipelineDefaults: Codable, Equatable {
     var intermediatePolicy = IntermediatePolicy.automatic
-    var overwriteExisting = false
-    var removeOriginalAfterSuccess = false
-    var continueOnError = false
     var softwareEncoder = false
-    var outputCommands = false
 }
 
 extension JobOptions {
-    var profileDefaults: ProfileJobDefaults {
-        ProfileJobDefaults(
-            startStage: startStage,
+    var profilePipelineDefaults: ProfilePipelineDefaults {
+        ProfilePipelineDefaults(
             intermediatePolicy: intermediatePolicy,
-            overwriteExisting: overwriteExisting,
-            removeOriginalAfterSuccess: removeOriginalAfterSuccess,
-            continueOnError: continueOnError,
-            softwareEncoder: softwareEncoder,
-            outputCommands: outputCommands
+            softwareEncoder: softwareEncoder
         )
     }
 
-    mutating func applyProfileDefaults(_ defaults: ProfileJobDefaults) {
-        startStage = defaults.startStage
+    mutating func applyProfilePipelineDefaults(_ defaults: ProfilePipelineDefaults) {
         intermediatePolicy = defaults.intermediatePolicy
-        overwriteExisting = defaults.overwriteExisting
-        removeOriginalAfterSuccess = defaults.removeOriginalAfterSuccess
-        continueOnError = defaults.continueOnError
         softwareEncoder = defaults.softwareEncoder
-        outputCommands = defaults.outputCommands
     }
 }
 
@@ -650,6 +635,100 @@ struct ConversionOptions: Codable, Equatable {
 
     var compactSummary: String {
         "\(videoSummary) · Audio: \(encoding.audioSummary) · Subtitles: \(encoding.subtitleSummary)"
+    }
+
+    @discardableResult
+    mutating func resetSourceScopedState(
+        for sourceKind: ConversionSourceKind,
+        titleSelection: inout DiscTitleSelection,
+        recoveryDecisionPresent: Bool
+    ) -> SourceScopedResetSummary {
+        SourceScopedResetPolicy.apply(
+            to: &self,
+            sourceKind: sourceKind,
+            titleSelection: &titleSelection,
+            recoveryDecisionPresent: recoveryDecisionPresent
+        )
+    }
+
+    @discardableResult
+    mutating func resetSourceScopedState(
+        for sourceKind: ConversionSourceKind
+    ) -> SourceScopedResetSummary {
+        var titleSelection = DiscTitleSelection.main
+        return resetSourceScopedState(
+            for: sourceKind,
+            titleSelection: &titleSelection,
+            recoveryDecisionPresent: false
+        )
+    }
+}
+
+struct SourceScopedResetSummary: Equatable {
+    enum Choice: String, CaseIterable, Equatable {
+        case restartStage = "restart stage"
+        case overwrite = "overwrite output"
+        case removeOriginal = "delete source after success"
+        case recovery = "recovery choices"
+        case titleSelection = "title selection"
+    }
+
+    let choices: [Choice]
+
+    var didReset: Bool {
+        !choices.isEmpty
+    }
+
+    var message: String? {
+        guard didReset else {
+            return nil
+        }
+        let labels = choices.map(\.rawValue)
+        let choicesText: String
+        if labels.count == 1 {
+            choicesText = labels[0]
+        } else if labels.count == 2 {
+            choicesText = labels.joined(separator: " and ")
+        } else {
+            choicesText = labels.dropLast().joined(separator: ", ") + ", and " + labels.last!
+        }
+        return "New source: reset \(choicesText)."
+    }
+}
+
+private enum SourceScopedResetPolicy {
+    static func apply(
+        to options: inout ConversionOptions,
+        sourceKind: ConversionSourceKind,
+        titleSelection: inout DiscTitleSelection,
+        recoveryDecisionPresent: Bool
+    ) -> SourceScopedResetSummary {
+        var choices: [SourceScopedResetSummary.Choice] = []
+
+        if options.job.startStage != .createMKV {
+            options.job.startStage = .createMKV
+            choices.append(.restartStage)
+        }
+        if options.job.overwriteExisting {
+            options.job.overwriteExisting = false
+            choices.append(.overwrite)
+        }
+        let removeOriginalWasEnabled = options.job.removeOriginalAfterSuccess
+        if removeOriginalWasEnabled || sourceKind == .physicalDisc {
+            options.job.removeOriginalAfterSuccess = false
+            if removeOriginalWasEnabled {
+                choices.append(.removeOriginal)
+            }
+        }
+        if options.job.continueOnError || recoveryDecisionPresent {
+            options.job.continueOnError = false
+            choices.append(.recovery)
+        }
+        if titleSelection != .main {
+            titleSelection = .main
+            choices.append(.titleSelection)
+        }
+        return SourceScopedResetSummary(choices: choices)
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -1,7 +1,7 @@
 import DiskArbitration
 import Foundation
 
-enum ConversionSourceKind: String, CaseIterable, Identifiable {
+enum ConversionSourceKind: String, CaseIterable, Codable, Hashable, Identifiable {
     case physicalDisc
     case discImage
     case bluRayFolder

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -1,12 +1,6 @@
 import DiskArbitration
 import Foundation
 
-extension Notification.Name {
-    static let conversionSourceSelectionRequested = Notification.Name(
-        "BluRayToVisionPro.conversionSourceSelectionRequested"
-    )
-}
-
 enum ConversionSourceKind: String, CaseIterable, Identifiable {
     case physicalDisc
     case discImage

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -1,6 +1,12 @@
 import DiskArbitration
 import Foundation
 
+extension Notification.Name {
+    static let conversionSourceSelectionRequested = Notification.Name(
+        "BluRayToVisionPro.conversionSourceSelectionRequested"
+    )
+}
+
 enum ConversionSourceKind: String, CaseIterable, Identifiable {
     case physicalDisc
     case discImage

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -21,11 +21,11 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
     var summary: String {
         switch self {
         case .balanced:
-            "HEVC 75, source resolution, automatic audio, English audio only, and subtitles."
+            "Source resolution with automatic audio, English audio, and subtitles."
         case .originalResolution:
             "Higher quality while preserving the source resolution."
         case .fourKUpscale:
-            "2× AI upscale with linked HEVC and upscale quality."
+            "Twice the source resolution with quality kept consistent through upscaling."
         }
     }
 

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -86,7 +86,7 @@ struct EncodingProfile: Identifiable, Equatable {
 }
 
 enum ProfilePersistenceCopy {
-    static let summary = "Profiles save video, audio, subtitle, reusable-file, and encoder settings. Restart, overwrite, delete-source, recovery, sound, and keep-awake choices are not saved."
+    static let summary = "Profiles save video, audio, subtitle, reusable-file, and encoder settings. Restart, overwrite, delete-source, recovery, command-output, sound, and keep-awake choices are not saved."
 }
 
 enum StandardMovieRenameNotice {

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -10,7 +10,7 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
     var name: String {
         switch self {
         case .balanced:
-            "Balanced"
+            "Standard Movie"
         case .originalResolution:
             "Original Resolution"
         case .fourKUpscale:
@@ -87,6 +87,115 @@ struct EncodingProfile: Identifiable, Equatable {
 
 enum ProfilePersistenceCopy {
     static let summary = "Profiles save video, audio, subtitle, reusable-file, and encoder settings. Restart, overwrite, delete-source, recovery, sound, and keep-awake choices are not saved."
+}
+
+enum StandardMovieRenameNotice {
+    static let message = "The Balanced profile is now called Standard Movie. Balanced is still a video quality choice. Your saved profiles are unchanged."
+}
+
+enum ReusableFileOutcome: String, CaseIterable, Identifiable {
+    case finishedMovieOnly
+    case finishedMovieAndReusableFiles
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .finishedMovieOnly:
+            "Just the finished movie"
+        case .finishedMovieAndReusableFiles:
+            "The finished movie plus reusable files"
+        }
+    }
+
+    var policy: IntermediatePolicy {
+        switch self {
+        case .finishedMovieOnly:
+            .automatic
+        case .finishedMovieAndReusableFiles:
+            .reusable
+        }
+    }
+
+    init(policy: IntermediatePolicy) {
+        self = policy.createsReusableArtifacts
+            ? .finishedMovieAndReusableFiles
+            : .finishedMovieOnly
+    }
+
+    var detail: String {
+        switch self {
+        case .finishedMovieOnly:
+            "You get one finished movie. Temporary processing files are removed after a successful conversion."
+        case .finishedMovieAndReusableFiles:
+            "You get the finished movie plus reusable left- and right-eye movies that can be used later without rereading the disc. This needs more storage and time, and some quality choices may be unavailable."
+        }
+    }
+}
+
+struct SetupEditSession: Equatable {
+    private(set) var originalProfileID: String
+    private(set) var originalProfileName: String
+    private(set) var originalProfileKind: EncodingProfile.Kind
+    private(set) var originalOptions: ConversionOptions
+
+    private(set) var profileID: String
+    private(set) var profileName: String
+    private(set) var draftOptions: ConversionOptions
+
+    init(profile: EncodingProfile, options: ConversionOptions) {
+        originalProfileID = profile.id
+        originalProfileName = profile.name
+        originalProfileKind = profile.kind
+        originalOptions = options
+        profileID = profile.id
+        profileName = profile.name
+        draftOptions = options
+    }
+
+    var isDirty: Bool {
+        draftOptions != originalOptions || profileName != originalProfileName
+    }
+
+    var canUpdateProfile: Bool {
+        originalProfileKind == .custom && profileID == originalProfileID
+    }
+
+    var profilePipelineDefaults: ProfilePipelineDefaults {
+        draftOptions.job.profilePipelineDefaults
+    }
+
+    mutating func updateName(_ name: String) {
+        profileName = name
+    }
+
+    mutating func updateOptions(_ options: ConversionOptions) {
+        draftOptions = options
+    }
+
+    mutating func load(profile: EncodingProfile, options: ConversionOptions) {
+        originalProfileID = profile.id
+        originalProfileName = profile.name
+        originalProfileKind = profile.kind
+        originalOptions = options
+        profileID = profile.id
+        profileName = profile.name
+        draftOptions = options
+    }
+
+    mutating func discard() {
+        profileID = originalProfileID
+        profileName = originalProfileName
+        draftOptions = originalOptions
+    }
+
+    func profileWriteValues() -> (name: String, options: EncodingOptions, pipelineDefaults: ProfilePipelineDefaults) {
+        (profileName, draftOptions.encoding, profilePipelineDefaults)
+    }
+
+    func switching(to profile: EncodingProfile, options: ConversionOptions) -> SetupEditSession {
+        SetupEditSession(profile: profile, options: options)
+    }
 }
 
 enum OutputLength: String, CaseIterable, Identifiable {

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -60,7 +60,7 @@ struct EncodingProfile: Identifiable, Equatable {
     let id: String
     var name: String
     var options: EncodingOptions
-    var jobDefaults: ProfileJobDefaults? = nil
+    var pipelineDefaults: ProfilePipelineDefaults? = nil
     let kind: Kind
     let systemImage: String
 
@@ -68,14 +68,14 @@ struct EncodingProfile: Identifiable, Equatable {
         id: String,
         name: String,
         options: EncodingOptions,
-        jobDefaults: ProfileJobDefaults? = nil,
+        pipelineDefaults: ProfilePipelineDefaults? = nil,
         kind: Kind,
         systemImage: String
     ) {
         self.id = id
         self.name = name
         self.options = options
-        self.jobDefaults = jobDefaults
+        self.pipelineDefaults = pipelineDefaults
         self.kind = kind
         self.systemImage = systemImage
     }
@@ -83,6 +83,10 @@ struct EncodingProfile: Identifiable, Equatable {
     var isBuiltIn: Bool { kind == .builtIn }
     var isCustom: Bool { kind == .custom }
     var summary: String { options.compactSummary }
+}
+
+enum ProfilePersistenceCopy {
+    static let summary = "Profiles save video, audio, subtitle, reusable-file, and encoder settings. Restart, overwrite, delete-source, recovery, sound, and keep-awake choices are not saved."
 }
 
 enum OutputLength: String, CaseIterable, Identifiable {

--- a/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
+++ b/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ConversionQueueDocument: Codable, Equatable {
-    static let currentVersion = 1
+    static let currentVersion = 2
 
     let version: Int
     var items: [DurableConversionQueueItem]
@@ -9,6 +9,18 @@ struct ConversionQueueDocument: Codable, Equatable {
     init(version: Int = currentVersion, items: [DurableConversionQueueItem] = []) {
         self.version = version
         self.items = items
+    }
+
+    private enum CodingKeys: String, CodingKey { case version, items }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try values.decode(Int.self, forKey: .version)
+        let items = try values.decode([DurableConversionQueueItem].self, forKey: .items)
+        guard version == 1 || version == Self.currentVersion else {
+            throw ConversionQueueStoreError.unsupportedVersion(version)
+        }
+        self.init(version: Self.currentVersion, items: items)
     }
 
     func restoredAfterLaunch() -> ConversionQueueDocument {
@@ -31,6 +43,7 @@ struct DurableConversionQueueItem: Codable, Equatable, Identifiable {
     var decision: DurableQueueDecision?
     var failure: DurableQueueFailure?
     var result: DurableQueueResult?
+    var resolutionTrace: DurableQueueResolutionTrace?
 
     init(
         id: UUID = UUID(),
@@ -43,7 +56,8 @@ struct DurableConversionQueueItem: Codable, Equatable, Identifiable {
         attempts: [DurableQueueAttempt] = [],
         decision: DurableQueueDecision? = nil,
         failure: DurableQueueFailure? = nil,
-        result: DurableQueueResult? = nil
+        result: DurableQueueResult? = nil,
+        resolutionTrace: DurableQueueResolutionTrace? = nil
     ) {
         self.id = id
         self.ordinal = ordinal
@@ -56,6 +70,7 @@ struct DurableConversionQueueItem: Codable, Equatable, Identifiable {
         self.decision = decision
         self.failure = failure
         self.result = result
+        self.resolutionTrace = resolutionTrace
     }
 
     func restoredAfterLaunch() -> DurableConversionQueueItem {
@@ -75,6 +90,25 @@ struct DurableConversionQueueItem: Codable, Equatable, Identifiable {
             break
         }
         return restored
+    }
+}
+
+struct DurableQueueResolutionTrace: Codable, Equatable {
+    let conflictID: String
+    let resolutionID: String
+    let qualityOutcome: String
+    let fileOutcome: String
+
+    init(
+        conflictID: String,
+        resolutionID: String,
+        qualityOutcome: String,
+        fileOutcome: String
+    ) {
+        self.conflictID = conflictID
+        self.resolutionID = resolutionID
+        self.qualityOutcome = qualityOutcome
+        self.fileOutcome = fileOutcome
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -21,6 +21,7 @@ struct PersistentQueueItem: Identifiable, Equatable {
     let draft: ConversionDraft
     let status: PersistentQueueItemStatus
     let attemptCount: Int
+    let resolutionTrace: DurableQueueResolutionTrace?
 
     init(item: DurableConversionQueueItem) throws {
         guard let sourceKind = ConversionSourceKind(rawValue: item.intent.source.kind) else {
@@ -83,6 +84,7 @@ struct PersistentQueueItem: Identifiable, Equatable {
         }
         status = resolvedStatus
         attemptCount = item.attempts.count
+        resolutionTrace = item.resolutionTrace
     }
 
     var displayName: String {

--- a/macos/BluRayToVisionPro/Models/QueueResolution.swift
+++ b/macos/BluRayToVisionPro/Models/QueueResolution.swift
@@ -49,7 +49,7 @@ struct QueueResolutionGroup: Identifiable, Equatable {
     }
 }
 
-enum QueueResolutionScope: Equatable {
+enum QueueResolutionScope: Hashable {
     case allMatching
     case item(UUID)
 }

--- a/macos/BluRayToVisionPro/Models/QueueResolution.swift
+++ b/macos/BluRayToVisionPro/Models/QueueResolution.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct QueueResolutionCandidate: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let draft: ConversionDraft
+    let conflict: RouteQualityConflict
+
+    init(id: UUID = UUID(), draft: ConversionDraft, conflict: RouteQualityConflict) {
+        self.id = id
+        title = draft.selectedTitle?.name ?? draft.source.displayName
+        self.draft = draft
+        self.conflict = conflict
+    }
+
+    var groupKey: String {
+        [
+            conflict.stableID,
+            draft.profile.id,
+            draft.source.kind.rawValue,
+            conflict.proposedRoute.kind.rawValue,
+            String(describing: conflict.proposedRoute.qualitySelection),
+            conflict.resolutions.filter(\.isAvailable).map(\.choice.rawValue).sorted().joined(separator: ","),
+        ].joined(separator: "|")
+    }
+}
+
+struct QueueResolutionGroup: Identifiable, Equatable {
+    let key: String
+    let candidates: [QueueResolutionCandidate]
+
+    var id: String { key }
+    var conflict: RouteQualityConflict { candidates[0].conflict }
+    var profileName: String { candidates[0].draft.profile.name }
+    var titleList: [String] { candidates.map(\.title) }
+    var titleDisclosure: String {
+        let visible = titleList.prefix(6)
+        let more = titleList.count - visible.count
+        return visible.joined(separator: ", ") + (more > 0 ? ", and \(more) more" : "")
+    }
+
+    static func group(_ candidates: [QueueResolutionCandidate]) -> [QueueResolutionGroup] {
+        Dictionary(grouping: candidates, by: \.groupKey)
+            .values
+            .map { QueueResolutionGroup(key: $0[0].groupKey, candidates: $0) }
+            .sorted { $0.titleList.joined() < $1.titleList.joined() }
+    }
+}
+
+enum QueueResolutionScope: Equatable {
+    case allMatching
+    case item(UUID)
+}
+
+struct QueueResolutionSelection: Equatable {
+    var resolutionID: String?
+    var scope: QueueResolutionScope = .allMatching
+    var shouldSuggest = false
+
+    var canApply: Bool { resolutionID != nil }
+}
+
+struct QueueResolutionApplication: Equatable {
+    let resolvedDrafts: [UUID: ConversionDraft]
+    let resolution: RouteQualityResolutionOption
+
+    static func apply(
+        group: QueueResolutionGroup,
+        selection: QueueResolutionSelection
+    ) -> Result<QueueResolutionApplication, RouteQualityResolutionError> {
+        guard let resolutionID = selection.resolutionID,
+              let resolution = group.conflict.resolutions.first(where: { $0.id == resolutionID })
+        else {
+            return .failure(.init(message: "Choose a resolution before applying it."))
+        }
+        let targetIDs: Set<UUID> = switch selection.scope {
+        case .allMatching: Set(group.candidates.map(\.id))
+        case let .item(identifier): [identifier]
+        }
+        var drafts: [UUID: ConversionDraft] = [:]
+        for candidate in group.candidates where targetIDs.contains(candidate.id) {
+            switch RouteQualityEngine.resolve(resolution, conflict: candidate.conflict) {
+            case let .success(draft): drafts[candidate.id] = ConversionDraft(
+                source: candidate.draft.source,
+                sourceDetails: candidate.draft.sourceDetails,
+                profile: candidate.draft.profile,
+                destinationURL: candidate.draft.destinationURL,
+                options: draft.options,
+                selectedTitle: candidate.draft.selectedTitle
+            )
+            case let .failure(error): return .failure(error)
+            }
+        }
+        return .success(QueueResolutionApplication(resolvedDrafts: drafts, resolution: resolution))
+    }
+}

--- a/macos/BluRayToVisionPro/Models/QueueResolution.swift
+++ b/macos/BluRayToVisionPro/Models/QueueResolution.swift
@@ -19,8 +19,10 @@ struct QueueResolutionCandidate: Identifiable, Equatable {
             draft.profile.id,
             draft.source.kind.rawValue,
             conflict.proposedRoute.kind.rawValue,
+            conflict.proposedRoute.includesUpscale ? "upscale" : "no-upscale",
+            "mapping-v\(conflict.mappingVersion)",
             String(describing: conflict.proposedRoute.qualitySelection),
-            conflict.resolutions.filter(\.isAvailable).map(\.choice.rawValue).sorted().joined(separator: ","),
+            conflict.resolutions.filter(\.isAvailable).map(\.id).sorted().joined(separator: ","),
         ].joined(separator: "|")
     }
 }

--- a/macos/BluRayToVisionPro/Models/RouteResolution.swift
+++ b/macos/BluRayToVisionPro/Models/RouteResolution.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 enum RouteQualityTrigger: String, CaseIterable, Codable, Identifiable {
     case generatedRouteRequirement = "generated_route_requirement"
@@ -190,7 +190,11 @@ enum RouteQualityEngine {
             proposed: proposed,
             proposedRoute: proposedRoute
         )
-        let reason = validationReason(for: proposed, route: proposedRoute)
+        let reason = conflictReason(
+            for: proposed,
+            priorRoute: priorRoute,
+            proposedRoute: proposedRoute
+        )
         return .conflict(
             RouteQualityConflict(
                 trigger: trigger(for: edit, priorRoute: priorRoute, proposedRoute: proposedRoute),
@@ -363,6 +367,28 @@ enum RouteQualityEngine {
         return "The selected route and quality settings are not compatible."
     }
 
+    private static func conflictReason(
+        for options: ConversionOptions,
+        priorRoute: VideoRoutePlan,
+        proposedRoute: VideoRoutePlan
+    ) -> String {
+        guard isValid(options, route: proposedRoute) else {
+            return validationReason(for: options, route: proposedRoute)
+        }
+        switch proposedRoute.kind {
+        case .generatedMVHEVC:
+            return "This change requires generated left- and right-eye files. Choose how the current quality choice should carry over."
+        case .directMVHEVC:
+            return "This change returns to direct video processing. Choose how the current quality choice should carry over."
+        case .av1Stereo:
+            return "AV1 uses exact Custom quality settings. Choose whether to keep the current workflow or continue with AV1."
+        case .existingArtifact:
+            return priorRoute.kind == .existingArtifact
+                ? "This restart changes which retained quality settings are applied. Choose how to continue."
+                : "This restart reuses an existing encoded video. Choose how retained quality settings should be handled."
+        }
+    }
+
     private static func resolutionOptions(
         prior: ConversionOptions,
         proposed: ConversionOptions,
@@ -476,6 +502,11 @@ final class RouteQualityResolutionState: ObservableObject {
         guard let conflict else {
             return
         }
+        guard options == conflict.priorOptions else {
+            reset()
+            invalidMessage = "Conversion settings changed while this choice was waiting. Review the current settings and try the change again."
+            return
+        }
         var selectedConflict = conflict
         selectedConflict.selectedResolutionID = option.id
         switch RouteQualityEngine.resolve(option, conflict: selectedConflict) {
@@ -497,5 +528,10 @@ final class RouteQualityResolutionState: ObservableObject {
         } else {
             invalidMessage = nil
         }
+    }
+
+    func reset() {
+        conflict = nil
+        invalidMessage = nil
     }
 }

--- a/macos/BluRayToVisionPro/Models/RouteResolution.swift
+++ b/macos/BluRayToVisionPro/Models/RouteResolution.swift
@@ -140,8 +140,10 @@ struct RouteQualityConflict: Equatable {
             trigger.rawValue,
             priorRoute.kind.rawValue,
             proposedRoute.kind.rawValue,
+            proposedRoute.includesUpscale ? "upscale" : "no-upscale",
             proposedRoute.generatedRequirement?.identifier ?? "none",
-            resolutions.filter(\.isAvailable).map(\.choice.rawValue).sorted().joined(separator: ","),
+            "mapping-v\(mappingVersion)",
+            resolutions.filter(\.isAvailable).map(\.id).sorted().joined(separator: ","),
         ].joined(separator: "|")
     }
 

--- a/macos/BluRayToVisionPro/Models/RouteResolution.swift
+++ b/macos/BluRayToVisionPro/Models/RouteResolution.swift
@@ -1,0 +1,501 @@
+import Foundation
+import Combine
+
+enum RouteQualityTrigger: String, CaseIterable, Codable, Identifiable {
+    case generatedRouteRequirement = "generated_route_requirement"
+    case reusableIntermediates = "reusable_intermediates"
+    case softwareEncoder = "software_encoder"
+    case restartStage = "restart_stage"
+    case upscaleCrop = "upscale_crop"
+    case fieldOfView = "field_of_view"
+    case resolutionOverride = "resolution_override"
+    case outputMode = "output_mode"
+    case qualitySettings = "quality_settings"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .generatedRouteRequirement:
+            "Generated route requirement"
+        case .reusableIntermediates:
+            "Reusable intermediates"
+        case .softwareEncoder:
+            "Software encoder"
+        case .restartStage:
+            "Restart stage"
+        case .upscaleCrop:
+            "Upscale and crop"
+        case .fieldOfView:
+            "Field of view"
+        case .resolutionOverride:
+            "Resolution override"
+        case .outputMode:
+            "Output mode"
+        case .qualitySettings:
+            "Quality settings"
+        }
+    }
+}
+
+enum RouteQualityEdit: Equatable {
+    case outputMode(VideoOutputMode)
+    case restartStage(ConversionStage)
+    case reusableIntermediates(Bool)
+    case softwareEncoder(Bool)
+    case upscaleEnabled(Bool)
+    case cropBlackBars(Bool)
+    case fieldOfView(Int)
+    case resolutionOverride(String)
+    case qualityStep(QualityStep)
+    case customQuality(VideoQualityCustomValues)
+    case linkGeneratedAndUpscaleQuality(Bool)
+
+    var trigger: RouteQualityTrigger {
+        switch self {
+        case .outputMode:
+            .outputMode
+        case .restartStage:
+            .restartStage
+        case .reusableIntermediates:
+            .reusableIntermediates
+        case .softwareEncoder:
+            .softwareEncoder
+        case .upscaleEnabled, .cropBlackBars:
+            .upscaleCrop
+        case .fieldOfView:
+            .fieldOfView
+        case .resolutionOverride:
+            .resolutionOverride
+        case .qualityStep:
+            .generatedRouteRequirement
+        case .customQuality:
+            .qualitySettings
+        case .linkGeneratedAndUpscaleQuality:
+            .qualitySettings
+        }
+    }
+}
+
+enum RouteQualityResolutionChoice: String, CaseIterable, Codable, Identifiable {
+    case preservePriorIntent = "preserve_prior_intent"
+    case keepRequestedWorkflow = "keep_requested_workflow"
+    case useCustomExactSettings = "custom_exact_settings"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .preservePriorIntent:
+            "Preserve prior intent"
+        case .keepRequestedWorkflow:
+            "Keep requested workflow"
+        case .useCustomExactSettings:
+            "Use Custom exact settings"
+        }
+    }
+}
+
+struct RouteQualityResolutionOption: Codable, Equatable, Identifiable {
+    let choice: RouteQualityResolutionChoice
+    let mappingVersion: Int
+    let mappedStep: QualityStep?
+    let isAvailable: Bool
+
+    var id: String {
+        "\(choice.rawValue):v\(mappingVersion)"
+    }
+
+    var title: String { choice.title }
+
+    var detail: String {
+        switch choice {
+        case .preservePriorIntent:
+            return "Leave the current route and quality intent unchanged."
+        case .keepRequestedWorkflow:
+            if let mappedStep {
+                return "Apply the requested route with the \(mappedStep.title) quality mapping."
+            }
+            return "No truthful guided quality mapping is available for this route."
+        case .useCustomExactSettings:
+            return "Apply the requested route with the exact concrete settings already shown."
+        }
+    }
+}
+
+struct RouteQualityConflict: Equatable {
+    let trigger: RouteQualityTrigger
+    let reason: String
+    let priorOptions: ConversionOptions
+    let proposedOptions: ConversionOptions
+    let priorRoute: VideoRoutePlan
+    let proposedRoute: VideoRoutePlan
+    let resolutions: [RouteQualityResolutionOption]
+    let mappingVersion: Int
+    var selectedResolutionID: String?
+
+    var blockReason: String {
+        "Resolve \(trigger.title.lowercased()) before starting, previewing, or adding this conversion to the queue."
+    }
+}
+
+struct RouteQualityDraft: Equatable {
+    let options: ConversionOptions
+    let mappingVersion: Int
+
+    var route: VideoRoutePlan {
+        VideoRoutePlan(options: options)
+    }
+}
+
+enum RouteQualityProposal: Equatable {
+    case resolved(RouteQualityDraft)
+    case conflict(RouteQualityConflict)
+    case invalid(String)
+}
+
+struct RouteQualityResolutionError: Error, Equatable, LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+enum RouteQualityEngine {
+    static let mappingVersion = VideoQualityCatalog.mappingVersion
+
+    static func propose(
+        options: ConversionOptions,
+        edit: RouteQualityEdit
+    ) -> RouteQualityProposal {
+        var proposed = options
+        do {
+            try apply(edit, to: &proposed)
+        } catch {
+            return .invalid(error.localizedDescription)
+        }
+
+        let priorRoute = VideoRoutePlan(options: options)
+        let proposedRoute = VideoRoutePlan(options: proposed)
+        let routeChanged = priorRoute.kind != proposedRoute.kind
+            || priorRoute.includesUpscale != proposedRoute.includesUpscale
+            || priorRoute.generatedRequirement != proposedRoute.generatedRequirement
+        let qualityDecisionRequired = routeChanged
+            && options.encoding.videoQuality.mode == .ladder
+        if !qualityDecisionRequired, isValid(proposed, route: proposedRoute) {
+            return .resolved(RouteQualityDraft(options: proposed, mappingVersion: mappingVersion))
+        }
+
+        let resolutions = resolutionOptions(
+            prior: options,
+            proposed: proposed,
+            proposedRoute: proposedRoute
+        )
+        let reason = validationReason(for: proposed, route: proposedRoute)
+        return .conflict(
+            RouteQualityConflict(
+                trigger: trigger(for: edit, priorRoute: priorRoute, proposedRoute: proposedRoute),
+                reason: reason,
+                priorOptions: options,
+                proposedOptions: proposed,
+                priorRoute: priorRoute,
+                proposedRoute: proposedRoute,
+                resolutions: resolutions,
+                mappingVersion: mappingVersion,
+                selectedResolutionID: nil
+            )
+        )
+    }
+
+    static func resolve(
+        _ option: RouteQualityResolutionOption,
+        conflict: RouteQualityConflict
+    ) -> Result<RouteQualityDraft, RouteQualityResolutionError> {
+        guard option.isAvailable,
+              conflict.resolutions.contains(option)
+        else {
+            return .failure(.init(message: "That route-quality resolution is not available."))
+        }
+
+        var resolved: ConversionOptions
+        switch option.choice {
+        case .preservePriorIntent:
+            resolved = conflict.priorOptions
+        case .keepRequestedWorkflow:
+            guard let mappedStep = option.mappedStep else {
+                return .failure(.init(message: "No truthful quality mapping is available for the requested workflow."))
+            }
+            resolved = conflict.proposedOptions
+            do {
+                try applyMappedQuality(mappedStep, to: &resolved)
+            } catch {
+                return .failure(.init(message: error.localizedDescription))
+            }
+        case .useCustomExactSettings:
+            resolved = conflict.proposedOptions
+            resolved.encoding.videoQuality = .custom(
+                lastLadderStep: conflict.priorOptions.encoding.videoQuality.lastLadderStep,
+                values: concreteQualityValues(from: conflict.priorOptions.encoding)
+            )
+            do {
+                try resolved.encoding.applyVideoQualityIntent()
+            } catch {
+                return .failure(.init(message: error.localizedDescription))
+            }
+        }
+
+        let route = VideoRoutePlan(options: resolved)
+        guard isValid(resolved, route: route) else {
+            return .failure(.init(message: validationReason(for: resolved, route: route)))
+        }
+        return .success(RouteQualityDraft(options: resolved, mappingVersion: mappingVersion))
+    }
+
+    static func validate(_ options: ConversionOptions) -> Result<RouteQualityDraft, RouteQualityResolutionError> {
+        let route = VideoRoutePlan(options: options)
+        guard isValid(options, route: route) else {
+            return .failure(.init(message: validationReason(for: options, route: route)))
+        }
+        return .success(RouteQualityDraft(options: options, mappingVersion: mappingVersion))
+    }
+
+    private static func apply(
+        _ edit: RouteQualityEdit,
+        to options: inout ConversionOptions
+    ) throws {
+        switch edit {
+        case let .outputMode(mode):
+            options.encoding.selectVideoOutputMode(mode)
+        case let .restartStage(stage):
+            options.job.startStage = stage
+        case let .reusableIntermediates(enabled):
+            options.job.intermediatePolicy = enabled ? .reusable : .automatic
+        case let .softwareEncoder(enabled):
+            options.job.softwareEncoder = enabled
+        case let .upscaleEnabled(enabled):
+            options.encoding.upscaleEnabled = enabled
+        case let .cropBlackBars(enabled):
+            options.encoding.cropBlackBars = enabled
+        case let .fieldOfView(value):
+            options.encoding.fieldOfView = value
+        case let .resolutionOverride(value):
+            options.encoding.resolutionOverride = value
+        case let .qualityStep(step):
+            try options.encoding.selectQualityStep(step)
+        case let .customQuality(values):
+            options.encoding.videoQuality = .custom(
+                lastLadderStep: options.encoding.videoQuality.lastLadderStep,
+                values: values
+            )
+            try options.encoding.applyVideoQualityIntent()
+        case let .linkGeneratedAndUpscaleQuality(linked):
+            var values = options.encoding.videoQuality.custom
+            if linked {
+                values.upscaleQuality = values.generatedMergeQuality
+            }
+            options.encoding.videoQuality = .custom(
+                lastLadderStep: options.encoding.videoQuality.lastLadderStep,
+                values: values
+            )
+            options.encoding.mvHEVC.linkGeneratedAndUpscaleQuality = linked
+            try options.encoding.applyVideoQualityIntent()
+        }
+    }
+
+    private static func applyMappedQuality(
+        _ step: QualityStep,
+        to options: inout ConversionOptions
+    ) throws {
+        guard options.encoding.videoOutputMode == .mvHEVC else {
+            throw VideoQualityStateError.incompatibleOutputMode
+        }
+        options.encoding.videoQuality.mode = .ladder
+        options.encoding.videoQuality.lastLadderStep = step
+        try options.encoding.applyVideoQualityIntent()
+    }
+
+    private static func isValid(
+        _ options: ConversionOptions,
+        route: VideoRoutePlan
+    ) -> Bool {
+        guard (try? options.encoding.validateQualityMirrors()) != nil else {
+            return false
+        }
+        guard options.encoding.videoQuality.mode == .ladder else {
+            return true
+        }
+        if route.kind == .existingArtifact, !route.includesUpscale {
+            return true
+        }
+        guard let target = qualityTarget(for: route) else {
+            return false
+        }
+        guard VideoQualityCatalog.supports(
+            options.encoding.videoQuality.lastLadderStep,
+            for: target
+        ) else {
+            return false
+        }
+        if route.kind == .generatedMVHEVC, route.includesUpscale {
+            return VideoQualityCatalog.supports(
+                options.encoding.videoQuality.lastLadderStep,
+                for: .fileUpscale
+            )
+        }
+        return true
+    }
+
+    private static func validationReason(
+        for options: ConversionOptions,
+        route: VideoRoutePlan
+    ) -> String {
+        do {
+            try options.encoding.validateQualityMirrors()
+        } catch {
+            return "The concrete quality settings do not match the selected quality intent."
+        }
+        if options.encoding.videoQuality.mode == .ladder,
+           route.kind != .existingArtifact || route.includesUpscale,
+           let target = qualityTarget(for: route),
+           !VideoQualityCatalog.supports(options.encoding.videoQuality.lastLadderStep, for: target)
+        {
+            return "The \(options.encoding.videoQuality.lastLadderStep.title) quality step is not available for the requested route."
+        }
+        return "The selected route and quality settings are not compatible."
+    }
+
+    private static func resolutionOptions(
+        prior: ConversionOptions,
+        proposed: ConversionOptions,
+        proposedRoute: VideoRoutePlan
+    ) -> [RouteQualityResolutionOption] {
+        let mappedStep = mappedStep(
+            from: prior.encoding.videoQuality,
+            for: proposedRoute
+        )
+        return RouteQualityResolutionChoice.allCases.map { choice in
+            RouteQualityResolutionOption(
+                choice: choice,
+                mappingVersion: mappingVersion,
+                mappedStep: choice == .keepRequestedWorkflow ? mappedStep : nil,
+                isAvailable: choice != .keepRequestedWorkflow || mappedStep != nil
+            )
+        }
+    }
+
+    private static func mappedStep(
+        from intent: VideoQualityIntent,
+        for route: VideoRoutePlan
+    ) -> QualityStep? {
+        guard intent.mode == .ladder else {
+            return nil
+        }
+        let supported: [QualityStep]
+        switch route.kind {
+        case .directMVHEVC:
+            supported = VideoQualityCatalog.supportedSteps(
+                for: route.includesUpscale ? .directMVHEVCMetalFX2x : .directMVHEVC
+            )
+        case .generatedMVHEVC:
+            supported = VideoQualityCatalog.supportedGeneratedSteps(
+                includingFileUpscale: route.includesUpscale
+            )
+        case .existingArtifact:
+            supported = route.includesUpscale
+                ? VideoQualityCatalog.supportedSteps(for: .fileUpscale)
+                : QualityStep.allCases
+        case .av1Stereo:
+            return nil
+        }
+        return supported.min {
+            abs($0.ordinal - intent.lastLadderStep.ordinal)
+                < abs($1.ordinal - intent.lastLadderStep.ordinal)
+        }
+    }
+
+    private static func qualityTarget(for route: VideoRoutePlan) -> VideoQualityTarget? {
+        switch route.kind {
+        case .directMVHEVC:
+            route.includesUpscale ? .directMVHEVCMetalFX2x : .directMVHEVC
+        case .generatedMVHEVC:
+            .generatedMVHEVC
+        case .existingArtifact:
+            route.includesUpscale ? .fileUpscale : nil
+        case .av1Stereo:
+            .av1Stereo
+        }
+    }
+
+    private static func concreteQualityValues(
+        from encoding: EncodingOptions
+    ) -> VideoQualityCustomValues {
+        VideoQualityCustomValues(
+            directFinalBitrate: encoding.mvHEVC.directFinalBitrate,
+            generatedEyeBitrate: encoding.mvHEVC.generatedEyeBitrate,
+            generatedMergeQuality: encoding.mvHEVC.generatedMergeQuality,
+            av1CRF: encoding.av1CRF,
+            upscaleQuality: encoding.upscaleQuality
+        )
+    }
+
+    private static func trigger(
+        for edit: RouteQualityEdit,
+        priorRoute: VideoRoutePlan,
+        proposedRoute: VideoRoutePlan
+    ) -> RouteQualityTrigger {
+        _ = priorRoute
+        _ = proposedRoute
+        return edit.trigger
+    }
+}
+
+final class RouteQualityResolutionState: ObservableObject {
+    @Published private(set) var conflict: RouteQualityConflict?
+    @Published private(set) var invalidMessage: String?
+
+    var blockReason: String? {
+        conflict?.blockReason ?? invalidMessage
+    }
+
+    func apply(_ edit: RouteQualityEdit, to options: inout ConversionOptions) {
+        guard conflict == nil else {
+            return
+        }
+        switch RouteQualityEngine.propose(options: options, edit: edit) {
+        case let .resolved(draft):
+            options = draft.options
+            invalidMessage = nil
+        case let .conflict(conflict):
+            self.conflict = conflict
+            invalidMessage = nil
+        case let .invalid(message):
+            invalidMessage = message
+        }
+    }
+
+    func resolve(_ option: RouteQualityResolutionOption, in options: inout ConversionOptions) {
+        guard let conflict else {
+            return
+        }
+        var selectedConflict = conflict
+        selectedConflict.selectedResolutionID = option.id
+        switch RouteQualityEngine.resolve(option, conflict: selectedConflict) {
+        case let .success(draft):
+            options = draft.options
+            self.conflict = nil
+            invalidMessage = nil
+        case let .failure(message):
+            invalidMessage = message.localizedDescription
+        }
+    }
+
+    func validate(_ options: ConversionOptions) {
+        guard conflict == nil else {
+            return
+        }
+        if case let .failure(message) = RouteQualityEngine.validate(options) {
+            invalidMessage = message.localizedDescription
+        } else {
+            invalidMessage = nil
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Models/RouteResolution.swift
+++ b/macos/BluRayToVisionPro/Models/RouteResolution.swift
@@ -134,6 +134,17 @@ struct RouteQualityConflict: Equatable {
     let mappingVersion: Int
     var selectedResolutionID: String?
 
+    /// A durable identity for a held decision. It deliberately excludes display copy.
+    var stableID: String {
+        [
+            trigger.rawValue,
+            priorRoute.kind.rawValue,
+            proposedRoute.kind.rawValue,
+            proposedRoute.generatedRequirement?.identifier ?? "none",
+            resolutions.filter(\.isAvailable).map(\.choice.rawValue).sorted().joined(separator: ","),
+        ].joined(separator: "|")
+    }
+
     var blockReason: String {
         "Resolve \(trigger.title.lowercased()) before starting, previewing, or adding this conversion to the queue."
     }

--- a/macos/BluRayToVisionPro/Models/RouteResolution.swift
+++ b/macos/BluRayToVisionPro/Models/RouteResolution.swift
@@ -17,9 +17,9 @@ enum RouteQualityTrigger: String, CaseIterable, Codable, Identifiable {
     var title: String {
         switch self {
         case .generatedRouteRequirement:
-            "Generated route requirement"
+            "Selected quality"
         case .reusableIntermediates:
-            "Reusable intermediates"
+            "Reusable files"
         case .softwareEncoder:
             "Software encoder"
         case .restartStage:
@@ -29,9 +29,9 @@ enum RouteQualityTrigger: String, CaseIterable, Codable, Identifiable {
         case .fieldOfView:
             "Field of view"
         case .resolutionOverride:
-            "Resolution override"
+            "Output resolution"
         case .outputMode:
-            "Output mode"
+            "Output format"
         case .qualitySettings:
             "Quality settings"
         }
@@ -111,14 +111,14 @@ struct RouteQualityResolutionOption: Codable, Equatable, Identifiable {
     var detail: String {
         switch choice {
         case .preservePriorIntent:
-            return "Leave the current route and quality intent unchanged."
+            return "Leave the current video and quality choices unchanged."
         case .keepRequestedWorkflow:
             if let mappedStep {
-                return "Apply the requested route with the \(mappedStep.title) quality mapping."
+                return "Use the requested file outcome with \(mappedStep.title) quality."
             }
-            return "No truthful guided quality mapping is available for this route."
+            return "No guided quality choice is available for the requested file outcome."
         case .useCustomExactSettings:
-            return "Apply the requested route with the exact concrete settings already shown."
+            return "Use the requested file outcome with the exact values shown in Advanced Settings."
         }
     }
 }
@@ -230,7 +230,7 @@ enum RouteQualityEngine {
         guard option.isAvailable,
               conflict.resolutions.contains(option)
         else {
-            return .failure(.init(message: "That route-quality resolution is not available."))
+            return .failure(.init(message: "That video and quality choice is not available."))
         }
 
         var resolved: ConversionOptions
@@ -239,7 +239,7 @@ enum RouteQualityEngine {
             resolved = conflict.priorOptions
         case .keepRequestedWorkflow:
             guard let mappedStep = option.mappedStep else {
-                return .failure(.init(message: "No truthful quality mapping is available for the requested workflow."))
+                return .failure(.init(message: "No guided quality choice is available for the requested file outcome."))
             }
             resolved = conflict.proposedOptions
             do {
@@ -368,16 +368,16 @@ enum RouteQualityEngine {
         do {
             try options.encoding.validateQualityMirrors()
         } catch {
-            return "The concrete quality settings do not match the selected quality intent."
+            return "The current quality choice no longer matches its detailed values. Review it before continuing."
         }
         if options.encoding.videoQuality.mode == .ladder,
            route.kind != .existingArtifact || route.includesUpscale,
            let target = qualityTarget(for: route),
            !VideoQualityCatalog.supports(options.encoding.videoQuality.lastLadderStep, for: target)
         {
-            return "The \(options.encoding.videoQuality.lastLadderStep.title) quality step is not available for the requested route."
+            return "\(options.encoding.videoQuality.lastLadderStep.title) quality is not available with the requested file outcome."
         }
-        return "The selected route and quality settings are not compatible."
+        return "The selected video and quality choices need review before continuing."
     }
 
     private static func conflictReason(
@@ -392,13 +392,13 @@ enum RouteQualityEngine {
         case .generatedMVHEVC:
             return "This change requires generated left- and right-eye files. Choose how the current quality choice should carry over."
         case .directMVHEVC:
-            return "This change returns to direct video processing. Choose how the current quality choice should carry over."
+            return "This change uses the source video directly. Choose how the current quality choice should carry over."
         case .av1Stereo:
-            return "AV1 uses exact Custom quality settings. Choose whether to keep the current workflow or continue with AV1."
+            return "This output format uses exact Custom quality settings. Choose how to continue."
         case .existingArtifact:
             return priorRoute.kind == .existingArtifact
                 ? "This restart changes which retained quality settings are applied. Choose how to continue."
-                : "This restart reuses an existing encoded video. Choose how retained quality settings should be handled."
+                : "This restart reuses an existing video. Choose how retained quality settings should be handled."
         }
     }
 

--- a/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
+++ b/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
@@ -6,12 +6,14 @@ enum SetupQueueAdmissionState: Equatable {
     case held(RouteQualityConflict)
     case running
     case completed
+    case attention
+    case stopped
 
     var acceptsChanges: Bool {
         switch self {
         case .waiting, .held:
             true
-        case .running, .completed:
+        case .running, .completed, .attention, .stopped:
             false
         }
     }
@@ -20,6 +22,7 @@ enum SetupQueueAdmissionState: Equatable {
 struct SetupQueueAdmissionItem: Identifiable, Equatable {
     let id: UUID
     let originalDraft: ConversionDraft
+    let originalConflict: RouteQualityConflict?
     var resolvedDraft: ConversionDraft?
     var state: SetupQueueAdmissionState
     var resolutionTrace: DurableQueueResolutionTrace?
@@ -31,6 +34,7 @@ struct SetupQueueAdmissionItem: Identifiable, Equatable {
     ) {
         self.id = id
         originalDraft = draft
+        originalConflict = conflict
         resolvedDraft = conflict == nil ? draft : nil
         state = conflict.map(SetupQueueAdmissionState.held) ?? .waiting
         resolutionTrace = nil
@@ -55,6 +59,7 @@ final class SetupQueueAdmission: ObservableObject {
     @Published private(set) var items: [SetupQueueAdmissionItem] = []
 
     var isBatch: Bool { items.count > 1 }
+    var hasItems: Bool { !items.isEmpty }
 
     var groups: [QueueResolutionGroup] {
         QueueResolutionGroup.group(
@@ -83,6 +88,9 @@ final class SetupQueueAdmission: ObservableObject {
 
     func add(drafts: [ConversionDraft], conflicts: [RouteQualityConflict?] = []) {
         guard !drafts.isEmpty else { return }
+        if items.allSatisfy({ $0.state == .completed || $0.state == .stopped }) {
+            items.removeAll()
+        }
         let suppliedConflicts = conflicts + Array(repeating: nil, count: max(0, drafts.count - conflicts.count))
         items.append(contentsOf: zip(drafts, suppliedConflicts).map {
             SetupQueueAdmissionItem(draft: $0.0, conflict: $0.1)
@@ -142,13 +150,58 @@ final class SetupQueueAdmission: ObservableObject {
         items[index].state = .running
     }
 
+    func markAllRunning() {
+        for index in items.indices where items[index].state == .waiting {
+            items[index].state = .running
+        }
+    }
+
+    func changeResolution(_ id: UUID) {
+        guard let index = items.firstIndex(where: { $0.id == id }),
+              items[index].state == .waiting,
+              let conflict = items[index].originalConflict
+        else {
+            return
+        }
+        items[index].resolvedDraft = nil
+        items[index].resolutionTrace = nil
+        items[index].state = .held(conflict)
+    }
+
+    func synchronize(with runtimeItems: [PersistentQueueItem]) {
+        for runtimeItem in runtimeItems {
+            guard let index = items.firstIndex(where: { $0.id == runtimeItem.id }) else {
+                continue
+            }
+            items[index].resolutionTrace = runtimeItem.resolutionTrace ?? items[index].resolutionTrace
+            switch runtimeItem.status {
+            case .waiting:
+                if items[index].currentDraft != nil {
+                    items[index].state = .waiting
+                }
+            case .inspecting, .processing, .stopping:
+                items[index].state = .running
+            case .completed:
+                items[index].state = .completed
+            case .interrupted, .attention, .failed:
+                items[index].state = .attention
+            case .stopped, .notStarted:
+                items[index].state = .stopped
+            }
+        }
+    }
+
     func durableItems() -> [DurableConversionQueueItem] {
         items.enumerated().compactMap { offset, item in
             guard let draft = item.currentDraft else { return nil }
             return DurableConversionQueueItem(
+                id: item.id,
                 ordinal: offset,
-                origin: item.originalDraft.selectedTitle == nil ? .singleSource : .multiTitle,
+                origin: item.originalDraft.source.kind == .sourceFolder
+                    ? .sourceFolder
+                    : (item.originalDraft.selectedTitle == nil ? .singleSource : .multiTitle),
                 intent: DurableQueueItemIntent(draft: draft),
+                inspection: draft.sourceDetails,
                 resolutionTrace: item.resolutionTrace
             )
         }

--- a/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
+++ b/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
@@ -60,6 +60,7 @@ final class SetupQueueAdmission: ObservableObject {
 
     var isBatch: Bool { items.count > 1 }
     var hasItems: Bool { !items.isEmpty }
+    var canClear: Bool { items.allSatisfy { $0.state != .running } }
 
     var groups: [QueueResolutionGroup] {
         QueueResolutionGroup.group(
@@ -153,6 +154,17 @@ final class SetupQueueAdmission: ObservableObject {
     func markAllRunning() {
         for index in items.indices where items[index].state == .waiting {
             items[index].state = .running
+        }
+    }
+
+    func markStartFailed(_ itemIDs: Set<UUID>) {
+        for index in items.indices where itemIDs.contains(items[index].id) {
+            switch items[index].state {
+            case .waiting, .running:
+                items[index].state = .attention
+            case .held, .completed, .attention, .stopped:
+                break
+            }
         }
     }
 

--- a/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
+++ b/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
@@ -1,0 +1,160 @@
+import Combine
+import Foundation
+
+enum SetupQueueAdmissionState: Equatable {
+    case waiting
+    case held(RouteQualityConflict)
+    case running
+    case completed
+
+    var acceptsChanges: Bool {
+        switch self {
+        case .waiting, .held:
+            true
+        case .running, .completed:
+            false
+        }
+    }
+}
+
+struct SetupQueueAdmissionItem: Identifiable, Equatable {
+    let id: UUID
+    let originalDraft: ConversionDraft
+    var resolvedDraft: ConversionDraft?
+    var state: SetupQueueAdmissionState
+    var resolutionTrace: DurableQueueResolutionTrace?
+
+    init(
+        id: UUID = UUID(),
+        draft: ConversionDraft,
+        conflict: RouteQualityConflict? = nil
+    ) {
+        self.id = id
+        originalDraft = draft
+        resolvedDraft = conflict == nil ? draft : nil
+        state = conflict.map(SetupQueueAdmissionState.held) ?? .waiting
+        resolutionTrace = nil
+    }
+
+    var displayName: String {
+        originalDraft.selectedTitle?.name ?? originalDraft.source.displayName
+    }
+
+    var currentDraft: ConversionDraft? {
+        resolvedDraft
+    }
+
+    var conflict: RouteQualityConflict? {
+        guard case let .held(conflict) = state else { return nil }
+        return conflict
+    }
+}
+
+@MainActor
+final class SetupQueueAdmission: ObservableObject {
+    @Published private(set) var items: [SetupQueueAdmissionItem] = []
+
+    var isBatch: Bool { items.count > 1 }
+
+    var groups: [QueueResolutionGroup] {
+        QueueResolutionGroup.group(
+            items.compactMap { item in
+                guard item.state.acceptsChanges,
+                      let conflict = item.conflict
+                else { return nil }
+                return QueueResolutionCandidate(id: item.id, draft: item.originalDraft, conflict: conflict)
+            }
+        )
+    }
+
+    var canStart: Bool {
+        guard !items.isEmpty else { return false }
+        return items.allSatisfy { item in
+            guard let draft = item.currentDraft else { return false }
+            if case .failure = RouteQualityEngine.validate(draft.options) { return false }
+            return item.state == .waiting
+        }
+    }
+
+    var startableDrafts: [ConversionDraft] {
+        guard canStart else { return [] }
+        return items.compactMap(\.currentDraft)
+    }
+
+    func add(drafts: [ConversionDraft], conflicts: [RouteQualityConflict?] = []) {
+        guard !drafts.isEmpty else { return }
+        let suppliedConflicts = conflicts + Array(repeating: nil, count: max(0, drafts.count - conflicts.count))
+        items.append(contentsOf: zip(drafts, suppliedConflicts).map {
+            SetupQueueAdmissionItem(draft: $0.0, conflict: $0.1)
+        })
+    }
+
+    func apply(
+        group: QueueResolutionGroup,
+        selection: QueueResolutionSelection
+    ) -> Result<Void, RouteQualityResolutionError> {
+        guard let resolutionID = selection.resolutionID,
+              let resolution = group.conflict.resolutions.first(where: { $0.id == resolutionID })
+        else {
+            return .failure(.init(message: "Choose a resolution before applying it."))
+        }
+        let candidateIDs: Set<UUID>
+        switch selection.scope {
+        case .allMatching:
+            candidateIDs = Set(group.candidates.map(\.id))
+        case let .item(id):
+            candidateIDs = [id]
+        }
+        let selectedCandidates = group.candidates.filter { candidateIDs.contains($0.id) }
+        guard !selectedCandidates.isEmpty else {
+            return .failure(.init(message: "Choose a waiting item before applying it."))
+        }
+        let selectedGroup = QueueResolutionGroup(key: group.key, candidates: selectedCandidates)
+        switch QueueResolutionApplication.apply(group: selectedGroup, selection: selection) {
+        case let .failure(error):
+            return .failure(error)
+        case let .success(application):
+            for candidate in selectedCandidates {
+                guard let draft = application.resolvedDrafts[candidate.id] else { continue }
+                guard let index = items.firstIndex(where: { $0.id == candidate.id }),
+                      items[index].state.acceptsChanges
+                else { continue }
+                let conflict = candidate.conflict
+                items[index].resolvedDraft = draft
+                items[index].state = .waiting
+                items[index].resolutionTrace = DurableQueueResolutionTrace(
+                    conflictID: conflict.stableID,
+                    resolutionID: resolution.id,
+                    qualityOutcome: "\(draft.options.videoRoutePlan.qualityTitle) quality",
+                    fileOutcome: draft.options.job.intermediatePolicy.createsReusableArtifacts
+                        ? "Reusable files kept"
+                        : "Reusable files removed"
+                )
+            }
+            return .success(())
+        }
+    }
+
+    func markRunning(_ id: UUID) {
+        guard let index = items.firstIndex(where: { $0.id == id }),
+              items[index].state == .waiting
+        else { return }
+        items[index].state = .running
+    }
+
+    func durableItems() -> [DurableConversionQueueItem] {
+        items.enumerated().compactMap { offset, item in
+            guard let draft = item.currentDraft else { return nil }
+            return DurableConversionQueueItem(
+                ordinal: offset,
+                origin: item.originalDraft.selectedTitle == nil ? .singleSource : .multiTitle,
+                intent: DurableQueueItemIntent(draft: draft),
+                resolutionTrace: item.resolutionTrace
+            )
+        }
+    }
+
+    func removeAll() {
+        items.removeAll()
+    }
+}

--- a/macos/BluRayToVisionPro/Models/VideoQuality.swift
+++ b/macos/BluRayToVisionPro/Models/VideoQuality.swift
@@ -153,6 +153,18 @@ enum VideoQualityCatalog {
         mapping(for: step, target: target) != nil
     }
 
+    static func qualityTitle(
+        for selection: VideoQualitySelection,
+        target: VideoQualityTarget
+    ) -> String {
+        switch selection {
+        case let .step(step):
+            supports(step, for: target) ? step.title : "Custom"
+        case .custom:
+            "Custom"
+        }
+    }
+
     static func supportsProfileMVHEVCIntent(_ step: QualityStep) -> Bool {
         supports(step, for: .directMVHEVC)
             && supports(step, for: .directMVHEVCMetalFX2x)

--- a/macos/BluRayToVisionPro/Models/VideoRouting.swift
+++ b/macos/BluRayToVisionPro/Models/VideoRouting.swift
@@ -220,6 +220,10 @@ struct VideoRoutePlan: Equatable {
         }
     }
 
+    var qualityTitle: String {
+        resolvedQualityTitle ?? "Not applied"
+    }
+
     var systemImage: String {
         switch kind {
         case .directMVHEVC:
@@ -255,7 +259,7 @@ struct VideoRoutePlan: Equatable {
                     rateControl = "Adaptive content quality"
                 }
             }
-            let summary = "\(qualitySelection.title) · \(rateControl)"
+            let summary = "\(resolvedQualityTitle ?? "Custom") · \(rateControl)"
             return includesUpscale ? "\(summary) · 2× MetalFX" : summary
         case .generatedMVHEVC:
             return generatedSettingsSummary(
@@ -268,7 +272,7 @@ struct VideoRoutePlan: Equatable {
             return "Custom · CRF \(av1CRF ?? 32)"
         case .existingArtifact:
             if let upscaleQuality {
-                return "\(qualitySelection.title) · upscale quality \(upscaleQuality)"
+                return "\(resolvedQualityTitle ?? "Custom") · upscale quality \(upscaleQuality)"
             }
             return "No video re-encode"
         }
@@ -394,6 +398,58 @@ struct VideoRoutePlan: Equatable {
         }
     }
 
+    private var qualityTargets: [VideoQualityTarget] {
+        switch kind {
+        case .directMVHEVC:
+            [includesUpscale ? .directMVHEVCMetalFX2x : .directMVHEVC]
+        case .generatedMVHEVC:
+            includesUpscale ? [.generatedMVHEVC, .fileUpscale] : [.generatedMVHEVC]
+        case .av1Stereo:
+            [.av1Stereo]
+        case .existingArtifact:
+            includesUpscale ? [.fileUpscale] : []
+        }
+    }
+
+    private var resolvedQualityTitle: String? {
+        guard !qualityTargets.isEmpty else {
+            return nil
+        }
+        switch qualitySelection {
+        case .custom:
+            return "Custom"
+        case let .step(step):
+            guard qualityTargets.allSatisfy({ target in
+                guard let mapping = VideoQualityCatalog.mapping(for: step, target: target),
+                      VideoQualityCatalog.qualityTitle(for: .step(step), target: target) == step.title
+                else {
+                    return false
+                }
+                return mappingMatchesRoute(mapping, target: target)
+            }) else {
+                return "Custom"
+            }
+            return step.title
+        }
+    }
+
+    private func mappingMatchesRoute(
+        _ mapping: VideoQualityRouteValues,
+        target: VideoQualityTarget
+    ) -> Bool {
+        switch (target, mapping) {
+        case (.directMVHEVC, .direct), (.directMVHEVCMetalFX2x, .direct):
+            directBitrateMbps == nil
+        case let (.generatedMVHEVC, .generated(eyeBitrateMbps, mergeQuality)):
+            self.generatedEyeBitrateMbps == eyeBitrateMbps
+                && self.generatedMergeQuality == mergeQuality
+        case let (.fileUpscale, .upscale(quality)):
+            upscaleQuality == quality
+        default:
+            false
+        }
+    }
+
     private func generatedSettingsSummary(
         mode: BitrateMode?,
         bitrateMbps: Int?,
@@ -401,7 +457,7 @@ struct VideoRoutePlan: Equatable {
         upscaleQuality: Int?
     ) -> String {
         let policy = mode == .custom ? "Fixed" : "Recommended"
-        let generated = "\(qualitySelection.title) · \(policy) \(bitrateMbps ?? Self.automaticGeneratedEyeBitrateMbps) Mbps per eye · merge \(mergeQuality ?? Self.automaticGeneratedMergeQuality)"
+        let generated = "\(resolvedQualityTitle ?? "Custom") · \(policy) \(bitrateMbps ?? Self.automaticGeneratedEyeBitrateMbps) Mbps per eye · merge \(mergeQuality ?? Self.automaticGeneratedMergeQuality)"
         return upscaleQuality.map { "\(generated) · upscale \($0)" } ?? generated
     }
 }
@@ -454,22 +510,14 @@ extension VideoRouteReport {
     }
 
     var selectedSettingsSummary: String {
-        VideoRouteReport.RouteSettings(
-            route: selected,
-            bitrateMbps: bitrateMbps,
-            eyeBitrateMbps: eyeBitrateMbps,
-            mergeQuality: mergeQuality,
-            crf: crf,
-            rateControl: rateControl,
-            quality: quality,
-            upscaleMode: upscaleMode,
-            upscaleQuality: upscaleQuality
-        ).settingsSummary(qualityTitle: qualityIntentDescription)
+        selectedRouteSettings.settingsSummary(
+            qualityTitle: selectedRouteSettings.qualityTitle(for: qualityIntent)
+        )
     }
 
     var requestedSettingsSummary: String? {
         requested.map {
-            "\($0.displayTitle) · \($0.settingsSummary(qualityTitle: qualityIntentDescription))"
+            "\($0.displayTitle) · \($0.settingsSummary(qualityTitle: $0.qualityTitle(for: qualityIntent)))"
         }
     }
 
@@ -492,18 +540,21 @@ extension VideoRouteReport {
     }
 
     private var qualityIntentDescription: String? {
-        guard let qualityIntent else {
-            return nil
-        }
-        if qualityIntent.mode == QualityIntentMode.custom.rawValue {
-            return "Custom"
-        }
-        guard let rawStep = qualityIntent.step,
-              let step = QualityStep(rawValue: rawStep)
-        else {
-            return "guided"
-        }
-        return step.title
+        selectedRouteSettings.qualityTitle(for: qualityIntent)
+    }
+
+    private var selectedRouteSettings: VideoRouteReport.RouteSettings {
+        VideoRouteReport.RouteSettings(
+            route: selected,
+            bitrateMbps: bitrateMbps,
+            eyeBitrateMbps: eyeBitrateMbps,
+            mergeQuality: mergeQuality,
+            crf: crf,
+            rateControl: rateControl,
+            quality: quality,
+            upscaleMode: upscaleMode,
+            upscaleQuality: upscaleQuality
+        )
     }
 
     private static func reasonDescription(_ reason: String) -> String {
@@ -573,6 +624,49 @@ extension VideoRouteReport.RouteSettings {
         }
     }
 
+    private var qualityTargets: [VideoQualityTarget] {
+        switch kind {
+        case .directMVHEVC:
+            [upscaleMode == "metalfx" ? .directMVHEVCMetalFX2x : .directMVHEVC]
+        case .generatedMVHEVC:
+            upscaleQuality == nil ? [.generatedMVHEVC] : [.generatedMVHEVC, .fileUpscale]
+        case .existingArtifact:
+            upscaleQuality == nil ? [] : [.fileUpscale]
+        case .av1Stereo:
+            [.av1Stereo]
+        case .none:
+            []
+        }
+    }
+
+    func qualityTitle(for qualityIntent: VideoRouteReport.QualityIntent?) -> String? {
+        guard !qualityTargets.isEmpty, let qualityIntent else {
+            return nil
+        }
+        guard qualityIntent.mode != QualityIntentMode.custom.rawValue else {
+            return "Custom"
+        }
+        guard qualityIntent.mappingVersion == VideoQualityCatalog.mappingVersion else {
+            return "Custom"
+        }
+        guard let rawStep = qualityIntent.step,
+              let step = QualityStep(rawValue: rawStep)
+        else {
+            return "Custom"
+        }
+        guard qualityTargets.allSatisfy({ target in
+            guard let mapping = VideoQualityCatalog.mapping(for: step, target: target),
+                  VideoQualityCatalog.qualityTitle(for: .step(step), target: target) == step.title
+            else {
+                return false
+            }
+            return mappingMatchesReport(mapping, target: target)
+        }) else {
+            return "Custom"
+        }
+        return step.title
+    }
+
     func settingsSummary(qualityTitle: String?) -> String {
         let concrete: String
         switch kind {
@@ -621,6 +715,27 @@ extension VideoRouteReport.RouteSettings {
 
     private static func withQualityTitle(_ qualityTitle: String?, concrete: String) -> String {
         qualityTitle.map { "\($0) · \(concrete)" } ?? concrete
+    }
+
+    private func mappingMatchesReport(
+        _ mapping: VideoQualityRouteValues,
+        target: VideoQualityTarget
+    ) -> Bool {
+        switch (target, mapping) {
+        case let (.directMVHEVC, .direct(expectedQuality)),
+             let (.directMVHEVCMetalFX2x, .direct(expectedQuality)):
+            guard let quality else {
+                return false
+            }
+            return abs(quality - expectedQuality) < 0.0001
+        case let (.generatedMVHEVC, .generated(expectedEyeBitrate, expectedMergeQuality)):
+            return eyeBitrateMbps == expectedEyeBitrate
+                && mergeQuality == expectedMergeQuality
+        case let (.fileUpscale, .upscale(expectedQuality)):
+            return upscaleQuality == expectedQuality
+        default:
+            return false
+        }
     }
 }
 

--- a/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
+++ b/macos/BluRayToVisionPro/Models/WorkerLifecycle.swift
@@ -152,6 +152,13 @@ struct WorkerLifecycleState: Equatable {
         resetJobState()
     }
 
+    mutating func prepareQueuedConversion(sourceURL: URL, inspection: SourceInspection) {
+        self.sourceURL = sourceURL
+        phase = .ready
+        resetJobState()
+        result = inspection
+    }
+
     mutating func begin(jobID: UUID, operationKind: WorkerOperationKind = .inspection) throws {
         guard sourceURL != nil else {
             throw WorkerLifecycleError.noSource

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -170,17 +170,6 @@ struct ContentView: View {
             }
         }
         .onAppear(perform: refreshDiscs)
-        .onReceive(NotificationCenter.default.publisher(for: .conversionSourceSelectionRequested)) { notification in
-            guard let sourceURL = notification.object as? URL else {
-                return
-            }
-            sourceResetMessage = nil
-            if let source = ConversionSource.infer(from: sourceURL) {
-                selectSource(source)
-            } else {
-                viewModel.selectSource(sourceURL)
-            }
-        }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
             refreshDiscs()
         }
@@ -219,6 +208,7 @@ struct ContentView: View {
         }
         .onChange(of: defaultJobOptions) { _, newValue in
             if viewModel.source == nil, !viewModel.hasActiveWork {
+                routeQualityState.reset()
                 if selectedProfile.pipelineDefaults == nil {
                     options.job = newValue
                 } else {
@@ -283,6 +273,7 @@ struct ContentView: View {
             else {
                 return
             }
+            routeQualityState.reset()
             options.encoding = currentProfile.options
             options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: currentProfile))
         }
@@ -879,6 +870,7 @@ struct ContentView: View {
     }
 
     private func resetProfile() {
+        routeQualityState.reset()
         options.encoding = selectedProfile.options
         options.job = defaultJobOptions
         options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: selectedProfile))
@@ -965,6 +957,7 @@ struct ContentView: View {
         guard canSelectSource else {
             return
         }
+        routeQualityState.reset()
         sourceResetMessage = nil
         if isNewSource(source) {
             sourceResetMessage = options.resetSourceScopedState(

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     @State private var isShowingDiagnosticReport = false
     @State private var isRefreshingDiscs = false
     @StateObject private var routeQualityState: RouteQualityResolutionState
+    @StateObject private var setupQueue = SetupQueueAdmission()
 
     init(
         viewModel: ConversionViewModel,
@@ -123,26 +124,9 @@ struct ContentView: View {
                 )
                 .frame(minWidth: 350, idealWidth: 390, maxWidth: 450)
 
-                ConversionSetupView(
-                    selectedProfileID: $selectedProfileID,
-                    selectedTab: $selectedTab,
-                    options: $options,
-                    profiles: profileStore.profiles,
-                    selectedProfile: selectedProfile,
-                    profileModified: profileModified,
-                    isLocked: viewModel.hasActiveWork
-                        || previewViewModel.hasActiveWorker
-                        || viewModel.state.phase == .decisionRequired,
-                    sourceKind: viewModel.source?.kind,
-                    routeQualityState: routeQualityState,
-                    resolutionMemoryStore: resolutionMemoryStore,
-                    isReady: true,
-                    openEditor: beginSetupEditor,
-                    saveSelectedProfile: saveSelectedProfile,
-                    saveAsNewProfile: beginSaveAsNewProfile,
-                    resetProfile: resetProfile
-                )
-                .frame(minWidth: 570, idealWidth: 680)
+                setupColumn
+
+                queueSidebar
             }
 
             Divider()
@@ -518,6 +502,47 @@ struct ContentView: View {
 
     private var selectedProfile: EncodingProfile {
         profileStore.profile(withID: selectedProfileID)
+    }
+
+    private var setupColumn: some View {
+        ConversionSetupView(
+            selectedProfileID: $selectedProfileID,
+            selectedTab: $selectedTab,
+            options: $options,
+            profiles: profileStore.profiles,
+            selectedProfile: selectedProfile,
+            profileModified: profileModified,
+            isLocked: viewModel.hasActiveWork || previewViewModel.hasActiveWorker || viewModel.state.phase == .decisionRequired,
+            sourceKind: viewModel.source?.kind,
+            routeQualityState: routeQualityState,
+            resolutionMemoryStore: resolutionMemoryStore,
+            isReady: true,
+            openEditor: beginSetupEditor,
+            saveSelectedProfile: saveSelectedProfile,
+            saveAsNewProfile: beginSaveAsNewProfile,
+            resetProfile: resetProfile,
+            sourceName: viewModel.source?.displayName,
+            destinationName: destinationURL.path,
+            estimate: "Finished movie size and time are estimated from this source.",
+            preview: { isShowingPreview = true },
+            addToQueue: addCurrentDraftsToQueue,
+            start: startReadyConversion,
+            canPreview: previewCanStart,
+            canAddToQueue: !conversionDrafts.isEmpty && !viewModel.hasActiveWork,
+            canStart: conversionCanStart
+        )
+        .frame(minWidth: 570, idealWidth: 680)
+    }
+
+    @ViewBuilder
+    private var queueSidebar: some View {
+        if setupQueue.isBatch {
+            SetupQueueAdmissionView(
+                admission: setupQueue,
+                memoryStore: resolutionMemoryStore,
+                start: startAdmittedQueue
+            )
+        }
     }
 
     private var diagnosticActionTitle: String {
@@ -1098,6 +1123,25 @@ struct ContentView: View {
             viewModel.startConversion(draft: conversionDrafts[0])
         } else {
             viewModel.startConversionQueue(drafts: conversionDrafts)
+        }
+    }
+
+    private func addCurrentDraftsToQueue() {
+        guard !conversionDrafts.isEmpty else { return }
+        setupQueue.add(drafts: conversionDrafts)
+    }
+
+    private func startAdmittedQueue() {
+        let drafts = setupQueue.startableDrafts
+        guard !drafts.isEmpty else { return }
+        viewModel.startConversionQueue(drafts: drafts)
+    }
+
+    private func startReadyConversion() {
+        if setupQueue.isBatch {
+            startAdmittedQueue()
+        } else {
+            startSelectedConversions()
         }
     }
 }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -68,18 +68,12 @@ struct ContentView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if let migrationNoticeMessage = profileStore.migrationNoticeMessage {
-                Label(migrationNoticeMessage, systemImage: "exclamationmark.triangle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.orange)
-                    .padding(.horizontal)
-                    .padding(.vertical, 10)
-            }
+        presentedContent
+    }
 
-            if !settings.hasAcknowledgedStandardMovieRenameNotice {
-                StandardMovieRenameNoticeView(settings: settings)
-            }
+    private var mainContent: some View {
+        VStack(spacing: 0) {
+            noticeContent
 
             HSplitView {
                 sourceOrQueueColumn
@@ -89,16 +83,40 @@ struct ContentView: View {
             Divider()
             statusFooter
 
-            if isShowingActivity {
-                Divider()
-                ActivityDrawer(
-                    state: viewModel.state,
-                    observabilityStatus: viewModel.liveObservabilityStatus,
-                    showTechnicalDetails: settings.showTechnicalDetails
-                )
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+            activityContent
         }
+    }
+
+    @ViewBuilder
+    private var noticeContent: some View {
+        if let migrationNoticeMessage = profileStore.migrationNoticeMessage {
+            Label(migrationNoticeMessage, systemImage: "exclamationmark.triangle.fill")
+                .font(.callout)
+                .foregroundStyle(.orange)
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+        }
+
+        if !settings.hasAcknowledgedStandardMovieRenameNotice {
+            StandardMovieRenameNoticeView(settings: settings)
+        }
+    }
+
+    @ViewBuilder
+    private var activityContent: some View {
+        if isShowingActivity {
+            Divider()
+            ActivityDrawer(
+                state: viewModel.state,
+                observabilityStatus: viewModel.liveObservabilityStatus,
+                showTechnicalDetails: settings.showTechnicalDetails
+            )
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+
+    private var baseContent: some View {
+        mainContent
         .accessibilityIdentifier("main-window-content")
         .focusedSceneValue(\.conversionSourceSelectionAction, sourceSelectionAction)
         .toolbar { toolbarContent }
@@ -118,9 +136,13 @@ struct ContentView: View {
                             .font(.title3.weight(.semibold))
                             .padding(14)
                             .background(.regularMaterial, in: Capsule())
-                    }
+                }
             }
         }
+    }
+
+    private var observedContent: some View {
+        baseContent
         .onAppear(perform: refreshDiscs)
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
             refreshDiscs()
@@ -236,6 +258,10 @@ struct ContentView: View {
             options.encoding = currentProfile.options
             options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: currentProfile))
         }
+    }
+
+    private var presentedContent: some View {
+        observedContent
         .sheet(isPresented: $isShowingSaveProfile) {
             SaveProfileSheet(name: $newProfileName) {
                 saveAsNewProfile()

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     @State private var isShowingActivity = false
     @State private var isDropTargeted = false
     @State private var isShowingSaveProfile = false
+    @State private var isShowingSetupEditor = false
     @State private var newProfileName = ""
     @State private var profileErrorMessage: String?
     @State private var preserveEncodingOnNextProfileChange = false
@@ -70,6 +71,10 @@ struct ContentView: View {
                     .foregroundStyle(.orange)
                     .padding(.horizontal)
                     .padding(.vertical, 10)
+            }
+
+            if !settings.hasAcknowledgedStandardMovieRenameNotice {
+                StandardMovieRenameNoticeView(settings: settings)
             }
 
             HSplitView {
@@ -127,6 +132,8 @@ struct ContentView: View {
                         || viewModel.state.phase == .decisionRequired,
                     sourceKind: viewModel.source?.kind,
                     routeQualityState: routeQualityState,
+                    isReady: true,
+                    openEditor: beginSetupEditor,
                     saveSelectedProfile: saveSelectedProfile,
                     saveAsNewProfile: beginSaveAsNewProfile,
                     resetProfile: resetProfile
@@ -281,6 +288,15 @@ struct ContentView: View {
             SaveProfileSheet(name: $newProfileName) {
                 saveAsNewProfile()
             }
+        }
+        .sheet(isPresented: $isShowingSetupEditor) {
+            SetupEditSheet(
+                initialProfile: selectedProfile,
+                initialOptions: options,
+                profiles: profileStore.profiles,
+                profileStore: profileStore,
+                applyToConversion: applyEditedConversion
+            )
         }
         .sheet(isPresented: $isShowingPreview, onDismiss: previewDidDismiss) {
             if let draft {
@@ -874,6 +890,23 @@ struct ContentView: View {
         options.encoding = selectedProfile.options
         options.job = defaultJobOptions
         options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: selectedProfile))
+    }
+
+    private func beginSetupEditor() {
+        guard !viewModel.hasActiveWork,
+              !previewViewModel.hasActiveWorker,
+              viewModel.state.phase != .decisionRequired
+        else {
+            return
+        }
+        isShowingSetupEditor = true
+    }
+
+    private func applyEditedConversion(_ profileID: String, _ editedOptions: ConversionOptions) {
+        routeQualityState.reset()
+        preserveEncodingOnNextProfileChange = true
+        selectedProfileID = profileID
+        options = editedOptions
     }
 
     private func profilePipelineDefaults(for profile: EncodingProfile) -> ProfilePipelineDefaults {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -82,51 +82,53 @@ struct ContentView: View {
             }
 
             HSplitView {
-                SourceWorkspaceView(
-                    source: viewModel.source,
-                    state: viewModel.state,
-                    batchQueue: viewModel.batchQueue,
-                    isBatchRunning: viewModel.isBatchRunning,
-                    insertedDiscs: insertedDiscs,
-                    makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
-                    profile: selectedProfile,
-                    options: options,
-                    profileModified: profileModified,
-                    titleSelection: titleSelection,
-                    titleSelectionSummary: titleSelectionSummary,
-                    selectedVideoCount: selectedVideoCount,
-                    queueItems: visibleQueueItems,
-                    destinationURL: $destinationURL,
-                    plannedOutputURLs: plannedOutputURLs,
-                    storageEstimate: VideoStorageEstimate(drafts: conversionDrafts),
-                    refreshDiscs: refreshDiscs,
-                    useDisc: selectSource,
-                    openDiscImage: { chooseFile(.discImage) },
-                    openBluRayFolder: { chooseFolder(.bluRayFolder) },
-                    openSourceFolder: { chooseFolder(.sourceFolder) },
-                    openMKV: { chooseFile(.matroska) },
-                    importTransportStream: { chooseFile(.transportStream) },
-                    changeSource: chooseExistingSource,
-                    chooseDestination: chooseDestination,
-                    retryAnalysis: viewModel.restartInspection,
-                    diagnosticsActionTitle: diagnosticActionTitle,
-                    canShowDiagnostics: canShowDiagnosticAction,
-                    showDiagnostics: showDiagnosticReport,
-                    resolveRecoveryChoice: { choice in
-                        _ = viewModel.resolveRecoveryChoice(choice)
-                    },
-                    retryBatchItem: { itemID, choice in
-                        viewModel.retryBatchItem(itemID, recoveryChoice: choice)
-                    },
-                    selectMainTitle: { titleSelection = .main },
-                    selectAllTitles: { titleSelection = .all },
-                    chooseTitles: { isShowingTitleChooser = true }
-                )
-                .frame(minWidth: 350, idealWidth: 390, maxWidth: 450)
+                if setupQueue.hasItems {
+                    queueSidebar
+                } else {
+                    SourceWorkspaceView(
+                        source: viewModel.source,
+                        state: viewModel.state,
+                        batchQueue: viewModel.batchQueue,
+                        isBatchRunning: viewModel.isBatchRunning,
+                        insertedDiscs: insertedDiscs,
+                        makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
+                        profile: selectedProfile,
+                        options: options,
+                        profileModified: profileModified,
+                        titleSelection: titleSelection,
+                        titleSelectionSummary: titleSelectionSummary,
+                        selectedVideoCount: selectedVideoCount,
+                        queueItems: visibleQueueItems,
+                        destinationURL: $destinationURL,
+                        plannedOutputURLs: plannedOutputURLs,
+                        storageEstimate: VideoStorageEstimate(drafts: conversionDrafts),
+                        refreshDiscs: refreshDiscs,
+                        useDisc: selectSource,
+                        openDiscImage: { chooseFile(.discImage) },
+                        openBluRayFolder: { chooseFolder(.bluRayFolder) },
+                        openSourceFolder: { chooseFolder(.sourceFolder) },
+                        openMKV: { chooseFile(.matroska) },
+                        importTransportStream: { chooseFile(.transportStream) },
+                        changeSource: chooseExistingSource,
+                        chooseDestination: chooseDestination,
+                        retryAnalysis: viewModel.restartInspection,
+                        diagnosticsActionTitle: diagnosticActionTitle,
+                        canShowDiagnostics: canShowDiagnosticAction,
+                        showDiagnostics: showDiagnosticReport,
+                        resolveRecoveryChoice: { choice in
+                            _ = viewModel.resolveRecoveryChoice(choice)
+                        },
+                        retryBatchItem: { itemID, choice in
+                            viewModel.retryBatchItem(itemID, recoveryChoice: choice)
+                        },
+                        selectMainTitle: { titleSelection = .main },
+                        selectAllTitles: { titleSelection = .all },
+                        chooseTitles: { isShowingTitleChooser = true }
+                    )
+                    .frame(minWidth: 300, idealWidth: 360, maxWidth: 430)
+                }
 
                 setupColumn
-
-                queueSidebar
             }
 
             Divider()
@@ -247,6 +249,9 @@ struct ContentView: View {
             if settings.playSound {
                 NSSound(named: "Glass")?.play()
             }
+        }
+        .onChange(of: viewModel.persistentQueueItems) { _, items in
+            setupQueue.synchronize(with: items)
         }
         .onChange(of: viewModel.state.result?.titles) { _, _ in
             if viewModel.source?.kind != .sourceFolder {
@@ -529,14 +534,16 @@ struct ContentView: View {
             start: startReadyConversion,
             canPreview: previewCanStart,
             canAddToQueue: !conversionDrafts.isEmpty && !viewModel.hasActiveWork,
-            canStart: conversionCanStart
+            canStart: setupQueue.hasItems
+                ? setupQueue.canStart && !viewModel.hasActiveWork
+                : conversionCanStart
         )
-        .frame(minWidth: 570, idealWidth: 680)
+        .frame(minWidth: 500, idealWidth: 680)
     }
 
     @ViewBuilder
     private var queueSidebar: some View {
-        if setupQueue.isBatch {
+        if setupQueue.hasItems {
             SetupQueueAdmissionView(
                 admission: setupQueue,
                 memoryStore: resolutionMemoryStore,
@@ -1132,13 +1139,20 @@ struct ContentView: View {
     }
 
     private func startAdmittedQueue() {
-        let drafts = setupQueue.startableDrafts
-        guard !drafts.isEmpty else { return }
-        viewModel.startConversionQueue(drafts: drafts)
+        guard setupQueue.canStart else { return }
+        if setupQueue.items.count == 1,
+           let draft = setupQueue.items[0].currentDraft
+        {
+            viewModel.startConversion(draft: draft)
+            setupQueue.removeAll()
+            return
+        }
+        viewModel.startConversionQueue(admissionItems: setupQueue.items)
+        setupQueue.markAllRunning()
     }
 
     private func startReadyConversion() {
-        if setupQueue.isBatch {
+        if setupQueue.hasItems {
             startAdmittedQueue()
         } else {
             startSelectedConversions()

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -82,52 +82,7 @@ struct ContentView: View {
             }
 
             HSplitView {
-                if setupQueue.hasItems, viewModel.state.phase != .decisionRequired {
-                    queueSidebar
-                } else {
-                    SourceWorkspaceView(
-                        source: viewModel.source,
-                        state: viewModel.state,
-                        batchQueue: viewModel.batchQueue,
-                        isBatchRunning: viewModel.isBatchRunning,
-                        insertedDiscs: insertedDiscs,
-                        makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
-                        profile: selectedProfile,
-                        options: options,
-                        profileModified: profileModified,
-                        titleSelection: titleSelection,
-                        titleSelectionSummary: titleSelectionSummary,
-                        selectedVideoCount: selectedVideoCount,
-                        queueItems: visibleQueueItems,
-                        destinationURL: $destinationURL,
-                        plannedOutputURLs: plannedOutputURLs,
-                        storageEstimate: VideoStorageEstimate(drafts: conversionDrafts),
-                        refreshDiscs: refreshDiscs,
-                        useDisc: selectSource,
-                        openDiscImage: { chooseFile(.discImage) },
-                        openBluRayFolder: { chooseFolder(.bluRayFolder) },
-                        openSourceFolder: { chooseFolder(.sourceFolder) },
-                        openMKV: { chooseFile(.matroska) },
-                        importTransportStream: { chooseFile(.transportStream) },
-                        changeSource: chooseExistingSource,
-                        chooseDestination: chooseDestination,
-                        retryAnalysis: viewModel.restartInspection,
-                        diagnosticsActionTitle: diagnosticActionTitle,
-                        canShowDiagnostics: canShowDiagnosticAction,
-                        showDiagnostics: showDiagnosticReport,
-                        resolveRecoveryChoice: { choice in
-                            _ = viewModel.resolveRecoveryChoice(choice)
-                        },
-                        retryBatchItem: { itemID, choice in
-                            viewModel.retryBatchItem(itemID, recoveryChoice: choice)
-                        },
-                        selectMainTitle: { titleSelection = .main },
-                        selectAllTitles: { titleSelection = .all },
-                        chooseTitles: { isShowingTitleChooser = true }
-                    )
-                    .frame(minWidth: 300, idealWidth: 360, maxWidth: 430)
-                }
-
+                sourceOrQueueColumn
                 setupColumn
             }
 
@@ -337,6 +292,59 @@ struct ContentView: View {
         } message: {
             Text(profileErrorMessage ?? "The profile could not be saved.")
         }
+    }
+
+    @ViewBuilder
+    private var sourceOrQueueColumn: some View {
+        if setupQueue.hasItems, viewModel.state.phase != .decisionRequired {
+            queueSidebar
+        } else {
+            sourceWorkspace
+        }
+    }
+
+    private var sourceWorkspace: some View {
+        SourceWorkspaceView(
+            source: viewModel.source,
+            state: viewModel.state,
+            batchQueue: viewModel.batchQueue,
+            isBatchRunning: viewModel.isBatchRunning,
+            insertedDiscs: insertedDiscs,
+            makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
+            profile: selectedProfile,
+            options: options,
+            profileModified: profileModified,
+            titleSelection: titleSelection,
+            titleSelectionSummary: titleSelectionSummary,
+            selectedVideoCount: selectedVideoCount,
+            queueItems: visibleQueueItems,
+            destinationURL: $destinationURL,
+            plannedOutputURLs: plannedOutputURLs,
+            storageEstimate: VideoStorageEstimate(drafts: conversionDrafts),
+            refreshDiscs: refreshDiscs,
+            useDisc: selectSource,
+            openDiscImage: { chooseFile(.discImage) },
+            openBluRayFolder: { chooseFolder(.bluRayFolder) },
+            openSourceFolder: { chooseFolder(.sourceFolder) },
+            openMKV: { chooseFile(.matroska) },
+            importTransportStream: { chooseFile(.transportStream) },
+            changeSource: chooseExistingSource,
+            chooseDestination: chooseDestination,
+            retryAnalysis: viewModel.restartInspection,
+            diagnosticsActionTitle: diagnosticActionTitle,
+            canShowDiagnostics: canShowDiagnosticAction,
+            showDiagnostics: showDiagnosticReport,
+            resolveRecoveryChoice: { choice in
+                _ = viewModel.resolveRecoveryChoice(choice)
+            },
+            retryBatchItem: { itemID, choice in
+                viewModel.retryBatchItem(itemID, recoveryChoice: choice)
+            },
+            selectMainTitle: { titleSelection = .main },
+            selectAllTitles: { titleSelection = .all },
+            chooseTitles: { isShowingTitleChooser = true }
+        )
+        .frame(minWidth: 300, idealWidth: 360, maxWidth: 430)
     }
 
     private var sourceSelectionAction: ConversionSourceSelectionAction? {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
     @State private var isShowingTitleChooser = false
     @State private var isShowingDiagnosticReport = false
     @State private var isRefreshingDiscs = false
+    @StateObject private var routeQualityState: RouteQualityResolutionState
 
     init(
         viewModel: ConversionViewModel,
@@ -58,6 +59,7 @@ struct ContentView: View {
         _selectedProfileID = State(initialValue: profile.id)
         _options = State(initialValue: initialOptions)
         _destinationURL = State(initialValue: settings.destinationURL)
+        _routeQualityState = StateObject(wrappedValue: RouteQualityResolutionState())
     }
 
     var body: some View {
@@ -124,6 +126,7 @@ struct ContentView: View {
                         || previewViewModel.hasActiveWorker
                         || viewModel.state.phase == .decisionRequired,
                     sourceKind: viewModel.source?.kind,
+                    routeQualityState: routeQualityState,
                     saveSelectedProfile: saveSelectedProfile,
                     saveAsNewProfile: beginSaveAsNewProfile,
                     resetProfile: resetProfile
@@ -167,6 +170,17 @@ struct ContentView: View {
             }
         }
         .onAppear(perform: refreshDiscs)
+        .onReceive(NotificationCenter.default.publisher(for: .conversionSourceSelectionRequested)) { notification in
+            guard let sourceURL = notification.object as? URL else {
+                return
+            }
+            sourceResetMessage = nil
+            if let source = ConversionSource.infer(from: sourceURL) {
+                selectSource(source)
+            } else {
+                viewModel.selectSource(sourceURL)
+            }
+        }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
             refreshDiscs()
         }
@@ -540,6 +554,9 @@ struct ContentView: View {
     }
 
     private var conversionDrafts: [ConversionDraft] {
+        guard routeQualityBlockReason == nil else {
+            return []
+        }
         guard let source = viewModel.source,
               source.kind != .sourceFolder,
               let inspection = viewModel.state.result
@@ -759,6 +776,7 @@ struct ContentView: View {
 
     private var conversionCanStart: Bool {
         guard capabilities.conversionAvailable,
+              routeQualityBlockReason == nil,
               !viewModel.hasActiveWork,
               !previewViewModel.hasActiveWorker,
               viewModel.state.phase != .decisionRequired
@@ -824,6 +842,9 @@ struct ContentView: View {
     }
 
     private var conversionUnavailableReason: String {
+        if let routeQualityBlockReason {
+            return routeQualityBlockReason
+        }
         guard capabilities.conversionAvailable else {
             return capabilities.conversionUnavailableReason
         }
@@ -845,6 +866,16 @@ struct ContentView: View {
         case .none:
             return capabilities.conversionUnavailableReason
         }
+    }
+
+    private var routeQualityBlockReason: String? {
+        if let stateReason = routeQualityState.blockReason {
+            return stateReason
+        }
+        if case let .failure(error) = RouteQualityEngine.validate(options) {
+            return "Resolve route and quality settings before starting, previewing, or adding this conversion to the queue. \(error.localizedDescription)"
+        }
+        return nil
     }
 
     private func resetProfile() {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -297,6 +297,7 @@ struct ContentView: View {
             SetupEditSheet(
                 initialProfile: selectedProfile,
                 initialOptions: options,
+                fallbackPipelineDefaults: defaultJobOptions.profilePipelineDefaults,
                 profiles: profileStore.profiles,
                 profileStore: profileStore,
                 resolutionMemoryStore: resolutionMemoryStore,

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
     @State private var isShowingPreview = false
     @State private var pendingReviewedPreview: PreviewDraft?
     @State private var titleSelection = DiscTitleSelection.main
+    @State private var sourceResetMessage: String?
     @State private var isShowingTitleChooser = false
     @State private var isShowingDiagnosticReport = false
     @State private var isRefreshingDiscs = false
@@ -46,8 +47,8 @@ struct ContentView: View {
 
         let profile = profileStore.profile(withID: settings.selectedProfileID)
         var initialJobOptions = Self.jobOptions(from: settings)
-        if let jobDefaults = profile.jobDefaults {
-            initialJobOptions.applyProfileDefaults(jobDefaults)
+        if let pipelineDefaults = profile.pipelineDefaults {
+            initialJobOptions.applyProfilePipelineDefaults(pipelineDefaults)
         }
         let initialOptions = ConversionOptions(
             encoding: profile.options,
@@ -61,6 +62,14 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            if let migrationNoticeMessage = profileStore.migrationNoticeMessage {
+                Label(migrationNoticeMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+            }
+
             HSplitView {
                 SourceWorkspaceView(
                     source: viewModel.source,
@@ -136,6 +145,7 @@ struct ContentView: View {
             }
         }
         .accessibilityIdentifier("main-window-content")
+        .focusedSceneValue(\.conversionSourceSelectionAction, sourceSelectionAction)
         .toolbar { toolbarContent }
         .animation(.easeInOut(duration: 0.18), value: isShowingActivity)
         .dropDestination(for: URL.self, action: acceptDrop) { targeted in
@@ -195,7 +205,7 @@ struct ContentView: View {
         }
         .onChange(of: defaultJobOptions) { _, newValue in
             if viewModel.source == nil, !viewModel.hasActiveWork {
-                if selectedProfile.jobDefaults == nil {
+                if selectedProfile.pipelineDefaults == nil {
                     options.job = newValue
                 } else {
                     options.job.keepAwake = newValue.keepAwake
@@ -255,12 +265,12 @@ struct ContentView: View {
                   let currentProfile = currentProfiles.first(where: { $0.id == selectedProfileID }),
                   !viewModel.hasActiveWork,
                   options.encoding == previousProfile.options,
-                  options.job.profileDefaults == profileJobDefaults(for: previousProfile)
+                  options.job.profilePipelineDefaults == profilePipelineDefaults(for: previousProfile)
             else {
                 return
             }
             options.encoding = currentProfile.options
-            options.job.applyProfileDefaults(profileJobDefaults(for: currentProfile))
+            options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: currentProfile))
         }
         .sheet(isPresented: $isShowingSaveProfile) {
             SaveProfileSheet(name: $newProfileName) {
@@ -305,6 +315,13 @@ struct ContentView: View {
         } message: {
             Text(profileErrorMessage ?? "The profile could not be saved.")
         }
+    }
+
+    private var sourceSelectionAction: ConversionSourceSelectionAction? {
+        guard canSelectSource else {
+            return nil
+        }
+        return ConversionSourceSelectionAction(perform: chooseExistingSource)
     }
 
     @ToolbarContentBuilder
@@ -375,6 +392,13 @@ struct ContentView: View {
                     Text(secondaryStatusText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+                if let sourceResetMessage {
+                    Label(sourceResetMessage, systemImage: "arrow.uturn.backward.circle")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .help(sourceResetMessage)
                 }
             }
             .accessibilityElement(children: .combine)
@@ -501,7 +525,7 @@ struct ContentView: View {
 
     private var profileModified: Bool {
         options.encoding != selectedProfile.options
-            || options.job.profileDefaults != profileJobDefaults(for: selectedProfile)
+            || options.job.profilePipelineDefaults != profilePipelineDefaults(for: selectedProfile)
     }
 
     private var defaultJobOptions: JobOptions {
@@ -642,6 +666,9 @@ struct ContentView: View {
         var components = ["Status: \(statusText)"]
         if let secondaryStatusText {
             components.append(secondaryStatusText)
+        }
+        if let sourceResetMessage {
+            components.append(sourceResetMessage)
         }
         if let elapsedText = viewModel.state.elapsedText, viewModel.hasActiveWorker {
             components.append("Elapsed time \(elapsedText)")
@@ -823,11 +850,11 @@ struct ContentView: View {
     private func resetProfile() {
         options.encoding = selectedProfile.options
         options.job = defaultJobOptions
-        options.job.applyProfileDefaults(profileJobDefaults(for: selectedProfile))
+        options.job.applyProfilePipelineDefaults(profilePipelineDefaults(for: selectedProfile))
     }
 
-    private func profileJobDefaults(for profile: EncodingProfile) -> ProfileJobDefaults {
-        profile.jobDefaults ?? defaultJobOptions.profileDefaults
+    private func profilePipelineDefaults(for profile: EncodingProfile) -> ProfilePipelineDefaults {
+        profile.pipelineDefaults ?? defaultJobOptions.profilePipelineDefaults
     }
 
     private static func jobOptions(from settings: AppSettings) -> JobOptions {
@@ -848,7 +875,7 @@ struct ContentView: View {
                 selectedProfile.id,
                 name: selectedProfile.name,
                 options: options.encoding,
-                jobDefaults: options.job.profileDefaults
+                pipelineDefaults: options.job.profilePipelineDefaults
             )
         } catch {
             profileErrorMessage = error.localizedDescription
@@ -865,7 +892,7 @@ struct ContentView: View {
             let identifier = try profileStore.createProfile(
                 name: newProfileName,
                 options: options.encoding,
-                jobDefaults: options.job.profileDefaults
+                pipelineDefaults: options.job.profilePipelineDefaults
             )
             selectedProfileID = identifier
             isShowingSaveProfile = false
@@ -907,11 +934,28 @@ struct ContentView: View {
         guard canSelectSource else {
             return
         }
+        sourceResetMessage = nil
+        if isNewSource(source) {
+            sourceResetMessage = options.resetSourceScopedState(
+                for: source.kind,
+                titleSelection: &titleSelection,
+                recoveryDecisionPresent: viewModel.state.recoveryDecision != nil
+                    || viewModel.state.phase == .decisionRequired
+            ).message
+        }
         if source.kind == .physicalDisc {
             options.job.removeOriginalAfterSuccess = false
         }
-        titleSelection = .main
         viewModel.selectSource(source)
+    }
+
+    private func isNewSource(_ source: ConversionSource) -> Bool {
+        guard let currentSource = viewModel.source else {
+            return true
+        }
+        return currentSource.kind != source.kind
+            || currentSource.url.standardizedFileURL != source.url.standardizedFileURL
+            || currentSource.workerSourcePath != source.workerSourcePath
     }
 
     private func chooseExistingSource() {
@@ -1005,7 +1049,7 @@ private struct SaveProfileSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Save New Profile")
                     .font(.title2.weight(.semibold))
-                Text("Video, audio, subtitle, pipeline, recovery, and output-file settings will be saved. Sound and awake preferences stay global.")
+                Text(ProfilePersistenceCopy.summary)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -82,7 +82,7 @@ struct ContentView: View {
             }
 
             HSplitView {
-                if setupQueue.hasItems {
+                if setupQueue.hasItems, viewModel.state.phase != .decisionRequired {
                     queueSidebar
                 } else {
                     SourceWorkspaceView(
@@ -217,7 +217,7 @@ struct ContentView: View {
         .onChange(of: viewModel.state.conversionResult) { _, result in
             guard viewModel.batchQueue == nil,
                   let result,
-                  viewModel.queueItems.count <= 1
+                  viewModel.queueItems.isEmpty
             else {
                 return
             }
@@ -253,6 +253,10 @@ struct ContentView: View {
         .onChange(of: viewModel.persistentQueueItems) { _, items in
             setupQueue.synchronize(with: items)
         }
+        .onChange(of: viewModel.setupQueueStartFailureItemIDs) { _, itemIDs in
+            guard !itemIDs.isEmpty else { return }
+            setupQueue.markStartFailed(itemIDs)
+        }
         .onChange(of: viewModel.state.result?.titles) { _, _ in
             if viewModel.source?.kind != .sourceFolder {
                 titleSelection = .main
@@ -287,10 +291,12 @@ struct ContentView: View {
                 initialProfile: selectedProfile,
                 initialOptions: options,
                 fallbackPipelineDefaults: defaultJobOptions.profilePipelineDefaults,
+                sourceKind: viewModel.source?.kind,
                 profiles: profileStore.profiles,
                 profileStore: profileStore,
                 resolutionMemoryStore: resolutionMemoryStore,
-                applyToConversion: applyEditedConversion
+                applyToConversion: applyEditedConversion,
+                queueConflictForReview: heldConflictQueueAction
             )
         }
         .sheet(isPresented: $isShowingPreview, onDismiss: previewDidDismiss) {
@@ -468,36 +474,6 @@ struct ContentView: View {
             if viewModel.hasStoppableWork {
                 Button("Stop", role: .destructive, action: viewModel.stopActiveWorker)
                     .keyboardShortcut("p", modifiers: .command)
-            } else if isBatchSource {
-                Button("Start Batch Conversion") {
-                    viewModel.startBatchConversion(
-                        profile: selectedProfile,
-                        destinationURL: destinationURL,
-                        options: options
-                    )
-                }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut("p", modifiers: .command)
-                .disabled(!conversionCanStart)
-                .help(conversionCanStart ? "Convert the queued sources sequentially." : conversionUnavailableReason)
-            } else if viewModel.source == nil || !conversionCanStart {
-                Button(startButtonTitle) {}
-                    .buttonStyle(.bordered)
-                    .disabled(true)
-                    .help(viewModel.source == nil ? "Choose a source before processing." : conversionUnavailableReason)
-            } else {
-                Button("Preview…") {
-                    isShowingPreview = true
-                }
-                .buttonStyle(.bordered)
-                .disabled(!previewCanStart)
-                .help(previewUnavailableReason)
-
-                Button(startButtonTitle) {
-                    startSelectedConversions()
-                }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut("p", modifiers: .command)
             }
         }
         .padding(.horizontal, 16)
@@ -528,6 +504,7 @@ struct ContentView: View {
             resetProfile: resetProfile,
             sourceName: viewModel.source?.displayName,
             destinationName: destinationURL.path,
+            changeDestination: chooseDestination,
             estimate: "Finished movie size and time are estimated from this source.",
             preview: { isShowingPreview = true },
             addToQueue: addCurrentDraftsToQueue,
@@ -536,7 +513,8 @@ struct ContentView: View {
             canAddToQueue: !conversionDrafts.isEmpty && !viewModel.hasActiveWork,
             canStart: setupQueue.hasItems
                 ? setupQueue.canStart && !viewModel.hasActiveWork
-                : conversionCanStart
+                : conversionCanStart,
+            showsStartAction: !setupQueue.hasItems
         )
         .frame(minWidth: 500, idealWidth: 680)
     }
@@ -547,7 +525,11 @@ struct ContentView: View {
             SetupQueueAdmissionView(
                 admission: setupQueue,
                 memoryStore: resolutionMemoryStore,
-                start: startAdmittedQueue
+                canStart: setupQueue.canStart
+                    && !viewModel.hasActiveWork
+                    && !previewViewModel.hasActiveWorker,
+                start: startAdmittedQueue,
+                clear: setupQueue.removeAll
             )
         }
     }
@@ -602,6 +584,13 @@ struct ContentView: View {
         guard routeQualityBlockReason == nil else {
             return []
         }
+        return makeConversionDrafts(options: options, profile: selectedProfile)
+    }
+
+    private func makeConversionDrafts(
+        options draftOptions: ConversionOptions,
+        profile draftProfile: EncodingProfile
+    ) -> [ConversionDraft] {
         guard let source = viewModel.source,
               source.kind != .sourceFolder,
               let inspection = viewModel.state.result
@@ -613,9 +602,9 @@ struct ContentView: View {
                 ConversionDraft(
                     source: source,
                     sourceDetails: inspection,
-                    profile: selectedProfile,
+                    profile: draftProfile,
                     destinationURL: destinationURL,
-                    options: options,
+                    options: draftOptions,
                     selectedTitle: title
                 )
             }
@@ -624,11 +613,24 @@ struct ContentView: View {
             ConversionDraft(
                 source: source,
                 sourceDetails: inspection,
-                profile: selectedProfile,
+                profile: draftProfile,
                 destinationURL: destinationURL,
-                options: options
+                options: draftOptions
             )
         ]
+    }
+
+    private var heldConflictQueueAction: ((String, RouteQualityConflict) -> Void)? {
+        guard viewModel.source != nil, viewModel.state.result != nil else { return nil }
+        return { profileID, conflict in
+            let profile = profileStore.profile(withID: profileID)
+            let drafts = makeConversionDrafts(options: conflict.proposedOptions, profile: profile)
+            guard !drafts.isEmpty else { return }
+            setupQueue.add(
+                drafts: drafts,
+                conflicts: Array(repeating: conflict, count: drafts.count)
+            )
+        }
     }
 
     private var draft: ConversionDraft? {
@@ -664,10 +666,6 @@ struct ContentView: View {
             }
             return "\(selectedTitles.count) Selected Videos"
         }
-    }
-
-    private var startButtonTitle: String {
-        selectedVideoCount > 1 ? "Convert \(selectedVideoCount) Videos" : "Start Full Conversion"
     }
 
     private var statusText: String {
@@ -744,6 +742,15 @@ struct ContentView: View {
     private var secondaryStatusText: String? {
         if let warningMessage = viewModel.state.warningMessage {
             return "Warning: \(warningMessage)"
+        }
+        if let durableQueueLoadErrorMessage = viewModel.durableQueueLoadErrorMessage {
+            return durableQueueLoadErrorMessage
+        }
+        if let durableQueueRuntimeDiagnostic = viewModel.durableQueueRuntimeDiagnostic {
+            return durableQueueRuntimeDiagnostic
+        }
+        if let persistentQueueProjectionError = viewModel.persistentQueueProjectionError {
+            return "Queue display is unavailable: \(String(describing: persistentQueueProjectionError))"
         }
         if viewModel.state.operationKind == .conversion,
            let videoRoute = viewModel.state.videoRoute
@@ -858,13 +865,13 @@ struct ContentView: View {
 
     private var previewUnavailableReason: String {
         if previewCanStart {
-            return "Create a finalized representative preview with the current route policy and settings."
+            return "Create a representative preview with the current video and quality choices."
         }
         if selectedVideoCount > 1 {
             return "Choose one 3D video to create a preview."
         }
         if !requestedVideoRoute.allowsFinalizedPreview {
-            return "A late-stage restart uses an existing video artifact. Choose an earlier start stage to generate a representative preview."
+            return "A late-stage restart reuses an existing video. Choose an earlier start stage to create a representative preview."
         }
         switch viewModel.source?.kind {
         case .physicalDisc:
@@ -918,7 +925,7 @@ struct ContentView: View {
             return stateReason
         }
         if case let .failure(error) = RouteQualityEngine.validate(options) {
-            return "Resolve route and quality settings before starting, previewing, or adding this conversion to the queue. \(error.localizedDescription)"
+            return "Resolve the video and quality choices before starting, previewing, or adding this conversion to the queue. \(error.localizedDescription)"
         }
         return nil
     }
@@ -1139,21 +1146,23 @@ struct ContentView: View {
     }
 
     private func startAdmittedQueue() {
-        guard setupQueue.canStart else { return }
-        if setupQueue.items.count == 1,
-           let draft = setupQueue.items[0].currentDraft
-        {
-            viewModel.startConversion(draft: draft)
-            setupQueue.removeAll()
-            return
-        }
-        viewModel.startConversionQueue(admissionItems: setupQueue.items)
+        guard setupQueue.canStart,
+              !viewModel.hasActiveWork,
+              !previewViewModel.hasActiveWorker,
+              viewModel.startConversionQueue(admissionItems: setupQueue.items)
+        else { return }
         setupQueue.markAllRunning()
     }
 
     private func startReadyConversion() {
         if setupQueue.hasItems {
             startAdmittedQueue()
+        } else if isBatchSource {
+            viewModel.startBatchConversion(
+                profile: selectedProfile,
+                destinationURL: destinationURL,
+                options: options
+            )
         } else {
             startSelectedConversions()
         }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @ObservedObject var diagnosticReportViewModel: DiagnosticReportViewModel
     @ObservedObject var settings: AppSettings
     @ObservedObject var profileStore: ProfileStore
+    @ObservedObject var resolutionMemoryStore: ResolutionMemoryStore
     let capabilities: AppCapabilities
 
     @State private var selectedProfileID: String
@@ -38,6 +39,7 @@ struct ContentView: View {
         diagnosticReportViewModel: DiagnosticReportViewModel,
         settings: AppSettings,
         profileStore: ProfileStore,
+        resolutionMemoryStore: ResolutionMemoryStore,
         capabilities: AppCapabilities
     ) {
         _viewModel = ObservedObject(wrappedValue: viewModel)
@@ -45,6 +47,7 @@ struct ContentView: View {
         _diagnosticReportViewModel = ObservedObject(wrappedValue: diagnosticReportViewModel)
         _settings = ObservedObject(wrappedValue: settings)
         _profileStore = ObservedObject(wrappedValue: profileStore)
+        _resolutionMemoryStore = ObservedObject(wrappedValue: resolutionMemoryStore)
         self.capabilities = capabilities
 
         let profile = profileStore.profile(withID: settings.selectedProfileID)
@@ -132,6 +135,7 @@ struct ContentView: View {
                         || viewModel.state.phase == .decisionRequired,
                     sourceKind: viewModel.source?.kind,
                     routeQualityState: routeQualityState,
+                    resolutionMemoryStore: resolutionMemoryStore,
                     isReady: true,
                     openEditor: beginSetupEditor,
                     saveSelectedProfile: saveSelectedProfile,
@@ -295,6 +299,7 @@ struct ContentView: View {
                 initialOptions: options,
                 profiles: profileStore.profiles,
                 profileStore: profileStore,
+                resolutionMemoryStore: resolutionMemoryStore,
                 applyToConversion: applyEditedConversion
             )
         }

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -21,6 +21,7 @@ struct ConversionSetupView: View {
     let resetProfile: () -> Void
     let sourceName: String?
     let destinationName: String?
+    let changeDestination: (() -> Void)?
     let estimate: String?
     let preview: () -> Void
     let addToQueue: () -> Void
@@ -28,6 +29,8 @@ struct ConversionSetupView: View {
     let canPreview: Bool
     let canAddToQueue: Bool
     let canStart: Bool
+    let showsStartAction: Bool
+    let queueConflictForReview: ((RouteQualityConflict) -> Void)?
 
     init(
         selectedProfileID: Binding<String>,
@@ -47,13 +50,16 @@ struct ConversionSetupView: View {
         resetProfile: @escaping () -> Void,
         sourceName: String? = nil,
         destinationName: String? = nil,
+        changeDestination: (() -> Void)? = nil,
         estimate: String? = nil,
         preview: @escaping () -> Void = {},
         addToQueue: @escaping () -> Void = {},
         start: @escaping () -> Void = {},
         canPreview: Bool = false,
         canAddToQueue: Bool = false,
-        canStart: Bool = false
+        canStart: Bool = false,
+        showsStartAction: Bool = true,
+        queueConflictForReview: ((RouteQualityConflict) -> Void)? = nil
     ) {
         _selectedProfileID = selectedProfileID
         _selectedTab = selectedTab
@@ -72,6 +78,7 @@ struct ConversionSetupView: View {
         self.resetProfile = resetProfile
         self.sourceName = sourceName
         self.destinationName = destinationName
+        self.changeDestination = changeDestination
         self.estimate = estimate
         self.preview = preview
         self.addToQueue = addToQueue
@@ -79,6 +86,8 @@ struct ConversionSetupView: View {
         self.canPreview = canPreview
         self.canAddToQueue = canAddToQueue
         self.canStart = canStart
+        self.showsStartAction = showsStartAction
+        self.queueConflictForReview = queueConflictForReview
     }
 
     var body: some View {
@@ -131,8 +140,16 @@ struct ConversionSetupView: View {
                 .background(.quaternary.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
                 .accessibilityIdentifier("profile-conversion-customized")
             }
-            LabeledContent("Destination", value: destinationName ?? "Choose a destination")
-                .accessibilityIdentifier("ready-destination")
+            HStack(alignment: .firstTextBaseline) {
+                LabeledContent("Destination", value: destinationName ?? "Choose a destination")
+                    .accessibilityIdentifier("ready-destination")
+                if let changeDestination {
+                    Spacer()
+                    Button("Change…", action: changeDestination)
+                        .disabled(isLocked)
+                        .accessibilityIdentifier("ready-change-destination")
+                }
+            }
             Text(estimate ?? "Finished movie size and time are estimated after source analysis.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -146,10 +163,13 @@ struct ConversionSetupView: View {
                     .disabled(!canAddToQueue)
                     .accessibilityIdentifier("ready-add-to-queue")
                 Spacer()
-                Button("Start", action: start)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!canStart)
-                    .accessibilityIdentifier("ready-start")
+                if showsStartAction {
+                    Button("Start", action: start)
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut("p", modifiers: .command)
+                        .disabled(!canStart)
+                        .accessibilityIdentifier("ready-start")
+                }
             }
         }
         .padding(18)
@@ -251,7 +271,12 @@ struct ConversionSetupView: View {
                         options: $options.encoding,
                         section: .video,
                         jobOptions: options.job,
-                        routeQualityState: routeQualityState
+                        routeQualityState: routeQualityState,
+                        conversionOptions: $options,
+                        profile: selectedProfile,
+                        sourceKind: sourceKind,
+                        memoryStore: resolutionMemoryStore,
+                        queueConflictForReview: queueConflictForReview
                     )
                 case .audioAndSubtitles:
                     EncodingOptionsEditor(options: $options.encoding, section: .audioAndSubtitles)
@@ -335,6 +360,7 @@ struct ConversionSetupView: View {
                         profile: selectedProfile,
                         sourceKind: sourceKind,
                         memoryStore: resolutionMemoryStore,
+                        queueForReview: queueConflictForReview.map { queue in { queue(conflict) } },
                         resolve: resolveRouteQuality
                     )
                 }
@@ -393,7 +419,10 @@ struct ConversionSetupView: View {
         let reusableSuffix = options.job.intermediatePolicy.createsReusableArtifacts
             ? " · reusable files kept"
             : ""
-        return "\(routePlan.qualityTitle) quality\(reusableSuffix)"
+        let qualitySummary = routePlan.kind == .existingArtifact
+            ? "existing video kept"
+            : "\(routePlan.qualityTitle) quality"
+        return "\(qualitySummary)\(reusableSuffix)"
     }
 
     private var softwareEncoderIsApplicable: Bool {
@@ -423,7 +452,7 @@ private struct OutcomeSummaryView: View {
             LabeledContent("Reusable files", value: reusableFilesSummary)
             LabeledContent("Temporary space", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Additional space while reusable files are kept" : "Removed after success")
             LabeledContent("Estimated time", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Longer processing" : "Standard processing")
-            LabeledContent("Quality", value: "\(options.videoRoutePlan.qualityTitle) quality")
+            LabeledContent("Quality", value: qualitySummary)
         }
         .font(.caption)
         .padding(12)
@@ -440,6 +469,12 @@ private struct OutcomeSummaryView: View {
         case .av1Stereo:
             "Stereo movie"
         }
+    }
+
+    private var qualitySummary: String {
+        options.videoRoutePlan.kind == .existingArtifact
+            ? "Existing video kept"
+            : "\(options.videoRoutePlan.qualityTitle) quality"
     }
 
     private var reusableFilesSummary: String {

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -12,6 +12,7 @@ struct ConversionSetupView: View {
     let profileModified: Bool
     let isLocked: Bool
     let sourceKind: ConversionSourceKind?
+    @ObservedObject var routeQualityState: RouteQualityResolutionState
     let saveSelectedProfile: () -> Void
     let saveAsNewProfile: () -> Void
     let resetProfile: () -> Void
@@ -101,7 +102,8 @@ struct ConversionSetupView: View {
                     EncodingOptionsEditor(
                         options: $options.encoding,
                         section: .video,
-                        jobOptions: options.job
+                        jobOptions: options.job,
+                        routeQualityState: routeQualityState
                     )
                 case .audioAndSubtitles:
                     EncodingOptionsEditor(options: $options.encoding, section: .audioAndSubtitles)
@@ -123,7 +125,7 @@ struct ConversionSetupView: View {
             Section("Pipeline and Recovery") {
                 VideoRouteSummaryView(plan: routePlan)
 
-                Picker("Start stage", selection: $options.job.startStage) {
+                Picker("Start stage", selection: startStageBinding) {
                     ForEach(ConversionStage.allCases) { stage in
                         Text(stage.title).tag(stage)
                     }
@@ -136,7 +138,7 @@ struct ConversionSetupView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 Toggle("Continue processing after recoverable errors", isOn: $options.job.continueOnError)
-                Toggle("Use software HEVC encoder", isOn: $options.job.softwareEncoder)
+                Toggle("Use software HEVC encoder", isOn: softwareEncoderBinding)
                     .disabled(!softwareEncoderIsApplicable)
                     .help(softwareEncoderHelp)
 
@@ -170,6 +172,21 @@ struct ConversionSetupView: View {
                 Toggle("Play a sound when finished", isOn: $options.job.playSound)
                 Toggle("Show generated commands in activity", isOn: $options.job.outputCommands)
             }
+
+            if let conflict = routeQualityState.conflict {
+                Section {
+                    RouteQualityConflictView(conflict: conflict) { option in
+                        resolveRouteQuality(option)
+                    }
+                }
+            }
+            if let invalidMessage = routeQualityState.invalidMessage {
+                Section {
+                    Label(invalidMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
         }
         .formStyle(.grouped)
     }
@@ -178,9 +195,35 @@ struct ConversionSetupView: View {
         Binding(
             get: { options.job.intermediatePolicy.createsReusableArtifacts },
             set: { enabled in
-                options.job.intermediatePolicy = enabled ? .reusable : .automatic
+                applyRouteEdit(.reusableIntermediates(enabled))
             }
         )
+    }
+
+    private var startStageBinding: Binding<ConversionStage> {
+        Binding(
+            get: { options.job.startStage },
+            set: { stage in
+                applyRouteEdit(.restartStage(stage))
+            }
+        )
+    }
+
+    private var softwareEncoderBinding: Binding<Bool> {
+        Binding(
+            get: { options.job.softwareEncoder },
+            set: { enabled in
+                applyRouteEdit(.softwareEncoder(enabled))
+            }
+        )
+    }
+
+    private func applyRouteEdit(_ edit: RouteQualityEdit) {
+        routeQualityState.apply(edit, to: &options)
+    }
+
+    private func resolveRouteQuality(_ option: RouteQualityResolutionOption) {
+        routeQualityState.resolve(option, in: &options)
     }
 
     private var routePlan: VideoRoutePlan {

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -70,22 +70,10 @@ struct ConversionSetupView: View {
 
             Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text(selectedProfile.name)
-                    .font(.headline)
-                Text(selectedProfile.summary)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                Text("Quality: \(options.encoding.videoSummary(for: options.videoRoutePlan))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text("Files: \(ReusableFileOutcome(policy: options.job.intermediatePolicy).title)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .accessibilityElement(children: .combine)
-            .accessibilityIdentifier("ready-profile-summary")
+            Text(profileOutcomeSummary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("ready-profile-summary")
 
             OutcomeSummaryView(options: options)
         }
@@ -172,6 +160,10 @@ struct ConversionSetupView: View {
 
             Divider()
 
+            OutcomeSummaryView(options: options)
+                .padding(.horizontal, 18)
+                .padding(.bottom, 12)
+
             Group {
                 switch selectedTab {
                 case .video:
@@ -209,17 +201,16 @@ struct ConversionSetupView: View {
 
                 Picker("Output files", selection: reusableFileOutcomeBinding) {
                     ForEach(ReusableFileOutcome.allCases) { outcome in
-                        Text(outcome.title).tag(outcome)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(outcome.title)
+                            Text(outcome.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(outcome)
                     }
                 }
                 .pickerStyle(.radioGroup)
-
-                Text(reusableFileOutcomeDetail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                OutcomeSummaryView(options: options)
 
                 Toggle("Continue processing after recoverable errors", isOn: $options.job.continueOnError)
                 Toggle("Use software HEVC encoder", isOn: softwareEncoderBinding)
@@ -318,8 +309,11 @@ struct ConversionSetupView: View {
         VideoRoutePlan(options: options)
     }
 
-    private var reusableFileOutcomeDetail: String {
-        ReusableFileOutcome(policy: options.job.intermediatePolicy).detail
+    private var profileOutcomeSummary: String {
+        let reusableSuffix = options.job.intermediatePolicy.createsReusableArtifacts
+            ? " · reusable files kept"
+            : ""
+        return "\(routePlan.qualityTitle) quality\(reusableSuffix)"
     }
 
     private var softwareEncoderIsApplicable: Bool {
@@ -345,11 +339,11 @@ private struct OutcomeSummaryView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("What you’ll get")
                 .font(.headline)
-            LabeledContent("Finished movie", value: options.encoding.videoSummary(for: options.videoRoutePlan))
-            LabeledContent("Temporary space", value: options.job.intermediatePolicy.createsReusableArtifacts ? "More space while keeping reusable files" : "Removed after success")
-            LabeledContent("Reusable files", value: ReusableFileOutcome(policy: options.job.intermediatePolicy).title)
+            LabeledContent("Finished movie", value: finishedMovieSummary)
+            LabeledContent("Reusable files", value: reusableFilesSummary)
+            LabeledContent("Temporary space", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Additional space while reusable files are kept" : "Removed after success")
             LabeledContent("Estimated time", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Longer processing" : "Standard processing")
-            LabeledContent("Quality", value: options.encoding.videoSummary(for: options.videoRoutePlan))
+            LabeledContent("Quality", value: "\(options.videoRoutePlan.qualityTitle) quality")
         }
         .font(.caption)
         .padding(12)
@@ -357,6 +351,21 @@ private struct OutcomeSummaryView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel("What you’ll get")
         .accessibilityIdentifier("conversion-outcome-summary")
+    }
+
+    private var finishedMovieSummary: String {
+        switch options.encoding.videoOutputMode {
+        case .mvHEVC:
+            "Vision Pro spatial movie"
+        case .av1Stereo:
+            "Stereo movie"
+        }
+    }
+
+    private var reusableFilesSummary: String {
+        options.job.intermediatePolicy.createsReusableArtifacts
+            ? "Left- and right-eye movies kept"
+            : "None kept"
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -13,11 +13,86 @@ struct ConversionSetupView: View {
     let isLocked: Bool
     let sourceKind: ConversionSourceKind?
     @ObservedObject var routeQualityState: RouteQualityResolutionState
+    let isReady: Bool
+    let openEditor: () -> Void
     let saveSelectedProfile: () -> Void
     let saveAsNewProfile: () -> Void
     let resetProfile: () -> Void
 
     var body: some View {
+        Group {
+            if isReady {
+                readyBody
+            } else {
+                editorBody
+            }
+        }
+    }
+
+    private var readyBody: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Profile")
+                        .font(.title3.weight(.semibold))
+                    Text("Choose a Profile, then edit only when you need to change a setting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Picker("Profile", selection: $selectedProfileID) {
+                    ForEach(profiles) { profile in
+                        Text(profile.name).tag(profile.id)
+                    }
+                }
+                .frame(width: 190)
+                .disabled(isLocked)
+                .accessibilityIdentifier("ready-profile-picker")
+
+                if profileModified {
+                    Text("For this conversion")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.quaternary, in: Capsule())
+                        .accessibilityIdentifier("profile-conversion-customized")
+                }
+
+                Button("Edit…", action: openEditor)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isLocked)
+                    .accessibilityIdentifier("edit-conversion-settings")
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(selectedProfile.name)
+                    .font(.headline)
+                Text(selectedProfile.summary)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Quality: \(options.encoding.videoSummary(for: options.videoRoutePlan))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Files: \(ReusableFileOutcome(policy: options.job.intermediatePolicy).title)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("ready-profile-summary")
+
+            OutcomeSummaryView(options: options)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var editorBody: some View {
         VStack(spacing: 0) {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -39,12 +114,12 @@ struct ConversionSetupView: View {
                 .disabled(isLocked)
 
                 if profileModified {
-                    Text("Modified")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.orange)
+                    Text("For this conversion")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
                         .padding(.horizontal, 7)
                         .padding(.vertical, 3)
-                        .background(Color.orange.opacity(0.12), in: Capsule())
+                        .background(.quaternary, in: Capsule())
                 }
 
                 Button(action: saveAsNewProfile) {
@@ -131,11 +206,19 @@ struct ConversionSetupView: View {
                     }
                 }
 
-                Toggle("Create reusable intermediate files", isOn: reusableIntermediatesBinding)
-                Text(intermediatePolicyDetail)
+                Picker("Output files", selection: reusableFileOutcomeBinding) {
+                    ForEach(ReusableFileOutcome.allCases) { outcome in
+                        Text(outcome.title).tag(outcome)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+
+                Text(reusableFileOutcomeDetail)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                OutcomeSummaryView(options: options)
 
                 Toggle("Continue processing after recoverable errors", isOn: $options.job.continueOnError)
                 Toggle("Use software HEVC encoder", isOn: softwareEncoderBinding)
@@ -191,11 +274,11 @@ struct ConversionSetupView: View {
         .formStyle(.grouped)
     }
 
-    private var reusableIntermediatesBinding: Binding<Bool> {
+    private var reusableFileOutcomeBinding: Binding<ReusableFileOutcome> {
         Binding(
-            get: { options.job.intermediatePolicy.createsReusableArtifacts },
-            set: { enabled in
-                applyRouteEdit(.reusableIntermediates(enabled))
+            get: { ReusableFileOutcome(policy: options.job.intermediatePolicy) },
+            set: { outcome in
+                applyRouteEdit(.reusableIntermediates(outcome == .finishedMovieAndReusableFiles))
             }
         )
     }
@@ -230,29 +313,8 @@ struct ConversionSetupView: View {
         VideoRoutePlan(options: options)
     }
 
-    private var intermediatePolicyDetail: String {
-        if options.job.intermediatePolicy.createsReusableArtifacts {
-            return switch routePlan.kind {
-            case .directMVHEVC:
-                "Creates and retains reusable stage artifacts."
-            case .generatedMVHEVC:
-                "Creates and retains generated eye files for inspection or external processing."
-            case .av1Stereo:
-                "Creates and retains reusable AV1 stage artifacts."
-            case .existingArtifact:
-                "Retains new stage artifacts created after the selected restart point; the existing video artifact is reused unchanged."
-            }
-        }
-        return switch routePlan.kind {
-        case .directMVHEVC:
-            "Direct jobs avoid eye movies. A generated fallback may create temporary eye files, which are removed after success."
-        case .generatedMVHEVC:
-            "Generated eye files are temporary and removed after a successful conversion."
-        case .av1Stereo:
-            "Temporary AV1 stage files are removed after a successful conversion."
-        case .existingArtifact:
-            "Temporary files created after the selected restart point are removed after success; the existing video artifact is preserved."
-        }
+    private var reusableFileOutcomeDetail: String {
+        ReusableFileOutcome(policy: options.job.intermediatePolicy).detail
     }
 
     private var softwareEncoderIsApplicable: Bool {
@@ -268,6 +330,28 @@ struct ConversionSetupView: View {
             return "The selected restart stage does not encode HEVC video."
         }
         return "Use libx265 instead of the default VideoToolbox HEVC encoder."
+    }
+}
+
+private struct OutcomeSummaryView: View {
+    let options: ConversionOptions
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("What you’ll get")
+                .font(.headline)
+            LabeledContent("Finished movie", value: options.encoding.videoSummary(for: options.videoRoutePlan))
+            LabeledContent("Temporary space", value: options.job.intermediatePolicy.createsReusableArtifacts ? "More space while keeping reusable files" : "Removed after success")
+            LabeledContent("Reusable files", value: ReusableFileOutcome(policy: options.job.intermediatePolicy).title)
+            LabeledContent("Estimated time", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Longer processing" : "Standard processing")
+            LabeledContent("Quality", value: options.encoding.videoSummary(for: options.videoRoutePlan))
+        }
+        .font(.caption)
+        .padding(12)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("What you’ll get")
+        .accessibilityIdentifier("conversion-outcome-summary")
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -19,6 +19,67 @@ struct ConversionSetupView: View {
     let saveSelectedProfile: () -> Void
     let saveAsNewProfile: () -> Void
     let resetProfile: () -> Void
+    let sourceName: String?
+    let destinationName: String?
+    let estimate: String?
+    let preview: () -> Void
+    let addToQueue: () -> Void
+    let start: () -> Void
+    let canPreview: Bool
+    let canAddToQueue: Bool
+    let canStart: Bool
+
+    init(
+        selectedProfileID: Binding<String>,
+        selectedTab: Binding<ConversionSetupTab>,
+        options: Binding<ConversionOptions>,
+        profiles: [EncodingProfile],
+        selectedProfile: EncodingProfile,
+        profileModified: Bool,
+        isLocked: Bool,
+        sourceKind: ConversionSourceKind?,
+        routeQualityState: RouteQualityResolutionState,
+        resolutionMemoryStore: ResolutionMemoryStore,
+        isReady: Bool,
+        openEditor: @escaping () -> Void,
+        saveSelectedProfile: @escaping () -> Void,
+        saveAsNewProfile: @escaping () -> Void,
+        resetProfile: @escaping () -> Void,
+        sourceName: String? = nil,
+        destinationName: String? = nil,
+        estimate: String? = nil,
+        preview: @escaping () -> Void = {},
+        addToQueue: @escaping () -> Void = {},
+        start: @escaping () -> Void = {},
+        canPreview: Bool = false,
+        canAddToQueue: Bool = false,
+        canStart: Bool = false
+    ) {
+        _selectedProfileID = selectedProfileID
+        _selectedTab = selectedTab
+        _options = options
+        self.profiles = profiles
+        self.selectedProfile = selectedProfile
+        self.profileModified = profileModified
+        self.isLocked = isLocked
+        self.sourceKind = sourceKind
+        self.routeQualityState = routeQualityState
+        self.resolutionMemoryStore = resolutionMemoryStore
+        self.isReady = isReady
+        self.openEditor = openEditor
+        self.saveSelectedProfile = saveSelectedProfile
+        self.saveAsNewProfile = saveAsNewProfile
+        self.resetProfile = resetProfile
+        self.sourceName = sourceName
+        self.destinationName = destinationName
+        self.estimate = estimate
+        self.preview = preview
+        self.addToQueue = addToQueue
+        self.start = start
+        self.canPreview = canPreview
+        self.canAddToQueue = canAddToQueue
+        self.canStart = canStart
+    }
 
     var body: some View {
         Group {
@@ -31,53 +92,72 @@ struct ConversionSetupView: View {
     }
 
     private var readyBody: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Profile")
-                        .font(.title3.weight(.semibold))
-                    Text("Choose a Profile, then edit only when you need to change a setting.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
+        VStack(alignment: .leading, spacing: 14) {
+            LabeledContent("Source", value: sourceName ?? "Choose a source")
+                .accessibilityIdentifier("ready-source")
+            Divider()
+            HStack(alignment: .firstTextBaseline) {
                 Picker("Profile", selection: $selectedProfileID) {
                     ForEach(profiles) { profile in
                         Text(profile.name).tag(profile.id)
                     }
                 }
-                .frame(width: 190)
+                .frame(maxWidth: 300)
                 .disabled(isLocked)
                 .accessibilityIdentifier("ready-profile-picker")
-
-                if profileModified {
-                    Text("For this conversion")
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.quaternary, in: Capsule())
-                        .accessibilityIdentifier("profile-conversion-customized")
-                }
-
+                Spacer()
                 Button("Edit…", action: openEditor)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.bordered)
                     .disabled(isLocked)
                     .accessibilityIdentifier("edit-conversion-settings")
             }
-
-            Divider()
-
             Text(profileOutcomeSummary)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .accessibilityIdentifier("ready-profile-summary")
-
-            OutcomeSummaryView(options: options)
+            if profileModified {
+                HStack(spacing: 8) {
+                    Text("For this conversion")
+                        .font(.caption.weight(.medium))
+                    Text(profileOutcomeSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer()
+                    Button("Revert", action: resetProfile)
+                    Button("Save as New…", action: saveAsNewProfile)
+                }
+                .padding(8)
+                .background(.quaternary.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+                .accessibilityIdentifier("profile-conversion-customized")
+            }
+            LabeledContent("Destination", value: destinationName ?? "Choose a destination")
+                .accessibilityIdentifier("ready-destination")
+            Text(estimate ?? "Finished movie size and time are estimated after source analysis.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("ready-estimate")
+            Divider()
+            HStack {
+                Button("Preview", action: preview)
+                    .disabled(!canPreview)
+                    .accessibilityIdentifier("ready-preview")
+                Button("Add to Queue", action: addToQueue)
+                    .disabled(!canAddToQueue)
+                    .accessibilityIdentifier("ready-add-to-queue")
+                Spacer()
+                Button("Start", action: start)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canStart)
+                    .accessibilityIdentifier("ready-start")
+            }
         }
         .padding(18)
+        .background(.background, in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(.separator.opacity(0.7))
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -13,6 +13,7 @@ struct ConversionSetupView: View {
     let isLocked: Bool
     let sourceKind: ConversionSourceKind?
     @ObservedObject var routeQualityState: RouteQualityResolutionState
+    @ObservedObject var resolutionMemoryStore: ResolutionMemoryStore
     let isReady: Bool
     let openEditor: () -> Void
     let saveSelectedProfile: () -> Void
@@ -258,9 +259,13 @@ struct ConversionSetupView: View {
 
             if let conflict = routeQualityState.conflict {
                 Section {
-                    RouteQualityConflictView(conflict: conflict) { option in
-                        resolveRouteQuality(option)
-                    }
+                    RouteQualityConflictView(
+                        conflict: conflict,
+                        profile: selectedProfile,
+                        sourceKind: sourceKind,
+                        memoryStore: resolutionMemoryStore,
+                        resolve: resolveRouteQuality
+                    )
                 }
             }
             if let invalidMessage = routeQualityState.invalidMessage {

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -20,21 +20,37 @@ struct EncodingOptionsEditor: View {
     @Binding var options: EncodingOptions
     let section: EncodingOptionsSection
     let jobOptions: JobOptions?
+    @ObservedObject var routeQualityState: RouteQualityResolutionState
 
     init(
         options: Binding<EncodingOptions>,
         section: EncodingOptionsSection,
-        jobOptions: JobOptions? = nil
+        jobOptions: JobOptions? = nil,
+        routeQualityState: RouteQualityResolutionState = RouteQualityResolutionState()
     ) {
         _options = options
         self.section = section
         self.jobOptions = jobOptions
+        self.routeQualityState = routeQualityState
     }
 
     var body: some View {
         switch section {
         case .video:
-            videoForm
+            VStack(alignment: .leading, spacing: 12) {
+                videoForm
+                if let conflict = routeQualityState.conflict {
+                    RouteQualityConflictView(conflict: conflict) { option in
+                        resolveRouteQuality(option)
+                    }
+                }
+                if let invalidMessage = routeQualityState.invalidMessage {
+                    Label(invalidMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         case .audioAndSubtitles:
             audioAndSubtitlesForm
         }
@@ -67,14 +83,18 @@ struct EncodingOptionsEditor: View {
 
                     Divider()
                     VideoRouteSummaryView(plan: routePlan)
-                    VideoQualityEditor(options: $options, context: qualityEditorContext)
+                    VideoQualityEditor(
+                        options: $options,
+                        context: qualityEditorContext,
+                        routeQualityState: routeQualityState
+                    )
                 }
 
                 if routePlan.kind != .existingArtifact {
                     Section("Picture") {
                         if options.videoOutputMode == .mvHEVC {
                             LabeledContent("Field of view") {
-                                Stepper(value: $options.fieldOfView, in: 0 ... 360) {
+                                Stepper(value: fieldOfViewBinding, in: 0 ... 360) {
                                     Text("\(options.fieldOfView)°")
                                         .monospacedDigit()
                                         .frame(width: 48, alignment: .trailing)
@@ -82,7 +102,7 @@ struct EncodingOptionsEditor: View {
                             }
 
                             LabeledContent("Resolution override") {
-                                TextField("", text: $options.resolutionOverride, prompt: Text("Use source"))
+                                TextField("", text: resolutionOverrideBinding, prompt: Text("Use source"))
                                     .textFieldStyle(.roundedBorder)
                                     .frame(width: 170)
                             }
@@ -101,7 +121,7 @@ struct EncodingOptionsEditor: View {
                     }
 
                     Section("Stereo Corrections") {
-                        Toggle("Crop black bars", isOn: $options.cropBlackBars)
+                        Toggle("Crop black bars", isOn: cropBlackBarsBinding)
                         Toggle("Swap left and right eyes", isOn: $options.swapEyes)
                     }
                 }
@@ -184,9 +204,54 @@ struct EncodingOptionsEditor: View {
         Binding(
             get: { options.videoOutputMode },
             set: { mode in
-                options.selectVideoOutputMode(mode)
+                applyRouteEdit(.outputMode(mode))
             }
         )
+    }
+
+    private var fieldOfViewBinding: Binding<Int> {
+        Binding(
+            get: { options.fieldOfView },
+            set: { value in
+                applyRouteEdit(.fieldOfView(value))
+            }
+        )
+    }
+
+    private var resolutionOverrideBinding: Binding<String> {
+        Binding(
+            get: { options.resolutionOverride },
+            set: { value in
+                applyRouteEdit(.resolutionOverride(value))
+            }
+        )
+    }
+
+    private var cropBlackBarsBinding: Binding<Bool> {
+        Binding(
+            get: { options.cropBlackBars },
+            set: { value in
+                applyRouteEdit(.cropBlackBars(value))
+            }
+        )
+    }
+
+    private func applyRouteEdit(_ edit: RouteQualityEdit) {
+        var conversionOptions = ConversionOptions(
+            encoding: options,
+            job: jobOptions ?? JobOptions()
+        )
+        routeQualityState.apply(edit, to: &conversionOptions)
+        options = conversionOptions.encoding
+    }
+
+    private func resolveRouteQuality(_ option: RouteQualityResolutionOption) {
+        var conversionOptions = ConversionOptions(
+            encoding: options,
+            job: jobOptions ?? JobOptions()
+        )
+        routeQualityState.resolve(option, in: &conversionOptions)
+        options = conversionOptions.encoding
     }
 
     private var routePlan: VideoRoutePlan {

--- a/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
+++ b/macos/BluRayToVisionPro/Views/EncodingOptionsEditor.swift
@@ -21,17 +21,32 @@ struct EncodingOptionsEditor: View {
     let section: EncodingOptionsSection
     let jobOptions: JobOptions?
     @ObservedObject var routeQualityState: RouteQualityResolutionState
+    let conversionOptions: Binding<ConversionOptions>?
+    let profile: EncodingProfile?
+    let sourceKind: ConversionSourceKind?
+    let memoryStore: ResolutionMemoryStore?
+    let queueConflictForReview: ((RouteQualityConflict) -> Void)?
 
     init(
         options: Binding<EncodingOptions>,
         section: EncodingOptionsSection,
         jobOptions: JobOptions? = nil,
-        routeQualityState: RouteQualityResolutionState = RouteQualityResolutionState()
+        routeQualityState: RouteQualityResolutionState = RouteQualityResolutionState(),
+        conversionOptions: Binding<ConversionOptions>? = nil,
+        profile: EncodingProfile? = nil,
+        sourceKind: ConversionSourceKind? = nil,
+        memoryStore: ResolutionMemoryStore? = nil,
+        queueConflictForReview: ((RouteQualityConflict) -> Void)? = nil
     ) {
         _options = options
         self.section = section
         self.jobOptions = jobOptions
         self.routeQualityState = routeQualityState
+        self.conversionOptions = conversionOptions
+        self.profile = profile
+        self.sourceKind = sourceKind
+        self.memoryStore = memoryStore
+        self.queueConflictForReview = queueConflictForReview
     }
 
     var body: some View {
@@ -40,9 +55,7 @@ struct EncodingOptionsEditor: View {
             VStack(alignment: .leading, spacing: 12) {
                 videoForm
                 if let conflict = routeQualityState.conflict {
-                    RouteQualityConflictView(conflict: conflict) { option in
-                        resolveRouteQuality(option)
-                    }
+                    routeQualityConflictView(conflict)
                 }
                 if let invalidMessage = routeQualityState.invalidMessage {
                     Label(invalidMessage, systemImage: "exclamationmark.triangle.fill")
@@ -237,6 +250,12 @@ struct EncodingOptionsEditor: View {
     }
 
     private func applyRouteEdit(_ edit: RouteQualityEdit) {
+        if let conversionOptions {
+            var updated = conversionOptions.wrappedValue
+            routeQualityState.apply(edit, to: &updated)
+            conversionOptions.wrappedValue = updated
+            return
+        }
         var conversionOptions = ConversionOptions(
             encoding: options,
             job: jobOptions ?? JobOptions()
@@ -246,6 +265,12 @@ struct EncodingOptionsEditor: View {
     }
 
     private func resolveRouteQuality(_ option: RouteQualityResolutionOption) {
+        if let conversionOptions {
+            var updated = conversionOptions.wrappedValue
+            routeQualityState.resolve(option, in: &updated)
+            conversionOptions.wrappedValue = updated
+            return
+        }
         var conversionOptions = ConversionOptions(
             encoding: options,
             job: jobOptions ?? JobOptions()
@@ -255,7 +280,10 @@ struct EncodingOptionsEditor: View {
     }
 
     private var routePlan: VideoRoutePlan {
-        VideoRoutePlan(
+        if let conversionOptions {
+            return conversionOptions.wrappedValue.videoRoutePlan
+        }
+        return VideoRoutePlan(
             encoding: options,
             job: jobOptions ?? JobOptions()
         )
@@ -263,5 +291,21 @@ struct EncodingOptionsEditor: View {
 
     private var qualityEditorContext: VideoQualityEditor.Context {
         jobOptions.map(VideoQualityEditor.Context.conversion) ?? .profile
+    }
+
+    @ViewBuilder
+    private func routeQualityConflictView(_ conflict: RouteQualityConflict) -> some View {
+        if let profile, let sourceKind, let memoryStore {
+            RouteQualityConflictView(
+                conflict: conflict,
+                profile: profile,
+                sourceKind: sourceKind,
+                memoryStore: memoryStore,
+                queueForReview: queueConflictForReview.map { queue in { queue(conflict) } },
+                resolve: resolveRouteQuality
+            )
+        } else {
+            RouteQualityConflictView(conflict: conflict, resolve: resolveRouteQuality)
+        }
     }
 }

--- a/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
+++ b/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
@@ -5,6 +5,7 @@ struct RouteQualityConflictView: View {
     let profile: EncodingProfile?
     let sourceKind: ConversionSourceKind?
     let memoryStore: ResolutionMemoryStore?
+    let queueForReview: (() -> Void)?
     let resolve: (RouteQualityResolutionOption) -> Void
     @State private var selectedResolutionID: String?
     @State private var shouldSuggest = false
@@ -16,12 +17,14 @@ struct RouteQualityConflictView: View {
         profile: EncodingProfile? = nil,
         sourceKind: ConversionSourceKind? = nil,
         memoryStore: ResolutionMemoryStore? = nil,
+        queueForReview: (() -> Void)? = nil,
         resolve: @escaping (RouteQualityResolutionOption) -> Void
     ) {
         self.conflict = conflict
         self.profile = profile
         self.sourceKind = sourceKind
         self.memoryStore = memoryStore
+        self.queueForReview = queueForReview
         self.resolve = resolve
         let suggestion = profile.flatMap { profile in sourceKind.flatMap {
             memoryStore?.suggestion(
@@ -31,13 +34,19 @@ struct RouteQualityConflictView: View {
                 mappingVersion: conflict.mappingVersion
             )
         } }
-        _selectedResolutionID = State(initialValue: suggestion?.isStale == false ? suggestion?.entry.resolutionID : nil)
+        let suggestedResolutionID = suggestion?.isStale == false
+            && conflict.resolutions.contains(where: {
+                $0.id == suggestion?.entry.resolutionID && $0.isAvailable
+            })
+            ? suggestion?.entry.resolutionID
+            : nil
+        _selectedResolutionID = State(initialValue: suggestedResolutionID)
         _scope = State(initialValue: profile.map { .profile($0.id) } ?? .global)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Label("Route and quality need a decision", systemImage: "arrow.triangle.branch")
+            Label("Quality and file choices need a decision", systemImage: "arrow.triangle.branch")
                 .font(.subheadline.weight(.semibold))
             Text(conflict.reason)
                 .font(.caption)
@@ -45,12 +54,12 @@ struct RouteQualityConflictView: View {
                 .fixedSize(horizontal: false, vertical: true)
             Picker("Resolution", selection: $selectedResolutionID) {
                 Text("Choose a resolution").tag(String?.none)
-                ForEach(conflict.resolutions) { option in
+                ForEach(conflict.resolutions.filter(\.isAvailable)) { option in
                     Text(option.title).tag(Optional(option.id))
                 }
             }
             .pickerStyle(.radioGroup)
-            ForEach(conflict.resolutions) { option in
+            ForEach(conflict.resolutions.filter(\.isAvailable)) { option in
                 if selectedResolutionID == option.id {
                     VStack(alignment: .leading, spacing: 2) {
                         HStack {
@@ -105,26 +114,34 @@ struct RouteQualityConflictView: View {
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            Button("Apply Choice") {
-                guard let option = conflict.resolutions.first(where: { $0.id == selectedResolutionID }) else { return }
-                if shouldSuggest, let memoryStore {
-                    do {
-                        try memoryStore.store(
-                            resolutionID: option.id,
-                            for: conflict.stableID,
-                            scope: scope,
-                            mappingVersion: conflict.mappingVersion
-                        )
-                        memoryErrorMessage = nil
-                    } catch {
-                        memoryErrorMessage = error.localizedDescription
-                        return
-                    }
+            HStack {
+                if let queueForReview {
+                    Button("Add to Queue for Review", action: queueForReview)
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier("route-quality-add-to-queue")
+                    Spacer()
                 }
-                resolve(option)
+                Button("Apply Choice") {
+                    guard let option = conflict.resolutions.first(where: { $0.id == selectedResolutionID }) else { return }
+                    if shouldSuggest, let memoryStore {
+                        do {
+                            try memoryStore.store(
+                                resolutionID: option.id,
+                                for: conflict.stableID,
+                                scope: scope,
+                                mappingVersion: conflict.mappingVersion
+                            )
+                            memoryErrorMessage = nil
+                        } catch {
+                            memoryErrorMessage = error.localizedDescription
+                            return
+                        }
+                    }
+                    resolve(option)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(selectedResolutionID == nil)
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(selectedResolutionID == nil)
         }
         .padding(12)
         .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))

--- a/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
+++ b/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
@@ -2,7 +2,37 @@ import SwiftUI
 
 struct RouteQualityConflictView: View {
     let conflict: RouteQualityConflict
+    let profile: EncodingProfile?
+    let sourceKind: ConversionSourceKind?
+    let memoryStore: ResolutionMemoryStore?
     let resolve: (RouteQualityResolutionOption) -> Void
+    @State private var selectedResolutionID: String?
+    @State private var shouldSuggest = false
+    @State private var scope: ResolutionMemoryScope
+
+    init(
+        conflict: RouteQualityConflict,
+        profile: EncodingProfile? = nil,
+        sourceKind: ConversionSourceKind? = nil,
+        memoryStore: ResolutionMemoryStore? = nil,
+        resolve: @escaping (RouteQualityResolutionOption) -> Void
+    ) {
+        self.conflict = conflict
+        self.profile = profile
+        self.sourceKind = sourceKind
+        self.memoryStore = memoryStore
+        self.resolve = resolve
+        let suggestion = profile.flatMap { profile in sourceKind.flatMap {
+            memoryStore?.suggestion(
+                conflictID: conflict.stableID,
+                profileID: profile.id,
+                sourceKind: $0,
+                mappingVersion: conflict.mappingVersion
+            )
+        } }
+        _selectedResolutionID = State(initialValue: suggestion?.isStale == false ? suggestion?.entry.resolutionID : nil)
+        _scope = State(initialValue: profile.map { .profile($0.id) } ?? .global)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -12,10 +42,15 @@ struct RouteQualityConflictView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            Picker("Resolution", selection: $selectedResolutionID) {
+                Text("Choose a resolution").tag(String?.none)
+                ForEach(conflict.resolutions) { option in
+                    Text(option.title).tag(Optional(option.id))
+                }
+            }
+            .pickerStyle(.radioGroup)
             ForEach(conflict.resolutions) { option in
-                Button {
-                    resolve(option)
-                } label: {
+                if selectedResolutionID == option.id {
                     VStack(alignment: .leading, spacing: 2) {
                         HStack {
                             Text(option.title)
@@ -35,11 +70,43 @@ struct RouteQualityConflictView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("route-quality-resolution-\(option.id)")
                 }
-                .buttonStyle(.bordered)
-                .disabled(!option.isAvailable)
-                .accessibilityIdentifier("route-quality-resolution-\(option.id)")
             }
+            if let suggestion, let memoryStore {
+                Text(suggestion.staleExplanation ?? "Suggested from \(suggestion.entry.scope.id). You’ll still be asked, with this choice already filled in.")
+                    .font(.caption)
+                    .foregroundStyle(suggestion.isStale ? .orange : .secondary)
+                Button("Forget suggestion") {
+                    try? memoryStore.forget(conflictID: conflict.stableID, scope: suggestion.entry.scope)
+                    selectedResolutionID = nil
+                }
+                .buttonStyle(.borderless)
+            }
+            if let profile, let memoryStore {
+                Toggle("Suggest this next time for \(profile.name)", isOn: $shouldSuggest)
+            }
+            if shouldSuggest, let profile {
+                Picker("Suggestion scope", selection: $scope) {
+                    Text(profile.name).tag(ResolutionMemoryScope.profile(profile.id))
+                    if let sourceKind { Text(sourceKind.rawValue).tag(ResolutionMemoryScope.sourceKind(sourceKind)) }
+                    Text("All sources").tag(ResolutionMemoryScope.global)
+                }
+            }
+            Button("Apply Choice") {
+                guard let option = conflict.resolutions.first(where: { $0.id == selectedResolutionID }) else { return }
+                if shouldSuggest, let memoryStore {
+                    try? memoryStore.store(
+                        resolutionID: option.id,
+                        for: conflict.stableID,
+                        scope: scope,
+                        mappingVersion: conflict.mappingVersion
+                    )
+                }
+                resolve(option)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(selectedResolutionID == nil)
         }
         .padding(12)
         .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
@@ -47,5 +114,15 @@ struct RouteQualityConflictView: View {
             RoundedRectangle(cornerRadius: 10)
                 .strokeBorder(.orange.opacity(0.35))
         }
+    }
+
+    private var suggestion: ResolutionMemorySuggestion? {
+        guard let sourceKind, let profile, let memoryStore else { return nil }
+        return memoryStore.suggestion(
+            conflictID: conflict.stableID,
+            profileID: profile.id,
+            sourceKind: sourceKind,
+            mappingVersion: conflict.mappingVersion
+        )
     }
 }

--- a/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
+++ b/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
@@ -9,6 +9,7 @@ struct RouteQualityConflictView: View {
     @State private var selectedResolutionID: String?
     @State private var shouldSuggest = false
     @State private var scope: ResolutionMemoryScope
+    @State private var memoryErrorMessage: String?
 
     init(
         conflict: RouteQualityConflict,
@@ -78,8 +79,13 @@ struct RouteQualityConflictView: View {
                     .font(.caption)
                     .foregroundStyle(suggestion.isStale ? .orange : .secondary)
                 Button("Forget suggestion") {
-                    try? memoryStore.forget(conflictID: conflict.stableID, scope: suggestion.entry.scope)
-                    selectedResolutionID = nil
+                    do {
+                        try memoryStore.forget(conflictID: conflict.stableID, scope: suggestion.entry.scope)
+                        selectedResolutionID = nil
+                        memoryErrorMessage = nil
+                    } catch {
+                        memoryErrorMessage = error.localizedDescription
+                    }
                 }
                 .buttonStyle(.borderless)
             }
@@ -93,15 +99,27 @@ struct RouteQualityConflictView: View {
                     Text("All sources").tag(ResolutionMemoryScope.global)
                 }
             }
+            if let memoryErrorMessage {
+                Label(memoryErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             Button("Apply Choice") {
                 guard let option = conflict.resolutions.first(where: { $0.id == selectedResolutionID }) else { return }
                 if shouldSuggest, let memoryStore {
-                    try? memoryStore.store(
-                        resolutionID: option.id,
-                        for: conflict.stableID,
-                        scope: scope,
-                        mappingVersion: conflict.mappingVersion
-                    )
+                    do {
+                        try memoryStore.store(
+                            resolutionID: option.id,
+                            for: conflict.stableID,
+                            scope: scope,
+                            mappingVersion: conflict.mappingVersion
+                        )
+                        memoryErrorMessage = nil
+                    } catch {
+                        memoryErrorMessage = error.localizedDescription
+                        return
+                    }
                 }
                 resolve(option)
             }

--- a/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
+++ b/macos/BluRayToVisionPro/Views/RouteResolutionView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct RouteQualityConflictView: View {
+    let conflict: RouteQualityConflict
+    let resolve: (RouteQualityResolutionOption) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Route and quality need a decision", systemImage: "arrow.triangle.branch")
+                .font(.subheadline.weight(.semibold))
+            Text(conflict.reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            ForEach(conflict.resolutions) { option in
+                Button {
+                    resolve(option)
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack {
+                            Text(option.title)
+                                .fontWeight(.semibold)
+                            Spacer()
+                            if option.choice == .keepRequestedWorkflow,
+                               let mappedStep = option.mappedStep
+                            {
+                                Text(mappedStep.title)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Text(option.detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!option.isAvailable)
+                .accessibilityIdentifier("route-quality-resolution-\(option.id)")
+            }
+        }
+        .padding(12)
+        .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(.orange.opacity(0.35))
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -114,6 +114,10 @@ private struct ProfilesSettingsPane: View {
                     .foregroundStyle(.orange)
             }
 
+            if !settings.hasAcknowledgedStandardMovieRenameNotice {
+                StandardMovieRenameNoticeView(settings: settings)
+            }
+
             HSplitView {
                 profileList
                     .frame(minWidth: 220, idealWidth: 240, maxWidth: 280)
@@ -654,6 +658,7 @@ private struct ProfileEditorSheet: View {
     @State private var options: EncodingOptions
     @State private var selectedSection = EncodingOptionsSection.video
     @State private var errorMessage: String?
+    @State private var isShowingDiscardConfirmation = false
     @StateObject private var routeQualityState = RouteQualityResolutionState()
 
     init(
@@ -697,7 +702,6 @@ private struct ProfileEditorSheet: View {
                 Button("Cancel") {
                     dismiss()
                 }
-                .keyboardShortcut(.cancelAction)
 
                 Button("Save") {
                     do {
@@ -724,6 +728,21 @@ private struct ProfileEditorSheet: View {
             idealHeight: 620,
             maxHeight: 760
         )
+        .onExitCommand {
+            if isDirty {
+                isShowingDiscardConfirmation = true
+            } else {
+                dismiss()
+            }
+        }
+        .alert("Discard Unsaved Changes?", isPresented: $isShowingDiscardConfirmation) {
+            Button("Discard Changes", role: .destructive) {
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Your unsaved settings will be discarded.")
+        }
         .alert(
             "Profile Could Not Be Saved",
             isPresented: Binding(
@@ -744,6 +763,10 @@ private struct ProfileEditorSheet: View {
         case .update:
             "Edit Profile"
         }
+    }
+
+    private var isDirty: Bool {
+        name != request.name || options != request.options
     }
 }
 
@@ -815,7 +838,15 @@ private struct AdvancedSettingsPane: View {
 
             Section("Defaults for New Jobs") {
                 Toggle("Default to the software encoder", isOn: $settings.useSoftwareEncoder)
-                Toggle("Create reusable intermediate files by default", isOn: reusableIntermediatesBinding)
+                Picker("Output files", selection: reusableFileOutcomeBinding) {
+                    ForEach(ReusableFileOutcome.allCases) { outcome in
+                        Text(outcome.title).tag(outcome)
+                    }
+                }
+                Text(ReusableFileOutcome(policy: settings.intermediatePolicy).detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Diagnostics") {
@@ -831,11 +862,11 @@ private struct AdvancedSettingsPane: View {
         .formStyle(.grouped)
     }
 
-    private var reusableIntermediatesBinding: Binding<Bool> {
+    private var reusableFileOutcomeBinding: Binding<ReusableFileOutcome> {
         Binding(
-            get: { settings.intermediatePolicy.createsReusableArtifacts },
-            set: { enabled in
-                settings.intermediatePolicy = enabled ? .reusable : .automatic
+            get: { ReusableFileOutcome(policy: settings.intermediatePolicy) },
+            set: { outcome in
+                settings.intermediatePolicy = outcome.policy
             }
         )
     }

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -109,6 +109,11 @@ private struct ProfilesSettingsPane: View {
                     .foregroundStyle(.orange)
             }
 
+            if let migrationNoticeMessage = profileStore.migrationNoticeMessage {
+                Label(migrationNoticeMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+            }
+
             HSplitView {
                 profileList
                     .frame(minWidth: 220, idealWidth: 240, maxWidth: 280)
@@ -133,12 +138,21 @@ private struct ProfilesSettingsPane: View {
             settings.selectedProfileID = profileStore.normalizedProfileID(settings.selectedProfileID)
         }
         .sheet(item: $editorRequest) { request in
-            ProfileEditorSheet(request: request) { mode, name, options in
+            ProfileEditorSheet(request: request) { mode, name, options, pipelineDefaults in
                 switch mode {
                 case .create:
-                    selectedProfileID = try profileStore.createProfile(name: name, options: options)
+                    selectedProfileID = try profileStore.createProfile(
+                        name: name,
+                        options: options,
+                        pipelineDefaults: pipelineDefaults
+                    )
                 case let .update(identifier):
-                    try profileStore.updateProfile(identifier, name: name, options: options)
+                    try profileStore.updateProfile(
+                        identifier,
+                        name: name,
+                        options: options,
+                        pipelineDefaults: pipelineDefaults
+                    )
                     selectedProfileID = identifier
                 }
             }
@@ -200,7 +214,8 @@ private struct ProfilesSettingsPane: View {
                     editorRequest = ProfileEditorRequest(
                         mode: .create,
                         name: "New Profile",
-                        options: BuiltInProfile.balanced.options
+                        options: BuiltInProfile.balanced.options,
+                        pipelineDefaults: nil
                     )
                 } label: {
                     Label("New Profile", systemImage: "plus")
@@ -286,7 +301,8 @@ private struct ProfilesSettingsPane: View {
                             editorRequest = ProfileEditorRequest(
                                 mode: .update(profile.id),
                                 name: profile.name,
-                                options: profile.options
+                                options: profile.options,
+                                pipelineDefaults: profile.pipelineDefaults
                             )
                         }
                         .buttonStyle(.borderedProminent)
@@ -347,7 +363,8 @@ private struct ProfilesSettingsPane: View {
         editorRequest = ProfileEditorRequest(
             mode: .create,
             name: profileStore.suggestedDuplicateName(for: profile.name),
-            options: profile.options
+            options: profile.options,
+            pipelineDefaults: profile.pipelineDefaults
         )
     }
 
@@ -471,7 +488,7 @@ private struct ProfileEncodingSummaryView: View {
         let route = VideoRoutePlan(encoding: options)
         var items = [
             ProfileSummaryItem(title: "Format", value: options.videoOutputMode.title),
-            ProfileSummaryItem(title: "Quality", value: options.videoQuality.displayTitle),
+            ProfileSummaryItem(title: "Quality", value: route.qualityTitle),
             ProfileSummaryItem(title: "Route", value: route.title),
         ]
         switch route.kind {
@@ -625,12 +642,13 @@ private struct ProfileEditorRequest: Identifiable {
     let mode: Mode
     let name: String
     let options: EncodingOptions
+    let pipelineDefaults: ProfilePipelineDefaults?
 }
 
 private struct ProfileEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
     let request: ProfileEditorRequest
-    let save: (ProfileEditorRequest.Mode, String, EncodingOptions) throws -> Void
+    let save: (ProfileEditorRequest.Mode, String, EncodingOptions, ProfilePipelineDefaults?) throws -> Void
 
     @State private var name: String
     @State private var options: EncodingOptions
@@ -639,7 +657,7 @@ private struct ProfileEditorSheet: View {
 
     init(
         request: ProfileEditorRequest,
-        save: @escaping (ProfileEditorRequest.Mode, String, EncodingOptions) throws -> Void
+        save: @escaping (ProfileEditorRequest.Mode, String, EncodingOptions, ProfilePipelineDefaults?) throws -> Void
     ) {
         self.request = request
         self.save = save
@@ -652,7 +670,7 @@ private struct ProfileEditorSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(editorTitle)
                     .font(.title2.weight(.semibold))
-                Text("Profiles save media-result settings only. Job, recovery, and destructive choices remain explicit per conversion.")
+                Text(ProfilePersistenceCopy.summary)
                     .foregroundStyle(.secondary)
             }
 
@@ -678,7 +696,7 @@ private struct ProfileEditorSheet: View {
 
                 Button("Save") {
                     do {
-                        try save(request.mode, name, options)
+                        try save(request.mode, name, options, request.pipelineDefaults)
                         dismiss()
                     } catch {
                         errorMessage = error.localizedDescription

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -654,6 +654,7 @@ private struct ProfileEditorSheet: View {
     @State private var options: EncodingOptions
     @State private var selectedSection = EncodingOptionsSection.video
     @State private var errorMessage: String?
+    @StateObject private var routeQualityState = RouteQualityResolutionState()
 
     init(
         request: ProfileEditorRequest,
@@ -685,7 +686,11 @@ private struct ProfileEditorSheet: View {
             .pickerStyle(.segmented)
             .labelsHidden()
 
-            EncodingOptionsEditor(options: $options, section: selectedSection)
+            EncodingOptionsEditor(
+                options: $options,
+                section: selectedSection,
+                routeQualityState: routeQualityState
+            )
 
             HStack {
                 Spacer()
@@ -704,7 +709,10 @@ private struct ProfileEditorSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(
+                    name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || routeQualityState.blockReason != nil
+                )
             }
         }
         .padding(24)

--- a/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
+++ b/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+struct SetupQueueAdmissionView: View {
+    @ObservedObject var admission: SetupQueueAdmission
+    @ObservedObject var memoryStore: ResolutionMemoryStore
+    let start: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Queue", systemImage: "list.number")
+                    .font(.headline)
+                Spacer()
+                Text("\(admission.items.count) items")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(admission.groups) { group in
+                        SetupQueueConflictGroupView(
+                            group: group,
+                            admission: admission,
+                            memoryStore: memoryStore
+                        )
+                    }
+                    ForEach(admission.items) { item in
+                        SetupQueueRow(item: item)
+                    }
+                }
+            }
+            Divider()
+            Button("Start Queue", action: start)
+                .buttonStyle(.borderedProminent)
+                .disabled(!admission.canStart)
+                .accessibilityIdentifier("queue-start")
+        }
+        .padding(14)
+        .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
+        .accessibilityIdentifier("batch-queue-sidebar")
+    }
+}
+
+private struct SetupQueueConflictGroupView: View {
+    let group: QueueResolutionGroup
+    @ObservedObject var admission: SetupQueueAdmission
+    @ObservedObject var memoryStore: ResolutionMemoryStore
+    @State private var selection = QueueResolutionSelection()
+    @State private var message: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("A choice is needed")
+                .font(.subheadline.weight(.semibold))
+            Text(group.titleDisclosure)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker("Resolution", selection: $selection.resolutionID) {
+                Text("Choose a resolution").tag(String?.none)
+                ForEach(group.conflict.resolutions) { option in
+                    Text(option.title).tag(Optional(option.id))
+                }
+            }
+            .pickerStyle(.radioGroup)
+            Picker("Apply to", selection: $selection.scope) {
+                Text("All \(group.candidates.count) matching items").tag(QueueResolutionScope.allMatching)
+                ForEach(group.candidates) { candidate in
+                    Text("\(candidate.title) only").tag(QueueResolutionScope.item(candidate.id))
+                }
+            }
+            .pickerStyle(.menu)
+            Toggle("Suggest this next time for \(group.profileName)", isOn: $selection.shouldSuggest)
+                .font(.caption)
+            HStack {
+                if let message {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                Spacer()
+                Button("Apply Choice") {
+                    guard let resolutionID = selection.resolutionID else { return }
+                    if selection.shouldSuggest,
+                       let option = group.conflict.resolutions.first(where: { $0.id == resolutionID }) {
+                        do {
+                            try memoryStore.store(
+                                resolutionID: option.id,
+                                for: group.conflict.stableID,
+                                scope: .profile(group.candidates[0].draft.profile.id),
+                                mappingVersion: group.conflict.mappingVersion
+                            )
+                        } catch {
+                            message = error.localizedDescription
+                            return
+                        }
+                    }
+                    switch admission.apply(group: group, selection: selection) {
+                    case .success:
+                        message = nil
+                    case let .failure(error):
+                        message = error.localizedDescription
+                    }
+                }
+                .disabled(!selection.canApply)
+                .accessibilityIdentifier("queue-apply-choice")
+            }
+        }
+        .padding(10)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier("queue-conflict-group")
+    }
+}
+
+private struct SetupQueueRow: View {
+    let item: SetupQueueAdmissionItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.displayName)
+                    .lineLimit(1)
+                Text(secondaryLine)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                if let trace = item.resolutionTrace {
+                    Text("\(trace.qualityOutcome) · \(trace.fileOutcome)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            Spacer()
+            if item.state.acceptsChanges {
+                Button("Change…") {}
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("queue-row-change")
+            }
+        }
+        .accessibilityIdentifier("queue-row-\(item.id.uuidString)")
+    }
+
+    private var secondaryLine: String {
+        switch item.state {
+        case .waiting: "Waiting · \(item.originalDraft.profile.name)"
+        case .held: "Needs a choice · \(item.originalDraft.profile.name)"
+        case .running: "Running · \(item.originalDraft.profile.name)"
+        case .completed: "Finished · \(item.originalDraft.profile.name)"
+        }
+    }
+
+    private var icon: String {
+        switch item.state {
+        case .waiting: "clock"
+        case .held: "exclamationmark.circle"
+        case .running: "gearshape"
+        case .completed: "checkmark.circle"
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
+++ b/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 struct SetupQueueAdmissionView: View {
     @ObservedObject var admission: SetupQueueAdmission
     @ObservedObject var memoryStore: ResolutionMemoryStore
+    let canStart: Bool
     let start: () -> Void
+    let clear: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -32,10 +34,17 @@ struct SetupQueueAdmissionView: View {
                 }
             }
             Divider()
-            Button("Start Queue", action: start)
-                .buttonStyle(.borderedProminent)
-                .disabled(!admission.canStart)
-                .accessibilityIdentifier("queue-start")
+            HStack {
+                Button("Clear Queue", role: .destructive, action: clear)
+                    .disabled(!admission.canClear)
+                    .accessibilityIdentifier("queue-clear")
+                Spacer()
+                Button("Start Queue", action: start)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut("p", modifiers: .command)
+                    .disabled(!canStart)
+                    .accessibilityIdentifier("queue-start")
+            }
         }
         .padding(14)
         .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
@@ -60,7 +69,7 @@ private struct SetupQueueConflictGroupView: View {
                 .foregroundStyle(.secondary)
             Picker("Resolution", selection: $selection.resolutionID) {
                 Text("Choose a resolution").tag(String?.none)
-                ForEach(group.conflict.resolutions) { option in
+                ForEach(group.conflict.resolutions.filter(\.isAvailable)) { option in
                     Text(option.title).tag(Optional(option.id))
                 }
             }
@@ -133,7 +142,9 @@ private struct SetupQueueConflictGroupView: View {
             guard !loadedSuggestion else { return }
             loadedSuggestion = true
             if let suggestion, !suggestion.isStale {
-                selection.resolutionID = suggestion.entry.resolutionID
+                selection.resolutionID = group.conflict.resolutions.contains(where: {
+                    $0.id == suggestion.entry.resolutionID && $0.isAvailable
+                }) ? suggestion.entry.resolutionID : nil
             }
         }
     }

--- a/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
+++ b/macos/BluRayToVisionPro/Views/SetupQueueAdmissionView.swift
@@ -25,7 +25,9 @@ struct SetupQueueAdmissionView: View {
                         )
                     }
                     ForEach(admission.items) { item in
-                        SetupQueueRow(item: item)
+                        SetupQueueRow(item: item) {
+                            admission.changeResolution(item.id)
+                        }
                     }
                 }
             }
@@ -47,6 +49,7 @@ private struct SetupQueueConflictGroupView: View {
     @ObservedObject var memoryStore: ResolutionMemoryStore
     @State private var selection = QueueResolutionSelection()
     @State private var message: String?
+    @State private var loadedSuggestion = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -71,6 +74,24 @@ private struct SetupQueueConflictGroupView: View {
             .pickerStyle(.menu)
             Toggle("Suggest this next time for \(group.profileName)", isOn: $selection.shouldSuggest)
                 .font(.caption)
+            if let suggestion {
+                Text(suggestion.staleExplanation ?? "Suggested for this Profile. You’ll still confirm it with Apply Choice.")
+                    .font(.caption)
+                    .foregroundStyle(suggestion.isStale ? .orange : .secondary)
+                Button("Forget suggestion") {
+                    do {
+                        try memoryStore.forget(
+                            conflictID: group.conflict.stableID,
+                            scope: suggestion.entry.scope
+                        )
+                        selection.resolutionID = nil
+                        message = nil
+                    } catch {
+                        message = error.localizedDescription
+                    }
+                }
+                .buttonStyle(.borderless)
+            }
             HStack {
                 if let message {
                     Text(message)
@@ -108,11 +129,29 @@ private struct SetupQueueConflictGroupView: View {
         .padding(10)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
         .accessibilityIdentifier("queue-conflict-group")
+        .onAppear {
+            guard !loadedSuggestion else { return }
+            loadedSuggestion = true
+            if let suggestion, !suggestion.isStale {
+                selection.resolutionID = suggestion.entry.resolutionID
+            }
+        }
+    }
+
+    private var suggestion: ResolutionMemorySuggestion? {
+        let candidate = group.candidates[0]
+        return memoryStore.suggestion(
+            conflictID: group.conflict.stableID,
+            profileID: candidate.draft.profile.id,
+            sourceKind: candidate.draft.source.kind,
+            mappingVersion: group.conflict.mappingVersion
+        )
     }
 }
 
 private struct SetupQueueRow: View {
     let item: SetupQueueAdmissionItem
+    let change: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
@@ -133,8 +172,8 @@ private struct SetupQueueRow: View {
                 }
             }
             Spacer()
-            if item.state.acceptsChanges {
-                Button("Change…") {}
+            if item.state == .waiting, item.originalConflict != nil {
+                Button("Change…", action: change)
                     .buttonStyle(.borderless)
                     .accessibilityIdentifier("queue-row-change")
             }
@@ -148,6 +187,8 @@ private struct SetupQueueRow: View {
         case .held: "Needs a choice · \(item.originalDraft.profile.name)"
         case .running: "Running · \(item.originalDraft.profile.name)"
         case .completed: "Finished · \(item.originalDraft.profile.name)"
+        case .attention: "Needs attention · \(item.originalDraft.profile.name)"
+        case .stopped: "Stopped · \(item.originalDraft.profile.name)"
         }
     }
 
@@ -157,6 +198,8 @@ private struct SetupQueueRow: View {
         case .held: "exclamationmark.circle"
         case .running: "gearshape"
         case .completed: "checkmark.circle"
+        case .attention: "exclamationmark.triangle"
+        case .stopped: "stop.circle"
         }
     }
 }

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -541,9 +541,9 @@ struct SourceWorkspaceView: View {
                     HStack(spacing: 6) {
                         Text(profile.name)
                         if profileModified {
-                            Text("Modified")
+                            Text("For this conversion")
                                 .font(.caption.weight(.medium))
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
+++ b/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
@@ -65,17 +65,6 @@ struct VideoQualityEditor: View {
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            if let conflict = routeQualityState.conflict {
-                RouteQualityConflictView(conflict: conflict) { option in
-                    resolveRouteQuality(option)
-                }
-            }
-            if let invalidMessage = routeQualityState.invalidMessage {
-                Label(invalidMessage, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
         }
         .onChange(of: options.videoQuality.mode) { _, mode in
             if mode == .custom {
@@ -398,16 +387,6 @@ struct VideoQualityEditor: View {
         var values = options.videoQuality.custom
         edit(&values)
         applyRouteEdit(.customQuality(values))
-        selectionError = routeQualityState.invalidMessage
-    }
-
-    private func resolveRouteQuality(_ option: RouteQualityResolutionOption) {
-        var conversionOptions = ConversionOptions(
-            encoding: options,
-            job: context.jobOptions
-        )
-        routeQualityState.resolve(option, in: &conversionOptions)
-        options = conversionOptions.encoding
         selectionError = routeQualityState.invalidMessage
     }
 

--- a/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
+++ b/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
@@ -107,7 +107,7 @@ struct VideoQualityEditor: View {
     private func retainedQualityStatus(detail: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             LabeledContent("Video quality") {
-                Text("\(options.videoQuality.displayTitle) · retained, not applied")
+                Text("\(routePlan.qualityTitle) · retained, not applied")
                     .foregroundStyle(.secondary)
             }
             Text(detail)
@@ -118,7 +118,7 @@ struct VideoQualityEditor: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Video quality")
-        .accessibilityValue("\(options.videoQuality.displayTitle), retained, not applied")
+        .accessibilityValue("\(routePlan.qualityTitle), retained, not applied")
         .accessibilityHint(detail)
     }
 
@@ -574,7 +574,7 @@ private struct QualitySelectionControl: View {
             Button("Custom", action: selectCustom)
         } label: {
             HStack {
-                Text(selection.title)
+                Text(selectionTitle)
                     .fontWeight(.medium)
                 Spacer()
                 Text(isCustomSelected ? "Exact settings" : "Guided")
@@ -598,7 +598,18 @@ private struct QualitySelectionControl: View {
     private var selectionValue: String {
         switch selection {
         case let .step(step):
-            "\(step.title), step \(step.ordinal) of \(QualityStep.allCases.count)"
+            availableSteps.contains(step)
+                ? "\(step.title), step \(step.ordinal) of \(QualityStep.allCases.count)"
+                : "Custom, retained values; previous guided step is unavailable"
+        case .custom:
+            "Custom"
+        }
+    }
+
+    private var selectionTitle: String {
+        switch selection {
+        case let .step(step):
+            availableSteps.contains(step) ? step.title : "Custom"
         case .custom:
             "Custom"
         }
@@ -609,7 +620,7 @@ private struct QualitySelectionControl: View {
         case let .step(step):
             availableSteps.contains(step)
                 ? step.detail
-                : "\(step.detail) This step is unavailable for the active route; choose another step or Custom."
+                : "The retained guided choice is unavailable for the active route; choose another step or Custom."
         case .custom:
             "Exact direct, generated, AV1, and upscale values are retained independently from the guided ladder."
         }

--- a/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
+++ b/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
@@ -21,15 +21,21 @@ struct VideoQualityEditor: View {
 
     @Binding var options: EncodingOptions
     let context: Context
+    @ObservedObject var routeQualityState: RouteQualityResolutionState
 
     @State private var showsExpertControls: Bool
     @State private var showsDirectRateControl: Bool
     @State private var showsGeneratedRateControl: Bool
     @State private var selectionError: String?
 
-    init(options: Binding<EncodingOptions>, context: Context) {
+    init(
+        options: Binding<EncodingOptions>,
+        context: Context,
+        routeQualityState: RouteQualityResolutionState = RouteQualityResolutionState()
+    ) {
         _options = options
         self.context = context
+        self.routeQualityState = routeQualityState
         _showsExpertControls = State(initialValue: options.wrappedValue.videoQuality.mode == .custom)
         _showsDirectRateControl = State(
             initialValue: options.wrappedValue.videoQuality.custom.directFinalBitrate.mode == .custom
@@ -49,12 +55,23 @@ struct VideoQualityEditor: View {
                 expertControls
             case .directMVHEVC, .generatedMVHEVC:
                 qualitySelectionControl
-                Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
+                Toggle("AI FX upscale to 2× resolution", isOn: upscaleBinding)
                 expertControls
             }
 
             if let selectionError {
                 Label(selectionError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let conflict = routeQualityState.conflict {
+                RouteQualityConflictView(conflict: conflict) { option in
+                    resolveRouteQuality(option)
+                }
+            }
+            if let invalidMessage = routeQualityState.invalidMessage {
+                Label(invalidMessage, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
@@ -78,7 +95,7 @@ struct VideoQualityEditor: View {
         if options.videoOutputMode == .mvHEVC,
            routePlan.startStage == ConversionStage.upscaleVideo.rawValue
         {
-            Toggle("AI FX upscale to 2× resolution", isOn: $options.upscaleEnabled)
+            Toggle("AI FX upscale to 2× resolution", isOn: upscaleBinding)
             if options.upscaleEnabled {
                 qualitySelectionControl
                 expertControls
@@ -345,25 +362,60 @@ struct VideoQualityEditor: View {
         guard availableSteps.contains(step) else {
             return
         }
-        do {
-            try options.selectQualityStep(step)
-            selectionError = nil
-        } catch {
-            selectionError = error.localizedDescription
-        }
+        applyRouteEdit(.qualityStep(step))
+        selectionError = routeQualityState.invalidMessage
     }
 
     private func selectCustomQuality() {
-        options.selectCustomQuality()
-        selectionError = nil
-        showsExpertControls = true
+        applyRouteEdit(.customQuality(options.videoQuality.custom))
+        selectionError = routeQualityState.invalidMessage
+        if routeQualityState.conflict == nil, routeQualityState.invalidMessage == nil {
+            showsExpertControls = true
+        }
+    }
+
+    private var upscaleBinding: Binding<Bool> {
+        Binding(
+            get: { options.upscaleEnabled },
+            set: { enabled in
+                applyRouteEdit(.upscaleEnabled(enabled))
+            }
+        )
+    }
+
+    private func applyRouteEdit(_ edit: RouteQualityEdit) {
+        var conversionOptions = ConversionOptions(
+            encoding: options,
+            job: context.jobOptions
+        )
+        routeQualityState.apply(edit, to: &conversionOptions)
+        options = conversionOptions.encoding
+    }
+
+    private func editCustomQuality(
+        _ edit: (inout VideoQualityCustomValues) -> Void
+    ) {
+        var values = options.videoQuality.custom
+        edit(&values)
+        applyRouteEdit(.customQuality(values))
+        selectionError = routeQualityState.invalidMessage
+    }
+
+    private func resolveRouteQuality(_ option: RouteQualityResolutionOption) {
+        var conversionOptions = ConversionOptions(
+            encoding: options,
+            job: context.jobOptions
+        )
+        routeQualityState.resolve(option, in: &conversionOptions)
+        options = conversionOptions.encoding
+        selectionError = routeQualityState.invalidMessage
     }
 
     private var directRateModeBinding: Binding<BitrateMode> {
         Binding(
             get: { customValues.directFinalBitrate.mode },
             set: { mode in
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.directFinalBitrate.mode = mode
                     if mode == .custom, custom.directFinalBitrate.customMbps == nil {
                         custom.directFinalBitrate.customMbps = VideoQualityCatalog.defaultDirectCustomBitrateMbps
@@ -377,7 +429,7 @@ struct VideoQualityEditor: View {
         Binding(
             get: { directCustomMbps },
             set: { newValue in
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.directFinalBitrate.mode = .custom
                     custom.directFinalBitrate.customMbps = newValue
                 }
@@ -389,7 +441,7 @@ struct VideoQualityEditor: View {
         Binding(
             get: { customValues.generatedEyeBitrate.mode },
             set: { mode in
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.generatedEyeBitrate.mode = mode
                     if mode == .custom, custom.generatedEyeBitrate.customMbps == nil {
                         custom.generatedEyeBitrate.customMbps = VideoQualityCatalog.balancedGeneratedEyeBitrateMbps
@@ -403,7 +455,7 @@ struct VideoQualityEditor: View {
         Binding(
             get: { generatedCustomMbps },
             set: { newValue in
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.generatedEyeBitrate.mode = .custom
                     custom.generatedEyeBitrate.customMbps = newValue
                 }
@@ -416,7 +468,7 @@ struct VideoQualityEditor: View {
             get: { customValues.generatedMergeQuality },
             set: { newValue in
                 let linked = options.mvHEVC.linkGeneratedAndUpscaleQuality
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.generatedMergeQuality = newValue
                     if linked {
                         custom.upscaleQuality = newValue
@@ -431,7 +483,7 @@ struct VideoQualityEditor: View {
             get: { customValues.upscaleQuality },
             set: { newValue in
                 let linked = options.mvHEVC.linkGeneratedAndUpscaleQuality
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.upscaleQuality = newValue
                     if linked {
                         custom.generatedMergeQuality = newValue
@@ -445,13 +497,7 @@ struct VideoQualityEditor: View {
         Binding(
             get: { options.mvHEVC.linkGeneratedAndUpscaleQuality },
             set: { linked in
-                options.selectCustomQuality()
-                options.mvHEVC.linkGeneratedAndUpscaleQuality = linked
-                if linked {
-                    options.editCustomQuality { custom in
-                        custom.upscaleQuality = custom.generatedMergeQuality
-                    }
-                }
+                applyRouteEdit(.linkGeneratedAndUpscaleQuality(linked))
             }
         )
     }
@@ -460,7 +506,7 @@ struct VideoQualityEditor: View {
         Binding(
             get: { customValues.av1CRF },
             set: { newValue in
-                options.editCustomQuality { custom in
+                editCustomQuality { custom in
                     custom.av1CRF = newValue
                 }
             }

--- a/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
+++ b/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
@@ -113,7 +113,7 @@ struct VideoQualityEditor: View {
     private func retainedQualityStatus(detail: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             LabeledContent("Video quality") {
-                Text("\(routePlan.qualityTitle) · retained, not applied")
+                Text("Retained for an earlier restart stage")
                     .foregroundStyle(.secondary)
             }
             Text(detail)
@@ -124,7 +124,7 @@ struct VideoQualityEditor: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Video quality")
-        .accessibilityValue("\(routePlan.qualityTitle), retained, not applied")
+        .accessibilityValue("Retained for an earlier restart stage")
         .accessibilityHint(detail)
     }
 
@@ -540,6 +540,7 @@ private struct QualitySelectionControl: View {
             .accessibilityLabel("Custom video quality")
             .accessibilityValue(isCustomSelected ? "Selected" : "Not selected")
             .accessibilityHint("Restores retained expert values and reveals route-specific controls.")
+            .accessibilityAddTraits(isCustomSelected ? .isSelected : [])
 
             Text(selectionDetail)
                 .font(.caption)
@@ -568,7 +569,8 @@ private struct QualitySelectionControl: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel(step.title)
                     .accessibilityValue(stepAccessibilityValue(step, available: true))
-                    .accessibilityHint("Uses the checked route mappings.")
+                    .accessibilityHint("Uses the checked values for this output.")
+                    .accessibilityAddTraits(selection == .step(step) ? .isSelected : [])
                 } else {
                     QualityStepCell(
                         step: step,

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -698,7 +698,7 @@ final class ConversionQueueStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         let fileURL = directoryURL.appendingPathComponent("queue.json")
-        let originalData = Data(#"{"items":[],"version":2}"#.utf8)
+        let originalData = Data("{\"items\":[],\"version\":\(ConversionQueueDocument.currentVersion + 1)}".utf8)
         try originalData.write(to: fileURL)
         let store = ConversionQueueStore(fileURL: fileURL)
 
@@ -713,6 +713,34 @@ final class ConversionQueueStoreTests: XCTestCase {
         }
         XCTAssertEqual(try Data(contentsOf: fileURL), originalData)
         XCTAssertTrue(store.items.isEmpty)
+    }
+
+    @MainActor
+    func testResolutionTraceMigratesFromV1AndSurvivesRestoration() async throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("queue.json")
+        let trace = DurableQueueResolutionTrace(
+            conflictID: "generated_route_requirement|direct_mv_hevc|generated_mv_hevc|reusable_intermediates_requested|keep_requested_workflow:v1",
+            resolutionID: "keep_requested_workflow:v1",
+            qualityOutcome: "Balanced quality",
+            fileOutcome: "Reusable files retained"
+        )
+        let item = makeItem(ordinal: 0, state: .waiting)
+        let v1Data = try JSONEncoder().encode(ConversionQueueDocument(version: 1, items: [item]))
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try v1Data.write(to: fileURL)
+
+        let store = ConversionQueueStore(fileURL: fileURL)
+        try await store.resolveWaitingItems(
+            [item.id],
+            intents: [item.id: item.intent],
+            trace: trace
+        )
+        let restored = ConversionQueueStore(fileURL: fileURL)
+
+        XCTAssertEqual(restored.document.version, ConversionQueueDocument.currentVersion)
+        XCTAssertEqual(restored.items.first?.resolutionTrace, trace)
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -2114,7 +2114,7 @@ final class ConversionViewModelTests: XCTestCase {
     func testDurableSourceFolderQueueFailsClosedWhenStartWritesAreBlocked() async throws {
         try await withTemporaryBatchSources(["feature.mkv"]) { folderURL, _, destinationURL in
             let queueURL = folderURL.appendingPathComponent("queue.json")
-            try Data(#"{"version":2,"items":[]}"#.utf8).write(to: queueURL)
+            try Data("{\"version\":\(ConversionQueueDocument.currentVersion + 1),\"items\":[]}".utf8).write(to: queueURL)
             let queueStore = ConversionQueueStore(fileURL: queueURL)
             var factoryCalls = 0
             let viewModel = ConversionViewModel(

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -56,15 +56,15 @@ final class ConversionViewModelTests: XCTestCase {
             XCTAssertEqual(summary.choices, SourceScopedResetSummary.Choice.allCases, sourceKind.rawValue)
             XCTAssertEqual(
                 summary.message,
-                "New source: reset restart stage, overwrite output, delete source after success, recovery choices, title selection, and source-derived exact overrides.",
+                "New source: reset restart stage, overwrite output, delete source after success, recovery choices, and title selection.",
                 sourceKind.rawValue
             )
             XCTAssertEqual(options.job.startStage, .createMKV, sourceKind.rawValue)
             XCTAssertFalse(options.job.overwriteExisting, sourceKind.rawValue)
             XCTAssertFalse(options.job.removeOriginalAfterSuccess, sourceKind.rawValue)
             XCTAssertFalse(options.job.continueOnError, sourceKind.rawValue)
-            XCTAssertEqual(options.encoding.frameRateOverride, "", sourceKind.rawValue)
-            XCTAssertEqual(options.encoding.resolutionOverride, "", sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.frameRateOverride, encoding.frameRateOverride, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.resolutionOverride, encoding.resolutionOverride, sourceKind.rawValue)
             XCTAssertEqual(titleSelection, .main, sourceKind.rawValue)
 
             XCTAssertEqual(options.encoding.videoOutputMode, encoding.videoOutputMode, sourceKind.rawValue)

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -921,6 +921,202 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testAdmissionQueueRunsMultipleSingleSourceDrafts() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let sourceURLs = ["One.mkv", "Two.mkv"].map { directoryURL.appendingPathComponent($0) }
+        for sourceURL in sourceURLs {
+            _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        }
+        let scenario = BatchWorkerScenario()
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(
+            clientFactory: { scenario.makeClient() },
+            durableQueueStore: queueStore
+        )
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: sourceURLs.map { sourceURL in
+            let inspection = SourceInspection(
+                name: sourceURL.deletingPathExtension().lastPathComponent,
+                resolution: "1920x1080",
+                frameRate: "24/1",
+                interlaced: false,
+                sizeBytes: 10
+            )
+            return ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: sourceURL),
+                sourceDetails: inspection,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: directoryURL,
+                options: ConversionOptions()
+            )
+        })
+
+        viewModel.startConversionQueue(admissionItems: admission.items)
+
+        while queueStore.items.count < sourceURLs.count { await Task.yield() }
+        while viewModel.hasActiveWorker || viewModel.hasQueuedWork { await Task.yield() }
+        XCTAssertEqual(
+            scenario.records.filter { $0.operation == "convert_source" }.map(\.sourcePath),
+            sourceURLs.map(\.path)
+        )
+        XCTAssertEqual(queueStore.items.map(\.origin), [.singleSource, .singleSource])
+        XCTAssertEqual(queueStore.items.map(\.state), [.completed, .completed])
+    }
+
+    @MainActor
+    func testSingleAdmissionQueuePreservesIdentityAndResolutionTrace() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let sourceURL = directoryURL.appendingPathComponent("Movie.mkv")
+        _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        let scenario = BatchWorkerScenario()
+        let queueStore = ConversionQueueStore.inMemory()
+        let viewModel = ConversionViewModel(
+            clientFactory: { scenario.makeClient() },
+            durableQueueStore: queueStore
+        )
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: sourceURL),
+            sourceDetails: SourceInspection(
+                name: "Movie",
+                resolution: "1920x1080",
+                frameRate: "24/1",
+                interlaced: false,
+                sizeBytes: 10
+            ),
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: directoryURL,
+            options: options
+        )
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else {
+            return XCTFail("Expected reusable-file conflict")
+        }
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft], conflicts: [conflict])
+        let group = try XCTUnwrap(admission.groups.first)
+        var selection = QueueResolutionSelection()
+        selection.resolutionID = try XCTUnwrap(
+            group.conflict.resolutions.first(where: {
+                $0.choice == .keepRequestedWorkflow && $0.isAvailable
+            })?.id
+        )
+        try admission.apply(group: group, selection: selection).get()
+        let admittedItem = try XCTUnwrap(admission.items.first)
+        let trace = try XCTUnwrap(admittedItem.resolutionTrace)
+
+        viewModel.startConversionQueue(admissionItems: admission.items)
+
+        while queueStore.items.isEmpty { await Task.yield() }
+        while viewModel.hasActiveWorker || viewModel.hasQueuedWork { await Task.yield() }
+        let storedItem = try XCTUnwrap(queueStore.items.first)
+        XCTAssertEqual(storedItem.id, admittedItem.id)
+        XCTAssertEqual(storedItem.resolutionTrace, trace)
+        XCTAssertEqual(storedItem.origin, .singleSource)
+        XCTAssertEqual(storedItem.state, .completed)
+    }
+
+    @MainActor
+    func testAdmissionQueueWriteFailureReturnsRowsToClearableAttention() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let sourceURL = directoryURL.appendingPathComponent("Movie.mkv")
+        _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        let queueStore = ConversionQueueStore(
+            fileURL: directoryURL.appendingPathComponent("queue.json"),
+            dataWriter: { _, _ in throw RuntimePersistenceTestError.writeFailed }
+        )
+        let viewModel = ConversionViewModel(durableQueueStore: queueStore)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [
+            ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: sourceURL),
+                sourceDetails: SourceInspection(
+                    name: "Movie",
+                    resolution: "1920x1080",
+                    frameRate: "24/1",
+                    interlaced: false,
+                    sizeBytes: 10
+                ),
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: directoryURL,
+                options: ConversionOptions()
+            ),
+        ])
+
+        XCTAssertTrue(viewModel.startConversionQueue(admissionItems: admission.items))
+        admission.markAllRunning()
+        while viewModel.setupQueueStartFailureItemIDs.isEmpty { await Task.yield() }
+        admission.markStartFailed(viewModel.setupQueueStartFailureItemIDs)
+
+        XCTAssertEqual(admission.items.map(\.state), [.attention])
+        XCTAssertTrue(admission.canClear)
+        XCTAssertNotNil(viewModel.durableQueueRuntimeDiagnostic)
+    }
+
+    @MainActor
+    func testAdmissionQueueTerminalWriteFailureReturnsRowsToClearableAttention() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let sourceURL = directoryURL.appendingPathComponent("Movie.mkv")
+        _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        let writeCount = RuntimePersistenceTestCounter()
+        let queueStore = ConversionQueueStore(
+            fileURL: directoryURL.appendingPathComponent("queue.json"),
+            dataWriter: { data, url in
+                if writeCount.incrementAndReturn() == 3 {
+                    throw RuntimePersistenceTestError.writeFailed
+                }
+                try data.write(to: url, options: .atomic)
+            }
+        )
+        let scenario = BatchWorkerScenario()
+        let viewModel = ConversionViewModel(
+            clientFactory: { scenario.makeClient() },
+            durableQueueStore: queueStore
+        )
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [
+            ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: sourceURL),
+                sourceDetails: SourceInspection(
+                    name: "Movie",
+                    resolution: "1920x1080",
+                    frameRate: "24/1",
+                    interlaced: false,
+                    sizeBytes: 10
+                ),
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: directoryURL,
+                options: ConversionOptions()
+            ),
+        ])
+
+        XCTAssertTrue(viewModel.startConversionQueue(admissionItems: admission.items))
+        admission.markAllRunning()
+        while viewModel.setupQueueStartFailureItemIDs.isEmpty { await Task.yield() }
+        admission.markStartFailed(viewModel.setupQueueStartFailureItemIDs)
+
+        XCTAssertEqual(admission.items.map(\.state), [.attention])
+        XCTAssertTrue(admission.canClear)
+        XCTAssertEqual(queueStore.items.map(\.state), [.processing])
+        XCTAssertNotNil(viewModel.durableQueueRuntimeDiagnostic)
+    }
+
+    @MainActor
     func testStopActiveWorkerCancelsConversionAndTransitionsToStopping() async throws {
         let inspectionDone = expectation(description: "inspection done")
         let conversionStarted = expectation(description: "conversion started")
@@ -945,6 +1141,12 @@ final class ConversionViewModelTests: XCTestCase {
             )
             viewModel.startConversion(draft: draft)
             await fulfillment(of: [conversionStarted], timeout: 2)
+
+            let admission = SetupQueueAdmission()
+            admission.add(drafts: [draft])
+            XCTAssertFalse(viewModel.startConversionQueue(admissionItems: admission.items))
+            XCTAssertEqual(admission.items.map(\.state), [.waiting])
+            XCTAssertTrue(admission.canClear)
 
             viewModel.stopActiveWorker()
 

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -5,6 +5,131 @@ import XCTest
 
 final class ConversionViewModelTests: XCTestCase {
     @MainActor
+    func testSourceScopedResetMatrixResetsOnlySourceState() {
+        let encoding = EncodingOptions(
+            videoOutputMode: .av1Stereo,
+            videoQuality: .custom(
+                mvHEVC: MVHEVCOptions(generatedMergeQuality: 82),
+                av1CRF: 28,
+                upscaleQuality: 88
+            ),
+            av1CRF: 28,
+            upscaleEnabled: true,
+            upscaleQuality: 88,
+            fieldOfView: 110,
+            frameRateOverride: "24000/1001",
+            resolutionOverride: "3840x2160",
+            cropBlackBars: true,
+            swapEyes: true,
+            audioHandling: .pcm,
+            audioBitrate: 512,
+            audioLanguages: AudioLanguagePolicy(
+                mode: .allLanguages,
+                preferredLanguage: .japanese
+            ),
+            subtitles: SubtitlePolicy(
+                mode: .preferredOnly,
+                preferredLanguage: .french
+            )
+        )
+        let job = JobOptions(
+            startStage: .upscaleVideo,
+            intermediatePolicy: .reusable,
+            overwriteExisting: true,
+            removeOriginalAfterSuccess: true,
+            continueOnError: true,
+            softwareEncoder: true,
+            outputCommands: true,
+            keepAwake: false,
+            playSound: false
+        )
+
+        for sourceKind in ConversionSourceKind.allCases {
+            var options = ConversionOptions(encoding: encoding, job: job)
+            var titleSelection = DiscTitleSelection.all
+            let summary = options.resetSourceScopedState(
+                for: sourceKind,
+                titleSelection: &titleSelection,
+                recoveryDecisionPresent: true
+            )
+
+            XCTAssertEqual(summary.choices, SourceScopedResetSummary.Choice.allCases, sourceKind.rawValue)
+            XCTAssertEqual(
+                summary.message,
+                "New source: reset restart stage, overwrite output, delete source after success, recovery choices, and title selection.",
+                sourceKind.rawValue
+            )
+            XCTAssertEqual(options.job.startStage, .createMKV, sourceKind.rawValue)
+            XCTAssertFalse(options.job.overwriteExisting, sourceKind.rawValue)
+            XCTAssertFalse(options.job.removeOriginalAfterSuccess, sourceKind.rawValue)
+            XCTAssertFalse(options.job.continueOnError, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.frameRateOverride, encoding.frameRateOverride, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.resolutionOverride, encoding.resolutionOverride, sourceKind.rawValue)
+            XCTAssertEqual(titleSelection, .main, sourceKind.rawValue)
+
+            XCTAssertEqual(options.encoding.videoOutputMode, encoding.videoOutputMode, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.videoQuality, encoding.videoQuality, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.cropBlackBars, encoding.cropBlackBars, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.swapEyes, encoding.swapEyes, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.audioHandling, encoding.audioHandling, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.audioLanguages, encoding.audioLanguages, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.subtitles, encoding.subtitles, sourceKind.rawValue)
+            XCTAssertEqual(options.job.intermediatePolicy, job.intermediatePolicy, sourceKind.rawValue)
+            XCTAssertEqual(options.job.softwareEncoder, job.softwareEncoder, sourceKind.rawValue)
+            XCTAssertEqual(options.job.outputCommands, job.outputCommands, sourceKind.rawValue)
+            XCTAssertEqual(options.job.keepAwake, job.keepAwake, sourceKind.rawValue)
+            XCTAssertEqual(options.job.playSound, job.playSound, sourceKind.rawValue)
+        }
+    }
+
+    @MainActor
+    func testSourceScopedResetIsSilentWhenNothingChanged() {
+        var options = ConversionOptions()
+        var titleSelection = DiscTitleSelection.main
+
+        let summary = options.resetSourceScopedState(
+            for: .matroska,
+            titleSelection: &titleSelection,
+            recoveryDecisionPresent: false
+        )
+
+        XCTAssertFalse(summary.didReset)
+        XCTAssertNil(summary.message)
+        XCTAssertEqual(options, ConversionOptions())
+        XCTAssertEqual(titleSelection, .main)
+    }
+
+    @MainActor
+    func testPhysicalDiscResetKeepsRemoveOriginalFalse() {
+        var options = ConversionOptions()
+        options.job.removeOriginalAfterSuccess = true
+
+        _ = options.resetSourceScopedState(for: .physicalDisc)
+
+        XCTAssertFalse(options.job.removeOriginalAfterSuccess)
+    }
+
+    @MainActor
+    func testSourceFolderSelectionTransitionsResetLifecycleState() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let firstFolderURL = rootURL.appendingPathComponent("first", isDirectory: true)
+        let secondFolderURL = rootURL.appendingPathComponent("second", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstFolderURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondFolderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let viewModel = ConversionViewModel()
+        viewModel.selectSource(ConversionSource(kind: .sourceFolder, url: firstFolderURL))
+        viewModel.selectSource(ConversionSource(kind: .sourceFolder, url: secondFolderURL))
+
+        XCTAssertEqual(viewModel.source?.url, secondFolderURL.standardizedFileURL)
+        XCTAssertEqual(viewModel.batchQueue?.folderSource.url, secondFolderURL.standardizedFileURL)
+        XCTAssertEqual(viewModel.state.phase, .empty)
+        XCTAssertNil(viewModel.state.recoveryDecision)
+    }
+
+    @MainActor
     func testCanonicalObservabilityUpdatesLiveStatusAndPersists() async throws {
         let terminalDelivered = expectation(description: "terminal delivered")
         let observabilityEvent = try makeTestObservabilityEvent(kind: "tool.started")

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -56,15 +56,15 @@ final class ConversionViewModelTests: XCTestCase {
             XCTAssertEqual(summary.choices, SourceScopedResetSummary.Choice.allCases, sourceKind.rawValue)
             XCTAssertEqual(
                 summary.message,
-                "New source: reset restart stage, overwrite output, delete source after success, recovery choices, and title selection.",
+                "New source: reset restart stage, overwrite output, delete source after success, recovery choices, title selection, and source-derived exact overrides.",
                 sourceKind.rawValue
             )
             XCTAssertEqual(options.job.startStage, .createMKV, sourceKind.rawValue)
             XCTAssertFalse(options.job.overwriteExisting, sourceKind.rawValue)
             XCTAssertFalse(options.job.removeOriginalAfterSuccess, sourceKind.rawValue)
             XCTAssertFalse(options.job.continueOnError, sourceKind.rawValue)
-            XCTAssertEqual(options.encoding.frameRateOverride, encoding.frameRateOverride, sourceKind.rawValue)
-            XCTAssertEqual(options.encoding.resolutionOverride, encoding.resolutionOverride, sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.frameRateOverride, "", sourceKind.rawValue)
+            XCTAssertEqual(options.encoding.resolutionOverride, "", sourceKind.rawValue)
             XCTAssertEqual(titleSelection, .main, sourceKind.rawValue)
 
             XCTAssertEqual(options.encoding.videoOutputMode, encoding.videoOutputMode, sourceKind.rawValue)

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -319,6 +319,7 @@ final class ConversionWorkflowTests: XCTestCase {
         XCTAssertEqual(route.kind, .existingArtifact)
         XCTAssertTrue(route.includesUpscale)
         XCTAssertEqual(route.title, "Existing artifact + 2× upscale")
+        XCTAssertEqual(route.qualityTitle, "Custom")
         XCTAssertEqual(route.settingsSummary, "Custom · upscale quality 66")
         XCTAssertEqual(route.speedGuidance, "Reuses the encoded artifact and runs file upscale.")
 
@@ -327,6 +328,7 @@ final class ConversionWorkflowTests: XCTestCase {
 
         XCTAssertFalse(route.includesUpscale)
         XCTAssertEqual(route.title, "Existing encoded video artifact")
+        XCTAssertEqual(route.qualityTitle, "Not applied")
         XCTAssertEqual(route.settingsSummary, "No video re-encode")
         XCTAssertEqual(route.speedGuidance, "Reuses the encoded artifact.")
     }

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -202,7 +202,7 @@ final class ConversionWorkflowTests: XCTestCase {
             EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
             "Direct MV-HEVC when available · Balanced · Adaptive quality 0.70 · source resolution · Audio: AAC 448 kbps, English only · Subtitles: English + others"
         )
-        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("English audio only"))
+        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("English audio"))
     }
 
     func testVideoRoutePlanCoversDirectGeneratedAV1AndExistingRoutes() {

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -713,7 +713,7 @@ final class ConversionWorkflowTests: XCTestCase {
             XCTAssertEqual(queue.items.count, 2)
             for item in queue.items {
                 let draft = try XCTUnwrap(item.draft)
-                XCTAssertEqual(draft.profile.name, "Balanced")
+                XCTAssertEqual(draft.profile.name, "Standard Movie")
                 XCTAssertEqual(draft.destinationURL, destinationURL)
                 XCTAssertEqual(draft.options.encoding.mvHEVC.generatedMergeQuality, 81)
                 XCTAssertEqual(draft.options.encoding.audioLanguages.mode, .preferredOnly)

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -54,67 +54,73 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testCustomProfilePersistsFilesAndRecoveryDefaults() throws {
+    func testCustomProfilePersistsPipelineDefaultsOnly() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
         let identifier = UUID(uuidString: "6C02DFB0-2B6A-4F6D-9335-3703487FB9D7")!
-        let jobDefaults = ProfileJobDefaults(
-            startStage: .extractMVCAndAudio,
+        let pipelineDefaults = ProfilePipelineDefaults(
             intermediatePolicy: .reusable,
-            overwriteExisting: true,
-            removeOriginalAfterSuccess: true,
-            continueOnError: true,
-            softwareEncoder: true,
-            outputCommands: true
+            softwareEncoder: true
         )
         let store = ProfileStore(fileURL: fileURL, idGenerator: { identifier })
 
         let profileID = try store.createProfile(
-            name: "Recovery",
+            name: "Reusable",
             options: EncodingOptions(),
-            jobDefaults: jobDefaults
+            pipelineDefaults: pipelineDefaults
         )
         let restoredProfile = ProfileStore(fileURL: fileURL).profile(withID: profileID)
 
-        XCTAssertEqual(restoredProfile.jobDefaults, jobDefaults)
+        XCTAssertEqual(restoredProfile.pipelineDefaults, pipelineDefaults)
     }
 
-    func testApplyingProfileJobDefaultsPreservesGlobalPreferences() {
-        var job = JobOptions(keepAwake: false, playSound: false)
-        job.applyProfileDefaults(
-            ProfileJobDefaults(
+    func testApplyingProfilePipelineDefaultsLeavesRunScopedOptionsUntouched() {
+        var job = JobOptions(
+            startStage: .extractMVCAndAudio,
+            overwriteExisting: true,
+            removeOriginalAfterSuccess: true,
+            continueOnError: true,
+            outputCommands: true,
+            keepAwake: false,
+            playSound: false
+        )
+        job.applyProfilePipelineDefaults(
+            ProfilePipelineDefaults(
                 intermediatePolicy: .reusable,
-                overwriteExisting: true,
                 softwareEncoder: true
             )
         )
 
+        XCTAssertEqual(job.startStage, .extractMVCAndAudio)
         XCTAssertEqual(job.intermediatePolicy, .reusable)
         XCTAssertTrue(job.overwriteExisting)
+        XCTAssertTrue(job.removeOriginalAfterSuccess)
+        XCTAssertTrue(job.continueOnError)
         XCTAssertTrue(job.softwareEncoder)
+        XCTAssertTrue(job.outputCommands)
         XCTAssertFalse(job.keepAwake)
         XCTAssertFalse(job.playSound)
     }
 
     @MainActor
-    func testUpdatingProfileWithoutJobDefaultsPreservesSavedFilesAndRecoveryDefaults() throws {
+    func testUpdatingProfileWithoutPipelineDefaultsPreservesPipelineDefaults() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
         let identifier = UUID(uuidString: "9B58E388-CB38-46ED-ADE4-F690F6A40D81")!
-        let jobDefaults = ProfileJobDefaults(overwriteExisting: true, continueOnError: true)
+        let pipelineDefaults = ProfilePipelineDefaults(intermediatePolicy: .reusable, softwareEncoder: true)
         let store = ProfileStore(fileURL: fileURL, idGenerator: { identifier })
         let profileID = try store.createProfile(
-            name: "Preserve Recovery",
+            name: "Preserve Pipeline",
             options: EncodingOptions(),
-            jobDefaults: jobDefaults
+            pipelineDefaults: pipelineDefaults
         )
 
-        try store.updateProfile(profileID, name: "Renamed Recovery", options: EncodingOptions())
+        try store.updateProfile(profileID, name: "Renamed Pipeline", options: EncodingOptions())
 
-        XCTAssertEqual(store.profile(withID: profileID).jobDefaults, jobDefaults)
-        XCTAssertEqual(ProfileStore(fileURL: fileURL).profile(withID: profileID).jobDefaults, jobDefaults)
+        XCTAssertEqual(store.profile(withID: profileID).pipelineDefaults, pipelineDefaults)
+        XCTAssertEqual(ProfileStore(fileURL: fileURL).profile(withID: profileID).pipelineDefaults, pipelineDefaults)
     }
 
     @MainActor
@@ -214,7 +220,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionFourPersistenceWritesCurrentIntentAndStableMirrorKeys() throws {
+    func testVersionSixPersistenceWritesCurrentIntentAndStableMirrorKeys() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
@@ -230,7 +236,7 @@ final class ProfileStoreTests: XCTestCase {
         let document = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(document["version"] as? Int, 5)
+        XCTAssertEqual(document["version"] as? Int, 6)
         let profiles = try XCTUnwrap(document["profiles"] as? [[String: Any]])
         let persistedOptions = try XCTUnwrap(profiles.first?["options"] as? [String: Any])
         let currentMVHEVC = try XCTUnwrap(persistedOptions["mvHEVC"] as? [String: Any])
@@ -316,6 +322,149 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: fileURL.appendingPathExtension("corrupt")), data)
     }
 
+    @MainActor
+    func testVersionFiveMigrationPreservesEncodingAndPipelineButDropsEveryUnsafeDefault() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        var options = EncodingOptions()
+        options.mvHEVC.generatedMergeQuality = 84
+        options.audioLanguages = AudioLanguagePolicy(mode: .preferredOnly, preferredLanguage: .japanese)
+        let expectedOptions = try options.normalizedQualityState()
+        let document: [String: Any] = [
+            "version": 5,
+            "profiles": [
+                [
+                    "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    "name": "Risky Library",
+                    "options": try encodedOptions(options),
+                    "jobDefaults": [
+                        "startStage": ConversionStage.extractMVCAndAudio.rawValue,
+                        "intermediatePolicy": IntermediatePolicy.reusable.rawValue,
+                        "overwriteExisting": true,
+                        "removeOriginalAfterSuccess": true,
+                        "continueOnError": true,
+                        "softwareEncoder": true,
+                        "outputCommands": true,
+                    ],
+                ]
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]).write(to: fileURL)
+
+        let store = ProfileStore(fileURL: fileURL)
+        let profile = try XCTUnwrap(store.customProfiles.first)
+
+        XCTAssertEqual(profile.id, "custom.a4cc523e-72fa-4f36-a38d-1fb0d6a84742")
+        XCTAssertEqual(profile.name, "Risky Library")
+        XCTAssertEqual(profile.options, expectedOptions)
+        XCTAssertEqual(
+            profile.pipelineDefaults,
+            ProfilePipelineDefaults(intermediatePolicy: .reusable, softwareEncoder: true)
+        )
+        XCTAssertTrue(store.migrationNoticeMessage?.contains("Risky Library") == true)
+
+        let migratedDocument = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        )
+        XCTAssertEqual(migratedDocument["version"] as? Int, 6)
+        let migratedProfile = try XCTUnwrap(
+            (migratedDocument["profiles"] as? [[String: Any]])?.first
+        )
+        let pipelineDefaults = try XCTUnwrap(migratedProfile["pipelineDefaults"] as? [String: Any])
+        XCTAssertEqual(pipelineDefaults["intermediatePolicy"] as? String, "reusable")
+        XCTAssertEqual(pipelineDefaults["softwareEncoder"] as? Bool, true)
+        XCTAssertNil(migratedProfile["jobDefaults"])
+        XCTAssertNil(pipelineDefaults["startStage"])
+        XCTAssertNil(pipelineDefaults["overwriteExisting"])
+        XCTAssertNil(pipelineDefaults["removeOriginalAfterSuccess"])
+        XCTAssertNil(pipelineDefaults["continueOnError"])
+        XCTAssertNil(pipelineDefaults["outputCommands"])
+    }
+
+    @MainActor
+    func testVersionFiveMigrationIsIdempotentAfterWritingVersionSix() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let document: [String: Any] = [
+            "version": 5,
+            "profiles": [
+                [
+                    "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    "name": "Idempotent",
+                    "options": try encodedOptions(EncodingOptions()),
+                    "jobDefaults": [
+                        "startStage": ConversionStage.createMKV.rawValue,
+                        "intermediatePolicy": IntermediatePolicy.automatic.rawValue,
+                        "overwriteExisting": false,
+                        "removeOriginalAfterSuccess": false,
+                        "continueOnError": false,
+                        "softwareEncoder": false,
+                        "outputCommands": false,
+                    ],
+                ]
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]).write(to: fileURL)
+
+        let migratedStore = ProfileStore(fileURL: fileURL)
+        let migratedData = try Data(contentsOf: fileURL)
+        let reopenedStore = ProfileStore(fileURL: fileURL)
+
+        XCTAssertEqual(reopenedStore.customProfiles, migratedStore.customProfiles)
+        XCTAssertNil(reopenedStore.migrationNoticeMessage)
+        XCTAssertEqual(try Data(contentsOf: fileURL), migratedData)
+    }
+
+    @MainActor
+    func testVersionFiveMigrationWriteFailureKeepsOriginalAndSafeInMemoryProfiles() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let document: [String: Any] = [
+            "version": 5,
+            "profiles": [
+                [
+                    "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+                    "name": "Read Only",
+                    "options": try encodedOptions(EncodingOptions()),
+                    "jobDefaults": [
+                        "startStage": ConversionStage.extractSubtitles.rawValue,
+                        "intermediatePolicy": IntermediatePolicy.reusable.rawValue,
+                        "overwriteExisting": true,
+                        "removeOriginalAfterSuccess": true,
+                        "continueOnError": true,
+                        "softwareEncoder": true,
+                        "outputCommands": true,
+                    ],
+                ]
+            ],
+        ]
+        let originalData = try JSONSerialization.data(withJSONObject: document, options: [.sortedKeys])
+        try originalData.write(to: fileURL)
+
+        let store = ProfileStore(
+            fileURL: fileURL,
+            dataWriter: { _, _ in throw TestWriteError.failed }
+        )
+        let profile = try XCTUnwrap(store.customProfiles.first)
+
+        XCTAssertEqual(
+            profile.pipelineDefaults,
+            ProfilePipelineDefaults(intermediatePolicy: .reusable, softwareEncoder: true)
+        )
+        XCTAssertTrue(store.migrationNoticeMessage?.contains("Read Only") == true)
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalData)
+        XCTAssertThrowsError(try store.createProfile(name: "Blocked", options: EncodingOptions())) { error in
+            XCTAssertEqual(error as? ProfileStoreError, .recoveryRequired)
+        }
+    }
+
     func testEncodingOptionsRejectMismatchedCompatibilityKeys() throws {
         var encoded = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: JSONEncoder().encode(EncodingOptions())) as? [String: Any]
@@ -370,7 +519,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionTwoProfilesMigrateAllAudioHandlingRawValuesToVersionFive() throws {
+    func testVersionTwoProfilesMigrateAllAudioHandlingRawValuesToVersionSix() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -411,7 +560,7 @@ final class ProfileStoreTests: XCTestCase {
         let persistedDocument = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(persistedDocument["version"] as? Int, 5)
+        XCTAssertEqual(persistedDocument["version"] as? Int, 6)
         let persistedProfiles = try XCTUnwrap(persistedDocument["profiles"] as? [[String: Any]])
         let persistedRawValues = try persistedProfiles.map { profile in
             let options = try XCTUnwrap(profile["options"] as? [String: Any])
@@ -421,7 +570,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionThreeProfilesMigrateToAllAudioLanguagesInVersionFive() throws {
+    func testVersionThreeProfilesMigrateToAllAudioLanguagesInVersionSix() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -451,7 +600,7 @@ final class ProfileStoreTests: XCTestCase {
         let persistedDocument = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(persistedDocument["version"] as? Int, 5)
+        XCTAssertEqual(persistedDocument["version"] as? Int, 6)
         let persistedProfiles = try XCTUnwrap(persistedDocument["profiles"] as? [[String: Any]])
         let persistedOptions = try XCTUnwrap(persistedProfiles.first?["options"] as? [String: Any])
         let audioLanguages = try XCTUnwrap(persistedOptions["audioLanguages"] as? [String: Any])
@@ -460,7 +609,7 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testVersionOneProfilesMigrateAtomicallyToCanonicalVersionFiveData() throws {
+    func testVersionOneProfilesMigrateAtomicallyToCanonicalVersionSixData() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -530,7 +679,7 @@ final class ProfileStoreTests: XCTestCase {
         let migratedJSON = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
         )
-        XCTAssertEqual(migratedJSON["version"] as? Int, 5)
+        XCTAssertEqual(migratedJSON["version"] as? Int, 6)
         let profiles = try XCTUnwrap(migratedJSON["profiles"] as? [[String: Any]])
         let options = try XCTUnwrap(profiles.first?["options"] as? [String: Any])
         let subtitles = try XCTUnwrap(options["subtitles"] as? [String: Any])
@@ -635,6 +784,35 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertFalse(store.customProfiles.contains { $0.id == firstID })
         XCTAssertEqual(store.profile(withID: firstID).id, BuiltInProfile.balanced.id)
         XCTAssertEqual(store.normalizedProfileID(firstID), BuiltInProfile.balanced.id)
+    }
+
+    @MainActor
+    func testDuplicateProfilePreservesEncodingAndPipelineDefaults() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        var identifiers = [
+            UUID(uuidString: "6C02DFB0-2B6A-4F6D-9335-3703487FB9D7")!,
+            UUID(uuidString: "9B58E388-CB38-46ED-ADE4-F690F6A40D81")!,
+        ].makeIterator()
+        let store = ProfileStore(fileURL: fileURL, idGenerator: { identifiers.next()! })
+        var options = EncodingOptions()
+        options.mvHEVC.generatedMergeQuality = 84
+        let pipelineDefaults = ProfilePipelineDefaults(intermediatePolicy: .reusable, softwareEncoder: true)
+
+        let originalID = try store.createProfile(
+            name: "Theater",
+            options: options,
+            pipelineDefaults: pipelineDefaults
+        )
+        let duplicateID = try store.duplicateProfile(originalID)
+
+        XCTAssertEqual(store.profile(withID: duplicateID).name, "Theater Copy")
+        XCTAssertEqual(store.profile(withID: duplicateID).options, store.profile(withID: originalID).options)
+        XCTAssertEqual(
+            store.profile(withID: duplicateID).pipelineDefaults,
+            store.profile(withID: originalID).pipelineDefaults
+        )
     }
 
     @MainActor
@@ -745,6 +923,12 @@ final class ProfileStoreTests: XCTestCase {
 
     private func legacyDocument(profiles: [[String: Any]]) throws -> Data {
         try JSONSerialization.data(withJSONObject: ["version": 1, "profiles": profiles], options: [.sortedKeys])
+    }
+
+    private func encodedOptions(_ options: EncodingOptions) throws -> [String: Any] {
+        try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(options)) as? [String: Any]
+        )
     }
 
     private func optionsJSON(audioHandlingRawValue: String) throws -> [String: Any] {

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -4,6 +4,38 @@ import XCTest
 
 final class ProfileStoreTests: XCTestCase {
     @MainActor
+    func testDeleteRollsBackProfileMemoriesWhenProfileWriteFails() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileURL = directory.appendingPathComponent("profiles.json")
+        var failWrites = false
+        let memoryStore = ResolutionMemoryStore.inMemory()
+        let store = ProfileStore(
+            fileURL: fileURL,
+            dataWriter: { data, url in
+                if failWrites {
+                    throw TestWriteError.failed
+                }
+                try data.write(to: url, options: .atomic)
+            },
+            resolutionMemoryStore: memoryStore
+        )
+        let identifier = try store.createProfile(name: "Rollback", options: EncodingOptions())
+        try memoryStore.store(
+            resolutionID: "keep_requested_workflow:v2",
+            for: "conflict",
+            scope: .profile(identifier),
+            mappingVersion: 2
+        )
+        failWrites = true
+
+        XCTAssertThrowsError(try store.deleteProfile(identifier))
+
+        XCTAssertNotNil(store.customProfiles.first(where: { $0.id == identifier }))
+        XCTAssertNotNil(memoryStore.entries.first(where: { $0.scope == .profile(identifier) }))
+    }
+
+    @MainActor
     func testLegacyBuiltInIdentifiersMigrate() {
         let store = ProfileStore(fileURL: temporaryProfileURL())
 

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -843,12 +843,12 @@ final class ProfileStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
         let store = ProfileStore(fileURL: fileURL)
-        _ = try store.createProfile(name: "Balanced Copy", options: EncodingOptions())
-        _ = try store.createProfile(name: "Balanced Copy 2", options: EncodingOptions())
+        _ = try store.createProfile(name: "Standard Movie Copy", options: EncodingOptions())
+        _ = try store.createProfile(name: "Standard Movie Copy 2", options: EncodingOptions())
 
         let identifier = try store.duplicateProfile(BuiltInProfile.balanced.id)
 
-        XCTAssertEqual(store.profile(withID: identifier).name, "Balanced Copy 3")
+        XCTAssertEqual(store.profile(withID: identifier).name, "Standard Movie Copy 3")
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/QueueResolutionTests.swift
+++ b/macos/BluRayToVisionProTests/QueueResolutionTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+final class QueueResolutionTests: XCTestCase {
+    func testGroupingRequiresSameCauseAndValidExitsAndDisclosesTitles() throws {
+        let first = try candidate(title: "One")
+        let second = try candidate(title: "Two")
+        var changedOptions = ConversionOptions()
+        try changedOptions.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(differentConflict) = RouteQualityEngine.propose(
+            options: changedOptions,
+            edit: .softwareEncoder(true)
+        ) else { return XCTFail("Expected conflict") }
+        let third = QueueResolutionCandidate(id: UUID(), draft: first.draft, conflict: differentConflict)
+
+        let groups = QueueResolutionGroup.group([first, second, third])
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups.first(where: { $0.candidates.count == 2 })?.titleDisclosure, "One, Two")
+    }
+
+    func testApplicationStartsUnselectedAndChangesOnlyChosenScope() throws {
+        let first = try candidate(title: "One")
+        let second = try candidate(title: "Two")
+        let group = try XCTUnwrap(QueueResolutionGroup.group([first, second]).first)
+        var selection = QueueResolutionSelection()
+        XCTAssertFalse(selection.canApply)
+        selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: { $0.isAvailable })?.id)
+        selection.scope = .item(first.id)
+
+        let application = try QueueResolutionApplication.apply(group: group, selection: selection).get()
+
+        XCTAssertEqual(Set(application.resolvedDrafts.keys), [first.id])
+    }
+
+    private func candidate(title: String) throws -> QueueResolutionCandidate {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else { throw TestError.missingConflict }
+        let source = ConversionSource(
+            kind: .matroska,
+            url: URL(fileURLWithPath: "/tmp/\(title).mkv"),
+            displayName: title,
+            workerSourcePath: "/tmp/\(title).mkv"
+        )
+        let draft = ConversionDraft(
+            source: source,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp"),
+            options: options
+        )
+        return QueueResolutionCandidate(id: UUID(), draft: draft, conflict: conflict)
+    }
+
+    private enum TestError: Error { case missingConflict }
+}

--- a/macos/BluRayToVisionProTests/ResolutionMemoryStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ResolutionMemoryStoreTests.swift
@@ -64,6 +64,64 @@ final class ResolutionMemoryStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testSuggestionsExpireAfterFourteenDays() throws {
+        let storedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        var currentDate = storedAt
+        let store = ResolutionMemoryStore.inMemory(now: { currentDate })
+        try store.store(resolutionID: "choice", for: "conflict", scope: .global, mappingVersion: 1)
+
+        currentDate = storedAt.addingTimeInterval(ResolutionMemoryStore.suggestionLifetime)
+        XCTAssertNotNil(store.suggestion(
+            conflictID: "conflict",
+            profileID: "builtin.balanced",
+            sourceKind: .matroska,
+            mappingVersion: 1
+        ))
+
+        currentDate.addTimeInterval(1)
+        XCTAssertNil(store.suggestion(
+            conflictID: "conflict",
+            profileID: "builtin.balanced",
+            sourceKind: .matroska,
+            mappingVersion: 1
+        ))
+        XCTAssertEqual(store.entries.count, 1)
+    }
+
+    @MainActor
+    func testVersionOneDocumentMigratesWithFreshTimestamp() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("resolution-memory.json")
+        let data = Data("""
+        {
+          "version": 1,
+          "entries": [
+            {
+              "conflictID": "conflict",
+              "resolutionID": "choice",
+              "scope": { "kind": "global" },
+              "mappingVersion": 1
+            }
+          ]
+        }
+        """.utf8)
+        try data.write(to: fileURL)
+        let migrationDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let store = ResolutionMemoryStore(fileURL: fileURL, now: { migrationDate })
+
+        XCTAssertEqual(store.entries.first?.storedAt, migrationDate)
+        let migrated = try JSONDecoder().decode(
+            ResolutionMemoryDocument.self,
+            from: Data(contentsOf: fileURL)
+        )
+        XCTAssertEqual(migrated.version, ResolutionMemoryDocument.currentVersion)
+        XCTAssertEqual(migrated.entries.first?.storedAt, migrationDate)
+    }
+
+    @MainActor
     func testCorruptDocumentIsPreserved() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/macos/BluRayToVisionProTests/ResolutionMemoryStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ResolutionMemoryStoreTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+final class ResolutionMemoryStoreTests: XCTestCase {
+    @MainActor
+    func testScopePrecedenceAndMappingVersionStaleness() throws {
+        let store = ResolutionMemoryStore.inMemory()
+        try store.store(resolutionID: "global", for: "conflict", scope: .global, mappingVersion: 1)
+        try store.store(resolutionID: "source", for: "conflict", scope: .sourceKind(.matroska), mappingVersion: 1)
+        try store.store(resolutionID: "profile", for: "conflict", scope: .profile("custom.one"), mappingVersion: 1)
+
+        let suggestion = try XCTUnwrap(store.suggestion(
+            conflictID: "conflict",
+            profileID: "custom.one",
+            sourceKind: .matroska,
+            mappingVersion: 2
+        ))
+        XCTAssertEqual(suggestion.entry.resolutionID, "profile")
+        XCTAssertTrue(suggestion.isStale)
+        XCTAssertEqual(
+            suggestion.staleExplanation,
+            "Quality options changed after an update. Choose a current option before applying this suggestion."
+        )
+    }
+
+    @MainActor
+    func testStableConflictIdentityKeepsAnOlderMappingVisibleAsStale() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else { return XCTFail("Expected conflict") }
+        let store = ResolutionMemoryStore.inMemory()
+        let resolutionID = try XCTUnwrap(conflict.resolutions.first(where: { $0.isAvailable })?.id)
+        try store.store(
+            resolutionID: resolutionID,
+            for: conflict.stableID,
+            scope: .profile(BuiltInProfile.balanced.id),
+            mappingVersion: conflict.mappingVersion - 1
+        )
+
+        let suggestion = try XCTUnwrap(store.suggestion(
+            conflictID: conflict.stableID,
+            profileID: BuiltInProfile.balanced.id,
+            sourceKind: .matroska,
+            mappingVersion: conflict.mappingVersion
+        ))
+        XCTAssertTrue(suggestion.isStale)
+    }
+
+    @MainActor
+    func testChangeForgetAndProfileDeletionCleanup() throws {
+        let store = ResolutionMemoryStore.inMemory()
+        try store.store(resolutionID: "first", for: "conflict", scope: .profile("custom.one"), mappingVersion: 1)
+        try store.store(resolutionID: "changed", for: "conflict", scope: .profile("custom.one"), mappingVersion: 1)
+        XCTAssertEqual(store.entries.map(\.resolutionID), ["changed"])
+
+        try store.removeProfileMemories(profileID: "custom.one")
+        XCTAssertTrue(store.entries.isEmpty)
+        try store.store(resolutionID: "again", for: "conflict", scope: .global, mappingVersion: 1)
+        try store.forget(conflictID: "conflict", scope: .global)
+        XCTAssertTrue(store.entries.isEmpty)
+    }
+
+    @MainActor
+    func testCorruptDocumentIsPreserved() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("resolution-memory.json")
+        let data = Data("not json".utf8)
+        try data.write(to: fileURL)
+
+        let store = ResolutionMemoryStore(fileURL: fileURL)
+
+        XCTAssertTrue(store.entries.isEmpty)
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertEqual(try Data(contentsOf: fileURL.appendingPathExtension("corrupt")), data)
+    }
+}

--- a/macos/BluRayToVisionProTests/RouteResolutionTests.swift
+++ b/macos/BluRayToVisionProTests/RouteResolutionTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import BluRayToVisionPro
 
 final class RouteResolutionTests: XCTestCase {
-    func testEveryTriggerAndQualityStepProducesAValidDraftOrConflict() throws {
+    func testEveryRouteForcingTriggerAndQualityStepProducesAValidExit() throws {
         let edits: [(RouteQualityTrigger, RouteQualityEdit)] = [
-            (.generatedRouteRequirement, .qualityStep(.maximumDetail)),
             (.reusableIntermediates, .reusableIntermediates(true)),
             (.softwareEncoder, .softwareEncoder(true)),
             (.restartStage, .restartStage(.createLeftRightFiles)),
             (.upscaleCrop, .upscaleEnabled(true)),
+            (.upscaleCrop, .cropBlackBars(true)),
             (.fieldOfView, .fieldOfView(0)),
             (.resolutionOverride, .resolutionOverride("1280x720")),
             (.outputMode, .outputMode(.av1Stereo)),
@@ -19,7 +19,11 @@ final class RouteResolutionTests: XCTestCase {
             try options.encoding.selectQualityStep(qualityStep)
 
             for (expectedTrigger, edit) in edits {
-                let proposal = RouteQualityEngine.propose(options: options, edit: edit)
+                var startingOptions = options
+                if edit == .cropBlackBars(true) || edit == .resolutionOverride("1280x720") {
+                    startingOptions.encoding.upscaleEnabled = true
+                }
+                let proposal = RouteQualityEngine.propose(options: startingOptions, edit: edit)
                 switch proposal {
                 case let .resolved(draft):
                     XCTAssertEqual(
@@ -51,6 +55,56 @@ final class RouteResolutionTests: XCTestCase {
                 }
             }
         }
+    }
+
+    func testGeneratedRouteRejectsUnsupportedGuidedStepWithCompleteExits() throws {
+        var options = ConversionOptions()
+        options.job.intermediatePolicy = .reusable
+        try options.encoding.selectQualityStep(.balanced)
+
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .qualityStep(.maximumDetail)
+        ) else {
+            return XCTFail("Expected unsupported generated-route quality conflict")
+        }
+
+        XCTAssertEqual(conflict.trigger, .generatedRouteRequirement)
+        XCTAssertEqual(conflict.proposedRoute.generatedRequirement, .reusableIntermediates)
+        XCTAssertNil(conflict.selectedResolutionID)
+        XCTAssertTrue(conflict.resolutions.contains { $0.choice == .preservePriorIntent && $0.isAvailable })
+        XCTAssertTrue(conflict.resolutions.contains { $0.choice == .keepRequestedWorkflow && $0.isAvailable })
+        XCTAssertTrue(conflict.resolutions.contains { $0.choice == .useCustomExactSettings && $0.isAvailable })
+    }
+
+    func testCustomQualityAndLinkEditsAreValidatedAtomically() throws {
+        var options = ConversionOptions()
+        let original = options
+        var values = options.encoding.videoQuality.custom
+        values.generatedMergeQuality = 82
+
+        guard case let .resolved(customDraft) = RouteQualityEngine.propose(
+            options: options,
+            edit: .customQuality(values)
+        ) else {
+            return XCTFail("Expected a valid Custom quality draft")
+        }
+        XCTAssertEqual(options, original)
+        XCTAssertEqual(customDraft.options.encoding.videoQuality.mode, .custom)
+        XCTAssertEqual(customDraft.options.encoding.mvHEVC.generatedMergeQuality, 82)
+
+        options = customDraft.options
+        guard case let .resolved(linkedDraft) = RouteQualityEngine.propose(
+            options: options,
+            edit: .linkGeneratedAndUpscaleQuality(true)
+        ) else {
+            return XCTFail("Expected a valid linked quality draft")
+        }
+        XCTAssertEqual(
+            linkedDraft.options.encoding.upscaleQuality,
+            linkedDraft.options.encoding.mvHEVC.generatedMergeQuality
+        )
+        XCTAssertEqual(RouteQualityEngine.validate(linkedDraft.options), .success(linkedDraft))
     }
 
     func testConflictDoesNotMutateLiveOptionsAndStartsUnselected() throws {
@@ -91,6 +145,52 @@ final class RouteResolutionTests: XCTestCase {
         XCTAssertEqual(customDraft.options.encoding.videoQuality.mode, .custom)
         XCTAssertEqual(customDraft.options.encoding.mvHEVC.generatedMergeQuality, options.encoding.mvHEVC.generatedMergeQuality)
         XCTAssertEqual(try XCTUnwrap(try? RouteQualityEngine.resolve(custom, conflict: conflict).get()).options, customDraft.options)
+    }
+
+    func testPendingConflictCannotOverwriteExternallyReplacedOptions() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        let state = RouteQualityResolutionState()
+        state.apply(.reusableIntermediates(true), to: &options)
+        let option = try XCTUnwrap(
+            state.conflict?.resolutions.first { $0.choice == .keepRequestedWorkflow }
+        )
+
+        var replacement = ConversionOptions()
+        replacement.encoding.fieldOfView = 110
+        options = replacement
+        state.resolve(option, in: &options)
+
+        XCTAssertEqual(options, replacement)
+        XCTAssertNil(state.conflict)
+        XCTAssertNotNil(state.invalidMessage)
+    }
+
+    func testResetDiscardsPendingConflictAndValidationMessage() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        let state = RouteQualityResolutionState()
+        state.apply(.reusableIntermediates(true), to: &options)
+        XCTAssertNotNil(state.conflict)
+
+        state.reset()
+
+        XCTAssertNil(state.conflict)
+        XCTAssertNil(state.invalidMessage)
+        XCTAssertNil(state.blockReason)
+    }
+
+    func testValidRouteChangeExplainsConsequenceRatherThanClaimingInvalidState() {
+        let options = ConversionOptions()
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else {
+            return XCTFail("Expected generated-route consequence conflict")
+        }
+
+        XCTAssertTrue(conflict.reason.contains("generated left- and right-eye files"))
+        XCTAssertFalse(conflict.reason.contains("not compatible"))
     }
 
     func testRendererCoversAllResolutionChoices() throws {

--- a/macos/BluRayToVisionProTests/RouteResolutionTests.swift
+++ b/macos/BluRayToVisionProTests/RouteResolutionTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+final class RouteResolutionTests: XCTestCase {
+    func testEveryTriggerAndQualityStepProducesAValidDraftOrConflict() throws {
+        let edits: [(RouteQualityTrigger, RouteQualityEdit)] = [
+            (.generatedRouteRequirement, .qualityStep(.maximumDetail)),
+            (.reusableIntermediates, .reusableIntermediates(true)),
+            (.softwareEncoder, .softwareEncoder(true)),
+            (.restartStage, .restartStage(.createLeftRightFiles)),
+            (.upscaleCrop, .upscaleEnabled(true)),
+            (.fieldOfView, .fieldOfView(0)),
+            (.resolutionOverride, .resolutionOverride("1280x720")),
+            (.outputMode, .outputMode(.av1Stereo)),
+        ]
+
+        for qualityStep in QualityStep.allCases {
+            var options = ConversionOptions()
+            try options.encoding.selectQualityStep(qualityStep)
+
+            for (expectedTrigger, edit) in edits {
+                let proposal = RouteQualityEngine.propose(options: options, edit: edit)
+                switch proposal {
+                case let .resolved(draft):
+                    XCTAssertEqual(
+                        RouteQualityEngine.validate(draft.options),
+                        .success(draft),
+                        "\(expectedTrigger.rawValue)/\(qualityStep.rawValue)"
+                    )
+                case let .conflict(conflict):
+                    XCTAssertEqual(conflict.trigger, expectedTrigger, "\(qualityStep.rawValue)")
+                    XCTAssertNil(conflict.selectedResolutionID)
+                    XCTAssertEqual(conflict.mappingVersion, VideoQualityCatalog.mappingVersion)
+                    XCTAssertEqual(conflict.resolutions.count, 3)
+                    XCTAssertTrue(conflict.resolutions.contains { $0.choice == .preservePriorIntent && $0.isAvailable })
+                    XCTAssertTrue(conflict.resolutions.contains { $0.choice == .useCustomExactSettings && $0.isAvailable })
+
+                    for option in conflict.resolutions where option.isAvailable {
+                        let result = RouteQualityEngine.resolve(option, conflict: conflict)
+                        guard case let .success(draft) = result else {
+                            return XCTFail("Resolution failed for \(expectedTrigger.rawValue)/\(qualityStep.rawValue): \(result)")
+                        }
+                        XCTAssertEqual(RouteQualityEngine.validate(draft.options), .success(draft))
+                        XCTAssertEqual(
+                            try XCTUnwrap(RouteQualityEngine.resolve(option, conflict: conflict).get().options),
+                            draft.options
+                        )
+                    }
+                case let .invalid(message):
+                    XCTFail("Unexpected invalid proposal for \(expectedTrigger.rawValue)/\(qualityStep.rawValue): \(message)")
+                }
+            }
+        }
+    }
+
+    func testConflictDoesNotMutateLiveOptionsAndStartsUnselected() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        let original = options
+        let state = RouteQualityResolutionState()
+
+        state.apply(.reusableIntermediates(true), to: &options)
+
+        XCTAssertEqual(options, original)
+        XCTAssertNotNil(state.conflict)
+        XCTAssertNil(state.conflict?.selectedResolutionID)
+        XCTAssertEqual(state.blockReason, state.conflict?.blockReason)
+    }
+
+    func testMappedAndCustomResolutionsAreStableAndIdempotent() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        let proposal = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        )
+        guard case let .conflict(conflict) = proposal else {
+            return XCTFail("Expected generated-route conflict")
+        }
+
+        let mapped = try XCTUnwrap(conflict.resolutions.first { $0.choice == .keepRequestedWorkflow })
+        XCTAssertEqual(mapped.mappedStep, .balanced)
+        XCTAssertEqual(mapped.id, "keep_requested_workflow:v\(VideoQualityCatalog.mappingVersion)")
+
+        let mappedDraft = try XCTUnwrap(try? RouteQualityEngine.resolve(mapped, conflict: conflict).get())
+        XCTAssertEqual(mappedDraft.options.encoding.videoQuality.selection, .step(.balanced))
+        XCTAssertEqual(try XCTUnwrap(try? RouteQualityEngine.resolve(mapped, conflict: conflict).get()).options, mappedDraft.options)
+
+        let custom = try XCTUnwrap(conflict.resolutions.first { $0.choice == .useCustomExactSettings })
+        let customDraft = try XCTUnwrap(try? RouteQualityEngine.resolve(custom, conflict: conflict).get())
+        XCTAssertEqual(customDraft.options.encoding.videoQuality.mode, .custom)
+        XCTAssertEqual(customDraft.options.encoding.mvHEVC.generatedMergeQuality, options.encoding.mvHEVC.generatedMergeQuality)
+        XCTAssertEqual(try XCTUnwrap(try? RouteQualityEngine.resolve(custom, conflict: conflict).get()).options, customDraft.options)
+    }
+
+    func testRendererCoversAllResolutionChoices() throws {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else {
+            return XCTFail("Expected route-quality conflict")
+        }
+
+        for option in conflict.resolutions {
+            XCTAssertFalse(option.id.isEmpty)
+            XCTAssertFalse(option.title.isEmpty)
+            XCTAssertFalse(option.detail.isEmpty)
+        }
+    }
+}

--- a/macos/BluRayToVisionProTests/SetupEditSessionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupEditSessionTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class SetupEditSessionTests: XCTestCase {
+    func testCancelRestoresExactPreEditState() {
+        let profile = BuiltInProfile.balanced.profile
+        var session = SetupEditSession(profile: profile, options: ConversionOptions())
+        var editedOptions = session.draftOptions
+        editedOptions.encoding.audioBitrate = 512
+        editedOptions.job.overwriteExisting = true
+        session.updateName("Temporary Name")
+        session.updateOptions(editedOptions)
+
+        XCTAssertTrue(session.isDirty)
+        session.discard()
+
+        XCTAssertFalse(session.isDirty)
+        XCTAssertEqual(session.draftOptions, session.originalOptions)
+        XCTAssertEqual(session.profileName, profile.name)
+    }
+
+    func testApplyOnlyLeavesProfileLibraryByteIdentical() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let store = ProfileStore(fileURL: fileURL)
+        let profileID = try store.createProfile(name: "Cinema", options: EncodingOptions())
+        let before = try Data(contentsOf: fileURL)
+        var session = SetupEditSession(
+            profile: store.profile(withID: profileID),
+            options: ConversionOptions(encoding: store.profile(withID: profileID).options)
+        )
+        var editedOptions = session.draftOptions
+        editedOptions.encoding.audioBitrate = 512
+        session.updateOptions(editedOptions)
+
+        XCTAssertNotEqual(session.draftOptions, session.originalOptions)
+        XCTAssertEqual(try Data(contentsOf: fileURL), before)
+        XCTAssertEqual(store.profile(withID: profileID).options.audioBitrate, 384)
+    }
+
+    func testCustomUpdateWritesOneProfileWithRunScopedOptionsExcluded() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let store = ProfileStore(fileURL: fileURL)
+        let profileID = try store.createProfile(name: "Cinema", options: EncodingOptions())
+        var conversionOptions = ConversionOptions(encoding: store.profile(withID: profileID).options)
+        conversionOptions.job.overwriteExisting = true
+        var session = SetupEditSession(profile: store.profile(withID: profileID), options: conversionOptions)
+        var editedOptions = session.draftOptions
+        editedOptions.encoding.audioBitrate = 512
+        editedOptions.job.removeOriginalAfterSuccess = true
+        session.updateOptions(editedOptions)
+        session.updateName("Cinema Updated")
+
+        let values = session.profileWriteValues()
+        try store.updateProfile(
+            profileID,
+            name: values.name,
+            options: values.options,
+            pipelineDefaults: values.pipelineDefaults
+        )
+
+        let restored = store.profile(withID: profileID)
+        XCTAssertEqual(restored.name, "Cinema Updated")
+        XCTAssertEqual(restored.options.audioBitrate, 512)
+        XCTAssertFalse(try String(decoding: Data(contentsOf: fileURL), as: UTF8.self).contains("overwriteExisting"))
+    }
+
+    func testSaveAsNewFromBuiltInCreatesCustomProfile() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        let store = ProfileStore(fileURL: fileURL)
+        var session = SetupEditSession(
+            profile: BuiltInProfile.balanced.profile,
+            options: ConversionOptions(encoding: BuiltInProfile.balanced.options)
+        )
+        var editedOptions = session.draftOptions
+        editedOptions.encoding.audioBitrate = 512
+        session.updateOptions(editedOptions)
+
+        let values = session.profileWriteValues()
+        let newID = try store.createProfile(
+            name: "My Standard Movie",
+            options: values.options,
+            pipelineDefaults: values.pipelineDefaults
+        )
+
+        XCTAssertTrue(newID.hasPrefix("custom."))
+        XCTAssertEqual(store.profile(withID: newID).options.audioBitrate, 512)
+    }
+
+    func testBuiltInProfileIsReadOnly() throws {
+        let store = ProfileStore(fileURL: temporaryProfileURL())
+
+        XCTAssertThrowsError(
+            try store.updateProfile(
+                BuiltInProfile.balanced.id,
+                name: "Changed",
+                options: EncodingOptions()
+            )
+        ) { error in
+            XCTAssertEqual(error as? ProfileStoreError, .builtInProfileIsReadOnly)
+        }
+    }
+
+    func testDirtyProfileSwitchRequiresDiscardAndReload() {
+        let first = BuiltInProfile.balanced.profile
+        let second = BuiltInProfile.originalResolution.profile
+        var session = SetupEditSession(profile: first, options: ConversionOptions(encoding: first.options))
+        var editedOptions = session.draftOptions
+        editedOptions.encoding.audioBitrate = 512
+        session.updateOptions(editedOptions)
+
+        XCTAssertTrue(session.isDirty)
+        let reloaded = session.switching(
+            to: second,
+            options: ConversionOptions(encoding: second.options)
+        )
+        XCTAssertEqual(reloaded.profileID, second.id)
+        XCTAssertFalse(reloaded.isDirty)
+    }
+
+    func testReusableFileOutcomesAreExplicitAndExplainConsequences() {
+        XCTAssertEqual(
+            ReusableFileOutcome.finishedMovieOnly.title,
+            "Just the finished movie"
+        )
+        XCTAssertEqual(
+            ReusableFileOutcome.finishedMovieAndReusableFiles.title,
+            "The finished movie plus reusable files"
+        )
+        XCTAssertTrue(ReusableFileOutcome.finishedMovieAndReusableFiles.detail.contains("left- and right-eye"))
+        XCTAssertTrue(ReusableFileOutcome.finishedMovieAndReusableFiles.detail.contains("storage"))
+        XCTAssertTrue(ReusableFileOutcome.finishedMovieAndReusableFiles.detail.contains("quality"))
+        XCTAssertEqual(
+            ReusableFileOutcome(policy: .reusable),
+            .finishedMovieAndReusableFiles
+        )
+    }
+
+    func testStandardMovieKeepsBalancedIdentifierAndNoticeCopy() {
+        XCTAssertEqual(BuiltInProfile.balanced.id, "builtin.balanced")
+        XCTAssertEqual(BuiltInProfile.balanced.name, "Standard Movie")
+        XCTAssertTrue(StandardMovieRenameNotice.message.contains("saved profiles are unchanged"))
+    }
+
+    func testUIInventoryKeepsReadyActionsAndAdvancedControlsReachable() throws {
+        let rootURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let setupSource = try String(
+            contentsOf: rootURL.appendingPathComponent("macos/BluRayToVisionPro/Views/ConversionSetupView.swift"),
+            encoding: .utf8
+        )
+        let sheetSource = try String(
+            contentsOf: rootURL.appendingPathComponent("macos/BluRayToVisionPro/Feature/SetupEditSession.swift"),
+            encoding: .utf8
+        )
+        let workflowSource = try String(
+            contentsOf: rootURL.appendingPathComponent("macos/BluRayToVisionPro/Models/ConversionWorkflow.swift"),
+            encoding: .utf8
+        )
+        let optionsSource = try String(
+            contentsOf: rootURL.appendingPathComponent("macos/BluRayToVisionPro/Models/ConversionOptions.swift"),
+            encoding: .utf8
+        )
+        let inventorySource = setupSource + sheetSource + workflowSource + optionsSource
+
+        for marker in [
+            "ready-profile-picker",
+            "edit-conversion-settings",
+            "conversion-outcome-summary",
+            "Audio & Subtitles",
+            "Files & Recovery",
+            "Start stage",
+            "Overwrite an existing output file",
+            "Remove original after success",
+            "Keep the Mac awake",
+            "Show generated commands in activity",
+            "Just the finished movie",
+            "The finished movie plus reusable files",
+        ] {
+            XCTAssertTrue(inventorySource.contains(marker), "Missing UI inventory marker: \(marker)")
+        }
+        for marker in [
+            "Cancel",
+            "Apply to This Conversion",
+            "Update Profile",
+            "Save as New Profile…",
+            "Discard and Load",
+        ] {
+            XCTAssertTrue(inventorySource.contains(marker), "Missing editor action marker: \(marker)")
+        }
+    }
+
+    private func temporaryDirectoryURL() -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bd-to-avp-573-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return directoryURL
+    }
+
+    private func temporaryProfileURL() -> URL {
+        temporaryDirectoryURL().appendingPathComponent("profiles.json")
+    }
+}

--- a/macos/BluRayToVisionProTests/SetupEditorRenderTests.swift
+++ b/macos/BluRayToVisionProTests/SetupEditorRenderTests.swift
@@ -8,6 +8,7 @@ final class SetupEditorRenderTests: XCTestCase {
     func testReadyProfileSurfaceRendersOutcomeAndPicker() throws {
         let profile = BuiltInProfile.balanced.profile
         let routeState = RouteQualityResolutionState()
+        let memoryStore = ResolutionMemoryStore.inMemory()
         let view = ConversionSetupView(
             selectedProfileID: .constant(profile.id),
             selectedTab: .constant(.video),
@@ -18,6 +19,7 @@ final class SetupEditorRenderTests: XCTestCase {
             isLocked: false,
             sourceKind: nil,
             routeQualityState: routeState,
+            resolutionMemoryStore: memoryStore,
             isReady: true,
             openEditor: {},
             saveSelectedProfile: {},

--- a/macos/BluRayToVisionProTests/SetupEditorRenderTests.swift
+++ b/macos/BluRayToVisionProTests/SetupEditorRenderTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class SetupEditorRenderTests: XCTestCase {
+    func testReadyProfileSurfaceRendersOutcomeAndPicker() throws {
+        let profile = BuiltInProfile.balanced.profile
+        let routeState = RouteQualityResolutionState()
+        let view = ConversionSetupView(
+            selectedProfileID: .constant(profile.id),
+            selectedTab: .constant(.video),
+            options: .constant(ConversionOptions(encoding: profile.options)),
+            profiles: [profile],
+            selectedProfile: profile,
+            profileModified: true,
+            isLocked: false,
+            sourceKind: nil,
+            routeQualityState: routeState,
+            isReady: true,
+            openEditor: {},
+            saveSelectedProfile: {},
+            saveAsNewProfile: {},
+            resetProfile: {}
+        )
+        let hostingView = NSHostingView(
+            rootView: view
+                .frame(width: 620, height: 520)
+                .preferredColorScheme(.light)
+        )
+        hostingView.frame = NSRect(x: 0, y: 0, width: 620, height: 520)
+        hostingView.layoutSubtreeIfNeeded()
+        let bitmap = try XCTUnwrap(hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds))
+        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+
+        XCTAssertGreaterThan(bitmap.pixelsWide, 0)
+        XCTAssertGreaterThan(bitmap.pixelsHigh, 0)
+        XCTAssertNotNil(bitmap.tiffRepresentation)
+    }
+}

--- a/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
@@ -55,6 +55,46 @@ final class SetupQueueAdmissionTests: XCTestCase {
         XCTAssertEqual(admission.items[1].state, .waiting)
     }
 
+    func testChangeRestoresHeldConflictAndClearsTrace() throws {
+        let draft = makeDraft()
+        let conflict = try conflict(for: draft.options)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft], conflicts: [conflict])
+        let group = try XCTUnwrap(admission.groups.first)
+        var selection = QueueResolutionSelection()
+        selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable)?.id)
+        XCTAssertNoThrow(try admission.apply(group: group, selection: selection).get())
+        let itemID = try XCTUnwrap(admission.items.first?.id)
+
+        admission.changeResolution(itemID)
+
+        XCTAssertFalse(admission.canStart)
+        XCTAssertNil(admission.items.first?.currentDraft)
+        XCTAssertNil(admission.items.first?.resolutionTrace)
+        XCTAssertEqual(admission.groups.first?.candidates.first?.id, itemID)
+    }
+
+    func testDurableAndRuntimeProjectionPreserveIdentityTraceAndState() throws {
+        let draft = makeDraft()
+        let conflict = try conflict(for: draft.options)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft, draft], conflicts: [conflict, conflict])
+        let group = try XCTUnwrap(admission.groups.first)
+        var selection = QueueResolutionSelection()
+        selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable)?.id)
+        XCTAssertNoThrow(try admission.apply(group: group, selection: selection).get())
+
+        var durable = try XCTUnwrap(admission.durableItems().first)
+        XCTAssertEqual(durable.id, admission.items[0].id)
+        XCTAssertEqual(durable.resolutionTrace, admission.items[0].resolutionTrace)
+        durable.state = .processing
+        let projected = try PersistentQueueItem(item: durable)
+        admission.synchronize(with: [projected])
+
+        XCTAssertEqual(admission.items[0].state, .running)
+        XCTAssertEqual(admission.items[0].resolutionTrace, durable.resolutionTrace)
+    }
+
     private func makeDraft() -> ConversionDraft {
         let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/Movie.mkv"))
         return ConversionDraft(

--- a/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
@@ -95,6 +95,35 @@ final class SetupQueueAdmissionTests: XCTestCase {
         XCTAssertEqual(admission.items[0].resolutionTrace, durable.resolutionTrace)
     }
 
+    func testClearQueueIsAvailableForAttentionButNotRunningItems() throws {
+        let admission = SetupQueueAdmission()
+        let draft = makeDraft()
+        admission.add(drafts: [draft])
+        let itemID = admission.items[0].id
+        admission.markRunning(itemID)
+
+        XCTAssertFalse(admission.canClear)
+
+        let failedItem = DurableConversionQueueItem(
+            id: itemID,
+            ordinal: 0,
+            origin: .singleSource,
+            intent: DurableQueueItemIntent(draft: draft),
+            inspection: draft.sourceDetails,
+            state: .failed,
+            failure: DurableQueueFailure(
+                code: "conversion_failed",
+                message: "Conversion failed",
+                details: nil,
+                retryable: true
+            )
+        )
+        admission.synchronize(with: [try PersistentQueueItem(item: failedItem)])
+        XCTAssertTrue(admission.canClear)
+        admission.removeAll()
+        XCTAssertTrue(admission.items.isEmpty)
+    }
+
     private func makeDraft() -> ConversionDraft {
         let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/Movie.mkv"))
         return ConversionDraft(

--- a/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class SetupQueueAdmissionTests: XCTestCase {
+    func testResolvedSnapshotsCanStartAndRemainFrozenAfterLaterEdits() throws {
+        let draft = makeDraft()
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft])
+
+        XCTAssertTrue(admission.canStart)
+        let snapshot = try XCTUnwrap(admission.startableDrafts.first)
+        var changed = draft.options
+        changed.encoding.audioBitrate = 512
+        XCTAssertNotEqual(snapshot.options, changed)
+    }
+
+    func testHeldItemGatesStartUntilExactResolutionIsApplied() throws {
+        let draft = makeDraft()
+        var proposed = draft.options
+        proposed.job.intermediatePolicy = .reusable
+        let conflict = try conflict(for: draft.options)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft], conflicts: [conflict])
+
+        XCTAssertFalse(admission.canStart)
+        let group = try XCTUnwrap(admission.groups.first)
+        let resolution = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable))
+        var selection = QueueResolutionSelection()
+        selection.resolutionID = resolution.id
+        XCTAssertNoThrow(try admission.apply(group: group, selection: selection).get())
+        XCTAssertTrue(admission.canStart)
+        XCTAssertEqual(
+            admission.items.first?.resolutionTrace?.qualityOutcome,
+            "\(try XCTUnwrap(admission.items.first?.currentDraft).options.videoRoutePlan.qualityTitle) quality"
+        )
+    }
+
+    func testOneScopeNeverMutatesAnotherWaitingItemOrRunningSnapshot() throws {
+        let draft = makeDraft()
+        let conflict = try conflict(for: draft.options)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft, draft], conflicts: [conflict, conflict])
+        let group = try XCTUnwrap(admission.groups.first)
+        var selection = QueueResolutionSelection()
+        selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable)?.id)
+        selection.scope = .item(group.candidates[0].id)
+        XCTAssertNoThrow(try admission.apply(group: group, selection: selection).get())
+        admission.markRunning(group.candidates[0].id)
+        selection.scope = .item(group.candidates[1].id)
+
+        XCTAssertNoThrow(try admission.apply(group: group, selection: selection).get())
+        XCTAssertEqual(admission.items[0].state, .running)
+        XCTAssertNotNil(admission.items[0].currentDraft)
+        XCTAssertEqual(admission.items[1].state, .waiting)
+    }
+
+    private func makeDraft() -> ConversionDraft {
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/Movie.mkv"))
+        return ConversionDraft(
+            source: source,
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp"),
+            options: ConversionOptions()
+        )
+    }
+
+    private func conflict(for options: ConversionOptions) throws -> RouteQualityConflict {
+        var maximumDetail = options
+        try maximumDetail.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: maximumDetail,
+            edit: .reusableIntermediates(true)
+        ) else {
+            throw TestError.missingConflict
+        }
+        return conflict
+    }
+
+    private enum TestError: Error { case missingConflict }
+}

--- a/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
+++ b/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
@@ -168,26 +168,24 @@ final class VideoQualityEditorRenderTests: XCTestCase {
     }
 
     func testRouteQualityConflictRendererCoversEveryTrigger() throws {
-        let edits: [(String, RouteQualityEdit)] = [
-            ("generated", .qualityStep(.maximumDetail)),
-            ("reusable", .reusableIntermediates(true)),
-            ("software", .softwareEncoder(true)),
-            ("restart", .restartStage(.createLeftRightFiles)),
-            ("upscale-crop", .upscaleEnabled(false)),
-            ("field-of-view", .fieldOfView(180)),
-            ("resolution", .resolutionOverride("1920x1080")),
-            ("output-mode", .outputMode(.av1Stereo)),
+        let cases: [(String, RouteQualityTrigger, ConversionOptions, RouteQualityEdit)] = try [
+            conflictRenderCase(name: "generated", trigger: .generatedRouteRequirement, edit: .qualityStep(.maximumDetail), generatedBase: true),
+            conflictRenderCase(name: "reusable", trigger: .reusableIntermediates, edit: .reusableIntermediates(true)),
+            conflictRenderCase(name: "software", trigger: .softwareEncoder, edit: .softwareEncoder(true)),
+            conflictRenderCase(name: "restart", trigger: .restartStage, edit: .restartStage(.createLeftRightFiles)),
+            conflictRenderCase(name: "upscale", trigger: .upscaleCrop, edit: .upscaleEnabled(true)),
+            conflictRenderCase(name: "crop", trigger: .upscaleCrop, edit: .cropBlackBars(true), upscaleBase: true),
+            conflictRenderCase(name: "field-of-view", trigger: .fieldOfView, edit: .fieldOfView(0)),
+            conflictRenderCase(name: "resolution", trigger: .resolutionOverride, edit: .resolutionOverride("1280x720"), upscaleBase: true),
+            conflictRenderCase(name: "output-mode", trigger: .outputMode, edit: .outputMode(.av1Stereo)),
         ]
-        var base = ConversionOptions()
-        base.encoding.upscaleEnabled = true
-        base.encoding.cropBlackBars = true
-        try base.encoding.selectQualityStep(.maximumDetail)
 
-        for (name, edit) in edits {
+        for (name, expectedTrigger, base, edit) in cases {
             let proposal = RouteQualityEngine.propose(options: base, edit: edit)
             guard case let .conflict(conflict) = proposal else {
                 return XCTFail("Expected conflict for \(name)")
             }
+            XCTAssertEqual(conflict.trigger, expectedTrigger)
             for (colorScheme, appearanceName) in [(ColorScheme.light, NSAppearance.Name.aqua), (.dark, .darkAqua)] {
                 try attachRender(
                     RouteQualityConflictView(conflict: conflict, resolve: { _ in }),
@@ -198,6 +196,20 @@ final class VideoQualityEditorRenderTests: XCTestCase {
                 )
             }
         }
+    }
+
+    private func conflictRenderCase(
+        name: String,
+        trigger: RouteQualityTrigger,
+        edit: RouteQualityEdit,
+        generatedBase: Bool = false,
+        upscaleBase: Bool = false
+    ) throws -> (String, RouteQualityTrigger, ConversionOptions, RouteQualityEdit) {
+        var options = ConversionOptions()
+        options.job.intermediatePolicy = generatedBase ? .reusable : .automatic
+        options.encoding.upscaleEnabled = upscaleBase
+        try options.encoding.selectQualityStep(generatedBase ? .balanced : .maximumDetail)
+        return (name, trigger, options, edit)
     }
 
     private func attachRender<Content: View>(

--- a/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
+++ b/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
@@ -167,6 +167,39 @@ final class VideoQualityEditorRenderTests: XCTestCase {
         }
     }
 
+    func testRouteQualityConflictRendererCoversEveryTrigger() throws {
+        let edits: [(String, RouteQualityEdit)] = [
+            ("generated", .qualityStep(.maximumDetail)),
+            ("reusable", .reusableIntermediates(true)),
+            ("software", .softwareEncoder(true)),
+            ("restart", .restartStage(.createLeftRightFiles)),
+            ("upscale-crop", .upscaleEnabled(false)),
+            ("field-of-view", .fieldOfView(180)),
+            ("resolution", .resolutionOverride("1920x1080")),
+            ("output-mode", .outputMode(.av1Stereo)),
+        ]
+        var base = ConversionOptions()
+        base.encoding.upscaleEnabled = true
+        base.encoding.cropBlackBars = true
+        try base.encoding.selectQualityStep(.maximumDetail)
+
+        for (name, edit) in edits {
+            let proposal = RouteQualityEngine.propose(options: base, edit: edit)
+            guard case let .conflict(conflict) = proposal else {
+                return XCTFail("Expected conflict for \(name)")
+            }
+            for (colorScheme, appearanceName) in [(ColorScheme.light, NSAppearance.Name.aqua), (.dark, .darkAqua)] {
+                try attachRender(
+                    RouteQualityConflictView(conflict: conflict, resolve: { _ in }),
+                    name: "route-quality-\(name)",
+                    width: 760,
+                    colorScheme: colorScheme,
+                    appearanceName: appearanceName
+                )
+            }
+        }
+    }
+
     private func attachRender<Content: View>(
         _ view: Content,
         name: String,

--- a/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
+++ b/macos/BluRayToVisionProTests/VideoQualityEditorRenderTests.swift
@@ -111,6 +111,62 @@ final class VideoQualityEditorRenderTests: XCTestCase {
         }
     }
 
+    func testRouteSummaryRendersUnsupportedQualityAsCustom() throws {
+        let reports = [
+            (
+                "generated-unsupported",
+                VideoRouteReport(
+                    intent: "generated",
+                    selected: "generated_mv_hevc",
+                    reason: "generated_route_requested",
+                    bitrateMbps: nil,
+                    eyeBitrateMbps: 33,
+                    mergeQuality: 88,
+                    crf: nil,
+                    fallbackReason: nil,
+                    fallbackTiming: nil,
+                    upscaleQuality: 66,
+                    qualityIntent: VideoRouteReport.QualityIntent(
+                        mode: "ladder",
+                        step: QualityStep.maximumDetail.rawValue,
+                        mappingVersion: VideoQualityCatalog.mappingVersion
+                    )
+                )
+            ),
+            (
+                "existing-unsupported",
+                VideoRouteReport(
+                    intent: "existing_artifact",
+                    selected: "existing_artifact",
+                    reason: "resume_uses_existing_video_artifact",
+                    bitrateMbps: nil,
+                    eyeBitrateMbps: nil,
+                    mergeQuality: nil,
+                    crf: nil,
+                    fallbackReason: nil,
+                    fallbackTiming: nil,
+                    upscaleQuality: 66,
+                    qualityIntent: VideoRouteReport.QualityIntent(
+                        mode: "ladder",
+                        step: QualityStep.maximumDetail.rawValue,
+                        mappingVersion: VideoQualityCatalog.mappingVersion
+                    )
+                )
+            ),
+        ]
+        for (name, report) in reports {
+            for (colorScheme, appearanceName) in [(ColorScheme.light, NSAppearance.Name.aqua), (.dark, .darkAqua)] {
+                try attachRender(
+                    VideoRouteSummaryView(report: report),
+                    name: "route-\(name)",
+                    width: 760,
+                    colorScheme: colorScheme,
+                    appearanceName: appearanceName
+                )
+            }
+        }
+    }
+
     private func attachRender<Content: View>(
         _ view: Content,
         name: String,

--- a/macos/BluRayToVisionProTests/VideoRouteQualitySummaryTests.swift
+++ b/macos/BluRayToVisionProTests/VideoRouteQualitySummaryTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class VideoRouteQualitySummaryTests: XCTestCase {
+    func testCatalogQualityTitlesCoverEveryTargetAndStep() {
+        for target in VideoQualityTarget.allCases {
+            for step in QualityStep.allCases {
+                let expected = VideoQualityCatalog.mapping(for: step, target: target) == nil
+                    ? "Custom"
+                    : step.title
+
+                XCTAssertEqual(
+                    VideoQualityCatalog.qualityTitle(for: .step(step), target: target),
+                    expected,
+                    "Unexpected title for \(target.rawValue) × \(step.rawValue)"
+                )
+            }
+        }
+    }
+
+    func testWorkerRouteSummariesUseOnlyMatchingMappedQualityTitles() {
+        for target in VideoQualityTarget.allCases {
+            for step in QualityStep.allCases {
+                let report = report(for: target, step: step)
+                let expectedTitle = expectedTitle(for: target, step: step)
+
+                XCTAssertTrue(
+                    report.settingsSummary.hasPrefix(expectedTitle),
+                    "Unexpected title for \(target.rawValue) × \(step.rawValue): \(report.settingsSummary)"
+                )
+                if expectedTitle == "Custom" {
+                    XCTAssertFalse(report.settingsSummary.contains(step.title))
+                }
+            }
+        }
+    }
+
+    func testWorkerRouteSummariesTreatMissingOrStaleMappingVersionsAsCustom() {
+        for mappingVersion in [nil, VideoQualityCatalog.mappingVersion - 1] {
+            let report = VideoRouteReport(
+                intent: "generated",
+                selected: "generated_mv_hevc",
+                reason: "generated_route_requested",
+                bitrateMbps: nil,
+                eyeBitrateMbps: 20,
+                mergeQuality: 75,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil,
+                qualityIntent: VideoRouteReport.QualityIntent(
+                    mode: QualityIntentMode.ladder.rawValue,
+                    step: QualityStep.balanced.rawValue,
+                    mappingVersion: mappingVersion
+                )
+            )
+
+            XCTAssertEqual(report.settingsSummary, "Custom · 20 Mbps per eye · merge 75")
+        }
+    }
+
+    func testGeneratedUpscaleAndExistingArtifactRequireConcreteMatchingValues() {
+        let generatedUpscale = VideoRouteReport(
+            intent: "generated",
+            selected: "generated_mv_hevc",
+            reason: "upscale_crop_requires_generated_artifacts",
+            bitrateMbps: nil,
+            eyeBitrateMbps: 20,
+            mergeQuality: 75,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil,
+            upscaleQuality: 66,
+            qualityIntent: ladderIntent(.balanced)
+        )
+        XCTAssertEqual(generatedUpscale.settingsSummary, "Custom · 20 Mbps per eye · merge 75 · upscale quality 66")
+
+        let existingArtifact = VideoRouteReport(
+            intent: "existing_artifact",
+            selected: "existing_artifact",
+            reason: "resume_uses_existing_video_artifact",
+            bitrateMbps: nil,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil,
+            upscaleQuality: 66,
+            qualityIntent: ladderIntent(.maximumDetail)
+        )
+        XCTAssertEqual(existingArtifact.settingsSummary, "Custom · Upscale quality 66")
+
+        let noReencode = VideoRouteReport(
+            intent: "existing_artifact",
+            selected: "existing_artifact",
+            reason: "resume_uses_existing_video_artifact",
+            bitrateMbps: nil,
+            eyeBitrateMbps: nil,
+            mergeQuality: nil,
+            crf: nil,
+            fallbackReason: nil,
+            fallbackTiming: nil,
+            qualityIntent: ladderIntent(.maximumDetail)
+        )
+        XCTAssertEqual(noReencode.settingsSummary, "No video re-encode")
+    }
+
+    func testRoutePlansLabelUnsupportedGeneratedAndExistingArtifactQualityCustom() throws {
+        var generatedOptions = EncodingOptions()
+        generatedOptions.videoQuality = VideoQualityIntent(
+            mode: .ladder,
+            lastLadderStep: .maximumDetail,
+            custom: .defaults
+        )
+        generatedOptions.upscaleEnabled = true
+        generatedOptions.cropBlackBars = true
+        let generatedPlan = VideoRoutePlan(encoding: generatedOptions)
+        XCTAssertEqual(generatedPlan.kind, .generatedMVHEVC)
+        XCTAssertTrue(generatedPlan.settingsSummary.hasPrefix("Custom ·"))
+        XCTAssertTrue(generatedPlan.settingsSummary.contains("20 Mbps per eye · merge 75"))
+
+        var existingOptions = generatedOptions
+        existingOptions.upscaleEnabled = true
+        let existingPlan = VideoRoutePlan(
+            encoding: existingOptions,
+            job: JobOptions(startStage: .upscaleVideo)
+        )
+        XCTAssertEqual(existingPlan.kind, .existingArtifact)
+        XCTAssertEqual(existingPlan.settingsSummary, "Custom · upscale quality 75")
+    }
+
+    private func report(for target: VideoQualityTarget, step: QualityStep) -> VideoRouteReport {
+        let mapping = VideoQualityCatalog.mapping(for: step, target: target)
+        switch target {
+        case .directMVHEVC, .directMVHEVCMetalFX2x:
+            let quality: Double
+            if case let .direct(mappedQuality) = mapping {
+                quality = mappedQuality
+            } else {
+                quality = 0.91
+            }
+            return VideoRouteReport(
+                intent: "automatic",
+                selected: "direct_mv_hevc",
+                reason: "direct_eligible",
+                bitrateMbps: nil,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil,
+                rateControl: "quality",
+                quality: quality,
+                upscaleMode: target == .directMVHEVCMetalFX2x ? "metalfx" : nil,
+                qualityIntent: ladderIntent(step)
+            )
+        case .generatedMVHEVC:
+            let eyeBitrate: Int
+            let mergeQuality: Int
+            if case let .generated(mappedEyeBitrate, mappedMergeQuality) = mapping {
+                eyeBitrate = mappedEyeBitrate
+                mergeQuality = mappedMergeQuality
+            } else {
+                eyeBitrate = 33
+                mergeQuality = 88
+            }
+            return VideoRouteReport(
+                intent: "generated",
+                selected: "generated_mv_hevc",
+                reason: "generated_route_requested",
+                bitrateMbps: nil,
+                eyeBitrateMbps: eyeBitrate,
+                mergeQuality: mergeQuality,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil,
+                qualityIntent: ladderIntent(step)
+            )
+        case .fileUpscale:
+            let quality: Int
+            if case let .upscale(mappedQuality) = mapping {
+                quality = mappedQuality
+            } else {
+                quality = 66
+            }
+            return VideoRouteReport(
+                intent: "existing_artifact",
+                selected: "existing_artifact",
+                reason: "resume_uses_existing_video_artifact",
+                bitrateMbps: nil,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: nil,
+                fallbackReason: nil,
+                fallbackTiming: nil,
+                upscaleQuality: quality,
+                qualityIntent: ladderIntent(step)
+            )
+        case .av1Stereo:
+            return VideoRouteReport(
+                intent: "encode",
+                selected: "av1",
+                reason: "av1_output_requested",
+                bitrateMbps: nil,
+                eyeBitrateMbps: nil,
+                mergeQuality: nil,
+                crf: 32,
+                fallbackReason: nil,
+                fallbackTiming: nil,
+                qualityIntent: ladderIntent(step)
+            )
+        }
+    }
+
+    private func expectedTitle(for target: VideoQualityTarget, step: QualityStep) -> String {
+        switch target {
+        case .directMVHEVC, .directMVHEVCMetalFX2x:
+            step.title
+        case .generatedMVHEVC:
+            step == .balanced ? step.title : "Custom"
+        case .fileUpscale:
+            [.balanced, .detailed].contains(step) ? step.title : "Custom"
+        case .av1Stereo:
+            "Custom"
+        }
+    }
+
+    private func ladderIntent(_ step: QualityStep) -> VideoRouteReport.QualityIntent {
+        VideoRouteReport.QualityIntent(
+            mode: "ladder",
+            step: step.rawValue,
+            mappingVersion: VideoQualityCatalog.mappingVersion
+        )
+    }
+}

--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -84,7 +84,7 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         XCTAssertTrue(waitUntil(timeout: 20) { !nameField.exists })
 
         let profileSummary = try readProfileSummary(syntheticHome: context.syntheticHome)
-        XCTAssertEqual(profileSummary.version, 5)
+        XCTAssertEqual(profileSummary.version, 6)
         XCTAssertEqual(profileSummary.count, 1)
         XCTAssertEqual(profileSummary.name, Self.profileName)
 
@@ -130,6 +130,49 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         let darkWindow = darkApp.windows.firstMatch
         XCTAssertTrue(darkWindow.waitForExistence(timeout: 30))
         attachScreenshot(darkWindow.screenshot(), name: "screenshot-dark.png")
+    }
+
+    func testDevelopmentSetupShell() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["BD_TO_AVP_UI_PHASE"] == "setup" else {
+            throw XCTSkip("Development setup-shell smoke is not requested.")
+        }
+        let appPath = try XCTUnwrap(environment["BD_TO_AVP_UI_APP_PATH"])
+        let syntheticHome = try XCTUnwrap(environment["BD_TO_AVP_UI_HOME"])
+        let app = XCUIApplication(url: URL(fileURLWithPath: appPath))
+        app.launchEnvironment = [
+            "HOME": syntheticHome,
+            "CFFIXED_USER_HOME": syntheticHome,
+        ]
+        app.launchArguments = QualificationAppearance.light.launchArguments
+        app.launch()
+        defer { app.terminate() }
+
+        let mainContent = app.descendants(matching: .any)["main-window-content"]
+        XCTAssertTrue(mainContent.waitForExistence(timeout: 30))
+        XCTAssertTrue(app.descendants(matching: .any)["ready-source"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["ready-profile-picker"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["ready-destination"].exists)
+        XCTAssertTrue(app.buttons["ready-change-destination"].exists)
+        XCTAssertTrue(app.buttons["ready-preview"].exists)
+        XCTAssertTrue(app.buttons["ready-add-to-queue"].exists)
+        XCTAssertEqual(app.buttons.matching(identifier: "ready-start").count, 1)
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.exists)
+        XCTAssertGreaterThanOrEqual(window.frame.width, 820)
+        attachScreenshot(window.screenshot(), name: "setup-ready-light.png")
+
+        let edit = app.buttons["edit-conversion-settings"]
+        XCTAssertTrue(edit.isEnabled)
+        edit.click()
+        XCTAssertTrue(app.buttons["setup-editor-cancel"].waitForExistence(timeout: 20))
+        XCTAssertTrue(app.buttons["setup-editor-apply"].exists)
+        XCTAssertTrue(app.buttons["setup-editor-save-as-new"].exists)
+        let sheet = app.sheets.firstMatch
+        XCTAssertTrue(sheet.exists)
+        XCTAssertGreaterThanOrEqual(sheet.frame.width, 640)
+        attachScreenshot(window.screenshot(), name: "setup-editor-light.png")
     }
 
     private func launchInstalledApp(

--- a/macos/README.md
+++ b/macos/README.md
@@ -61,7 +61,11 @@ English audio, while existing profile choices remain unchanged and version-1
 through version-3 profiles migrate to all-languages behavior. Profile document
 version 5 stores stable route-relative quality intent separately from retained
 Custom controls while continuing to write concrete compatibility fields.
-Version-1 through version-4 profiles migrate losslessly: exact production
+Profile document version 6 stores encoding options plus only reusable-intermediate
+policy and software-encoder pipeline defaults. Version-1 through version-5 profiles
+migrate without carrying restart, overwrite, source-removal, continue-on-error, or
+diagnostic command-output defaults forward. Version-1 through version-4 profiles
+migrate losslessly for encoding settings: exact production
 defaults become `Balanced`, while every other combination remains `Custom`.
 Mapping version 2 resolves all seven checked direct positions, only `Balanced`
 for generated MV-HEVC, and `Balanced` plus `Detailed` for stage-6 file upscale.

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -282,7 +282,12 @@ class NativeAppPackagingTests(unittest.TestCase):
         conversion_options = (MACOS_ROOT / "BluRayToVisionPro" / "Models" / "ConversionOptions.swift").read_text(
             encoding="utf-8"
         )
-        conversion_ui = setup_view + encoding_editor + quality_editor + language_picker + conversion_options
+        conversion_workflow = (MACOS_ROOT / "BluRayToVisionPro" / "Models" / "ConversionWorkflow.swift").read_text(
+            encoding="utf-8"
+        )
+        conversion_ui = (
+            setup_view + encoding_editor + quality_editor + language_picker + conversion_options + conversion_workflow
+        )
 
         self.assertIn('.accessibilityLabel("\\(purpose.label): \\(selection.displayName)")', language_picker)
         self.assertNotIn('.accessibilityLabel("Preferred language:', language_picker)
@@ -319,7 +324,7 @@ class NativeAppPackagingTests(unittest.TestCase):
             "Subtitle handling",
             "Subtitle language",
             "Start stage",
-            "Create reusable intermediate files",
+            "The finished movie plus reusable files",
             "Continue processing after recoverable errors",
             "Use software HEVC encoder",
             "Overwrite an existing output file",


### PR DESCRIPTION
## Summary

Completes the #568–#575 repetition-first Conversion Setup workstream:

- truthful route-aware quality labels and safe Profile schema v6 migration
- shared source-reset policy and focused-scene source selection
- atomic route/quality conflict resolution with stale-state protection
- transactional Profile editing and explicit reusable-file outcomes
- scoped, forgettable, mapping-aware suggestions with 14-day expiry
- grouped queue conflict resolution with durable IDs and resolution traces
- production Ready, Customized, Editor, Conflict, and Queue states
- narrow-window layout, queue recovery, destination editing, and one primary action

Final review repairs also ensure single-source admissions execute through the durable queue, held conflicts can be queued without mutating live/Profile state, unavailable choices cannot be selected, queue start is acknowledged before rows become running, and all admission persistence failures leave affected rows visible and clearable.

## Validation

- GitHub CI — 4/4 checks passed on head `19a00b4` on August 18, 2026
- `uv run python scripts/native_app.py test` — 472 tests passed
- `uv run python -m unittest discover -s tests -t .` — 1,762 tests passed, 3 skipped
- `uv run mypy bd_to_avp` — clean
- `uv run ruff format --check tests/test_native_app.py` — clean
- `uv run ruff check tests/test_native_app.py` — clean
- `uv run python scripts/native_app.py build` — succeeded
- Installed UI target `build-for-testing` — succeeded
- `git diff --check` — clean
- Live native window reviewed at 1080×732

The original CI packaging failure was a stale assertion for retired reusable-file copy; it now verifies the explicit outcome copy used by production. CI also exposed an Xcode 26.6 SwiftUI type-check limit that local Xcode 27 did not reproduce. `ContentView` now separates root content, observers, and presentation modifiers into independently type-checked views; the fresh Xcode 26.6 CI run is green.

## Independent Review

Multiple Claude Opus audits found production-path blockers during implementation; each concrete finding was reproduced, repaired, and covered by regression tests. The final Opus closeout attempt was unavailable with provider `529 Overloaded`. Gemini/Antigravity returned empty output in four independent attempts and is recorded as a provider/tool failure, not a passing review. A final independent `code-gpt-5.6-sol` fallback audit returned **GO** against the repaired implementation and 472-test state.

## Known Validation Limits

- Live XCUITest execution was attempted twice, but macOS refused to initialize UI automation because a system authentication session was active. Both attempts failed before tests began; the UI target still builds successfully.
- The configured JetBrains changed-files inspection completed with 1,519 warning-only `IncorrectFormatting` findings and no other inspection type. Every finding is IntelliJ formatter whitespace across whole Swift files; the repository defines no Swift formatter/style command, so this PR does not introduce a 1,500-line formatter rewrite. This remains an explicit IDE-policy mismatch rather than a semantic-code finding.
- The PR remains draft and is behind current `main`, although GitHub reports it mergeable and all checks are green. Advancing it from draft or merging requires a deliberate review/merge decision.

Refs #568
Refs #569
Refs #570
Refs #571
Refs #572
Refs #573
Refs #574
Refs #575