### PR TITLE
Handle stale staged Sparkle qualification states

### DIFF
--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -134,7 +134,8 @@ The runner performs this bounded sequence:
    waits for the exact candidate on disk, and launches that candidate; staged
    installs remain bounded until Sparkle exposes the final action or the exact
    candidate appears on disk with a replacement application process, including
-   relaunches completed between UI polls.
+   relaunches completed between UI polls while Accessibility still reports a
+   stale downloading, installing, or staged state.
 6. Verify the final candidate bundle, build, signed app tree, and replacement
    running process, then verify the selected route, unrelated preference, and
    byte-for-byte profile library are preserved.
@@ -152,6 +153,11 @@ root and is deleted; public evidence records only its SHA-256 digest. Raw AX
 trees, XCTest logs, `.xcresult` bundles, local paths, and full-screen captures
 are deleted. Retained screenshots contain only the app window. A failed run
 does not emit either accepted receipt.
+
+Timeout failures include only bounded public-safe state context: the final
+state, staged/action counts, process relation, exact-candidate result, and the
+ordered state enum history. They do not retain raw Accessibility output, paths,
+process IDs, usernames, or hostnames.
 
 The updater state machine prefers the Sparkle `SUUpdateAlert` window and
 `SPUUserUpdateChoiceInstall` action identifiers. A title fallback is permitted

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1632,6 +1632,31 @@ def _perform_sparkle_update(
             return False
         return True
 
+    def staged_candidate_replacement_detected() -> bool:
+        current_process_id = operations.app_process_id(app_path)
+        return (
+            staged_pressed
+            and current_process_id is not None
+            and current_process_id != prior_process_id
+            and exact_candidate_installed()
+        )
+
+    def staged_interaction() -> UpdateInteraction:
+        if last_pressed is None:
+            raise AssertionError("staged Sparkle update lost its pressed action")
+        return UpdateInteraction(
+            clicked_button=last_pressed.action_title,
+            outcome=SparkleUpdateOutcome.STAGED,
+            action_identifier=last_pressed.action_identifier,
+            window_match=last_pressed.window_match,
+            states_observed=tuple(states_observed),
+            intent_checkpoint_sha256=intent_checkpoint_sha256,
+            journal_sha256=journal_sha256,
+            attempt=attempt,
+            retry_reason_code=retry_reason_code,
+            prior_process_id=prior_process_id,
+        )
+
     while time.monotonic() < deadline:
         observation = operations.observe_updater()
         state = observation.state
@@ -1645,23 +1670,8 @@ def _perform_sparkle_update(
 
         if state == SparkleUpdateState.WAITING_FOR_WINDOW:
             current_process_id = operations.app_process_id(app_path)
-            if staged_pressed and (
-                current_process_id is None or (current_process_id != prior_process_id and exact_candidate_installed())
-            ):
-                if last_pressed is None:
-                    raise AssertionError("staged Sparkle update lost its pressed action")
-                return UpdateInteraction(
-                    clicked_button=last_pressed.action_title,
-                    outcome=SparkleUpdateOutcome.STAGED,
-                    action_identifier=last_pressed.action_identifier,
-                    window_match=last_pressed.window_match,
-                    states_observed=tuple(states_observed),
-                    intent_checkpoint_sha256=intent_checkpoint_sha256,
-                    journal_sha256=journal_sha256,
-                    attempt=attempt,
-                    retry_reason_code=retry_reason_code,
-                    prior_process_id=prior_process_id,
-                )
+            if staged_pressed and (current_process_id is None or staged_candidate_replacement_detected()):
+                return staged_interaction()
             if saw_owned_window and action_count == 0:
                 cancelled = UpdateObservation(
                     state=SparkleUpdateState.CANCELLED,
@@ -1681,9 +1691,13 @@ def _perform_sparkle_update(
             continue
 
         if state in {SparkleUpdateState.DOWNLOADING, SparkleUpdateState.INSTALLING}:
+            if staged_candidate_replacement_detected():
+                return staged_interaction()
             time.sleep(UPDATE_POLL_SECONDS)
             continue
         if state == SparkleUpdateState.STAGED_INSTALL and staged_pressed:
+            if staged_candidate_replacement_detected():
+                return staged_interaction()
             time.sleep(UPDATE_POLL_SECONDS)
             continue
 
@@ -1792,8 +1806,19 @@ def _perform_sparkle_update(
             prior_process_id=prior_process_id,
         )
 
+    current_process_id = operations.app_process_id(app_path)
+    if current_process_id is None:
+        process_relation = "none"
+    elif current_process_id == prior_process_id:
+        process_relation = "same-prior"
+    else:
+        process_relation = "replacement"
     raise SparkleUpdateFailure(
-        "Sparkle updater did not reach a bounded install state before timeout.",
+        "Sparkle updater did not reach a bounded install state before timeout "
+        f"(last_state={(last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW).value}, "
+        f"staged_pressed={str(staged_pressed).lower()}, action_count={action_count}, "
+        f"process_relation={process_relation}, candidate_exact={str(exact_candidate_installed()).lower()}, "
+        f"states_observed={','.join(states_observed)}).",
         reason_code="update-window-timeout",
         state=last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW,
         action_pressed=action_count > 0,

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -64,6 +64,8 @@ class FakeOperations(QualificationOperations):
         press_state_change_failures: int = 0,
         press_state_change_after_actions: int = 0,
         staged_relaunches_directly: bool = False,
+        staged_relaunch_stays_installing: bool = False,
+        staged_relaunch_repeats_action: bool = False,
         staged_candidate_installed_before_final_action: bool = False,
         oscillate_non_actionable: bool = False,
         sentinel_failure: bool = False,
@@ -84,6 +86,8 @@ class FakeOperations(QualificationOperations):
         self.press_state_change_failures = press_state_change_failures
         self.press_state_change_after_actions = press_state_change_after_actions
         self.staged_relaunches_directly = staged_relaunches_directly
+        self.staged_relaunch_stays_installing = staged_relaunch_stays_installing
+        self.staged_relaunch_repeats_action = staged_relaunch_repeats_action
         self.staged_candidate_installed_before_final_action = staged_candidate_installed_before_final_action
         self.oscillate_non_actionable = oscillate_non_actionable
         self.sentinel_failure = sentinel_failure
@@ -223,12 +227,22 @@ class FakeOperations(QualificationOperations):
                 action_title="Install Update",
             )
             if self.staged_relaunches_directly and self.pressed_actions:
-                observation = UpdateObservation(
-                    state=SparkleUpdateState.WAITING_FOR_WINDOW,
-                    window_match="none",
-                    action_identifier="",
-                    action_title="",
-                )
+                if self.staged_relaunch_stays_installing:
+                    observation = UpdateObservation(
+                        state=SparkleUpdateState.INSTALLING,
+                        window_match="identifier",
+                        action_identifier="SPUUserUpdateChoiceInstall",
+                        action_title="Install Update",
+                    )
+                elif self.staged_relaunch_repeats_action:
+                    observation = staged_observation
+                else:
+                    observation = UpdateObservation(
+                        state=SparkleUpdateState.WAITING_FOR_WINDOW,
+                        window_match="none",
+                        action_identifier="",
+                        action_title="",
+                    )
             elif not self.pressed_actions:
                 observation = staged_observation
             elif self.post_staged_observations < self.staged_repeats_after_press:
@@ -966,6 +980,40 @@ class Tier3CleanMachineTests(unittest.TestCase):
                 ["staged-install", "installing", "waiting-for-window"],
             )
 
+    def test_run_detects_candidate_relaunch_while_updater_stays_installing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_relaunches_directly = True
+            operations.staged_relaunch_stays_installing = True
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertEqual(update_evidence["outcome"], "staged")
+            self.assertEqual(update_evidence["states_observed"], ["staged-install", "installing"])
+
+    def test_run_detects_candidate_relaunch_while_staged_action_repeats(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_relaunches_directly = True
+            operations.staged_relaunch_repeats_action = True
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertEqual(update_evidence["outcome"], "staged")
+            self.assertEqual(update_evidence["states_observed"], ["staged-install", "installing", "staged-install"])
+
     def test_run_does_not_skip_visible_final_action_when_candidate_is_on_disk(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -993,6 +1041,28 @@ class Tier3CleanMachineTests(unittest.TestCase):
                 [observation.state for observation in operations.pressed_actions],
                 [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
             )
+
+    def test_run_reports_bounded_post_press_timeout_context(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_repeats_after_press = 1_000_000
+
+            with (
+                patch("scripts.tier3_clean_machine.GUI_TIMEOUT_SECONDS", 0.01),
+                patch("scripts.tier3_clean_machine.UPDATE_POLL_SECONDS", 0),
+            ):
+                with self.assertRaisesRegex(
+                    CleanMachineError,
+                    "last_state=staged-install, staged_pressed=true, action_count=1, "
+                    "process_relation=same-prior, candidate_exact=false",
+                ):
+                    run_qualification(config, operations)
+
+            self.assertEqual(operations.update_attempts, 1)
+            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertFalse(config.evidence_directory.exists())
 
     def test_run_retries_one_clean_attempt_for_pre_press_environmental_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- accept a staged Sparkle relaunch only after exact signed candidate verification and replacement process turnover, even when Accessibility remains stale at downloading, installing, or staged
- continue pressing visible final install/relaunch actions
- add bounded public-safe timeout context for any remaining post-press stall
- add regression tests and update the clean-machine contract documentation

## Failure Evidence
Fresh-machine milestone runs `32309768771` and `32312177622` both failed after one post-press 20-minute updater loop on exact main/evidence identity. No further retry is being attempted without this repair.

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (37 tests)
- focused release qualification suite (189 tests)
- `uv run ruff check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run mypy scripts/tier3_clean_machine.py`
- independent two-model safety review: no blockers

## Inspection
JetBrains changed-files inspection remains unavailable because IntelliJ is stuck in a stale `already_opening` lifecycle state; the helper returned `UNKNOWN`, not an actionable code finding.

## Safety
Visible `READY_INSTALL_RELAUNCH` and `READY_INSTALL_ON_QUIT` actions are never skipped. Success still requires the exact signed app-tree identity and replacement PID, and every post-press failure remains terminal.