### PR TITLE
Use editor header profile action in installed UI acceptance

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -71,10 +71,10 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         XCTAssertTrue(editAction.isEnabled)
         editAction.click()
 
-        let saveAction = lightApp.buttons["setup-editor-save-as-new"]
+        let saveAction = lightApp.buttons["save-profile-action"]
         XCTAssertTrue(saveAction.waitForExistence(timeout: 20))
         XCTAssertEqual(saveAction.elementType, .button)
-        XCTAssertEqual(saveAction.label, "Save as New Profile…")
+        XCTAssertEqual(saveAction.label, "Save current settings as new profile")
         XCTAssertTrue(saveAction.isEnabled)
 
         saveAction.click()


### PR DESCRIPTION
## Summary
- use the reliable Conversion Setup header profile action in the installed UI acceptance test
- keep the nested profile-name sheet and schema-6 evidence flow unchanged

## Release recovery
- fixes the signed-artifact UI failure from Prerelease run `32204477610`
- follows the proven sequence: open Conversion Setup, click `save-profile-action`, enter `setup-editor-new-profile-name`, then save
- references release plan #584 and Beta plan #579

## Validation
- `uv run python scripts/native_app.py generate`
- `xcodebuild -project BluRayToVisionPro.xcodeproj -scheme BluRayToVisionProInstalledUI -configuration Debug -derivedDataPath build/InstalledUIDerivedData CODE_SIGNING_ALLOWED=NO build-for-testing`
- result: `** TEST BUILD SUCCEEDED **`
