### PR TITLE
Record Beta 1 change-scoped qualification

### DIFF
--- a/docs/qualification/release-evidence-v1.json
+++ b/docs/qualification/release-evidence-v1.json
@@ -341,6 +341,66 @@
       "source": "tier3_automation_receipt",
       "source_sha": "22982d5037e3b2bd03bbc9fa25332be2c8b04c97",
       "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "gui-preview-cancel-cleanup",
+      "receipt_id": "v0.3.2-beta.1:gui-preview-cancel-cleanup:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "gui-preview-failure-cleanup",
+      "receipt_id": "v0.3.2-beta.1:gui-preview-failure-cleanup:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "network-generated-final-output",
+      "receipt_id": "v0.3.2-beta.1:network-generated-final-output:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "overwrite-and-conversion-cancel",
+      "receipt_id": "v0.3.2-beta.1:overwrite-and-conversion-cancel:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "malformed-pgs-parser-recovery",
+      "receipt_id": "v0.3.2-beta.1:malformed-pgs-parser-recovery:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-18T22:06:40Z",
+      "case_id": "subtitle-partial-output-diagnostics",
+      "receipt_id": "v0.3.2-beta.1:subtitle-partial-output-diagnostics:98636e5",
+      "reference": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json",
+      "sha256": "5cc4d68088ccb32287f165b4f5d9d39315be870dc17b3363840b9ce9eb5fbdef",
+      "source": "signed_artifact_receipt",
+      "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
+      "status": "accepted"
     }
   ],
   "schema_version": 1

--- a/docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json
+++ b/docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": 1,
+  "qualification_id": "v0.3.2-beta.1-change-scoped-evidence-v1",
+  "recorded_at": "2026-08-18T22:06:40Z",
+  "source": {
+    "build_version": "163",
+    "package_version": "0.3.2b1",
+    "public_version": "0.3.2-beta.1",
+    "release_tag": "v0.3.2-beta.1",
+    "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e"
+  },
+  "failed_preparation_run": {
+    "run_id": 32189732991,
+    "run_attempt": 1,
+    "conclusion": "failure",
+    "failed_job": "Qualify release preparation",
+    "signing_started": false,
+    "release_identity_created": false
+  },
+  "packaged_candidate": {
+    "app_tree_sha256": "68204d4a1afba0341f40e3fc86ca0b550b7edf2a324a5357b0aa12881cf45fdf",
+    "architecture": "arm64",
+    "bundle_identifier": "com.shinycomputers.bd-to-avp",
+    "codesign_verification": "passed",
+    "package_command": "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package",
+    "preview_presentation_smoke": "passed",
+    "signing": "ad_hoc_local",
+    "worker_cancellation_smoke": "passed"
+  },
+  "evidence_source_semantics": {
+    "developer_id_or_notarization_claimed": false,
+    "index_source": "signed_artifact_receipt",
+    "meaning": "Change-scoped evidence from the exact locally packaged, code-signed app tree; production Developer ID signing remains owned by the guarded release run.",
+    "project_precedent": "docs/qualification/v0.3.1-mkv-audio-handling-v1.json"
+  },
+  "validation": {
+    "native_tests": {
+      "command": "uv run python scripts/native_app.py test",
+      "failed": 0,
+      "passed": 473
+    },
+    "python_tests": {
+      "command": "uv run python -m unittest discover -s tests -t .",
+      "failed": 0,
+      "passed": 1763,
+      "skipped": 3
+    },
+    "subtitle_focused_tests": {
+      "command": "uv run python -m unittest tests.test_subtitles tests.test_vendor_pgsrip_edge_cases tests.test_vendor_pgsrip_cli",
+      "failed": 0,
+      "passed": 71
+    }
+  },
+  "cases": [
+    {
+      "case_id": "gui-preview-cancel-cleanup",
+      "observations": {
+        "cancelled_preview_removes_partial_workspace": true,
+        "owned_worker_and_descendant_processes_reaped": true,
+        "packaged_worker_cancellation_smoke": "passed"
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCancelledPreviewRemovesPartialWorkspace",
+        "macos/BluRayToVisionProTests/WorkerProcessClientTests.swift:testCancellationAllowsWorkerToReapSeparateSessionChild",
+        "scripts/native_app.py:packaged worker cancellation smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "gui-preview-failure-cleanup",
+      "observations": {
+        "destination_workspace_failure_is_actionable": true,
+        "empty_owned_destination_root_removed": true,
+        "transient_cleanup_failure_retried": true
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testDestinationWorkspacePreparationFailureIsActionable",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testDestinationWorkspaceCleanupRemovesEmptyHiddenRoot",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCleanupRetriesTransientRemovalFailure"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "network-generated-final-output",
+      "observations": {
+        "destination_snapshot_preserved_through_queue_execution": true,
+        "generated_mv_hevc_route_resolution_preserved": true,
+        "packaged_worker_and_final_output_regression_suite": "passed"
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift",
+        "macos/BluRayToVisionProTests/ConversionViewModelTests.swift",
+        "macos/BluRayToVisionProTests/ConversionWorkflowTests.swift",
+        "scripts/native_app.py:packaged worker smoke"
+      ],
+      "scope": {
+        "current_change_review": "The invalidating host changes preserve destination snapshots, generated-route resolution, and worker output publication boundaries.",
+        "mounted_network_conversion_rerun": false,
+        "prior_real_network_evidence": "docs/qualification/v0.3.1-mkv-audio-handling-v1.json",
+        "qualification_kind": "exact_candidate_change_scoped_regression"
+      },
+      "status": "passed"
+    },
+    {
+      "case_id": "overwrite-and-conversion-cancel",
+      "observations": {
+        "existing_output_rejected_before_workspace_mutation": true,
+        "owned_partial_outputs_removed_after_cancellation": true,
+        "resumed_and_unowned_workspaces_preserved": true,
+        "view_model_stop_transitions_to_stopping": true
+      },
+      "proof": [
+        "tests/test_process_preflight.py:test_existing_output_aborts_before_workspace_mutation",
+        "tests/test_process_preflight.py:test_cancelled_conversion_cleans_owned_workspaces",
+        "tests/test_process_preflight.py:test_cancelled_conversion_preserves_unowned_workspaces",
+        "macos/BluRayToVisionProTests/ConversionViewModelTests.swift:testStopActiveWorkerCancelsConversionAndTransitionsToStopping"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "malformed-pgs-parser-recovery",
+      "observations": {
+        "declared_pixel_bounds_enforced": true,
+        "malformed_display_sets_isolated": true,
+        "truncated_and_unknown_segments_bounded": true,
+        "usable_peer_subtitles_preserved": true
+      },
+      "proof": [
+        "tests/test_subtitles.py",
+        "tests/test_vendor_pgsrip_edge_cases.py",
+        "tests/test_vendor_pgsrip_cli.py"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "subtitle-partial-output-diagnostics",
+      "observations": {
+        "aggregate_track_counts_recorded": true,
+        "cancelled_outcome_distinguished": true,
+        "failed_outcome_distinguished": true,
+        "partial_outcome_distinguished": true,
+        "successful_outcome_distinguished": true
+      },
+      "proof": [
+        "tests/test_subtitles.py",
+        "tests/test_vendor_pgsrip_edge_cases.py",
+        "tests/test_vendor_pgsrip_cli.py"
+      ],
+      "status": "passed"
+    }
+  ],
+  "privacy": {
+    "diagnostic_tokens_recorded": false,
+    "private_hostnames_recorded": false,
+    "private_media_identifiers_recorded": false,
+    "private_paths_recorded": false
+  },
+  "acceptance": {
+    "blocking_case_ids": [],
+    "failed_case_count": 0,
+    "passed": true,
+    "passed_case_count": 6
+  },
+  "result": "accepted_public_safe_summary"
+}

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -205,11 +205,21 @@ configured qualification record and every immutable candidate field remains
 present with an explicit JSON `null`. The candidate must advance from the bound
 published Stable identity to a newer derived Stable version and global build,
 and the evidence index may only
-append receipts without modifying or deleting accepted history. Any mutation
-under `docs/release-evidence/`, any evidence-index change without that validated
-preparation transition, or any qualification record carrying release IDs, run
-IDs, source SHA, artifact digests, or appcast digest still requires exactly one
-canonical checked release receipt on the idempotent
+append receipts without modifying or deleting accepted history.
+
+A Beta preparation remediation may also append change-scoped Tier 2 receipts
+without resetting the Stable qualification record. This lane requires the exact
+`qualify/<beta-tag>` branch, one new public-safe
+`docs/qualification/<beta-tag>-change-scoped-evidence-v1.json` document, receipts
+bound to the pull-request base SHA and that document's digest, and policy cases
+owned by the `release_candidate` phase. It rejects artifact-owned, live
+publication, milestone, Tier 1, and Tier 3 evidence, and it cannot claim
+Developer ID signing, notarization, or a created release identity.
+
+Any mutation under `docs/release-evidence/`, any other evidence-index change
+without a validated preparation transition, or any qualification record carrying
+release IDs, run IDs, source SHA, artifact digests, or appcast digest still
+requires exactly one canonical checked release receipt on the idempotent
 `automation/release-evidence-<tag>` branch.
 
 **Early gate (`qualify-preparation`)** runs after `prepare` and before `package`

--- a/scripts/qualify_release_scope.py
+++ b/scripts/qualify_release_scope.py
@@ -80,6 +80,7 @@ class QualificationScopeError(RuntimeError):
 
 
 ChangedPaths = Callable[[str, str], set[str]]
+IsAncestor = Callable[[str, str], bool]
 ReferenceContent = Callable[[str], bytes]
 
 
@@ -554,6 +555,30 @@ def git_changed_paths(repo: Path) -> ChangedPaths:
         return cache[key]
 
     return changed
+
+
+def git_is_ancestor(repo: Path) -> IsAncestor:
+    cache: dict[tuple[str, str], bool] = {}
+
+    def is_ancestor(ancestor_sha: str, candidate_sha: str) -> bool:
+        key = (ancestor_sha, candidate_sha)
+        if key not in cache:
+            result = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", ancestor_sha, candidate_sha],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+            )
+            if result.returncode not in {0, 1}:
+                detail = result.stderr.decode("utf-8", errors="replace").strip() or "git merge-base failed"
+                raise QualificationScopeError(
+                    f"Unable to verify evidence SHA {ancestor_sha} is an ancestor of candidate "
+                    f"{candidate_sha}: {detail}"
+                )
+            cache[key] = result.returncode == 0
+        return cache[key]
+
+    return is_ancestor
 
 
 def git_checked_reference_content(repo: Path) -> ReferenceContent:
@@ -1189,6 +1214,7 @@ def classify_release_scope(
     *,
     candidate_sha: str,
     changed_paths: ChangedPaths,
+    is_ancestor: IsAncestor | None = None,
     repo: Path = REPO_ROOT,
     reference_content: ReferenceContent | None = None,
     qualification_id: str | None = None,
@@ -1205,6 +1231,8 @@ def classify_release_scope(
 ) -> dict[str, Any]:
     if SHA_PATTERN.fullmatch(candidate_sha) is None:
         raise QualificationScopeError("Candidate SHA must be a full lowercase Git SHA.")
+    if is_ancestor is None:
+        raise QualificationScopeError("Evidence ancestry validation is required.")
     if release_stage not in {"alpha", "beta", "rc", "stable"}:
         raise QualificationScopeError("Release stage must be alpha, beta, rc, or stable.")
     if workflow_phase not in WORKFLOW_PHASES:
@@ -1339,7 +1367,15 @@ def classify_release_scope(
         release_blocking = _release_blocking(case)
         accepted = receipt_map.get(case_id, [])
         exact = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] == candidate_sha), None)
-        prior = next((receipt for receipt in reversed(accepted) if receipt["source_sha"] != candidate_sha), None)
+        prior = next(
+            (
+                receipt
+                for receipt in reversed(accepted)
+                if receipt["source_sha"] != candidate_sha
+                and is_ancestor(cast(str, receipt["source_sha"]), candidate_sha)
+            ),
+            None,
+        )
         status: str
         reason: str
         invalidating_paths: list[str] = []
@@ -1686,6 +1722,7 @@ def main(argv: list[str] | None = None) -> int:
                 evidence,
                 candidate_sha=args.candidate_sha,
                 changed_paths=git_changed_paths(args.repo),
+                is_ancestor=git_is_ancestor(args.repo),
                 repo=args.repo,
                 qualification_id=qualification_id,
                 fresh_retest=fresh_retest,

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
-from scripts.release import ReleaseError, parse_build_version, parse_release_version
+from scripts.release import ReleaseError, parse_build_version, parse_release_tag, parse_release_version
 from scripts.release_evidence import effective_successful_workflow_run_id
 from scripts.release_qualification_manifest import (
     MANIFEST_NAME,
@@ -32,6 +32,7 @@ RUNNER_BOUND_QUALIFICATION_PATHS = {
 }
 RECEIPT_PATH_PATTERN = re.compile(r"^docs/release-evidence/(v[^/]+)/release-receipt\.json$")
 MANIFEST_PATH_PATTERN = re.compile(rf"^docs/release-evidence/(v[^/]+)/{re.escape(MANIFEST_NAME)}$")
+CHANGE_SCOPED_EVIDENCE_PATH_PATTERN = re.compile(r"^docs/qualification/(v[^/]+)-change-scoped-evidence-v1\.json$")
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
@@ -191,7 +192,7 @@ def _validate_prepublication_candidate_transition(
             )
 
 
-def _validate_append_only_evidence_index(repo_root: Path, *, base_sha: str) -> None:
+def _validate_append_only_evidence_index(repo_root: Path, *, base_sha: str) -> list[Mapping[str, Any]]:
     base_evidence = _load_json_at_revision(repo_root, base_sha, EVIDENCE_INDEX_PATH, "base qualification evidence")
     head_evidence = _load_json(repo_root / EVIDENCE_INDEX_PATH, "qualification evidence")
     if base_evidence.get("schema_version") != 1 or head_evidence.get("schema_version") != 1:
@@ -201,6 +202,157 @@ def _validate_append_only_evidence_index(repo_root: Path, *, base_sha: str) -> N
     if len(head_receipts) <= len(base_receipts) or head_receipts[: len(base_receipts)] != base_receipts:
         raise ReleaseMilestoneContextError(
             "Prepublication qualification evidence may only append receipts without changing accepted history."
+        )
+    return [
+        _mapping(receipt, f"appended qualification receipt {index}")
+        for index, receipt in enumerate(head_receipts[len(base_receipts) :])
+    ]
+
+
+def _validate_beta_change_scoped_evidence_append(
+    repo_root: Path,
+    *,
+    base_sha: str,
+    head_branch: str,
+    changed_paths: Sequence[str],
+    policy_relative: str,
+    appended_receipts: Sequence[Mapping[str, Any]],
+) -> None:
+    evidence_matches = [
+        (path, match.group(1))
+        for path in changed_paths
+        if (match := CHANGE_SCOPED_EVIDENCE_PATH_PATTERN.fullmatch(path)) is not None
+    ]
+    if len(evidence_matches) != 1:
+        raise ReleaseMilestoneContextError(
+            "Prepublication Beta evidence requires exactly one change-scoped evidence document."
+        )
+    evidence_relative, release_tag = evidence_matches[0]
+    try:
+        version = parse_release_tag(release_tag, allow_legacy_rc=False)
+    except ReleaseError as error:
+        raise ReleaseMilestoneContextError(f"Prepublication Beta evidence release tag is invalid: {error}") from error
+    if version.stage != "beta":
+        raise ReleaseMilestoneContextError("Prepublication change-scoped evidence is limited to Beta releases.")
+    if head_branch != f"qualify/{release_tag}":
+        raise ReleaseMilestoneContextError(
+            f"Prepublication Beta evidence must use branch {f'qualify/{release_tag}'!r}."
+        )
+    tracked_in_base = subprocess.run(
+        ["git", "cat-file", "-e", f"{base_sha}:{evidence_relative}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if tracked_in_base.returncode == 0:
+        raise ReleaseMilestoneContextError("Prepublication Beta evidence document must be new and immutable.")
+
+    evidence_path = repo_root / evidence_relative
+    evidence_bytes = evidence_path.read_bytes()
+    evidence = _load_json(evidence_path, "prepublication Beta change-scoped evidence")
+    source = _mapping(evidence.get("source"), "prepublication Beta evidence source")
+    try:
+        source_version = parse_release_version(_string(source.get("package_version"), "Beta package version"))
+        source_build = parse_build_version(_string(source.get("build_version"), "Beta build version"))
+    except ReleaseError as error:
+        raise ReleaseMilestoneContextError(f"Prepublication Beta evidence identity is invalid: {error}") from error
+    if (
+        source_version.stage != "beta"
+        or source_version.release_tag != release_tag
+        or source.get("public_version") != source_version.public_version
+        or source.get("release_tag") != release_tag
+        or source.get("source_sha") != base_sha
+        or source_build <= 0
+    ):
+        raise ReleaseMilestoneContextError(
+            "Prepublication Beta evidence source identity must match the release tag and pull-request base SHA."
+        )
+    failed_run = _mapping(evidence.get("failed_preparation_run"), "prepublication Beta failed run")
+    semantics = _mapping(evidence.get("evidence_source_semantics"), "prepublication Beta evidence semantics")
+    privacy = _mapping(evidence.get("privacy"), "prepublication Beta evidence privacy")
+    acceptance = _mapping(evidence.get("acceptance"), "prepublication Beta evidence acceptance")
+    if (
+        evidence.get("schema_version") != 1
+        or evidence.get("result") != "accepted_public_safe_summary"
+        or failed_run.get("signing_started") is not False
+        or failed_run.get("release_identity_created") is not False
+        or semantics.get("developer_id_or_notarization_claimed") is not False
+        or semantics.get("index_source") != "signed_artifact_receipt"
+        or acceptance.get("passed") is not True
+        or acceptance.get("failed_case_count") != 0
+        or list(_sequence(acceptance.get("blocking_case_ids"), "Beta blocking case IDs"))
+    ):
+        raise ReleaseMilestoneContextError(
+            "Prepublication Beta evidence must remain public-safe, unsigned-release-scoped, and fully passing."
+        )
+    for field in (
+        "private_paths_recorded",
+        "private_hostnames_recorded",
+        "private_media_identifiers_recorded",
+        "diagnostic_tokens_recorded",
+    ):
+        if privacy.get(field) is not False:
+            raise ReleaseMilestoneContextError(f"Prepublication Beta evidence privacy.{field} must be false.")
+
+    evidence_cases: dict[str, Mapping[str, Any]] = {}
+    for index, raw_case in enumerate(_sequence(evidence.get("cases"), "prepublication Beta evidence cases")):
+        evidence_case = _mapping(raw_case, f"prepublication Beta evidence case {index}")
+        case_id = _string(evidence_case.get("case_id"), "prepublication Beta evidence case ID")
+        if case_id in evidence_cases or evidence_case.get("status") != "passed":
+            raise ReleaseMilestoneContextError(
+                "Prepublication Beta evidence cases must be uniquely identified and passed."
+            )
+        evidence_cases[case_id] = evidence_case
+    if acceptance.get("passed_case_count") != len(evidence_cases):
+        raise ReleaseMilestoneContextError(
+            "Prepublication Beta evidence passed_case_count must match the proved case count."
+        )
+
+    policy = _load_json(repo_root / policy_relative, "prepublication Beta qualification policy")
+    policy_cases = {
+        _string(case.get("id"), "qualification policy case ID"): case
+        for index, raw_case in enumerate(_sequence(policy.get("cases"), "qualification policy cases"))
+        for case in [_mapping(raw_case, f"qualification policy case {index}")]
+    }
+    evidence_digest = hashlib.sha256(evidence_bytes).hexdigest()
+    receipt_case_ids: set[str] = set()
+    for receipt in appended_receipts:
+        case_id = _string(receipt.get("case_id"), "prepublication Beta receipt case ID")
+        policy_case = policy_cases.get(case_id)
+        allowed_sources = (
+            list(_sequence(policy_case.get("allowed_evidence_sources"), f"policy case {case_id} evidence sources"))
+            if policy_case is not None
+            else []
+        )
+        if (
+            case_id in receipt_case_ids
+            or case_id not in evidence_cases
+            or policy_case is None
+            or policy_case.get("tier") != 2
+            or policy_case.get("blocking_phase") != "release_candidate"
+            or policy_case.get("artifact_owned") is True
+            or policy_case.get("requires_live_publication") is True
+            or "signed_artifact_receipt" not in allowed_sources
+        ):
+            raise ReleaseMilestoneContextError(
+                "Prepublication Beta receipts may cover only proved release-candidate Tier 2 cases."
+            )
+        receipt_id = _string(receipt.get("receipt_id"), "prepublication Beta receipt ID")
+        if (
+            receipt.get("status") != "accepted"
+            or receipt.get("source") != "signed_artifact_receipt"
+            or receipt.get("source_sha") != base_sha
+            or receipt.get("reference") != evidence_relative
+            or receipt.get("sha256") != evidence_digest
+            or receipt_id != f"{release_tag}:{case_id}:{base_sha[:7]}"
+        ):
+            raise ReleaseMilestoneContextError(
+                "Prepublication Beta receipt identity must match the base candidate and change-scoped evidence."
+            )
+        receipt_case_ids.add(case_id)
+    if receipt_case_ids != set(evidence_cases):
+        raise ReleaseMilestoneContextError(
+            "Prepublication Beta evidence cases and appended receipt cases must match exactly."
         )
 
 
@@ -288,6 +440,11 @@ def discover_milestone_receipt(
     ]
     config = _load_json(repo_root / GITHUB_CONFIG_PATH, "GitHub repository config")
     operations = _mapping(config.get("releaseOperations"), "releaseOperations")
+    _policy_path, policy_relative = _repository_path(
+        repo_root,
+        operations.get("qualificationPolicyPath"),
+        "qualificationPolicyPath",
+    )
     _qualification_path, qualification_relative = _repository_path(
         repo_root,
         operations.get("qualificationRecordPath"),
@@ -303,6 +460,11 @@ def discover_milestone_receipt(
         if checked_release_mutation:
             raise ReleaseMilestoneContextError(
                 "Release evidence changes require exactly one checked release receipt in the pull-request diff."
+            )
+        runner_input_changes = sorted(RUNNER_BOUND_QUALIFICATION_PATHS.intersection(changed_paths))
+        if evidence_index_mutation and runner_input_changes:
+            raise ReleaseMilestoneContextError(
+                f"Prepublication evidence may not change runner-bound policy or route inputs: {runner_input_changes!r}."
             )
         unbound_candidate = False
         if qualification_mutation:
@@ -324,12 +486,23 @@ def discover_milestone_receipt(
                 candidate=candidate,
             )
             unbound_candidate = True
-        if evidence_index_mutation and not unbound_candidate:
-            raise ReleaseMilestoneContextError(
-                "Release evidence changes require exactly one checked release receipt in the pull-request diff."
-            )
+        appended_receipts: list[Mapping[str, Any]] = []
         if evidence_index_mutation:
-            _validate_append_only_evidence_index(repo_root, base_sha=base_sha)
+            appended_receipts = _validate_append_only_evidence_index(repo_root, base_sha=base_sha)
+        change_scoped_mutation = any(CHANGE_SCOPED_EVIDENCE_PATH_PATTERN.fullmatch(path) for path in changed_paths)
+        if unbound_candidate and change_scoped_mutation:
+            raise ReleaseMilestoneContextError(
+                "Beta change-scoped evidence may not be combined with a Stable qualification reset."
+            )
+        if evidence_index_mutation and not unbound_candidate:
+            _validate_beta_change_scoped_evidence_append(
+                repo_root,
+                base_sha=base_sha,
+                head_branch=head_branch,
+                changed_paths=changed_paths,
+                policy_relative=policy_relative,
+                appended_receipts=appended_receipts,
+            )
         return None
     if len(receipt_matches) != 1:
         raise ReleaseMilestoneContextError(

--- a/scripts/release_qualification_status.py
+++ b/scripts/release_qualification_status.py
@@ -5,13 +5,15 @@ import subprocess
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
 from scripts.qualify_release_scope import (
+    RECORDED_NONBLOCKING_STATUSES,
     classify_release_scope,
     git_changed_paths,
+    git_is_ancestor,
     load_evidence,
     load_policy,
     load_qualification_overrides,
@@ -69,6 +71,35 @@ def _string(value: object, description: str) -> str:
     if not isinstance(value, str) or not value:
         raise ReleaseQualificationControllerError(f"{description} must be a non-empty string.")
     return value
+
+
+def _evidence_as_of(evidence: Mapping[str, Any], cutoff: date | None) -> Mapping[str, Any]:
+    if cutoff is None:
+        return evidence
+    snapshot = dict(evidence)
+    receipts: list[Any] = []
+    for index, raw_receipt in enumerate(_sequence(evidence.get("receipts"), "release qualification receipts")):
+        receipt = _mapping(raw_receipt, f"release qualification receipt {index}")
+        if receipt.get("status") not in {"accepted", *RECORDED_NONBLOCKING_STATUSES}:
+            receipts.append(raw_receipt)
+            continue
+        accepted_at = receipt.get("accepted_at")
+        if not isinstance(accepted_at, str) or not accepted_at:
+            raise ReleaseQualificationControllerError(f"Release qualification receipt {index} requires accepted_at.")
+        try:
+            accepted_timestamp = datetime.fromisoformat(accepted_at.replace("Z", "+00:00"))
+        except ValueError as error:
+            raise ReleaseQualificationControllerError(
+                f"Release qualification receipt {index} has invalid accepted_at {accepted_at!r}."
+            ) from error
+        if accepted_timestamp.tzinfo is None:
+            raise ReleaseQualificationControllerError(
+                f"Release qualification receipt {index} accepted_at must include a timezone."
+            )
+        if accepted_timestamp.astimezone(timezone.utc).date() <= cutoff:
+            receipts.append(raw_receipt)
+    snapshot["receipts"] = receipts
+    return snapshot
 
 
 def _canonical_release_tag(value: str) -> str:
@@ -249,7 +280,7 @@ def build_status(
             base_revision=_string(canonical_evidence.get("base_sha"), "manifest evidence base SHA"),
         )
     policy = _load_bound_policy(repo_root, binding)
-    evidence = load_evidence(repo_root / context.evidence_path)
+    evidence = _evidence_as_of(load_evidence(repo_root / context.evidence_path), as_of)
     qualification_id, fresh_retest = load_qualification_overrides(
         repo_root / context.qualification_path,
         policy,
@@ -259,6 +290,7 @@ def build_status(
         evidence,
         candidate_sha=context.candidate_sha,
         changed_paths=git_changed_paths(repo_root),
+        is_ancestor=git_is_ancestor(repo_root),
         repo=repo_root,
         qualification_id=qualification_id,
         fresh_retest=fresh_retest,

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -48,6 +48,13 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
     def setUp(self) -> None:
         self.policy = load_policy(DEFAULT_POLICY_PATH)
 
+    def checked_evidence_as_of(self, cutoff: date) -> dict[str, Any]:
+        evidence = json.loads((REPO_ROOT / "docs/qualification/release-evidence-v1.json").read_text(encoding="utf-8"))
+        evidence["receipts"] = [
+            receipt for receipt in evidence["receipts"] if date.fromisoformat(receipt["accepted_at"][:10]) <= cutoff
+        ]
+        return evidence
+
     def test_milestone_tier1_receipt_accepts_explicit_successful_recovery(self) -> None:
         release_receipt = {"source_sha": CANDIDATE_SHA, "workflow": {"run_id": 12345}}
         evidence_receipt = {
@@ -1186,7 +1193,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     )
 
     def test_checked_rc3_live_publication_evidence_matches_milestone_receipt(self) -> None:
-        evidence = json.loads((REPO_ROOT / "docs/qualification/release-evidence-v1.json").read_text(encoding="utf-8"))
+        evidence = self.checked_evidence_as_of(date(2026, 8, 9))
         report = classify_release_scope(
             self.policy,
             evidence,

--- a/tests/test_qualify_release_scope.py
+++ b/tests/test_qualify_release_scope.py
@@ -6,10 +6,10 @@ import unittest
 
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import replace
-from datetime import date
+from datetime import date, datetime, timezone
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from scripts.qualify_release_scope import (
     DEFAULT_POLICY_PATH,
@@ -51,7 +51,10 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
     def checked_evidence_as_of(self, cutoff: date) -> dict[str, Any]:
         evidence = json.loads((REPO_ROOT / "docs/qualification/release-evidence-v1.json").read_text(encoding="utf-8"))
         evidence["receipts"] = [
-            receipt for receipt in evidence["receipts"] if date.fromisoformat(receipt["accepted_at"][:10]) <= cutoff
+            receipt
+            for receipt in evidence["receipts"]
+            if datetime.fromisoformat(receipt["accepted_at"].replace("Z", "+00:00")).astimezone(timezone.utc).date()
+            <= cutoff
         ]
         return evidence
 
@@ -123,6 +126,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         root: Path,
         *,
         changed: set[str] | None = None,
+        is_ancestor: Callable[[str, str], bool] | None = None,
         fresh: dict[str, bool] | None = None,
         workflow_phase: str = "preparation",
         artifact_receipt_path: Path | None = None,
@@ -139,6 +143,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             evidence,
             candidate_sha=CANDIDATE_SHA,
             changed_paths=lambda _base, _candidate: changed or set(),
+            is_ancestor=is_ancestor or (lambda _source_sha, _candidate_sha: True),
             repo=root,
             reference_content=lambda reference: (root / reference).read_bytes(),
             fresh_retest=fresh,
@@ -512,6 +517,25 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
         self.assertEqual(result["status"], "carry")
         self.assertEqual(result["evidence"]["receipt_id"], "overwrite-and-conversion-cancel-receipt-v1")
 
+    def test_descendant_receipt_is_not_treated_as_prior_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            evidence = self.evidence(root, "overwrite-and-conversion-cancel")
+            descendant = dict(evidence["receipts"][0])
+            descendant["receipt_id"] = "overwrite-and-conversion-cancel-descendant-v1"
+            descendant["source_sha"] = "c" * 40
+            descendant["accepted_at"] = "2026-08-02T00:00:00Z"
+            evidence["receipts"].append(descendant)
+            report = self.classify(
+                evidence,
+                root,
+                is_ancestor=lambda source_sha, _candidate_sha: source_sha == PRIOR_SHA,
+            )
+
+        result = self.result_for(report, "overwrite-and-conversion-cancel")
+        self.assertEqual(result["status"], "carry")
+        self.assertEqual(result["evidence"]["receipt_id"], "overwrite-and-conversion-cancel-receipt-v1")
+
     def test_missing_evidence_is_a_blocking_retest(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             report = self.classify({"schema_version": 1, "receipts": []}, Path(temporary_directory))
@@ -678,6 +702,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     {"schema_version": 1, "receipts": []},
                     candidate_sha=CANDIDATE_SHA,
                     changed_paths=lambda _base, _candidate: set(),
+                    is_ancestor=lambda _source_sha, _candidate_sha: True,
                     repo=root,
                     reference_content=lambda reference: (root / reference).read_bytes(),
                     workflow_phase="artifact",
@@ -943,6 +968,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             evidence,
             candidate_sha=candidate_sha,
             changed_paths=lambda _base, _candidate: set(),
+            is_ancestor=lambda _source_sha, _candidate_sha: True,
             repo=REPO_ROOT,
             reference_content=lambda path: reference_bytes if path == reference else (REPO_ROOT / path).read_bytes(),
             fresh_retest={"native-sparkle-release-notes": True},
@@ -1183,6 +1209,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                         evidence,
                         candidate_sha="0b06582a83a45bb38d851e62ccf38cd148c7bb95",
                         changed_paths=lambda _base, _candidate: set(),
+                        is_ancestor=lambda _source_sha, _candidate_sha: True,
                         repo=REPO_ROOT,
                         reference_content=lambda path, content=reference_bytes: (
                             content
@@ -1199,6 +1226,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
             evidence,
             candidate_sha="0b06582a83a45bb38d851e62ccf38cd148c7bb95",
             changed_paths=lambda _base, _candidate: set(),
+            is_ancestor=lambda _source_sha, _candidate_sha: True,
             repo=REPO_ROOT,
             workflow_phase="milestone",
             milestone_receipt_path=REPO_ROOT / "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
@@ -1243,6 +1271,7 @@ class ReleaseQualificationScopeTests(unittest.TestCase):
                     evidence,
                     candidate_sha=CANDIDATE_SHA,
                     changed_paths=lambda _base, _candidate: set(),
+                    is_ancestor=lambda _source_sha, _candidate_sha: True,
                     repo=root,
                     workflow_phase="preparation",
                     as_of=date(2026, 8, 5),

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -71,7 +71,14 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                             "id": "profile-save-action-accessibility",
                             "invalidates_on": {"contracts": ["profile-storage"], "paths": []},
                             "tier": 2,
-                        }
+                        },
+                        {
+                            "allowed_evidence_sources": ["signed_artifact_receipt"],
+                            "blocking_phase": "release_candidate",
+                            "id": "beta-change-scoped-case",
+                            "invalidates_on": {"contracts": [], "paths": []},
+                            "tier": 2,
+                        },
                     ],
                     "policy_id": "release-qualification-policy-v1",
                     "result_states": ["covered", "carry", "retest", "external"],
@@ -227,6 +234,85 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         subprocess.run(["git", "add", "."], cwd=root, check=True)
         subprocess.run(["git", "commit", "-qm", "evidence"], cwd=root, check=True)
         return receipt_path
+
+    @staticmethod
+    def append_beta_change_scoped_evidence(
+        root: Path,
+        *,
+        case_id: str = "beta-change-scoped-case",
+        source_sha: str | None = None,
+        receipt_digest: str | None = None,
+    ) -> tuple[str, str]:
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        release_tag = "v0.3.1-beta.1"
+        evidence_relative = f"docs/qualification/{release_tag}-change-scoped-evidence-v1.json"
+        evidence_path = root / evidence_relative
+        evidence = {
+            "schema_version": 1,
+            "qualification_id": "beta-change-scoped-v1",
+            "result": "accepted_public_safe_summary",
+            "source": {
+                "package_version": "0.3.1b1",
+                "public_version": "0.3.1-beta.1",
+                "build_version": "162",
+                "release_tag": release_tag,
+                "source_sha": source_sha or base_sha,
+            },
+            "failed_preparation_run": {
+                "signing_started": False,
+                "release_identity_created": False,
+            },
+            "evidence_source_semantics": {
+                "developer_id_or_notarization_claimed": False,
+                "index_source": "signed_artifact_receipt",
+            },
+            "privacy": {
+                "private_paths_recorded": False,
+                "private_hostnames_recorded": False,
+                "private_media_identifiers_recorded": False,
+                "diagnostic_tokens_recorded": False,
+            },
+            "acceptance": {
+                "passed": True,
+                "passed_case_count": 1,
+                "failed_case_count": 0,
+                "blocking_case_ids": [],
+            },
+            "cases": [{"case_id": case_id, "status": "passed"}],
+        }
+        evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        digest = receipt_digest or hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+        evidence_index_path = root / EVIDENCE_INDEX_PATH
+        evidence_index = json.loads(evidence_index_path.read_text(encoding="utf-8"))
+        evidence_index["receipts"].append(
+            {
+                "case_id": case_id,
+                "receipt_id": f"{release_tag}:{case_id}:{base_sha[:7]}",
+                "source": "signed_artifact_receipt",
+                "status": "accepted",
+                "source_sha": source_sha or base_sha,
+                "accepted_at": "2026-08-18T20:00:00Z",
+                "reference": evidence_relative,
+                "sha256": digest,
+            }
+        )
+        evidence_index_path.write_text(json.dumps(evidence_index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        subprocess.run(["git", "add", evidence_path, evidence_index_path], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "append beta evidence"], cwd=root, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return base_sha, head_sha
 
     def test_resolves_checked_stable_milestone_context(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -766,6 +852,176 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             )
 
         self.assertIsNone(discovered)
+
+    def test_allows_beta_change_scoped_evidence_append_without_checked_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.append_beta_change_scoped_evidence(root)
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="qualify/v0.3.1-beta.1",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(discovered)
+
+    def test_rejects_beta_change_scoped_evidence_on_wrong_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.append_beta_change_scoped_evidence(root)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "qualify/v0.3.1-beta.1"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="feature/beta-evidence",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_beta_change_scoped_evidence_digest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.append_beta_change_scoped_evidence(root, receipt_digest="0" * 64)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "receipt identity"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="qualify/v0.3.1-beta.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_beta_change_scoped_evidence_for_artifact_owned_case(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.append_beta_change_scoped_evidence(
+                root,
+                case_id="profile-save-action-accessibility",
+            )
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "release-candidate Tier 2"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="qualify/v0.3.1-beta.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_beta_change_scoped_evidence_for_non_base_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.append_beta_change_scoped_evidence(root, source_sha="f" * 40)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "base SHA"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="qualify/v0.3.1-beta.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_beta_change_scoped_evidence_with_policy_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, _head_sha = self.append_beta_change_scoped_evidence(root)
+            policy_path = root / "docs/qualification/release-qualification-policy-v1.json"
+            policy = json.loads(policy_path.read_text(encoding="utf-8"))
+            policy["policy_id"] = "self-authorized-policy"
+            policy_path.write_text(json.dumps(policy, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", policy_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "--amend", "-qm", "append beta evidence and policy"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "runner-bound policy"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="qualify/v0.3.1-beta.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_beta_change_scoped_evidence_with_stable_reset(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, _head_sha = self.append_beta_change_scoped_evidence(root)
+            qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+            for field in (
+                "source_git_sha",
+                "release_run_id",
+                "release_id",
+                "dmg_sha256",
+                "appcast_sha256",
+                "signed_app_tree_sha256",
+            ):
+                qualification["candidate"][field] = None
+            qualification["candidate"].update(
+                {
+                    "package_version": "0.3.1",
+                    "public_version": "0.3.1",
+                    "build_version": "162",
+                    "release_tag": "v0.3.1",
+                    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1.dmg",
+                }
+            )
+            qualification_path.write_text(json.dumps(qualification) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", qualification_path], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "--amend", "-qm", "combine beta evidence and stable reset"],
+                cwd=root,
+                check=True,
+            )
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "may not be combined"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="qualify/v0.3.1-beta.1",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
 
     def test_rejects_same_version_prepublication_reset(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_qualification_controller.py
+++ b/tests/test_release_qualification_controller.py
@@ -393,16 +393,36 @@ class ReleaseQualificationControllerTests(unittest.TestCase):
             patch("scripts.release_qualification_status._require_checked_file"),
             patch("scripts.release_qualification_status.validate_manifest_evidence_history") as validate_history,
             patch("scripts.release_qualification_status._load_bound_policy", return_value=policy),
-            patch("scripts.release_qualification_status.load_evidence", return_value={"schema_version": 1}),
+            patch(
+                "scripts.release_qualification_status.load_evidence",
+                return_value={
+                    "schema_version": 1,
+                    "receipts": [
+                        {"receipt_id": "historical", "status": "accepted", "accepted_at": "2026-08-10T12:00:00Z"},
+                        {"receipt_id": "future", "status": "accepted", "accepted_at": "2026-08-18T12:00:00Z"},
+                        {"receipt_id": "historical-failed", "status": "failed", "accepted_at": "2026-08-10T13:00:00Z"},
+                        {"receipt_id": "future-failed", "status": "failed", "accepted_at": "2026-08-18T13:00:00Z"},
+                    ],
+                },
+            ),
             patch(
                 "scripts.release_qualification_status.load_qualification_overrides",
                 return_value=("qualification", {}),
             ),
-            patch("scripts.release_qualification_status.classify_release_scope", return_value=classification),
+            patch(
+                "scripts.release_qualification_status.classify_release_scope", return_value=classification
+            ) as classify,
         ):
             payload = build_status(REPO_ROOT, "v0.3.1", as_of=date(2026, 8, 10))
 
         validate_history.assert_called_once_with(manifest, repo_root=REPO_ROOT, base_revision="b" * 40)
+        self.assertEqual(
+            classify.call_args.args[1]["receipts"],
+            [
+                {"receipt_id": "historical", "status": "accepted", "accepted_at": "2026-08-10T12:00:00Z"},
+                {"receipt_id": "historical-failed", "status": "failed", "accepted_at": "2026-08-10T13:00:00Z"},
+            ],
+        )
         self.assertEqual(payload["evidence_binding"]["expected_evidence_ref"], "automation/release-evidence-v0.3.1")
         self.assertEqual(payload["overall_status"], "complete")
 


### PR DESCRIPTION
## Summary
- record exact-source, change-scoped qualification for the six Tier 2 cases that blocked Prerelease run 32189732991
- bind all receipts to the reviewed evidence document digest and packaged source SHA 98636e5b7e413b198447954c0d67f6668c10c31e
- preserve historical qualification semantics by excluding future receipts and rejecting descendant evidence as carry-forward input

## Scope boundary
- no product changes
- no Developer ID signing or notarization claim
- no claim that a fresh mounted-network conversion was run; the network case uses exact-candidate regression coverage plus the prior real-network receipt

## Validation
- `uv run ruff check --no-fix scripts/qualify_release_scope.py scripts/release_qualification_status.py tests/test_qualify_release_scope.py tests/test_release_qualification_controller.py`
- `uv run ruff format --check scripts/qualify_release_scope.py scripts/release_qualification_status.py tests/test_qualify_release_scope.py tests/test_release_qualification_controller.py`
- focused release suite: 157 passed
- full Python suite: 1,764 passed, 3 skipped
- preparation classifier on `1a63a6ab71789ad4d2ae20ecfa1a779e8e6b3709`: `passed: true`, `blocking_retests: []`
- independent exact-diff reviews completed; review findings were addressed before push

Refs #584
Refs #579