### PR TITLE
Fix editor profile-name UI acceptance

### DIFF
--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -346,7 +346,6 @@ private struct ProfileNameSheet: View {
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
                     .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    .accessibilityIdentifier("setup-editor-new-profile-confirm")
             }
         }
         .padding(24)

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -346,6 +346,7 @@ private struct ProfileNameSheet: View {
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
                     .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityIdentifier("setup-editor-new-profile-confirm")
             }
         }
         .padding(24)

--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -78,12 +78,12 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         XCTAssertTrue(saveAction.isEnabled)
 
         saveAction.click()
-        let nameField = lightApp.textFields["save-profile-name-field"]
+        let nameField = lightApp.textFields["setup-editor-new-profile-name"]
         XCTAssertTrue(nameField.waitForExistence(timeout: 20))
         nameField.click()
         nameField.typeKey("a", modifierFlags: .command)
         nameField.typeText(Self.profileName)
-        let confirmButton = lightApp.buttons["save-profile-confirm"]
+        let confirmButton = lightApp.buttons["setup-editor-new-profile-confirm"]
         XCTAssertTrue(confirmButton.isEnabled)
         confirmButton.click()
         XCTAssertTrue(waitUntil(timeout: 20) { !nameField.exists })

--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -83,7 +83,8 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         nameField.click()
         nameField.typeKey("a", modifierFlags: .command)
         nameField.typeText(Self.profileName)
-        let confirmButton = lightApp.buttons["setup-editor-new-profile-confirm"]
+        let confirmButton = lightApp.buttons["Save"].firstMatch
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 20))
         XCTAssertTrue(confirmButton.isEnabled)
         confirmButton.click()
         XCTAssertTrue(waitUntil(timeout: 20) { !nameField.exists })

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1886,7 +1886,7 @@ def normalize_installed_ui_candidate_evidence(
     )
     expected_candidate = {
         "main_window_ready": True,
-        "profile_document_version": 5,
+        "profile_document_version": 6,
         "profile_save_accessible": True,
         "profile_save_succeeded": True,
         "profiles_after": 1,
@@ -1981,7 +1981,7 @@ def normalize_installed_ui_candidate_evidence(
         evidence_directory / "ui-result.json",
         {
             "main_window_ready": True,
-            "profile_document_version": 5,
+            "profile_document_version": 6,
             "profile_save_accessible": True,
             "profile_save_succeeded": True,
             "release_notes_url_sha256": hashlib.sha256(release_notes_url.encode()).hexdigest(),

--- a/tests/test_signed_artifact_ui.py
+++ b/tests/test_signed_artifact_ui.py
@@ -48,7 +48,7 @@ class FakeOperations:
             json.dumps(
                 {
                     "main_window_ready": True,
-                    "profile_document_version": 5,
+                    "profile_document_version": 6,
                     "profile_save_accessible": True,
                     "profile_save_succeeded": True,
                     "profiles_after": 1,

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -303,7 +303,7 @@ class FakeOperations(QualificationOperations):
             json.dumps(
                 {
                     "main_window_ready": True,
-                    "profile_document_version": 5,
+                    "profile_document_version": 6,
                     "profile_save_accessible": True,
                     "profile_save_succeeded": True,
                     "profiles_after": 1,


### PR DESCRIPTION
## Summary
- update the installed signed-artifact UI test to follow the Conversion Setup editor and nested Save-as-New profile sheet
- use the sheet's existing accessible `Save` label rather than adding a test-only product identifier
- advance the maintained installed-UI acceptance result from profile document schema 5 to schema 6 while retaining the schema-5 seed, so the lane continues to prove migration

## Release failures addressed
- run `32198633906`: stale Ready-screen `save-profile-action`
- run `32201610972`: stale `save-profile-name-field`
- exact local signed-DMG replay then exposed the downstream normalizer still requiring schema 5 even though Beta 1 migrated and saved schema 6

## Validation
- exact signed draft DMG replay through `scripts.signed_artifact_ui`: passed end-to-end
- focused Python tests: 34 passed
- full Python suite: 1,771 passed, 3 skipped
- native suite from the preceding editor-flow fix: 473 passed

Refs #584
Refs #579