### PR TITLE
Default evidence reruns to checked prior releases

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1283,7 +1283,7 @@ def build_parser() -> argparse.ArgumentParser:
     qualification_base.add_argument("--release-tag", required=True)
     qualification_base.add_argument("--releases-json", type=Path, required=True)
     qualification_base.add_argument("--head-ref", required=True)
-    qualification_base.add_argument("--checked-receipts-root", type=Path)
+    qualification_base.add_argument("--checked-receipts-root", type=Path, default=Path("docs/release-evidence"))
     qualification_base.add_argument("--github-output", type=Path)
 
     prepare = commands.add_parser("prepare", help="Atomically prepare a newer committed release version and build.")

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -987,6 +987,21 @@ class QualificationUpdateBaseTests(unittest.TestCase):
         self.assertEqual(selection.prior_tag, "v1.2.3")
         self.assertEqual(selection.sparkle_route, "beta")
 
+    def test_qualification_base_cli_defaults_to_checked_release_evidence(self) -> None:
+        args = release.build_parser().parse_args(
+            [
+                "qualification-base",
+                "--release-tag",
+                "v1.2.4-beta.2",
+                "--releases-json",
+                "releases.json",
+                "--head-ref",
+                "candidate-head",
+            ]
+        )
+
+        self.assertEqual(args.checked_receipts_root, Path("docs/release-evidence"))
+
     def test_first_prerelease_uses_candidate_route_after_stable(self) -> None:
         selection = release.select_qualification_update_base(
             "v1.2.4-beta.1",


### PR DESCRIPTION
## Summary
- default `scripts.release qualification-base` to checked receipts under `docs/release-evidence`
- preserve the explicit override for tests and alternate repositories
- ensure reruns of the original Release Evidence workflow definition still skip unreconciled prior releases

## Validation
- focused qualification-base tests: 9 passed
- Ruff lint/format and mypy
- live repository selection without the new workflow flag resolves `v0.3.1` with Sparkle route `beta`

Refs #593
