### PR TITLE
Match dynamic milestone run names

### DIFF
--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -533,8 +533,9 @@ def _workflow_runs(client: GitHubAPI, identity: ResumeIdentity) -> tuple[list[Ma
 def _run_matches(run: Mapping[str, Any], identity: ResumeIdentity) -> bool:
     actor = run.get("actor")
     triggering_actor = run.get("triggering_actor")
+    run_name = run.get("name")
     return (
-        run.get("name") == WORKFLOW_NAME
+        run_name in {WORKFLOW_NAME, identity.workflow_display_title}
         and run.get("path") == WORKFLOW_PATH
         and run.get("display_title") == identity.workflow_display_title
         and run.get("event") == "workflow_dispatch"

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -22,6 +22,7 @@ from scripts.release_qualification_resume import (
     _dispatch,
     _require_no_active_exact_runs,
     _revalidate_remote_identity,
+    _run_matches,
     _write_checkpoint,
     resume_qualification,
     safety_error_payload,
@@ -953,6 +954,12 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
             "run-name: Milestone ${{ inputs.candidate_tag }} ${{ inputs.manifest_sha256 }}",
             workflow,
         )
+
+    def test_dynamic_workflow_run_name_matches_the_bound_display_title(self) -> None:
+        run = workflow_run(101, status="completed", conclusion="failure")
+        run["name"] = f"Milestone {RELEASE_TAG} {MANIFEST_SHA}"
+
+        self.assertTrue(_run_matches(run, identity()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- accept GitHub's dynamic `run-name` in the Milestone Qualification exact-run matcher
- retain static workflow-name compatibility for historical runs
- keep path, display title, event, branch, SHA, actor, and triggering-actor identity checks unchanged

## Validation
- `tests.test_release_qualification_resume`: 31 passed
- Ruff lint and format pass
- direct mypy remains blocked by four pre-existing controller protocol/type findings outside this change

Refs #593
