### PR TITLE
chore: normalize optional return annotation

### DIFF
--- a/bd_to_avp/modules/sub.py
+++ b/bd_to_avp/modules/sub.py
@@ -423,7 +423,7 @@ def get_languages_in_mkv(
     run_context: RunContext | None = None,
     cancellation_event: threading.Event | None = None,
     observability_context: ObservabilityContext | None = None,
-) -> None | list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     mkv_info = run_ffprobe(
         mkv_path,
         run_context=run_context,


### PR DESCRIPTION
## Summary
- reorder the subtitle language helper's optional return annotation so `None` appears last
- keep runtime behavior unchanged while satisfying Ruff 0.16's RUF036 rule
- unblock the dependency update in #566 after this cleanup merges

## Validation
- `uvx --from ruff==0.16.3 ruff check .`
- `uvx --from ruff==0.16.3 ruff format --check bd_to_avp/modules/sub.py`
- `uv run ruff check .`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest discover -s tests -t .` (1762 passed, 3 skipped)