### PR TITLE
Simplify Conversion Setup after Beta 1 feedback

### DIFF
--- a/macos/BluRayToVisionPro/Feature/AppSettings.swift
+++ b/macos/BluRayToVisionPro/Feature/AppSettings.swift
@@ -11,7 +11,6 @@ final class AppSettings: ObservableObject {
         static let showTechnicalDetails = "native.showTechnicalDetails"
         static let keepIntermediateFiles = "native.keepIntermediateFiles"
         static let useSoftwareEncoder = "native.useSoftwareEncoder"
-        static let standardMovieRenameNoticeAcknowledged = "native.standardMovieRenameNoticeAcknowledged"
     }
 
     private let defaults: UserDefaults
@@ -54,8 +53,6 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(useSoftwareEncoder, forKey: Key.useSoftwareEncoder) }
     }
 
-    @Published private(set) var hasAcknowledgedStandardMovieRenameNotice: Bool
-
     init(
         defaults: UserDefaults = .standard,
         homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -75,9 +72,6 @@ final class AppSettings: ObservableObject {
             legacyKeepStageFiles: defaults.object(forKey: Key.keepIntermediateFiles) as? Bool ?? false
         )
         useSoftwareEncoder = defaults.object(forKey: Key.useSoftwareEncoder) as? Bool ?? false
-        hasAcknowledgedStandardMovieRenameNotice = defaults.bool(
-            forKey: Key.standardMovieRenameNoticeAcknowledged
-        )
     }
 
     func resetAdvancedSettings() {
@@ -90,8 +84,4 @@ final class AppSettings: ObservableObject {
         destinationURL = fallbackDestinationURL
     }
 
-    func acknowledgeStandardMovieRenameNotice() {
-        hasAcknowledgedStandardMovieRenameNotice = true
-        defaults.set(true, forKey: Key.standardMovieRenameNoticeAcknowledged)
-    }
 }

--- a/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
+++ b/macos/BluRayToVisionPro/Feature/SetupEditSession.swift
@@ -1,29 +1,5 @@
 import SwiftUI
 
-struct StandardMovieRenameNoticeView: View {
-    @ObservedObject var settings: AppSettings
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Label(StandardMovieRenameNotice.message, systemImage: "info.circle")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 8)
-            Button("Got it") {
-                settings.acknowledgeStandardMovieRenameNotice()
-            }
-            .buttonStyle(.borderless)
-            .accessibilityIdentifier("standard-movie-rename-notice-dismiss")
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(.quaternary.opacity(0.45))
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("standard-movie-rename-notice")
-    }
-}
-
 struct SetupEditSheet: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -73,13 +49,6 @@ struct SetupEditSheet: View {
         profiles.first(where: { $0.id == session.profileID }) ?? initialProfile
     }
 
-    private var nameBinding: Binding<String> {
-        Binding(
-            get: { session.profileName },
-            set: { session.updateName($0) }
-        )
-    }
-
     private var optionsBinding: Binding<ConversionOptions> {
         Binding(
             get: { session.draftOptions },
@@ -96,42 +65,6 @@ struct SetupEditSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(alignment: .firstTextBaseline) {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text("Edit Conversion Settings")
-                            .font(.title2.weight(.semibold))
-                        Text("Based on \(selectedProfile.name)")
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if session.isDirty {
-                        Text("Unsaved changes")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                Text(ProfilePersistenceCopy.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                if selectedProfile.isCustom {
-                    TextField("Profile name", text: nameBinding)
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityIdentifier("edit-profile-name-field")
-                } else {
-                    Label("\(selectedProfile.name) is built in and read-only. Use Save as New Profile… to keep changes as a custom Profile.", systemImage: "lock")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .padding(.horizontal, 20)
-            .padding(.top, 18)
-            .padding(.bottom, 12)
-
             ConversionSetupView(
                 selectedProfileID: selectedProfileBinding,
                 selectedTab: $selectedTab,
@@ -178,7 +111,7 @@ struct SetupEditSheet: View {
             }
             .padding(16)
         }
-        .frame(minWidth: 640, idealWidth: 720, minHeight: 620, idealHeight: 760)
+        .frame(minWidth: 820, idealWidth: 920, minHeight: 680, idealHeight: 800)
         .onExitCommand(perform: requestDismissal)
         .alert(
             "Discard Unsaved Changes?",

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -759,6 +759,14 @@ extension BuiltInProfile {
         switch self {
         case .balanced:
             return EncodingOptions(videoQuality: .balanced)
+        case .smallerFile:
+            return EncodingOptions(
+                videoQuality: VideoQualityIntent(
+                    mode: .ladder,
+                    lastLadderStep: .compact,
+                    custom: .defaults
+                )
+            )
         case .originalResolution:
             let mvHEVC = MVHEVCOptions(
                 generatedMergeQuality: 85,

--- a/macos/BluRayToVisionPro/Models/ConversionOptions.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionOptions.swift
@@ -17,6 +17,28 @@ enum ConversionSetupTab: String, CaseIterable, Identifiable {
             "Files & Recovery"
         }
     }
+
+    var systemImage: String {
+        switch self {
+        case .video:
+            "film"
+        case .audioAndSubtitles:
+            "captions.bubble"
+        case .filesAndRecovery:
+            "folder.badge.gearshape"
+        }
+    }
+
+    var accessibilityIdentifier: String {
+        switch self {
+        case .video:
+            "setup-editor-section-video"
+        case .audioAndSubtitles:
+            "setup-editor-section-audioAndSubtitles"
+        case .filesAndRecovery:
+            "setup-editor-section-filesAndRecovery"
+        }
+    }
 }
 
 enum AudioHandling: String, CaseIterable, Codable, Identifiable {

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum BuiltInProfile: String, CaseIterable, Identifiable {
     case balanced = "builtin.balanced"
+    case smallerFile = "builtin.smaller-file"
     case originalResolution = "builtin.original-resolution"
     case fourKUpscale = "builtin.4k-upscale"
 
@@ -11,6 +12,8 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
         switch self {
         case .balanced:
             "Recommended"
+        case .smallerFile:
+            "Smaller File"
         case .originalResolution:
             "Higher Quality"
         case .fourKUpscale:
@@ -22,6 +25,8 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
         switch self {
         case .balanced:
             "The best starting point for most movies, with source resolution and automatic audio and subtitles."
+        case .smallerFile:
+            "Uses less storage with a modest reduction in fine detail."
         case .originalResolution:
             "More detail at the source resolution, with a slower conversion and larger file."
         case .fourKUpscale:
@@ -33,6 +38,8 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
         switch self {
         case .balanced:
             "slider.horizontal.3"
+        case .smallerFile:
+            "externaldrive.badge.minus"
         case .originalResolution:
             "rectangle.inset.filled"
         case .fourKUpscale:

--- a/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
+++ b/macos/BluRayToVisionPro/Models/ConversionWorkflow.swift
@@ -10,9 +10,9 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
     var name: String {
         switch self {
         case .balanced:
-            "Standard Movie"
+            "Recommended"
         case .originalResolution:
-            "Original Resolution"
+            "Higher Quality"
         case .fourKUpscale:
             "4K Upscale"
         }
@@ -21,11 +21,11 @@ enum BuiltInProfile: String, CaseIterable, Identifiable {
     var summary: String {
         switch self {
         case .balanced:
-            "Source resolution with automatic audio, English audio, and subtitles."
+            "The best starting point for most movies, with source resolution and automatic audio and subtitles."
         case .originalResolution:
-            "Higher quality while preserving the source resolution."
+            "More detail at the source resolution, with a slower conversion and larger file."
         case .fourKUpscale:
-            "Twice the source resolution with quality kept consistent through upscaling."
+            "Upscale the source to 4K for a slower conversion and larger file."
         }
     }
 
@@ -87,10 +87,6 @@ struct EncodingProfile: Identifiable, Equatable {
 
 enum ProfilePersistenceCopy {
     static let summary = "Profiles save video, audio, subtitle, reusable-file, and encoder settings. Restart, overwrite, delete-source, recovery, command-output, sound, and keep-awake choices are not saved."
-}
-
-enum StandardMovieRenameNotice {
-    static let message = "The Balanced profile is now called Standard Movie. Balanced is still a video quality choice. Your saved profiles are unchanged."
 }
 
 enum ReusableFileOutcome: String, CaseIterable, Identifiable {

--- a/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
+++ b/macos/BluRayToVisionPro/Models/SetupQueueAdmission.swift
@@ -54,6 +54,13 @@ struct SetupQueueAdmissionItem: Identifiable, Equatable {
     }
 }
 
+struct SetupQueueAddResult: Equatable {
+    let addedCount: Int
+    let duplicateDisplayNames: [String]
+
+    var duplicateCount: Int { duplicateDisplayNames.count }
+}
+
 @MainActor
 final class SetupQueueAdmission: ObservableObject {
     @Published private(set) var items: [SetupQueueAdmissionItem] = []
@@ -87,15 +94,43 @@ final class SetupQueueAdmission: ObservableObject {
         return items.compactMap(\.currentDraft)
     }
 
-    func add(drafts: [ConversionDraft], conflicts: [RouteQualityConflict?] = []) {
-        guard !drafts.isEmpty else { return }
+    func canAdd(drafts: [ConversionDraft]) -> Bool {
+        guard !drafts.isEmpty else { return false }
+        if items.allSatisfy({ $0.state == .completed || $0.state == .stopped }) {
+            return true
+        }
+        let existingIDs = Set(items.map { ConversionQueueItem.stablePreviewID(for: $0.originalDraft) })
+        return drafts.contains { !existingIDs.contains(ConversionQueueItem.stablePreviewID(for: $0)) }
+    }
+
+    @discardableResult
+    func add(drafts: [ConversionDraft], conflicts: [RouteQualityConflict?] = []) -> SetupQueueAddResult {
+        guard !drafts.isEmpty else {
+            return SetupQueueAddResult(addedCount: 0, duplicateDisplayNames: [])
+        }
         if items.allSatisfy({ $0.state == .completed || $0.state == .stopped }) {
             items.removeAll()
         }
         let suppliedConflicts = conflicts + Array(repeating: nil, count: max(0, drafts.count - conflicts.count))
-        items.append(contentsOf: zip(drafts, suppliedConflicts).map {
-            SetupQueueAdmissionItem(draft: $0.0, conflict: $0.1)
-        })
+        var admittedIDs = Set(items.map { ConversionQueueItem.stablePreviewID(for: $0.originalDraft) })
+        var admittedItems: [SetupQueueAdmissionItem] = []
+        var duplicateDisplayNames: [String] = []
+
+        for (index, draft) in drafts.enumerated() {
+            let identity = ConversionQueueItem.stablePreviewID(for: draft)
+            guard admittedIDs.insert(identity).inserted else {
+                duplicateDisplayNames.append(draft.selectedTitle?.name ?? draft.source.displayName)
+                continue
+            }
+            admittedItems.append(
+                SetupQueueAdmissionItem(draft: draft, conflict: suppliedConflicts[index])
+            )
+        }
+        items.append(contentsOf: admittedItems)
+        return SetupQueueAddResult(
+            addedCount: admittedItems.count,
+            duplicateDisplayNames: duplicateDisplayNames
+        )
     }
 
     func apply(

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -97,9 +97,6 @@ struct ContentView: View {
                 .padding(.vertical, 10)
         }
 
-        if !settings.hasAcknowledgedStandardMovieRenameNotice {
-            StandardMovieRenameNoticeView(settings: settings)
-        }
     }
 
     @ViewBuilder
@@ -415,7 +412,7 @@ struct ContentView: View {
             Divider()
             Button("Open Disc Image…") { chooseFile(.discImage) }
             Button("Open Blu-ray Folder…") { chooseFolder(.bluRayFolder) }
-            Button("Open Source Folder…") { chooseFolder(.sourceFolder) }
+            Button("Add Folder of Movies…") { chooseFolder(.sourceFolder) }
             Button("Open 3D MKV…") { chooseFile(.matroska) }
 
             Divider()

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @State private var isShowingSetupEditor = false
     @State private var newProfileName = ""
     @State private var profileErrorMessage: String?
+    @State private var queueAdmissionNoticeMessage: String?
     @State private var preserveEncodingOnNextProfileChange = false
     @State private var isShowingPreview = false
     @State private var pendingReviewedPreview: PreviewDraft?
@@ -315,6 +316,17 @@ struct ContentView: View {
         } message: {
             Text(profileErrorMessage ?? "The profile could not be saved.")
         }
+        .alert(
+            "Already in Queue",
+            isPresented: Binding(
+                get: { queueAdmissionNoticeMessage != nil },
+                set: { if !$0 { queueAdmissionNoticeMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(queueAdmissionNoticeMessage ?? "This movie is already in the queue.")
+        }
     }
 
     @ViewBuilder
@@ -541,7 +553,7 @@ struct ContentView: View {
             addToQueue: addCurrentDraftsToQueue,
             start: startReadyConversion,
             canPreview: previewCanStart,
-            canAddToQueue: !conversionDrafts.isEmpty && !viewModel.hasActiveWork,
+            canAddToQueue: setupQueue.canAdd(drafts: conversionDrafts) && !viewModel.hasActiveWork,
             canStart: setupQueue.hasItems
                 ? setupQueue.canStart && !viewModel.hasActiveWork
                 : conversionCanStart,
@@ -1173,7 +1185,24 @@ struct ContentView: View {
 
     private func addCurrentDraftsToQueue() {
         guard !conversionDrafts.isEmpty else { return }
-        setupQueue.add(drafts: conversionDrafts)
+        let result = setupQueue.add(drafts: conversionDrafts)
+        queueAdmissionNoticeMessage = queueAdmissionMessage(for: result)
+    }
+
+    private func queueAdmissionMessage(for result: SetupQueueAddResult) -> String? {
+        guard result.duplicateCount > 0 else { return nil }
+
+        let skippedMessage: String
+        if result.duplicateCount == 1 {
+            let name = result.duplicateDisplayNames[0]
+            skippedMessage = "\(name) is already in the queue, so it wasn’t added again."
+        } else {
+            skippedMessage = "\(result.duplicateCount) movies are already in the queue, so they weren’t added again."
+        }
+
+        guard result.addedCount > 0 else { return skippedMessage }
+        let noun = result.addedCount == 1 ? "movie was" : "movies were"
+        return "\(skippedMessage) \(result.addedCount) other \(noun) added."
     }
 
     private func startAdmittedQueue() {

--- a/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
+++ b/macos/BluRayToVisionPro/Views/ConversionSetupView.swift
@@ -106,7 +106,7 @@ struct ConversionSetupView: View {
                 .accessibilityIdentifier("ready-source")
             Divider()
             HStack(alignment: .firstTextBaseline) {
-                Picker("Profile", selection: $selectedProfileID) {
+                Picker("Result", selection: $selectedProfileID) {
                     ForEach(profiles) { profile in
                         Text(profile.name).tag(profile.id)
                     }
@@ -115,7 +115,7 @@ struct ConversionSetupView: View {
                 .disabled(isLocked)
                 .accessibilityIdentifier("ready-profile-picker")
                 Spacer()
-                Button("Edit…", action: openEditor)
+                Button("Advanced Settings…", action: openEditor)
                     .buttonStyle(.bordered)
                     .disabled(isLocked)
                     .accessibilityIdentifier("edit-conversion-settings")
@@ -185,16 +185,16 @@ struct ConversionSetupView: View {
         VStack(spacing: 0) {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Conversion Setup")
+                    Text("Advanced Settings")
                         .font(.title3.weight(.semibold))
-                    Text("These choices apply to the current disc or source.")
+                    Text("Change only what you need for this conversion.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 Spacer()
 
-                Picker("Profile", selection: $selectedProfileID) {
+                Picker("Start with", selection: $selectedProfileID) {
                     ForEach(profiles) { profile in
                         Text(profile.name).tag(profile.id)
                     }
@@ -247,42 +247,62 @@ struct ConversionSetupView: View {
 
             Divider()
 
-            Picker("Conversion settings", selection: $selectedTab) {
-                ForEach(ConversionSetupTab.allCases) { tab in
-                    Text(tab.title).tag(tab)
+            HStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Settings")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.bottom, 2)
+
+                    ForEach(ConversionSetupTab.allCases) { tab in
+                        Button {
+                            selectedTab = tab
+                        } label: {
+                            Label(tab.title, systemImage: tab.systemImage)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 8)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .background(
+                            selectedTab == tab ? Color.accentColor.opacity(0.14) : Color.clear,
+                            in: RoundedRectangle(cornerRadius: 7)
+                        )
+                        .foregroundStyle(selectedTab == tab ? Color.accentColor : Color.primary)
+                        .accessibilityIdentifier(tab.accessibilityIdentifier)
+                    }
+
+                    Spacer()
                 }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal, 18)
-            .padding(.vertical, 12)
-            .disabled(isLocked)
+                .padding(12)
+                .frame(width: 190)
+                .background(.bar)
 
-            Divider()
+                Divider()
 
-            OutcomeSummaryView(options: options)
-                .padding(.horizontal, 18)
-                .padding(.bottom, 12)
-
-            Group {
-                switch selectedTab {
-                case .video:
-                    EncodingOptionsEditor(
-                        options: $options.encoding,
-                        section: .video,
-                        jobOptions: options.job,
-                        routeQualityState: routeQualityState,
-                        conversionOptions: $options,
-                        profile: selectedProfile,
-                        sourceKind: sourceKind,
-                        memoryStore: resolutionMemoryStore,
-                        queueConflictForReview: queueConflictForReview
-                    )
-                case .audioAndSubtitles:
-                    EncodingOptionsEditor(options: $options.encoding, section: .audioAndSubtitles)
-                case .filesAndRecovery:
-                    filesAndRecoveryForm
+                Group {
+                    switch selectedTab {
+                    case .video:
+                        EncodingOptionsEditor(
+                            options: $options.encoding,
+                            section: .video,
+                            jobOptions: options.job,
+                            routeQualityState: routeQualityState,
+                            conversionOptions: $options,
+                            profile: selectedProfile,
+                            sourceKind: sourceKind,
+                            memoryStore: resolutionMemoryStore,
+                            queueConflictForReview: queueConflictForReview
+                        )
+                    case .audioAndSubtitles:
+                        EncodingOptionsEditor(options: $options.encoding, section: .audioAndSubtitles)
+                    case .filesAndRecovery:
+                        filesAndRecoveryForm
+                    }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .disabled(isLocked)
         }
@@ -416,6 +436,9 @@ struct ConversionSetupView: View {
     }
 
     private var profileOutcomeSummary: String {
+        if !profileModified, let builtInProfile = BuiltInProfile(rawValue: selectedProfile.id) {
+            return builtInProfile.summary
+        }
         let reusableSuffix = options.job.intermediatePolicy.createsReusableArtifacts
             ? " · reusable files kept"
             : ""
@@ -438,49 +461,6 @@ struct ConversionSetupView: View {
             return "The selected restart stage does not encode HEVC video."
         }
         return "Use libx265 instead of the default VideoToolbox HEVC encoder."
-    }
-}
-
-private struct OutcomeSummaryView: View {
-    let options: ConversionOptions
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("What you’ll get")
-                .font(.headline)
-            LabeledContent("Finished movie", value: finishedMovieSummary)
-            LabeledContent("Reusable files", value: reusableFilesSummary)
-            LabeledContent("Temporary space", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Additional space while reusable files are kept" : "Removed after success")
-            LabeledContent("Estimated time", value: options.job.intermediatePolicy.createsReusableArtifacts ? "Longer processing" : "Standard processing")
-            LabeledContent("Quality", value: qualitySummary)
-        }
-        .font(.caption)
-        .padding(12)
-        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("What you’ll get")
-        .accessibilityIdentifier("conversion-outcome-summary")
-    }
-
-    private var finishedMovieSummary: String {
-        switch options.encoding.videoOutputMode {
-        case .mvHEVC:
-            "Vision Pro spatial movie"
-        case .av1Stereo:
-            "Stereo movie"
-        }
-    }
-
-    private var qualitySummary: String {
-        options.videoRoutePlan.kind == .existingArtifact
-            ? "Existing video kept"
-            : "\(options.videoRoutePlan.qualityTitle) quality"
-    }
-
-    private var reusableFilesSummary: String {
-        options.job.intermediatePolicy.createsReusableArtifacts
-            ? "Left- and right-eye movies kept"
-            : "None kept"
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -114,10 +114,6 @@ private struct ProfilesSettingsPane: View {
                     .foregroundStyle(.orange)
             }
 
-            if !settings.hasAcknowledgedStandardMovieRenameNotice {
-                StandardMovieRenameNoticeView(settings: settings)
-            }
-
             HSplitView {
                 profileList
                     .frame(minWidth: 220, idealWidth: 240, maxWidth: 280)

--- a/macos/BluRayToVisionPro/Views/SourcePicker.swift
+++ b/macos/BluRayToVisionPro/Views/SourcePicker.swift
@@ -40,11 +40,11 @@ enum SourcePicker {
     @MainActor
     static func chooseFolder(kind: ConversionSourceKind) -> ConversionSource? {
         let panel = NSOpenPanel()
-        panel.title = kind == .bluRayFolder ? "Open a Blu-ray Folder" : "Open a Source Folder"
-        panel.prompt = "Open Folder"
+        panel.title = kind == .bluRayFolder ? "Open a Blu-ray Folder" : "Add a Folder of Movies"
+        panel.prompt = kind == .bluRayFolder ? "Open Folder" : "Add Folder"
         panel.message = kind == .bluRayFolder
             ? "Choose a folder containing a BDMV directory."
-            : "Choose a folder containing disc images, MKV, MTS, or M2TS sources."
+            : "Choose a folder containing ISO disc images, MKV, MTS, or M2TS movies. Each supported movie will be added to the conversion queue."
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false

--- a/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/SourceWorkspaceView.swift
@@ -127,23 +127,32 @@ struct SourceWorkspaceView: View {
 
                 Divider()
 
-                Text("Other Sources")
+                Text("Add a Source")
                     .font(.headline)
 
                 VStack(spacing: 8) {
                     HStack(spacing: 8) {
-                        sourceButton("Open Disc Image…", systemImage: "opticaldiscdrive", action: openDiscImage)
-                        sourceButton("Open Blu-ray Folder…", systemImage: "folder.badge.gearshape", action: openBluRayFolder)
+                        sourceButton("Disc Image…", systemImage: "opticaldiscdrive", action: openDiscImage)
+                        sourceButton("Blu-ray Folder…", systemImage: "folder.badge.gearshape", action: openBluRayFolder)
                     }
                     HStack(spacing: 8) {
-                        sourceButton("Open 3D MKV…", systemImage: "film.stack", action: openMKV)
-                        sourceButton("Open Source Folder…", systemImage: "folder", action: openSourceFolder)
+                        sourceButton("3D MKV…", systemImage: "film.stack", action: openMKV)
+                        sourceButton("MTS or M2TS…", systemImage: "film", action: importTransportStream)
                     }
                 }
 
-                Button("Import MTS or M2TS transport stream…", action: importTransportStream)
-                    .buttonStyle(.link)
-                    .font(.callout)
+                Divider()
+
+                Text("Folder of Movies")
+                    .font(.headline)
+
+                sourceButton("Add Folder of Movies…", systemImage: "folder.badge.plus", action: openSourceFolder)
+                    .controlSize(.large)
+
+                Text("Adds every supported ISO, MKV, MTS, and M2TS movie in the folder to the conversion queue.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(4)
         } label: {

--- a/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
+++ b/macos/BluRayToVisionPro/Views/VideoQualityEditor.swift
@@ -511,9 +511,8 @@ private struct QualitySelectionControl: View {
                     .foregroundStyle(.secondary)
             }
 
-            ViewThatFits(in: .horizontal) {
+            ScrollView(.horizontal, showsIndicators: false) {
                 wideLadder
-                narrowMenu
             }
 
             Button(action: selectCustom) {
@@ -554,7 +553,7 @@ private struct QualitySelectionControl: View {
     }
 
     private var wideLadder: some View {
-        HStack(alignment: .top, spacing: 6) {
+        HStack(alignment: .top, spacing: 5) {
             ForEach(QualityStep.allCases) { step in
                 if availableSteps.contains(step) {
                     Button {
@@ -585,37 +584,6 @@ private struct QualitySelectionControl: View {
             }
         }
         .fixedSize(horizontal: true, vertical: false)
-    }
-
-    private var narrowMenu: some View {
-        Menu {
-            ForEach(QualityStep.allCases) { step in
-                Button {
-                    selectStep(step)
-                } label: {
-                    Text(menuTitle(step))
-                }
-                .disabled(!availableSteps.contains(step))
-            }
-            Divider()
-            Button("Custom", action: selectCustom)
-        } label: {
-            HStack {
-                Text(selectionTitle)
-                    .fontWeight(.medium)
-                Spacer()
-                Text(isCustomSelected ? "Exact settings" : "Guided")
-                    .foregroundStyle(.secondary)
-                Image(systemName: "chevron.up.chevron.down")
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
-        }
-        .menuStyle(.borderlessButton)
-        .accessibilityLabel("Video quality")
-        .accessibilityValue(selectionValue)
     }
 
     private var isCustomSelected: Bool {
@@ -672,9 +640,6 @@ private struct QualitySelectionControl: View {
         return parts.joined(separator: ", ")
     }
 
-    private func menuTitle(_ step: QualityStep) -> String {
-        availableSteps.contains(step) ? step.title : "\(step.title) — Unavailable"
-    }
 }
 
 private struct QualityStepCell: View {
@@ -703,7 +668,7 @@ private struct QualityStepCell: View {
                 .font(.caption2)
                 .foregroundStyle(available ? Color.secondary : Color.secondary.opacity(0.75))
         }
-        .frame(width: 82, height: 84)
+        .frame(width: 72, height: 84)
         .padding(.vertical, 6)
         .background(background, in: RoundedRectangle(cornerRadius: 9))
         .overlay {

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -202,7 +202,7 @@ final class ConversionWorkflowTests: XCTestCase {
             EncodingOptions(audioHandling: .convertAAC, audioBitrate: 448).compactSummary,
             "Direct MV-HEVC when available · Balanced · Adaptive quality 0.70 · source resolution · Audio: AAC 448 kbps, English only · Subtitles: English + others"
         )
-        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("English audio"))
+        XCTAssertTrue(BuiltInProfile.balanced.summary.contains("automatic audio"))
     }
 
     func testVideoRoutePlanCoversDirectGeneratedAV1AndExistingRoutes() {
@@ -713,7 +713,7 @@ final class ConversionWorkflowTests: XCTestCase {
             XCTAssertEqual(queue.items.count, 2)
             for item in queue.items {
                 let draft = try XCTUnwrap(item.draft)
-                XCTAssertEqual(draft.profile.name, "Standard Movie")
+                XCTAssertEqual(draft.profile.name, "Recommended")
                 XCTAssertEqual(draft.destinationURL, destinationURL)
                 XCTAssertEqual(draft.options.encoding.mvHEVC.generatedMergeQuality, 81)
                 XCTAssertEqual(draft.options.encoding.audioLanguages.mode, .preferredOnly)

--- a/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionWorkflowTests.swift
@@ -156,6 +156,9 @@ final class ConversionWorkflowTests: XCTestCase {
 
         XCTAssertEqual(Set(identifiers).count, profiles.count)
         XCTAssertFalse(BuiltInProfile.balanced.options.upscaleEnabled)
+        XCTAssertEqual(BuiltInProfile.smallerFile.id, "builtin.smaller-file")
+        XCTAssertEqual(BuiltInProfile.smallerFile.name, "Smaller File")
+        XCTAssertEqual(BuiltInProfile.smallerFile.options.videoQuality.selectedStep, .compact)
         XCTAssertTrue(BuiltInProfile.fourKUpscale.options.upscaleEnabled)
         XCTAssertTrue(BuiltInProfile.fourKUpscale.options.resolutionOverride.isEmpty)
         XCTAssertEqual(BuiltInProfile.originalResolution.options.mvHEVC.generatedMergeQuality, 85)

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -875,12 +875,12 @@ final class ProfileStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("profiles.json")
         let store = ProfileStore(fileURL: fileURL)
-        _ = try store.createProfile(name: "Standard Movie Copy", options: EncodingOptions())
-        _ = try store.createProfile(name: "Standard Movie Copy 2", options: EncodingOptions())
+        _ = try store.createProfile(name: "Recommended Copy", options: EncodingOptions())
+        _ = try store.createProfile(name: "Recommended Copy 2", options: EncodingOptions())
 
         let identifier = try store.duplicateProfile(BuiltInProfile.balanced.id)
 
-        XCTAssertEqual(store.profile(withID: identifier).name, "Standard Movie Copy 3")
+        XCTAssertEqual(store.profile(withID: identifier).name, "Recommended Copy 3")
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/SetupEditSessionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupEditSessionTests.swift
@@ -143,10 +143,10 @@ final class SetupEditSessionTests: XCTestCase {
         )
     }
 
-    func testStandardMovieKeepsBalancedIdentifierAndNoticeCopy() {
+    func testRecommendedKeepsBalancedIdentifier() {
         XCTAssertEqual(BuiltInProfile.balanced.id, "builtin.balanced")
-        XCTAssertEqual(BuiltInProfile.balanced.name, "Standard Movie")
-        XCTAssertTrue(StandardMovieRenameNotice.message.contains("saved profiles are unchanged"))
+        XCTAssertEqual(BuiltInProfile.balanced.name, "Recommended")
+        XCTAssertEqual(BuiltInProfile.originalResolution.name, "Higher Quality")
     }
 
     func testUIInventoryKeepsReadyActionsAndAdvancedControlsReachable() throws {
@@ -175,7 +175,9 @@ final class SetupEditSessionTests: XCTestCase {
         for marker in [
             "ready-profile-picker",
             "edit-conversion-settings",
-            "conversion-outcome-summary",
+            "setup-editor-section-video",
+            "setup-editor-section-audioAndSubtitles",
+            "setup-editor-section-filesAndRecovery",
             "Audio & Subtitles",
             "Files & Recovery",
             "Start stage",

--- a/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
+++ b/macos/BluRayToVisionProTests/SetupQueueAdmissionTests.swift
@@ -38,9 +38,10 @@ final class SetupQueueAdmissionTests: XCTestCase {
 
     func testOneScopeNeverMutatesAnotherWaitingItemOrRunningSnapshot() throws {
         let draft = makeDraft()
+        let secondDraft = makeDraft(path: "/tmp/Second Movie.mkv")
         let conflict = try conflict(for: draft.options)
         let admission = SetupQueueAdmission()
-        admission.add(drafts: [draft, draft], conflicts: [conflict, conflict])
+        admission.add(drafts: [draft, secondDraft], conflicts: [conflict, conflict])
         let group = try XCTUnwrap(admission.groups.first)
         var selection = QueueResolutionSelection()
         selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable)?.id)
@@ -76,9 +77,10 @@ final class SetupQueueAdmissionTests: XCTestCase {
 
     func testDurableAndRuntimeProjectionPreserveIdentityTraceAndState() throws {
         let draft = makeDraft()
+        let secondDraft = makeDraft(path: "/tmp/Second Movie.mkv")
         let conflict = try conflict(for: draft.options)
         let admission = SetupQueueAdmission()
-        admission.add(drafts: [draft, draft], conflicts: [conflict, conflict])
+        admission.add(drafts: [draft, secondDraft], conflicts: [conflict, conflict])
         let group = try XCTUnwrap(admission.groups.first)
         var selection = QueueResolutionSelection()
         selection.resolutionID = try XCTUnwrap(group.conflict.resolutions.first(where: \.isAvailable)?.id)
@@ -124,14 +126,85 @@ final class SetupQueueAdmissionTests: XCTestCase {
         XCTAssertTrue(admission.items.isEmpty)
     }
 
-    private func makeDraft() -> ConversionDraft {
-        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/tmp/Movie.mkv"))
+    func testDuplicateDraftIsRejectedAcrossAddCalls() {
+        let draft = makeDraft()
+        let admission = SetupQueueAdmission()
+
+        let firstResult = admission.add(drafts: [draft])
+        let duplicateResult = admission.add(drafts: [draft])
+
+        XCTAssertEqual(firstResult, SetupQueueAddResult(addedCount: 1, duplicateDisplayNames: []))
+        XCTAssertEqual(
+            duplicateResult,
+            SetupQueueAddResult(addedCount: 0, duplicateDisplayNames: ["Movie.mkv"])
+        )
+        XCTAssertEqual(admission.items.count, 1)
+        XCTAssertFalse(admission.canAdd(drafts: [draft]))
+    }
+
+    func testDuplicateDraftIsRejectedWithinIncomingBatch() {
+        let draft = makeDraft()
+        let admission = SetupQueueAdmission()
+
+        let result = admission.add(drafts: [draft, draft])
+
+        XCTAssertEqual(result.addedCount, 1)
+        XCTAssertEqual(result.duplicateDisplayNames, ["Movie.mkv"])
+        XCTAssertEqual(admission.items.count, 1)
+    }
+
+    func testDifferentTitlesFromSameSourceCanBothBeAdded() {
+        let firstDraft = makeDraft(selectedTitle: makeTitle(id: "title:1", name: "First Feature"))
+        let secondDraft = makeDraft(selectedTitle: makeTitle(id: "title:2", name: "Second Feature"))
+        let admission = SetupQueueAdmission()
+
+        let result = admission.add(drafts: [firstDraft, secondDraft])
+
+        XCTAssertEqual(result.addedCount, 2)
+        XCTAssertTrue(result.duplicateDisplayNames.isEmpty)
+        XCTAssertEqual(admission.items.count, 2)
+    }
+
+    func testChangedSettingsDoNotPermitDuplicateSourceTitle() {
+        let draft = makeDraft()
+        var changedOptions = draft.options
+        changedOptions.encoding.audioBitrate = 512
+        let changedDraft = makeDraft(options: changedOptions)
+        let admission = SetupQueueAdmission()
+        admission.add(drafts: [draft])
+
+        let result = admission.add(drafts: [changedDraft])
+
+        XCTAssertEqual(result.addedCount, 0)
+        XCTAssertEqual(result.duplicateCount, 1)
+        XCTAssertEqual(admission.items.count, 1)
+    }
+
+    private func makeDraft(
+        path: String = "/tmp/Movie.mkv",
+        options: ConversionOptions = ConversionOptions(),
+        selectedTitle: SourceTitle? = nil
+    ) -> ConversionDraft {
+        let source = ConversionSource(kind: .matroska, url: URL(fileURLWithPath: path))
         return ConversionDraft(
             source: source,
             sourceDetails: nil,
             profile: BuiltInProfile.balanced.profile,
             destinationURL: URL(fileURLWithPath: "/tmp"),
-            options: ConversionOptions()
+            options: options,
+            selectedTitle: selectedTitle
+        )
+    }
+
+    private func makeTitle(id: String, name: String) -> SourceTitle {
+        SourceTitle(
+            id: id,
+            name: name,
+            outputName: name,
+            durationSeconds: 7_200,
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            mainFeature: false
         )
     }
 

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -293,7 +293,9 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertNotIn('.accessibilityLabel("Preferred language:', language_picker)
 
         self.assertIn("Convert a 3D Blu-ray Disc", source_view)
-        self.assertIn("Import MTS or M2TS transport stream", source_view)
+        self.assertIn("MTS or M2TS…", source_view)
+        self.assertIn("Add Folder of Movies…", source_view)
+        self.assertIn("Adds every supported ISO, MKV, MTS, and M2TS movie", source_view)
         self.assertIn('Label("Save current settings as new profile", systemImage: "plus.square.on.square")', setup_view)
         self.assertIn('.accessibilityLabel("Save current settings as new profile")', setup_view)
         self.assertNotIn('Button("Save Current Settings as New Profile…", action: saveAsNewProfile)', setup_view)
@@ -301,7 +303,7 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertIn("state.phase.isRunning || state.phase == .decisionRequired", source_view)
         self.assertLess(
             source_view.index("Convert a 3D Blu-ray Disc"),
-            source_view.index("Import MTS or M2TS transport stream"),
+            source_view.index("MTS or M2TS…"),
         )
         for label in (
             "Video quality",


### PR DESCRIPTION
## Summary
- make folder batch conversion a first-class `Add Folder of Movies…` action
- replace unclear built-in names with `Recommended`, `Higher Quality`, and `4K Upscale` while preserving stable IDs
- remove the obsolete profile-rename notice and the middle `What you’ll get` card
- replace the cramped segmented settings stack with a wider sidebar/detail editor
- shorten source labels and show plain-language result guidance in the main window

## User feedback addressed
- Beta 1 looks bad and remains confusing
- folder-of-movies conversion is not obvious
- `Standard Movie` and `Original Resolution` do not communicate intent
- the profile rename notice is unnecessary internal churn
- the middle outcome pane is redundant
- the settings pane is long and awkward inside the scroll area

## Validation
- `uv run python scripts/native_app.py test` — 473 native tests passed
- `uv run python -m unittest tests.test_native_app tests.test_signed_artifact_ui tests.test_tier3_clean_machine` — 98 tests passed
- live development-app review at 1180×780 for empty-source and Advanced Settings states
- JetBrains changed-files inspection: inconclusive because the IDE could not open the isolated worktree; no inspection run started

Refs #591
Refs #579
