### PR TITLE
Update signed UI profile acceptance path

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -66,10 +66,15 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         let mainContent = lightApp.descendants(matching: .any)["main-window-content"]
         XCTAssertTrue(mainContent.waitForExistence(timeout: 30))
 
-        let saveAction = lightApp.buttons["save-profile-action"]
+        let editAction = lightApp.buttons["edit-conversion-settings"]
+        XCTAssertTrue(editAction.waitForExistence(timeout: 20))
+        XCTAssertTrue(editAction.isEnabled)
+        editAction.click()
+
+        let saveAction = lightApp.buttons["setup-editor-save-as-new"]
         XCTAssertTrue(saveAction.waitForExistence(timeout: 20))
         XCTAssertEqual(saveAction.elementType, .button)
-        XCTAssertEqual(saveAction.label, "Save current settings as new profile")
+        XCTAssertEqual(saveAction.label, "Save as New Profile…")
         XCTAssertTrue(saveAction.isEnabled)
 
         saveAction.click()


### PR DESCRIPTION
## Summary
- update the signed-artifact UI acceptance test to enter the Conversion Setup editor before saving a profile
- assert the current `setup-editor-save-as-new` control instead of the retired main-window `save-profile-action`

## Release failure addressed
Prerelease run `32198633906` failed in `InstalledUIAcceptanceTests.testCandidateMainWindowProfileAndSettings` because the test still expected the pre-Conversion-Setup save action on the Ready screen. The product UI is behaving as designed; this patch updates the workflow test to follow the reviewed editor path.

## Validation
- native suite: 473 passed
- signed draft DMG local repro reached UI automation startup with the amended test target; local macOS automation initialization timed out before test execution, so exact installed UI execution remains CI-owned

Refs #584
Refs #579