### PR TITLE
Complete staged Sparkle install on quit

### DIFF
--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -135,7 +135,10 @@ The runner performs this bounded sequence:
    installs remain bounded until Sparkle exposes the final action or the exact
    candidate appears on disk with a replacement application process, including
    relaunches completed between UI polls while Accessibility still reports a
-   stale downloading, installing, or staged state.
+   stale downloading, installing, or staged state. If Sparkle closes the updater
+   window after `Install Update` while the exact prior process remains active,
+   the runner gracefully quits that process to trigger the staged installation,
+   waits for the exact candidate on disk, and launches it.
 6. Verify the final candidate bundle, build, signed app tree, and replacement
    running process, then verify the selected route, unrelated preference, and
    byte-for-byte profile library are preserved.
@@ -155,9 +158,9 @@ are deleted. Retained screenshots contain only the app window. A failed run
 does not emit either accepted receipt.
 
 Timeout failures include only bounded public-safe state context: the final
-state, staged/action counts, process relation, exact-candidate result, and the
-ordered state enum history. They do not retain raw Accessibility output, paths,
-process IDs, usernames, or hostnames.
+state, staged/quit/action counts, process relation, exact-candidate result, and
+the ordered state enum history. They do not retain raw Accessibility output,
+paths, process IDs, usernames, or hostnames.
 
 The updater state machine prefers the Sparkle `SUUpdateAlert` window and
 `SPUUserUpdateChoiceInstall` action identifiers. A title fallback is permitted

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1587,6 +1587,7 @@ def _perform_sparkle_update(
     last_recorded_state: SparkleUpdateState | None = None
     saw_owned_window = False
     staged_pressed = False
+    staged_quit_requested = False
     action_count = 0
     last_pressed: UpdateObservation | None = None
     intent_checkpoint_sha256 = ""
@@ -1672,6 +1673,16 @@ def _perform_sparkle_update(
             current_process_id = operations.app_process_id(app_path)
             if staged_pressed and (current_process_id is None or staged_candidate_replacement_detected()):
                 return staged_interaction()
+            if (
+                staged_pressed
+                and not staged_quit_requested
+                and current_process_id == prior_process_id
+                and not exact_candidate_installed()
+            ):
+                journal_sha256 = record_transition("staged-quit", observation)
+                operations.quit_app()
+                staged_quit_requested = True
+                continue
             if saw_owned_window and action_count == 0:
                 cancelled = UpdateObservation(
                     state=SparkleUpdateState.CANCELLED,
@@ -1816,7 +1827,8 @@ def _perform_sparkle_update(
     raise SparkleUpdateFailure(
         "Sparkle updater did not reach a bounded install state before timeout "
         f"(last_state={(last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW).value}, "
-        f"staged_pressed={str(staged_pressed).lower()}, action_count={action_count}, "
+        f"staged_pressed={str(staged_pressed).lower()}, staged_quit_requested={str(staged_quit_requested).lower()}, "
+        f"action_count={action_count}, "
         f"process_relation={process_relation}, candidate_exact={str(exact_candidate_installed()).lower()}, "
         f"states_observed={','.join(states_observed)}).",
         reason_code="update-window-timeout",
@@ -2207,7 +2219,9 @@ def _run_qualification(
             attempt=attempt,
             retry_reason_code=retry_reason_code,
         )
-        if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT:
+        if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT or (
+            interaction.outcome == SparkleUpdateOutcome.STAGED and not operations.app_running(app_path)
+        ):
             operations.quit_app()
             _wait_for_candidate_on_disk(app_path, candidate)
             operations.launch_app(app_path, synthetic_home)

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -66,6 +66,8 @@ class FakeOperations(QualificationOperations):
         staged_relaunches_directly: bool = False,
         staged_relaunch_stays_installing: bool = False,
         staged_relaunch_repeats_action: bool = False,
+        staged_window_closes_after_press: bool = False,
+        staged_installs_on_quit: bool = False,
         staged_candidate_installed_before_final_action: bool = False,
         oscillate_non_actionable: bool = False,
         sentinel_failure: bool = False,
@@ -88,6 +90,8 @@ class FakeOperations(QualificationOperations):
         self.staged_relaunches_directly = staged_relaunches_directly
         self.staged_relaunch_stays_installing = staged_relaunch_stays_installing
         self.staged_relaunch_repeats_action = staged_relaunch_repeats_action
+        self.staged_window_closes_after_press = staged_window_closes_after_press
+        self.staged_installs_on_quit = staged_installs_on_quit
         self.staged_candidate_installed_before_final_action = staged_candidate_installed_before_final_action
         self.oscillate_non_actionable = oscillate_non_actionable
         self.sentinel_failure = sentinel_failure
@@ -108,6 +112,7 @@ class FakeOperations(QualificationOperations):
         self.next_process_id = 1000
         self.post_staged_observations = 0
         self.observation_calls = 0
+        self.staged_quit_triggered = False
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
         return EnvironmentFacts(
@@ -243,6 +248,13 @@ class FakeOperations(QualificationOperations):
                         action_identifier="",
                         action_title="",
                     )
+            elif self.staged_window_closes_after_press and self.pressed_actions:
+                observation = UpdateObservation(
+                    state=SparkleUpdateState.WAITING_FOR_WINDOW,
+                    window_match="none",
+                    action_identifier="",
+                    action_title="",
+                )
             elif not self.pressed_actions:
                 observation = staged_observation
             elif self.post_staged_observations < self.staged_repeats_after_press:
@@ -415,6 +427,17 @@ class FakeOperations(QualificationOperations):
 
     def quit_app(self) -> None:
         self.quit_calls += 1
+        if (
+            self.staged_installs_on_quit
+            and self.pressed_actions
+            and self.pressed_actions[-1].state == SparkleUpdateState.STAGED_INSTALL
+            and not self.staged_quit_triggered
+        ):
+            if self.current_app_path is None:
+                raise AssertionError("fake staged install was quit before the updater opened")
+            shutil.rmtree(self.current_app_path)
+            shutil.copytree(self.candidate_source, self.current_app_path, symlinks=True)
+            self.staged_quit_triggered = True
         self.running = False
         self.running_app_path = None
         self.running_process_id = None
@@ -1014,6 +1037,28 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertEqual(update_evidence["outcome"], "staged")
             self.assertEqual(update_evidence["states_observed"], ["staged-install", "installing", "staged-install"])
 
+    def test_run_quits_prior_app_to_complete_staged_install(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.install_action = "Install Update"
+            operations.staged_window_closes_after_press = True
+            operations.staged_installs_on_quit = True
+
+            run_qualification(config, operations)
+
+            update_evidence = json.loads(
+                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertTrue(operations.staged_quit_triggered)
+            self.assertEqual(operations.launch_calls, 2)
+            self.assertEqual(update_evidence["outcome"], "staged")
+            self.assertEqual(
+                update_evidence["states_observed"],
+                ["staged-install", "installing", "waiting-for-window"],
+            )
+
     def test_run_does_not_skip_visible_final_action_when_candidate_is_on_disk(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -1055,7 +1100,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             ):
                 with self.assertRaisesRegex(
                     CleanMachineError,
-                    "last_state=staged-install, staged_pressed=true, action_count=1, "
+                    "last_state=staged-install, staged_pressed=true, staged_quit_requested=false, action_count=1, "
                     "process_relation=same-prior, candidate_exact=false",
                 ):
                     run_qualification(config, operations)


### PR DESCRIPTION
## Summary
- handle the exact observed Sparkle state where `Install Update` closes its window but leaves the same prior process running
- durably record a staged-quit transition, gracefully quit the prior app, wait for the exact signed candidate on disk, and launch it
- preserve final exact candidate verification and replacement-PID requirements
- add regression coverage and update the clean-machine contract

## Exact Failure Evidence
Milestone run `32316618793` reported:

`last_state=waiting-for-window, staged_pressed=true, action_count=1, process_relation=same-prior, candidate_exact=false`

No generic retry is being used. This PR directly handles that staged-on-quit state.

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (38 tests)
- focused release qualification suite (190 tests)
- `uv run ruff check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run mypy scripts/tier3_clean_machine.py`
- independent two-model safety review: no blockers

## Inspection
JetBrains changed-files inspection is unavailable because the configured IntelliJ inspection plugin/API did not register; the helper returned `UNKNOWN`, not an actionable code finding.

## Safety
The new quit path is reachable only after a staged action was pressed, the updater window disappeared, the same prior PID remains, and the exact candidate is not installed. It then requires the exact signed candidate on disk, launches it, and still requires replacement PID plus final identity verification.