### PR TITLE
build: exclude legacy GUI from worker runtime

### DIFF
--- a/docs/distribution-policy.md
+++ b/docs/distribution-policy.md
@@ -75,7 +75,8 @@ on Homebrew FFmpeg and Python 3.12, and omits the PySide6 GUI packages. The base
 PyPI package follows the same CLI-only boundary; users who intentionally want
 the legacy Python GUI may install the `gui` extra. The production DMG uses the
 SwiftUI interface while retaining Briefcase only to stage the embedded Python
-engine and its dependencies.
+worker engine and its non-GUI dependencies. Legacy Qt GUI packages are excluded
+from the production DMG runtime.
 
 The formula does not depend on a MakeMKV cask. MakeMKV is optional for existing
 MKV, MTS, and M2TS inputs, remains external for disc extraction, and should be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ requires = [
     "opencv-python==5.0.0.93",
     "psutil>=5.9.8,<8",
     "pyobjc-framework-vision>=11.0,<13",
-    # PySide6 6.10+ includes macOS binaries that require macOS 15.
-    "pyside6>=6.7.1,<6.10",
     "pysrt>=1.1.2,<2",
     "trakit>=0.2.2,<0.3",
     "wakepy>=0.9.1,<1.1",

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -20,6 +20,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 briefcase = importlib.import_module("briefcase")
 briefcase_config = importlib.import_module("briefcase.config")
 briefcase_console = importlib.import_module("briefcase.console")
+PYSIDE_RUNTIME_PACKAGE_NAMES = frozenset({"pyside6", "pyside6-addons", "pyside6-essentials", "shiboken6"})
+
+
+def normalized_requirement_name(requirement: str) -> str:
+    package_name = re.split(r"[\[<>=!~;@\s]", requirement.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", package_name).lower()
 
 
 def make_release_files(root: Path, *, version: str = "1.2.3", build: str = "10") -> tuple[Path, Path]:
@@ -129,11 +135,21 @@ class ReleaseMetadataTests(unittest.TestCase):
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
             pyproject = tomllib.load(handle)
 
-        pyside_requirement = "pyside6>=6.7.1,<6.10"
-        self.assertNotIn(pyside_requirement, pyproject["project"]["dependencies"])
-        self.assertEqual(pyproject["project"]["optional-dependencies"]["gui"], [pyside_requirement])
-        self.assertIn(pyside_requirement, pyproject["dependency-groups"]["dev"])
-        self.assertIn(pyside_requirement, pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["requires"])
+        gui_requirements = pyproject["project"]["optional-dependencies"]["gui"]
+        gui_package_names = {normalized_requirement_name(requirement) for requirement in gui_requirements}
+        base_package_names = {
+            normalized_requirement_name(requirement) for requirement in pyproject["project"]["dependencies"]
+        }
+        self.assertIn("pyside6", gui_package_names)
+        self.assertTrue(gui_package_names.isdisjoint(base_package_names))
+        self.assertTrue(PYSIDE_RUNTIME_PACKAGE_NAMES.isdisjoint(base_package_names))
+
+        dev_requirements = pyproject["dependency-groups"]["dev"]
+        briefcase_requirements = pyproject["tool"]["briefcase"]["app"]["bd-to-avp"]["requires"]
+        for requirement in gui_requirements:
+            self.assertIn(requirement, dev_requirements)
+        briefcase_package_names = {normalized_requirement_name(requirement) for requirement in briefcase_requirements}
+        self.assertTrue(PYSIDE_RUNTIME_PACKAGE_NAMES.isdisjoint(briefcase_package_names))
 
     def test_repository_uses_expected_briefcase_version(self) -> None:
         with (REPO_ROOT / "pyproject.toml").open("rb") as handle:


### PR DESCRIPTION
## Summary
- keep PySide6 in the optional legacy `gui` extra and development environment
- exclude PySide6/Qt from the Briefcase runtime staged for the native SwiftUI worker
- replace the hardcoded PySide version assertion with structural dependency-boundary checks
- document that the production DMG stages only the non-GUI Python worker dependencies

## Rationale
The native application launches `bd_to_avp.worker`; it does not use the legacy PySide GUI. Briefcase was nevertheless staging and shipping the full Qt runtime. In local package builds, excluding Qt reduced the staged app from approximately 1.1 GB to 410 MB while preserving the worker and native package smokes.

This does not change the native app's macOS 26 deployment target or the legacy PyPI GUI's current macOS 14 compatibility cap. The PySide portion of #566 remains a separate support-policy decision.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check tests/test_release.py`
- `uv lock --check`
- `uv run python -m unittest discover -s tests -t .` (1762 passed, 3 skipped before the final boundary inversion)
- `uv run python -m unittest tests.test_release tests.test_native_app` (125 passed on final state)
- `uv run python -m scripts.briefcase_app create --no-input`
- `uv run python -m scripts.briefcase_app build --no-input`
- `uv run python scripts/verify_app_tools.py`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`