### PR TITLE
Fix Sparkle milestone qualification state races

### DIFF
--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -151,9 +151,11 @@ The maintained clean-machine, Sparkle, and installed UI/accessibility collector 
 synthetic home in a runner-owned disposable location, reuses the installed-app
 package smoke, revalidates the exact prior signed app immediately before an
 identifier-scoped bounded updater state machine, permits one clean retry only
-for classified pre-press environmental startup failures, verifies the final
-candidate identity, and emits checked `clean-machine-signed-update` and
-`installed-ui-accessibility` receipts.
+for classified pre-press environmental startup failures or a guarded state
+change before any action is pressed, detects exact candidate relaunches and
+application-process turnover between UI polls, verifies the final candidate
+identity, and emits checked
+`clean-machine-signed-update` and `installed-ui-accessibility` receipts.
 
 Physical drive, protected-media conversion, and Vision Pro playback evidence
 uses the guided collector and bounded receipt builder documented in

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -132,10 +132,12 @@ The runner performs this bounded sequence:
 5. Durably record each selected action inside the owned qualification root
    before pressing it. Install-on-quit explicitly terminates the prior app,
    waits for the exact candidate on disk, and launches that candidate; staged
-   installs remain bounded until Sparkle exposes the final action or relaunches.
-6. Verify the final candidate bundle, build, signed app tree, and running app,
-   then verify the selected route, unrelated preference, and byte-for-byte profile
-   library are preserved.
+   installs remain bounded until Sparkle exposes the final action or the exact
+   candidate appears on disk with a replacement application process, including
+   relaunches completed between UI polls.
+6. Verify the final candidate bundle, build, signed app tree, and replacement
+   running process, then verify the selected route, unrelated preference, and
+   byte-for-byte profile library are preserved.
 7. Run the candidate installed-app XCUITest lane. It verifies main-window
    readiness, profile-save accessibility and success, updater settings, the
    public releases link, and cropped light/dark app-window screenshots.
@@ -162,10 +164,12 @@ candidate-version fields plus the journal and intent SHA-256 digests. It never
 retains window text, local paths, usernames, hostnames, or raw AX output.
 
 One clean retry is allowed only for a classified pre-press application-start,
-update-menu, or update-window timeout. The first attempt must fully dispose its
-owned root and app process before retry. Cancellation, updater-reported failure,
-unknown UI, identity mismatch, preference/profile drift, action-limit failure,
-and every failure after a press are terminal. No other implicit retry occurs.
+update-menu, update-window timeout, or guarded state-change race where the
+updater changed after durable intent but before any action was pressed. The
+first attempt must fully dispose its owned root and app process before retry.
+Cancellation, updater-reported failure, unknown UI, identity mismatch,
+preference/profile drift, action-limit failure, and every failure after a press
+are terminal. No other implicit retry occurs.
 
 Native Sparkle-window presentation sampling remains visible operational
 evidence but is nonblocking. The state-machine result, exact release-note source,

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -72,6 +72,7 @@ RETRYABLE_UPDATE_FAILURES = frozenset(
     {
         "application-process-timeout",
         "update-menu-timeout",
+        "updater-state-changed",
         "update-window-timeout",
     }
 )
@@ -222,6 +223,7 @@ class UpdateInteraction:
     journal_sha256: str
     attempt: int
     retry_reason_code: str | None
+    prior_process_id: int
 
 
 class QualificationOperations(Protocol):
@@ -268,6 +270,9 @@ class QualificationOperations(Protocol):
         raise NotImplementedError
 
     def app_running(self, app_path: Path | None = None) -> bool:
+        raise NotImplementedError
+
+    def app_process_id(self, app_path: Path | None = None) -> int | None:
         raise NotImplementedError
 
     def quit_app(self) -> None:
@@ -1115,7 +1120,7 @@ class MacOSOperations:
                 raise CleanMachineError("Installed UI candidate release-link evidence is not source-bound.")
 
     @staticmethod
-    def app_running(app_path: Path | None = None) -> bool:
+    def _application_process_ids() -> tuple[int, ...]:
         script = (
             'tell application "System Events" to return unix id of every '
             f'application process whose bundle identifier is "{BUNDLE_IDENTIFIER}"'
@@ -1127,18 +1132,22 @@ class MacOSOperations:
             timeout=COMMAND_TIMEOUT_SECONDS,
         )
         if result.returncode != 0:
-            return False
+            return ()
         output = result.stdout.strip()
         if not output:
-            return False
+            return ()
         try:
-            process_ids = tuple(int(value.strip()) for value in output.split(",") if value.strip())
+            return tuple(int(value.strip()) for value in output.split(",") if value.strip())
         except ValueError:
-            return False
+            return ()
+
+    @classmethod
+    def app_process_id(cls, app_path: Path | None = None) -> int | None:
+        process_ids = cls._application_process_ids()
         if app_path is None:
-            return bool(process_ids)
+            return process_ids[0] if len(process_ids) == 1 else None
         if len(process_ids) != 1:
-            return False
+            return None
         try:
             info = _mapping(
                 plistlib.loads((app_path / "Contents" / "Info.plist").read_bytes()),
@@ -1146,7 +1155,7 @@ class MacOSOperations:
             )
             executable_name = _string(info.get("CFBundleExecutable"), "installed app executable name")
         except (OSError, plistlib.InvalidFileException, CleanMachineError):
-            return False
+            return None
         executable_path = (app_path / "Contents" / "MacOS" / executable_name).resolve()
         process = subprocess.run(
             ["/bin/ps", "-p", str(process_ids[0]), "-o", "command="],
@@ -1155,9 +1164,17 @@ class MacOSOperations:
             timeout=COMMAND_TIMEOUT_SECONDS,
         )
         command = process.stdout.strip()
-        return process.returncode == 0 and (
+        if process.returncode != 0 or not (
             command == str(executable_path) or command.startswith(f"{executable_path} ")
-        )
+        ):
+            return None
+        return process_ids[0]
+
+    @classmethod
+    def app_running(cls, app_path: Path | None = None) -> bool:
+        if app_path is None:
+            return bool(cls._application_process_ids())
+        return cls.app_process_id(app_path) is not None
 
     def quit_app(self) -> None:
         script = f'''tell application "System Events"
@@ -1556,6 +1573,14 @@ def _perform_sparkle_update(
     }
     journal_sha256 = _write_durable_json(checkpoint_path, journal)
     operations.open_updater(app_path, synthetic_home)
+    prior_process_id = operations.app_process_id(app_path)
+    if prior_process_id is None:
+        raise SparkleUpdateFailure(
+            "Sparkle updater did not retain the exact prior application process after opening.",
+            reason_code="application-process-timeout",
+            state=SparkleUpdateState.WAITING_FOR_WINDOW,
+            action_pressed=False,
+        )
 
     deadline = time.monotonic() + GUI_TIMEOUT_SECONDS
     states_observed: list[str] = []
@@ -1588,6 +1613,25 @@ def _perform_sparkle_update(
         )
         return _write_durable_json(checkpoint_path, journal)
 
+    def exact_candidate_installed() -> bool:
+        if not staged_pressed or not app_path.exists():
+            return False
+        try:
+            identity = read_bundle_identity(app_path)
+        except CleanMachineError:
+            return False
+        if (
+            identity.bundle_identifier != BUNDLE_IDENTIFIER
+            or identity.package_version != candidate.package_version
+            or identity.build_version != candidate.build_version
+        ):
+            return False
+        try:
+            verify_installed_app(app_path, candidate)
+        except CleanMachineError:
+            return False
+        return True
+
     while time.monotonic() < deadline:
         observation = operations.observe_updater()
         state = observation.state
@@ -1600,7 +1644,10 @@ def _perform_sparkle_update(
             saw_owned_window = True
 
         if state == SparkleUpdateState.WAITING_FOR_WINDOW:
-            if staged_pressed and not operations.app_running():
+            current_process_id = operations.app_process_id(app_path)
+            if staged_pressed and (
+                current_process_id is None or (current_process_id != prior_process_id and exact_candidate_installed())
+            ):
                 if last_pressed is None:
                     raise AssertionError("staged Sparkle update lost its pressed action")
                 return UpdateInteraction(
@@ -1613,6 +1660,7 @@ def _perform_sparkle_update(
                     journal_sha256=journal_sha256,
                     attempt=attempt,
                     retry_reason_code=retry_reason_code,
+                    prior_process_id=prior_process_id,
                 )
             if saw_owned_window and action_count == 0:
                 cancelled = UpdateObservation(
@@ -1711,7 +1759,7 @@ def _perform_sparkle_update(
                 "Sparkle updater changed after intent was durably recorded; no action was pressed.",
                 reason_code="updater-state-changed",
                 state=observation.state,
-                action_pressed=False,
+                action_pressed=action_count > 0,
             ) from error
         journal_sha256 = record_transition("pressed", observation)
         action_count += 1
@@ -1741,6 +1789,7 @@ def _perform_sparkle_update(
             journal_sha256=journal_sha256,
             attempt=attempt,
             retry_reason_code=retry_reason_code,
+            prior_process_id=prior_process_id,
         )
 
     raise SparkleUpdateFailure(
@@ -1755,6 +1804,7 @@ def _wait_for_candidate(
     app_path: Path,
     candidate: ReleaseArtifact,
     operations: QualificationOperations,
+    prior_process_id: int,
 ) -> BundleIdentity:
     deadline = time.monotonic() + UPDATE_TIMEOUT_SECONDS
     last_error: CleanMachineError | None = None
@@ -1765,7 +1815,8 @@ def _wait_for_candidate(
             except CleanMachineError as error:
                 last_error = error
             else:
-                if operations.app_running(app_path):
+                current_process_id = operations.app_process_id(app_path)
+                if current_process_id is not None and current_process_id != prior_process_id:
                     return identity
         time.sleep(1)
     detail = f" Last identity error: {last_error}" if last_error is not None else ""
@@ -2135,7 +2186,12 @@ def _run_qualification(
             operations.quit_app()
             _wait_for_candidate_on_disk(app_path, candidate)
             operations.launch_app(app_path, synthetic_home)
-        candidate_identity = _wait_for_candidate(app_path, candidate, operations)
+        candidate_identity = _wait_for_candidate(
+            app_path,
+            candidate,
+            operations,
+            interaction.prior_process_id,
+        )
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
         sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
         profile_after_sha256 = file_sha256(profile_path)

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -61,7 +61,10 @@ class FakeOperations(QualificationOperations):
         tamper_prior_before_update: bool = False,
         wrong_running_path: bool = False,
         staged_repeats_after_press: int = 0,
-        press_state_changed: bool = False,
+        press_state_change_failures: int = 0,
+        press_state_change_after_actions: int = 0,
+        staged_relaunches_directly: bool = False,
+        staged_candidate_installed_before_final_action: bool = False,
         oscillate_non_actionable: bool = False,
         sentinel_failure: bool = False,
         tamper_marker: bool = False,
@@ -78,7 +81,10 @@ class FakeOperations(QualificationOperations):
         self.tamper_prior_before_update = tamper_prior_before_update
         self.wrong_running_path = wrong_running_path
         self.staged_repeats_after_press = staged_repeats_after_press
-        self.press_state_changed = press_state_changed
+        self.press_state_change_failures = press_state_change_failures
+        self.press_state_change_after_actions = press_state_change_after_actions
+        self.staged_relaunches_directly = staged_relaunches_directly
+        self.staged_candidate_installed_before_final_action = staged_candidate_installed_before_final_action
         self.oscillate_non_actionable = oscillate_non_actionable
         self.sentinel_failure = sentinel_failure
         self.tamper_marker = tamper_marker
@@ -94,6 +100,8 @@ class FakeOperations(QualificationOperations):
         self.launch_calls = 0
         self.quit_calls = 0
         self.running_app_path: Path | None = None
+        self.running_process_id: int | None = None
+        self.next_process_id = 1000
         self.post_staged_observations = 0
         self.observation_calls = 0
 
@@ -135,6 +143,8 @@ class FakeOperations(QualificationOperations):
         self.launch_calls += 1
         self.running = True
         self.running_app_path = app_path
+        self.running_process_id = self.next_process_id
+        self.next_process_id += 1
 
     def open_updater(self, app_path: Path, synthetic_home: Path) -> None:
         self.launch_app(app_path, synthetic_home)
@@ -212,7 +222,14 @@ class FakeOperations(QualificationOperations):
                 action_identifier="SPUUserUpdateChoiceInstall",
                 action_title="Install Update",
             )
-            if not self.pressed_actions:
+            if self.staged_relaunches_directly and self.pressed_actions:
+                observation = UpdateObservation(
+                    state=SparkleUpdateState.WAITING_FOR_WINDOW,
+                    window_match="none",
+                    action_identifier="",
+                    action_title="",
+                )
+            elif not self.pressed_actions:
                 observation = staged_observation
             elif self.post_staged_observations < self.staged_repeats_after_press:
                 self.post_staged_observations += 1
@@ -248,7 +265,8 @@ class FakeOperations(QualificationOperations):
         checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
         transitions = checkpoint["transitions"]
         self.intent_seen_before_press = bool(transitions and transitions[-1]["phase"] == "intent")
-        if self.press_state_changed:
+        if self.press_state_change_failures > 0 and len(self.pressed_actions) >= self.press_state_change_after_actions:
+            self.press_state_change_failures -= 1
             raise SparkleUpdateFailure(
                 "simulated updater state change",
                 reason_code="updater-state-changed",
@@ -257,6 +275,14 @@ class FakeOperations(QualificationOperations):
             )
         self.pressed_actions.append(observation)
         if observation.state == SparkleUpdateState.STAGED_INSTALL:
+            if self.staged_relaunches_directly or self.staged_candidate_installed_before_final_action:
+                app_path = self.current_app_path
+                shutil.rmtree(app_path)
+                shutil.copytree(self.candidate_source, app_path, symlinks=True)
+                self.running = True
+                self.running_app_path = app_path
+                self.running_process_id = self.next_process_id
+                self.next_process_id += 1
             return
         if self.tamper_marker:
             marker_path = self.current_synthetic_home.parent / ".bd-to-avp-tier3-owned.json"
@@ -266,6 +292,8 @@ class FakeOperations(QualificationOperations):
         shutil.copytree(self.candidate_source, app_path, symlinks=True)
         self.running = True
         self.running_app_path = self.candidate_source if self.wrong_running_path else app_path
+        self.running_process_id = self.next_process_id
+        self.next_process_id += 1
 
     def collect_ui_evidence(
         self,
@@ -366,10 +394,16 @@ class FakeOperations(QualificationOperations):
             return False
         return app_path is None or self.running_app_path == app_path
 
+    def app_process_id(self, app_path: Path | None = None) -> int | None:
+        if not self.app_running(app_path):
+            return None
+        return self.running_process_id
+
     def quit_app(self) -> None:
         self.quit_calls += 1
         self.running = False
         self.running_app_path = None
+        self.running_process_id = None
 
 
 class Tier3CleanMachineTests(unittest.TestCase):
@@ -910,6 +944,42 @@ class Tier3CleanMachineTests(unittest.TestCase):
                 ["staged-install", "installing", "ready-install-relaunch"],
             )
 
+    def test_run_detects_candidate_relaunch_after_staged_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_relaunches_directly = True
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                [observation.state for observation in operations.pressed_actions],
+                [SparkleUpdateState.STAGED_INSTALL],
+            )
+            self.assertEqual(update_evidence["outcome"], "staged")
+            self.assertEqual(
+                update_evidence["states_observed"],
+                ["staged-install", "installing", "waiting-for-window"],
+            )
+
+    def test_run_does_not_skip_visible_final_action_when_candidate_is_on_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_candidate_installed_before_final_action = True
+
+            run_qualification(config, operations)
+
+            self.assertEqual(
+                [observation.state for observation in operations.pressed_actions],
+                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
+            )
+
     def test_run_does_not_press_a_repeated_staged_action(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -953,18 +1023,52 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertEqual(len(operations.pressed_actions), 1)
             self.assertFalse(config.evidence_directory.exists())
 
-    def test_run_fails_closed_when_updater_changes_after_intent_recording(self) -> None:
+    def test_run_retries_when_updater_changes_after_intent_recording(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
-            operations.press_state_changed = True
+            operations.press_state_change_failures = 1
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(operations.update_attempts, 2)
+            self.assertTrue(operations.intent_seen_before_press)
+            self.assertEqual(update_evidence["attempt"], 2)
+            self.assertEqual(update_evidence["retry_reason_code"], "updater-state-changed")
+
+    def test_run_fails_closed_after_repeated_updater_state_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.press_state_change_failures = 2
+
+            with self.assertRaisesRegex(CleanMachineError, "changed after intent"):
+                run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 2)
+            self.assertTrue(operations.intent_seen_before_press)
+            self.assertFalse(operations.pressed_actions)
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_does_not_retry_state_change_after_staged_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.press_state_change_failures = 1
+            operations.press_state_change_after_actions = 1
 
             with self.assertRaisesRegex(CleanMachineError, "changed after intent"):
                 run_qualification(config, operations)
 
             self.assertEqual(operations.update_attempts, 1)
-            self.assertTrue(operations.intent_seen_before_press)
-            self.assertFalse(operations.pressed_actions)
+            self.assertEqual(
+                [observation.state for observation in operations.pressed_actions],
+                [SparkleUpdateState.STAGED_INSTALL],
+            )
             self.assertFalse(config.evidence_directory.exists())
 
     def test_run_classifies_terminal_failure_without_retry(self) -> None:


### PR DESCRIPTION
## Summary
- retry a guarded Sparkle state change only when no updater action has been pressed
- detect exact staged candidate relaunches after the updater window disappears
- require application-process turnover before accepting relaunch evidence
- preserve visible final actions and exact signed app-tree verification

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (34 tests)
- focused release qualification suite (186 tests)
- `uv run ruff check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run mypy scripts/tier3_clean_machine.py`
- independent two-model safety review: no blockers

## Inspection
JetBrains changed-files inspection remains unavailable because IntelliJ is stuck in a stale `already_opening` lifecycle state; the helper returned `UNKNOWN`, not an actionable code finding.

## Release Safety
This does not rebuild, retag, republish, or replace `v0.3.2-beta.2`. It keeps all post-press failures terminal and still requires the exact signed candidate identity.