### PR TITLE
Detect MakeMKV installed in an Applications subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ and install MakeMKV from the [MakeMKV] website.
 brew install ffmpeg python@3.12
 
 # Install the current macOS MakeMKV build from https://www.makemkv.com/.
-# The app bundle is detected automatically from /Applications/MakeMKV.app.
+# The app bundle is detected automatically from /Applications/MakeMKV.app
+# or /Applications/MakeMKV/MakeMKV.app.
 
 # Ensure Python 3.12 is correctly installed then create a virtual environment
 python3.12 -m pip install --upgrade pip

--- a/bd_to_avp/modules/config.py
+++ b/bd_to_avp/modules/config.py
@@ -21,7 +21,10 @@ SCRIPT_PATH = Path(__file__).parent.parent
 SCRIPT_PATH_BIN = SCRIPT_PATH / "bin"
 HOMEBREW_PREFIX = Path("/opt/homebrew")
 HOMEBREW_PREFIX_BIN = HOMEBREW_PREFIX / "bin"
-MAKEMKV_APP_BUNDLE_BIN = Path("/Applications/MakeMKV.app/Contents/MacOS")
+MAKEMKV_APP_BUNDLE_BINS = (
+    Path("/Applications/MakeMKV.app/Contents/MacOS"),
+    Path("/Applications/MakeMKV/MakeMKV.app/Contents/MacOS"),
+)
 
 
 def tool_env_var(tool_name: str) -> str:
@@ -58,8 +61,8 @@ def resolve_tool_path(
 
 
 def resolve_makemkvcon_path() -> Path:
-    app_bundle_tool = MAKEMKV_APP_BUNDLE_BIN / "makemkvcon"
-    return resolve_tool_path("makemkvcon", extra_paths=[app_bundle_tool])
+    app_bundle_tools = [bundle_bin / "makemkvcon" for bundle_bin in MAKEMKV_APP_BUNDLE_BINS]
+    return resolve_tool_path("makemkvcon", extra_paths=app_bundle_tools)
 
 
 class Stage(Enum):

--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -60,7 +60,8 @@ smoke without requiring MKVToolNix or Tesseract.
 External dependencies must be visible to the user and recoverable without
 reinstalling BD_to_AVP.
 
-- MakeMKV is currently external and expected at `/Applications/MakeMKV.app`.
+- MakeMKV is currently external and detected at `/Applications/MakeMKV.app` or
+  `/Applications/MakeMKV/MakeMKV.app`.
 - A missing external dependency should produce a message that names the external
   app/tool and explains the next step.
 - A missing bundled dependency should be treated as a release blocker or linked

--- a/macos/BluRayToVisionPro/Models/ConversionSource.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionSource.swift
@@ -144,11 +144,21 @@ struct ConversionSource: Equatable {
 }
 
 enum DiscSourceDetector {
-    private static let makeMKVPath = "/Applications/MakeMKV.app/Contents/MacOS/makemkvcon"
+    static let makeMKVExecutablePaths = [
+        "/Applications/MakeMKV.app/Contents/MacOS/makemkvcon",
+        "/Applications/MakeMKV/MakeMKV.app/Contents/MacOS/makemkvcon",
+    ]
     static let makeMKVDownloadURL = URL(string: "https://www.makemkv.com/download/")
 
     static var makeMKVAvailable: Bool {
-        FileManager.default.isExecutableFile(atPath: makeMKVPath)
+        hasMakeMKVExecutable(at: makeMKVExecutablePaths)
+    }
+
+    static func hasMakeMKVExecutable(
+        at paths: [String],
+        fileManager: FileManager = .default
+    ) -> Bool {
+        paths.contains(where: fileManager.isExecutableFile(atPath:))
     }
 
     static func insertedDiscs(fileManager: FileManager = .default) -> [ConversionSource] {

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -741,6 +741,32 @@ final class ConversionWorkflowTests: XCTestCase {
         }
     }
 
+    func testMakeMKVDiscoverySupportsDirectAndNestedApplicationLocations() throws {
+        XCTAssertEqual(
+            DiscSourceDetector.makeMKVExecutablePaths,
+            [
+                "/Applications/MakeMKV.app/Contents/MacOS/makemkvcon",
+                "/Applications/MakeMKV/MakeMKV.app/Contents/MacOS/makemkvcon",
+            ]
+        )
+
+        try withTemporaryDirectory { directoryURL in
+            let missingURL = directoryURL.appendingPathComponent("missing-makemkvcon")
+            let executableURL = directoryURL.appendingPathComponent("makemkvcon")
+            try Data().write(to: executableURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executableURL.path
+            )
+
+            XCTAssertTrue(
+                DiscSourceDetector.hasMakeMKVExecutable(
+                    at: [missingURL.path, executableURL.path]
+                )
+            )
+        }
+    }
+
     func testInsertedDiscDetectionCarriesResolvedDevicePath() throws {
         try withTemporaryDirectory { volumeURL in
             try FileManager.default.createDirectory(

--- a/tests/test_tool_resolution.py
+++ b/tests/test_tool_resolution.py
@@ -65,7 +65,26 @@ class ToolResolutionTests(unittest.TestCase):
 
             with (
                 patch.dict(os.environ, {}, clear=True),
-                patch("bd_to_avp.modules.config.MAKEMKV_APP_BUNDLE_BIN", app_bundle_bin),
+                patch("bd_to_avp.modules.config.MAKEMKV_APP_BUNDLE_BINS", (app_bundle_bin,)),
+                patch("bd_to_avp.modules.config.shutil.which", return_value=None),
+            ):
+                self.assertEqual(resolve_makemkvcon_path(), makemkvcon)
+
+    def test_makemkv_nested_app_bundle_is_used_when_direct_bundle_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temporary_path = Path(temp_dir)
+            direct_bundle_bin = temporary_path / "direct"
+            nested_bundle_bin = temporary_path / "nested"
+            nested_bundle_bin.mkdir()
+            makemkvcon = nested_bundle_bin / "makemkvcon"
+            makemkvcon.touch()
+
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch(
+                    "bd_to_avp.modules.config.MAKEMKV_APP_BUNDLE_BINS",
+                    (direct_bundle_bin, nested_bundle_bin),
+                ),
                 patch("bd_to_avp.modules.config.shutil.which", return_value=None),
             ):
                 self.assertEqual(resolve_makemkvcon_path(), makemkvcon)


### PR DESCRIPTION
## Summary

- recognize MakeMKV at both `/Applications/MakeMKV.app` and `/Applications/MakeMKV/MakeMKV.app`
- keep native preflight and Python worker resolution aligned
- document both supported layouts
- add resolver coverage for direct and nested application bundles

## Validation

- `uv run ruff format --check bd_to_avp/modules/config.py tests/test_tool_resolution.py`
- `uv run ruff check bd_to_avp/modules/config.py tests/test_tool_resolution.py`
- `uv run mypy bd_to_avp`
- `uv run python -m unittest tests.test_tool_resolution` — 19 passed
- `uv run python scripts/native_app.py test` — 419 passed
- `git diff --check`

JetBrains inspection was attempted twice. The first run was blocked by indexing/worktree lifecycle mutation; the allowed retry returned `UNKNOWN language_sdk_missing` with zero findings. CI remains the authoritative final gate.

Fixes #553
Refs #579