### PR TITLE
Record Beta 2 change-scoped qualification

### DIFF
--- a/docs/qualification/release-evidence-v1.json
+++ b/docs/qualification/release-evidence-v1.json
@@ -401,6 +401,96 @@
       "source": "signed_artifact_receipt",
       "source_sha": "98636e5b7e413b198447954c0d67f6668c10c31e",
       "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "gui-preview-low-local-ample-destination",
+      "receipt_id": "v0.3.2-beta.2:gui-preview-low-local-ample-destination:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "gui-preview-cancel-cleanup",
+      "receipt_id": "v0.3.2-beta.2:gui-preview-cancel-cleanup:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "gui-preview-failure-cleanup",
+      "receipt_id": "v0.3.2-beta.2:gui-preview-failure-cleanup:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "capacity-known-low",
+      "receipt_id": "v0.3.2-beta.2:capacity-known-low:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "capacity-unknown-and-conflicting",
+      "receipt_id": "v0.3.2-beta.2:capacity-unknown-and-conflicting:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "network-generated-final-output",
+      "receipt_id": "v0.3.2-beta.2:network-generated-final-output:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "overwrite-and-conversion-cancel",
+      "receipt_id": "v0.3.2-beta.2:overwrite-and-conversion-cancel:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "malformed-pgs-parser-recovery",
+      "receipt_id": "v0.3.2-beta.2:malformed-pgs-parser-recovery:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
+    },
+    {
+      "accepted_at": "2026-08-19T16:13:41Z",
+      "case_id": "subtitle-partial-output-diagnostics",
+      "receipt_id": "v0.3.2-beta.2:subtitle-partial-output-diagnostics:e24bc4d",
+      "reference": "docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json",
+      "sha256": "bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66",
+      "source": "signed_artifact_receipt",
+      "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324",
+      "status": "accepted"
     }
   ],
   "schema_version": 1

--- a/docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json
+++ b/docs/qualification/v0.3.2-beta.2-change-scoped-evidence-v1.json
@@ -1,0 +1,204 @@
+{
+  "schema_version": 1,
+  "qualification_id": "v0.3.2-beta.2-change-scoped-evidence-v1",
+  "recorded_at": "2026-08-19T16:13:41Z",
+  "source": {
+    "build_version": "164",
+    "package_version": "0.3.2b2",
+    "public_version": "0.3.2-beta.2",
+    "release_tag": "v0.3.2-beta.2",
+    "source_sha": "e24bc4d88aa9fda221b44fde0c065356bb69d324"
+  },
+  "failed_preparation_run": {
+    "run_id": 32274644175,
+    "run_attempt": 1,
+    "conclusion": "failure",
+    "failed_job": "Qualify release preparation",
+    "signing_started": false,
+    "release_identity_created": false
+  },
+  "packaged_candidate": {
+    "app_tree_sha256": "a61ad3626426c0de4812669b2636f7af564b2f25c7002243b8206c09d6c1040d",
+    "architecture": "arm64",
+    "bundle_identifier": "com.shinycomputers.bd-to-avp",
+    "codesign_verification": "passed",
+    "package_command": "BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package",
+    "preview_presentation_smoke": "passed",
+    "signing": "ad_hoc_local",
+    "worker_cancellation_smoke": "passed"
+  },
+  "evidence_source_semantics": {
+    "developer_id_or_notarization_claimed": false,
+    "index_source": "signed_artifact_receipt",
+    "meaning": "Change-scoped evidence from the exact locally packaged, code-signed app tree; production Developer ID signing remains owned by the guarded release run.",
+    "project_precedent": "docs/qualification/v0.3.2-beta.1-change-scoped-evidence-v1.json"
+  },
+  "validation": {
+    "native_tests": {
+      "command": "uv run python scripts/native_app.py test",
+      "failed": 0,
+      "passed": 477
+    },
+    "python_tests": {
+      "command": "uv run python -m unittest discover -s tests -t .",
+      "failed": 0,
+      "passed": 1771,
+      "skipped": 3
+    },
+    "release_focused_tests": {
+      "command": "uv run python -m unittest tests.test_release tests.test_native_app tests.test_sparkle_packaging tests.test_qualify_release_scope",
+      "failed": 0,
+      "passed": 194
+    }
+  },
+  "cases": [
+    {
+      "case_id": "gui-preview-low-local-ample-destination",
+      "observations": {
+        "destination_workspace_selected_for_disc_image_preview": true,
+        "destination_workspace_selected_for_bluray_folder_preview": true,
+        "sufficient_destination_capacity_allows_preview": true
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testDiscImagePreviewUsesSelectedDestinationWorkspace",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testBluRayFolderPreviewUsesSelectedDestinationAndTitle"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "gui-preview-cancel-cleanup",
+      "observations": {
+        "cancelled_preview_removes_partial_workspace": true,
+        "owned_worker_and_descendant_processes_reaped": true,
+        "packaged_worker_cancellation_smoke": "passed"
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCancelledPreviewRemovesPartialWorkspace",
+        "macos/BluRayToVisionProTests/WorkerProcessClientTests.swift:testCancellationAllowsWorkerToReapSeparateSessionChild",
+        "scripts/native_app.py:packaged worker cancellation smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "gui-preview-failure-cleanup",
+      "observations": {
+        "destination_workspace_failure_is_actionable": true,
+        "empty_owned_destination_root_removed": true,
+        "transient_cleanup_failure_retried": true
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testDestinationWorkspacePreparationFailureIsActionable",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testDestinationWorkspaceCleanupRemovesEmptyHiddenRoot",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCleanupRetriesTransientRemovalFailure"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "capacity-known-low",
+      "observations": {
+        "known_low_capacity_blocks_before_worker_launch": true,
+        "partial_workspace_is_not_created": true,
+        "support_diagnostic_evidence_is_available": true
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testKnownLowDestinationCapacityBlocksBeforeWorkerLaunch",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCapacityAssessmentBlocksOnlyTrustworthyLowReading"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "capacity-unknown-and-conflicting",
+      "observations": {
+        "conflicting_capacity_warns_without_blocking": true,
+        "unknown_capacity_warns_without_blocking": true,
+        "worker_launch_remains_available": true
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testUnknownAndConflictingDestinationCapacityWarnWithoutBlocking",
+        "macos/BluRayToVisionProTests/PreviewViewModelTests.swift:testCapacityAssessmentBlocksOnlyTrustworthyLowReading"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "network-generated-final-output",
+      "observations": {
+        "destination_snapshot_preserved_through_queue_execution": true,
+        "generated_mv_hevc_route_resolution_preserved": true,
+        "packaged_worker_and_final_output_regression_suite": "passed"
+      },
+      "proof": [
+        "macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift",
+        "macos/BluRayToVisionProTests/ConversionViewModelTests.swift",
+        "macos/BluRayToVisionProTests/ConversionWorkflowTests.swift",
+        "scripts/native_app.py:packaged worker smoke"
+      ],
+      "scope": {
+        "current_change_review": "The source-first setup and queue duplicate guard preserve destination snapshots, generated-route resolution, and worker output publication boundaries.",
+        "mounted_network_conversion_rerun": false,
+        "prior_real_network_evidence": "docs/qualification/v0.3.1-mkv-audio-handling-v1.json",
+        "qualification_kind": "exact_candidate_change_scoped_regression"
+      },
+      "status": "passed"
+    },
+    {
+      "case_id": "overwrite-and-conversion-cancel",
+      "observations": {
+        "existing_output_rejected_before_workspace_mutation": true,
+        "owned_partial_outputs_removed_after_cancellation": true,
+        "resumed_and_unowned_workspaces_preserved": true,
+        "view_model_stop_transitions_to_stopping": true
+      },
+      "proof": [
+        "tests/test_process_preflight.py:test_existing_output_aborts_before_workspace_mutation",
+        "tests/test_process_preflight.py:test_cancelled_conversion_cleans_owned_workspaces",
+        "tests/test_process_preflight.py:test_cancelled_conversion_preserves_unowned_workspaces",
+        "macos/BluRayToVisionProTests/ConversionViewModelTests.swift:testStopActiveWorkerCancelsConversionAndTransitionsToStopping"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "malformed-pgs-parser-recovery",
+      "observations": {
+        "declared_pixel_bounds_enforced": true,
+        "malformed_display_sets_isolated": true,
+        "truncated_and_unknown_segments_bounded": true,
+        "usable_peer_subtitles_preserved": true
+      },
+      "proof": [
+        "tests/test_subtitles.py",
+        "tests/test_vendor_pgsrip_edge_cases.py",
+        "tests/test_vendor_pgsrip_cli.py"
+      ],
+      "status": "passed"
+    },
+    {
+      "case_id": "subtitle-partial-output-diagnostics",
+      "observations": {
+        "aggregate_track_counts_recorded": true,
+        "cancelled_outcome_distinguished": true,
+        "failed_outcome_distinguished": true,
+        "partial_outcome_distinguished": true,
+        "successful_outcome_distinguished": true
+      },
+      "proof": [
+        "tests/test_subtitles.py",
+        "tests/test_vendor_pgsrip_edge_cases.py",
+        "tests/test_vendor_pgsrip_cli.py"
+      ],
+      "status": "passed"
+    }
+  ],
+  "privacy": {
+    "diagnostic_tokens_recorded": false,
+    "private_hostnames_recorded": false,
+    "private_media_identifiers_recorded": false,
+    "private_paths_recorded": false
+  },
+  "acceptance": {
+    "blocking_case_ids": [],
+    "failed_case_count": 0,
+    "passed": true,
+    "passed_case_count": 9
+  },
+  "result": "accepted_public_safe_summary"
+}


### PR DESCRIPTION
## Summary
- record exact-source change-scoped qualification for the nine Tier 2 cases blocking Prerelease run `32274644175`
- bind every receipt to protected-main preparation SHA `e24bc4d88aa9fda221b44fde0c065356bb69d324` and the evidence document digest
- preserve immutable receipt history with append-only index entries

## Scope boundary
- no product changes
- no Developer ID signing or notarization claim
- the failed run stopped at `Qualify release preparation`; signing never started and no release identity was created
- no claim that a fresh mounted-network conversion was run; the network case uses exact-candidate regression coverage plus prior real-network evidence

## Validation
- `uv run python -m scripts.release_milestone_context --base-sha e24bc4d88aa9fda221b44fde0c065356bb69d324 --head-sha ba5cf7e182a82f22142c87acdf8a7bb6020f5f80 --head-branch qualify/v0.3.2-beta.2 --base-repo cbusillo/BD_to_AVP --head-repo cbusillo/BD_to_AVP --base-branch main --repo-root .`
- 73 focused qualification/context tests passed
- preparation classifier: `passed: true`, `blocking_retests: []`, 9 carried receipts
- evidence digest: `bcc73631e26333a9566c0538178696421a575da07603860c06f3e4965a399e66`

Refs #579
Refs #593