### PR TITLE
Diagnose Sparkle installs in hosted Applications lane

### DIFF
--- a/.github/workflows/milestone-qualification.yml
+++ b/.github/workflows/milestone-qualification.yml
@@ -287,11 +287,12 @@ jobs:
 
       - name: Preflight exact clean-machine qualification
         env:
+          BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           CANDIDATE_TAG: ${{ inputs.candidate_tag }}
         run: |
           set -euo pipefail
           source qualification-inputs/paths.env
-          QUALIFICATION_ROOT="$HOME/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          QUALIFICATION_ROOT="$RUNNER_TEMP/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           test ! -e "$QUALIFICATION_ROOT"
           uv run python -m scripts.tier3_clean_machine preflight \
             --repo evidence \
@@ -301,15 +302,16 @@ jobs:
             --prior-dmg "$PRIOR_DMG" \
             --qualification-root "$QUALIFICATION_ROOT" \
             --route "$ROUTE" \
-            --environment-class restorable-location
+            --environment-class resettable-vm
 
       - name: Run exact clean-machine qualification
         env:
+          BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           CANDIDATE_TAG: ${{ inputs.candidate_tag }}
         run: |
           set -euo pipefail
           source qualification-inputs/paths.env
-          QUALIFICATION_ROOT="$HOME/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          QUALIFICATION_ROOT="$RUNNER_TEMP/Tier3-BD-to-AVP-Qualification-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           uv run python -m scripts.tier3_clean_machine run \
             --repo evidence \
             --candidate-release-receipt "evidence/docs/release-evidence/$CANDIDATE_TAG/release-receipt.json" \
@@ -318,10 +320,11 @@ jobs:
             --prior-dmg "$PRIOR_DMG" \
             --qualification-root "$QUALIFICATION_ROOT" \
             --route "$ROUTE" \
-            --environment-class restorable-location \
+            --environment-class resettable-vm \
             --output-receipt qualification-output/clean-machine-signed-update.json \
             --ui-output-receipt qualification-output/installed-ui-accessibility.json \
-            --evidence-directory qualification-output/clean-machine-signed-update-evidence
+            --evidence-directory qualification-output/clean-machine-signed-update-evidence \
+            --diagnostics-output qualification-output/sparkle-install-diagnostics.json
           uv run python -m scripts.tier3_receipt \
             --case-id clean-machine-signed-update \
             --receipt qualification-output/clean-machine-signed-update.json \
@@ -382,6 +385,15 @@ jobs:
             echo "- Blocking clean-machine receipt: \`$(jq -r .receipt_sha256 qualification-output/clean-machine-signed-update.json)\`"
             echo "- Blocking installed UI receipt: \`$(jq -r .receipt_sha256 qualification-output/installed-ui-accessibility.json)\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain bounded Sparkle installer diagnostics
+        if: ${{ failure() && hashFiles('qualification-output/sparkle-install-diagnostics.json') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: milestone-sparkle-diagnostics-${{ inputs.candidate_tag }}-${{ github.run_attempt }}
+          path: qualification-output/sparkle-install-diagnostics.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Retain exact qualification receipts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -147,10 +147,13 @@ satisfy a blocking assertion. Blocking cases reject failed or skipped index
 entries. Only a passed receipt may be indexed as accepted release evidence.
 
 The maintained clean-machine, Sparkle, and installed UI/accessibility collector is documented in
-[`docs/tier3-clean-machine.md`](tier3-clean-machine.md). It uses an isolated
-synthetic home in a runner-owned disposable location, reuses the installed-app
-package smoke, revalidates the exact prior signed app immediately before an
-identifier-scoped bounded updater state machine, permits one clean retry only
+[`docs/tier3-clean-machine.md`](tier3-clean-machine.md). Its local
+`restorable-location` lane uses an isolated synthetic home in a runner-owned
+location. Its GitHub-hosted `resettable-vm` lane uses the runner's real home and
+normal `/Applications`, with strict hosted-runner, clean-state, exact-bundle
+cleanup, and bounded diagnostic guards. Both reuse the installed-app package
+smoke, revalidate the exact prior signed app immediately before an
+identifier-scoped bounded updater state machine, permit one clean retry only
 for classified pre-press environmental startup failures or a guarded state
 change before any action is pressed, detects exact candidate relaunches and
 application-process turnover between UI polls, verifies the final candidate

--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -8,18 +8,22 @@ environment, or changes the live appcast.
 
 ## Maintained Environment
 
-The first maintained lane is `restorable-location` on Apple Silicon macOS 26.
-The qualification root must not exist before the run and must be a dedicated
-location under the current user's home directory. The runner creates an
-isolated synthetic home with `HOME` and `CFFIXED_USER_HOME`, installs the app
-under that owned root, and deletes the complete root after bounded cleanup.
+Two maintained layouts run on Apple Silicon macOS 26. The local
+`restorable-location` lane requires a dedicated qualification root under the
+current user's home, creates an isolated synthetic home, installs the app under
+that owned root, and deletes the complete root after bounded cleanup. The
+workflow-only `resettable-vm` lane runs on GitHub-hosted macOS, keeps the
+runner's real account home unchanged, installs the signed app in normal
+`/Applications`, and keeps scratch data under `RUNNER_TEMP`. It fails before
+mutation on local or self-hosted machines, when the app destination already
+exists, or when app-owned state is already present in the runner home.
 
 The host must provide:
 
 - macOS 26 on `arm64`;
 - Accessibility control for the terminal or automation host;
-- Xcode with `xcodebuild`, plus `defaults`, `ditto`, `hdiutil`, `open`, and
-  `osascript`;
+- Xcode with `xcodebuild`, plus `defaults`, `ditto`, `hdiutil`, `log`, `open`,
+  and `osascript`;
 - enough free space for both DMGs, two candidate copies, and 2 GiB of working
   headroom;
 - no running production app process; and
@@ -27,8 +31,9 @@ The host must provide:
 
 When the operator workstation is not running the policy-required macOS major
 version, use the owner-dispatched `Milestone Qualification` workflow instead of
-weakening the environment check. The workflow runs the same collector on the
-GitHub-hosted `macos-26` image with read-only repository and Actions access. It
+weakening the environment check. The workflow runs the collector in the
+`resettable-vm` layout on the GitHub-hosted `macos-26` image with read-only
+repository and Actions access. It
 accepts only the canonical `automation/release-evidence-<tag>` branch at its
 exact remote head, rejects non-documentation differences from protected
 `main`, validates the checked qualification manifest by its self digest,
@@ -49,7 +54,12 @@ gh workflow run milestone-qualification.yml \
 
 The successful run uploads the validated signed-artifact UI receipt, both Tier
 3 receipts, normalized evidence, checked manifest digest, evidence branch SHA,
-and a bounded run summary with 30-day retention. Download those outputs,
+and a bounded run summary with 30-day retention. A failed Sparkle installation
+uploads a separate `sparkle-install-diagnostics.json` artifact containing only
+fixed classifications, runtime-layout enums, directory-state enums, process
+state, and installed-build state; it excludes raw unified logs, paths,
+usernames, hostnames, process IDs, Accessibility output, and exception text.
+Download successful outputs,
 validate them again, and add the accepted receipts to the same evidence branch.
 The hosted collector proves the real Sparkle install/relaunch path, exact
 appcast-bound release-notes URL, and installed accessibility semantics. The
@@ -119,9 +129,10 @@ The runner performs this bounded sequence:
 
 1. Install the exact candidate from its DMG, verify bundle and signed app-tree
    identity, and run `scripts/smoke_release_app.py` from the installed copy.
-2. Clear the owned runtime location, install the exact prior release, and seed a
+2. Clear the owned smoke location, install the exact prior release, and seed a
    valid profile library plus route and unrelated preference sentinels in the
-   synthetic home.
+   selected runtime home. The hosted lane uses the real runner home; the local
+   lane uses its synthetic home.
 3. Run the installed-app XCUITest lane against the exact prior app, verifying
    Sparkle controls and the source-bound release-notes URL without installing.
 4. Revalidate the exact prior bundle and signed app tree immediately before
@@ -146,7 +157,10 @@ The runner performs this bounded sequence:
    readiness, profile-save accessibility and success, updater settings, the
    public releases link, and cropped light/dark app-window screenshots.
 8. Quit the app, detach every mounted DMG, verify the cleanup ownership marker,
-   and delete the qualification root with raw XCTest and build output.
+   and delete the qualification root with raw XCTest and build output. The
+   hosted lane additionally removes only the exact verified prior/candidate app
+   and allowlisted app-owned home state. It refuses to delete an unknown or
+   partially replaced bundle and relies on VM teardown for containment.
 9. Emit normalized public-safe evidence and validated receipts for both policy
    cases with `cleanup.status = disposed`.
 

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import plistlib
+import pwd
 import re
 import shutil
 import subprocess
@@ -39,6 +40,9 @@ CLEAN_MACHINE_CASE_ID = "clean-machine-signed-update"
 INSTALLED_UI_CASE_ID = "installed-ui-accessibility"
 APP_NAME = "3D Blu-ray to Vision Pro.app"
 BUNDLE_IDENTIFIER = "com.shinycomputers.bd-to-avp"
+RESTORABLE_LOCATION_ENVIRONMENT_CLASS = "restorable-location"
+RESETTABLE_VM_ENVIRONMENT_CLASS = "resettable-vm"
+SYSTEM_APPLICATIONS_DIRECTORY = Path("/Applications")
 PREFERENCES_DOMAIN = BUNDLE_IDENTIFIER
 UPDATE_ROUTE_KEY = "BDToAVPUpdateChannel"
 SENTINEL_KEY = "BDToAVPTier3Sentinel"
@@ -89,6 +93,7 @@ SYSTEM_TOOL_PATHS = {
     "defaults": Path("/usr/bin/defaults"),
     "ditto": Path("/usr/bin/ditto"),
     "hdiutil": Path("/usr/bin/hdiutil"),
+    "log": Path("/usr/bin/log"),
     "open": Path("/usr/bin/open"),
     "osascript": Path("/usr/bin/osascript"),
     "xcrun": Path("/usr/bin/xcrun"),
@@ -178,6 +183,23 @@ class EnvironmentFacts:
 
 
 @dataclass(frozen=True)
+class RuntimeLayout:
+    app_path: Path
+    home: Path
+    kind: str
+    smoke_home: Path
+
+
+@dataclass(frozen=True)
+class SparkleDiagnosticFacts:
+    cache_root_state: str
+    classifications: tuple[str, ...]
+    home_library_state: str
+    log_event_count: int
+    log_query_status: str
+
+
+@dataclass(frozen=True)
 class FeedCandidate:
     feed_sha256: str
     build_version: str
@@ -202,6 +224,7 @@ class QualificationConfig:
     output_receipt: Path | None = None
     ui_output_receipt: Path | None = None
     evidence_directory: Path | None = None
+    diagnostics_output: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -233,7 +256,7 @@ class QualificationOperations(Protocol):
     def fetch_live_feed(self) -> bytes:
         raise NotImplementedError
 
-    def install_app(self, dmg_path: Path, destination: Path) -> None:
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
         raise NotImplementedError
 
     def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
@@ -276,6 +299,12 @@ class QualificationOperations(Protocol):
         raise NotImplementedError
 
     def quit_app(self) -> None:
+        raise NotImplementedError
+
+    def clear_preferences(self, runtime_home: Path) -> None:
+        raise NotImplementedError
+
+    def collect_sparkle_diagnostics(self, runtime_home: Path) -> SparkleDiagnosticFacts:
         raise NotImplementedError
 
 
@@ -356,6 +385,117 @@ def _write_durable_json(path: Path, value: Mapping[str, Any]) -> str:
 
 def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _uses_real_runner_home(home: Path) -> bool:
+    return home.resolve() == _account_home()
+
+
+def _account_home() -> Path:
+    return Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()
+
+
+def _runtime_layout(config: QualificationConfig) -> RuntimeLayout:
+    qualification_root = config.qualification_root.resolve()
+    smoke_home = qualification_root / "SmokeHome"
+    if config.environment_class == RESTORABLE_LOCATION_ENVIRONMENT_CLASS:
+        return RuntimeLayout(
+            app_path=qualification_root / "Applications" / APP_NAME,
+            home=qualification_root / "Home",
+            kind="owned-root-synthetic-home",
+            smoke_home=smoke_home,
+        )
+    if config.environment_class != RESETTABLE_VM_ENVIRONMENT_CLASS:
+        raise CleanMachineError("This runner does not support the requested qualification environment class.")
+    required_environment = {
+        "BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT": "github-hosted",
+        "CI": "true",
+        "GITHUB_ACTIONS": "true",
+        "RUNNER_OS": "macOS",
+    }
+    if any(os.environ.get(key) != value for key, value in required_environment.items()):
+        raise CleanMachineError("The resettable-vm lane requires an ephemeral GitHub-hosted macOS runner.")
+    environment_home = os.environ.get("HOME")
+    account_home = _account_home()
+    if environment_home is None or Path(environment_home).resolve() != account_home:
+        raise CleanMachineError("The resettable-vm lane requires the runner's unchanged real home directory.")
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp is None:
+        raise CleanMachineError("The resettable-vm lane requires the GitHub runner temporary directory.")
+    try:
+        qualification_root.relative_to(Path(runner_temp).resolve())
+    except ValueError as error:
+        raise CleanMachineError(
+            "The resettable-vm qualification root must be inside the runner temporary directory."
+        ) from error
+    if not SYSTEM_APPLICATIONS_DIRECTORY.is_dir():
+        raise CleanMachineError("The resettable-vm lane requires the normal system Applications directory.")
+    return RuntimeLayout(
+        app_path=SYSTEM_APPLICATIONS_DIRECTORY / APP_NAME,
+        home=account_home,
+        kind="system-applications-real-home",
+        smoke_home=smoke_home,
+    )
+
+
+def _directory_state(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    if not path.is_dir():
+        return "not-directory"
+    return "writable" if os.access(path, os.W_OK | os.X_OK) else "read-only"
+
+
+def _managed_real_home_paths(home: Path) -> tuple[Path, ...]:
+    return (
+        home / "Library" / "Application Support" / "3D Blu-ray to Vision Pro",
+        home / "Library" / "Preferences" / f"{BUNDLE_IDENTIFIER}.plist",
+        home / "Library" / "Caches" / BUNDLE_IDENTIFIER,
+        home / "Library" / "HTTPStorages" / BUNDLE_IDENTIFIER,
+        home / "Library" / "Saved Application State" / f"{BUNDLE_IDENTIFIER}.savedState",
+        home / "Library" / "WebKit" / BUNDLE_IDENTIFIER,
+    )
+
+
+def _remove_managed_real_home_state(home: Path) -> None:
+    for path in _managed_real_home_paths(home):
+        if path.is_symlink():
+            raise CleanMachineError("Refusing to remove symlinked application state from the runner home.")
+        if path.is_dir():
+            shutil.rmtree(path)
+        elif path.exists():
+            path.unlink()
+
+
+def classify_sparkle_log_output(output: str) -> tuple[str, ...]:
+    normalized = output.lower()
+    classifications: set[str] = set()
+    if (
+        "failed to create installation cache directory" in normalized
+        or "failed to create cache directory" in normalized
+    ):
+        classifications.add("installation-cache-create-failed")
+    if "couldn't access its bundle info for app-bound domains" in normalized:
+        classifications.add("app-bound-domain-provenance-failed")
+    if "operation not permitted" in normalized or "permission denied" in normalized:
+        classifications.add("permission-denied")
+    if ("signature" in normalized or "code sign" in normalized) and any(
+        marker in normalized for marker in ("failed", "invalid", "rejected")
+    ):
+        classifications.add("candidate-signature-validation-failed")
+    if any(marker in normalized for marker in ("failed to extract", "extraction failed", "unarchive failed")):
+        classifications.add("archive-extraction-failed")
+    if any(marker in normalized for marker in ("failed to launch installer", "installer launch failed")):
+        classifications.add("installer-launch-failed")
+    if any(marker in normalized for marker in ("failed to replace", "could not replace", "replacement failed")):
+        classifications.add("bundle-replacement-failed")
+    if "install on quit" in normalized:
+        classifications.add("install-on-quit-observed")
+    if not output.strip():
+        classifications.add("no-sparkle-log-events")
+    elif not classifications:
+        classifications.add("unclassified-sparkle-events")
+    return tuple(sorted(classifications))
 
 
 def _parse_update_observation(output: str) -> UpdateObservation:
@@ -637,8 +777,11 @@ def validate_environment(
     environment = _mapping(case.get("environment"), "Tier 3 case environment")
     if facts.environment_class not in set(cast(Sequence[str], environment.get("classes", []))):
         raise CleanMachineError("Qualification environment class is not allowed by policy.")
-    if facts.environment_class != "restorable-location":
-        raise CleanMachineError("This runner currently supports the fully disposable restorable-location lane.")
+    if facts.environment_class not in {
+        RESTORABLE_LOCATION_ENVIRONMENT_CLASS,
+        RESETTABLE_VM_ENVIRONMENT_CLASS,
+    }:
+        raise CleanMachineError("This runner does not support the requested qualification environment class.")
     if facts.architecture not in set(cast(Sequence[str], environment.get("architectures", []))):
         raise CleanMachineError("Qualification architecture is not allowed by policy.")
     try:
@@ -666,7 +809,7 @@ def validate_environment(
 
 
 class MacOSOperations:
-    required_tools = ("defaults", "ditto", "hdiutil", "open", "osascript", "xcrun", "xcodebuild")
+    required_tools = ("defaults", "ditto", "hdiutil", "log", "open", "osascript", "xcrun", "xcodebuild")
 
     @staticmethod
     def _run(
@@ -814,10 +957,11 @@ class MacOSOperations:
             shutil.copyfile(source, output_directory / expected_name)
 
     @staticmethod
-    def _synthetic_env(synthetic_home: Path) -> dict[str, str]:
+    def _runtime_env(synthetic_home: Path) -> dict[str, str]:
         env = dict(os.environ)
-        env["HOME"] = str(synthetic_home)
-        env["CFFIXED_USER_HOME"] = str(synthetic_home)
+        if not _uses_real_runner_home(synthetic_home):
+            env["HOME"] = str(synthetic_home)
+            env["CFFIXED_USER_HOME"] = str(synthetic_home)
         env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
         return env
 
@@ -893,8 +1037,9 @@ class MacOSOperations:
         if failures:
             raise CleanMachineError(f"Unable to detach qualification mounts: {'; '.join(failures)}")
 
-    def install_app(self, dmg_path: Path, destination: Path) -> None:
-        mount_point = destination.parent.parent / "Mount"
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        if destination.exists():
+            raise CleanMachineError("Qualification app destination already exists before DMG installation.")
         if mount_point.exists():
             raise CleanMachineError("Qualification mount point already exists before DMG installation.")
         self._mount_dmg(dmg_path, mount_point)
@@ -908,14 +1053,14 @@ class MacOSOperations:
             if len(candidates) != 1:
                 raise CleanMachineError("Mounted release DMG must contain exactly one production app bundle.")
             if destination.exists():
-                shutil.rmtree(destination)
+                raise CleanMachineError("Qualification app destination appeared before DMG installation.")
             destination.parent.mkdir(parents=True, exist_ok=True)
             self._run(["ditto", str(candidates[0]), str(destination)], timeout=SMOKE_TIMEOUT_SECONDS)
         finally:
             self._detach_mounts([mount_point])
 
     def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
-        env = self._synthetic_env(synthetic_home)
+        env = self._runtime_env(synthetic_home)
         result = subprocess.run(
             [sys.executable, str(REPO_ROOT / "scripts" / "smoke_release_app.py"), "--app-path", str(app_path)],
             capture_output=True,
@@ -931,7 +1076,7 @@ class MacOSOperations:
 
     def write_preferences(self, synthetic_home: Path, route: str) -> None:
         synthetic_home.mkdir(parents=True, exist_ok=True)
-        env = self._synthetic_env(synthetic_home)
+        env = self._runtime_env(synthetic_home)
         self._run(["defaults", "write", PREFERENCES_DOMAIN, UPDATE_ROUTE_KEY, route], env=env)
         self._run(["defaults", "write", PREFERENCES_DOMAIN, SENTINEL_KEY, SENTINEL_VALUE], env=env)
         self._run(
@@ -942,25 +1087,32 @@ class MacOSOperations:
     def read_preference(self, synthetic_home: Path, key: str) -> str:
         result = self._run(
             ["defaults", "read", PREFERENCES_DOMAIN, key],
-            env=self._synthetic_env(synthetic_home),
+            env=self._runtime_env(synthetic_home),
         )
         return result.stdout.strip()
 
-    def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
-        env = self._synthetic_env(synthetic_home)
-        self._run(
-            [
-                "open",
-                "-n",
-                "-F",
-                "--env",
-                f"HOME={synthetic_home}",
-                "--env",
-                f"CFFIXED_USER_HOME={synthetic_home}",
-                str(app_path),
-            ],
-            env=env,
+    def clear_preferences(self, runtime_home: Path) -> None:
+        subprocess.run(
+            [str(SYSTEM_TOOL_PATHS["defaults"]), "delete", PREFERENCES_DOMAIN],
+            capture_output=True,
+            env=self._runtime_env(runtime_home),
+            timeout=COMMAND_TIMEOUT_SECONDS,
         )
+
+    def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
+        env = self._runtime_env(synthetic_home)
+        command = ["open", "-n", "-F"]
+        if not _uses_real_runner_home(synthetic_home):
+            command.extend(
+                [
+                    "--env",
+                    f"HOME={synthetic_home}",
+                    "--env",
+                    f"CFFIXED_USER_HOME={synthetic_home}",
+                ]
+            )
+        command.append(str(app_path))
+        self._run(command, env=env)
 
     def open_updater(self, app_path: Path, synthetic_home: Path) -> None:
         self.launch_app(app_path, synthetic_home)
@@ -1214,6 +1366,43 @@ end tell'''
             time.sleep(0.5)
         if self.app_running():
             raise CleanMachineError("Production app did not terminate during cleanup.")
+
+    def collect_sparkle_diagnostics(self, runtime_home: Path) -> SparkleDiagnosticFacts:
+        predicate = (
+            'subsystem == "org.sparkle-project.Sparkle" OR '
+            'process == "InstallerLauncher" OR process == "Autoupdate" OR process == "Updater"'
+        )
+        result = subprocess.run(
+            [
+                str(SYSTEM_TOOL_PATHS["log"]),
+                "show",
+                "--style",
+                "compact",
+                "--last",
+                "15m",
+                "--predicate",
+                predicate,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        if result.returncode == 0:
+            output = result.stdout[-200_000:]
+            classifications = classify_sparkle_log_output(output)
+            log_query_status = "passed"
+            log_event_count = min(sum(1 for line in output.splitlines() if line.strip()), 10_000)
+        else:
+            classifications = ("log-query-failed",)
+            log_query_status = "failed"
+            log_event_count = 0
+        return SparkleDiagnosticFacts(
+            cache_root_state=_directory_state(runtime_home / "Library" / "Caches"),
+            classifications=classifications,
+            home_library_state=_directory_state(runtime_home / "Library"),
+            log_event_count=log_event_count,
+            log_query_status=log_query_status,
+        )
 
     @staticmethod
     def _updater_open_script() -> str:
@@ -1470,7 +1659,9 @@ def prepare_qualification(
     qualification_root = config.qualification_root.resolve()
     if qualification_root.exists():
         raise CleanMachineError("Qualification root must not exist before the runner starts.")
-    if qualification_root == Path.home().resolve() or Path.home().resolve() not in qualification_root.parents:
+    if config.environment_class == RESTORABLE_LOCATION_ENVIRONMENT_CLASS and (
+        qualification_root == Path.home().resolve() or Path.home().resolve() not in qualification_root.parents
+    ):
         raise CleanMachineError("Qualification root must be a dedicated location inside the current home directory.")
     if config.output_receipt is not None and qualification_root in config.output_receipt.resolve().parents:
         raise CleanMachineError("Output receipt must be outside the disposable qualification root.")
@@ -1484,6 +1675,26 @@ def prepare_qualification(
         raise CleanMachineError("Clean-machine and installed UI receipts must use different output paths.")
     if config.evidence_directory is not None and qualification_root in config.evidence_directory.resolve().parents:
         raise CleanMachineError("Evidence directory must be outside the disposable qualification root.")
+    if config.diagnostics_output is not None and qualification_root in config.diagnostics_output.resolve().parents:
+        raise CleanMachineError("Diagnostics output must be outside the disposable qualification root.")
+    file_output_paths = [
+        path.resolve()
+        for path in (config.output_receipt, config.ui_output_receipt, config.diagnostics_output)
+        if path is not None
+    ]
+    if len(file_output_paths) != len(set(file_output_paths)):
+        raise CleanMachineError("Qualification receipt and diagnostics outputs must use distinct paths.")
+    if config.evidence_directory is not None:
+        evidence_directory = config.evidence_directory.resolve()
+        if any(path == evidence_directory or evidence_directory in path.parents for path in file_output_paths):
+            raise CleanMachineError("Qualification file outputs must be outside the evidence directory.")
+    runtime_layout = _runtime_layout(config)
+    if runtime_layout.app_path.exists():
+        raise CleanMachineError("The qualification app destination must not exist before the runner starts.")
+    if config.environment_class == RESETTABLE_VM_ENVIRONMENT_CLASS and any(
+        path.exists() or path.is_symlink() for path in _managed_real_home_paths(runtime_layout.home)
+    ):
+        raise CleanMachineError("The resettable-vm runner has preexisting managed application state.")
     required_free_bytes = BASE_FREE_SPACE_BYTES + prior.dmg_size + (candidate.dmg_size * 2)
     environment = operations.inspect_environment(qualification_root, config.environment_class)
     validate_environment(environment, clean_machine_case, required_free_bytes=required_free_bytes)
@@ -1502,6 +1713,7 @@ def preflight_report(
     operations: QualificationOperations,
 ) -> Mapping[str, Any]:
     _, _, _, prior, candidate, environment, feed = prepare_qualification(config, operations)
+    runtime_layout = _runtime_layout(config)
     return {
         "candidate": {
             "build_version": candidate.build_version,
@@ -1512,6 +1724,7 @@ def preflight_report(
         },
         "developer_state": {
             "homebrew_present": environment.homebrew_present,
+            "runtime_layout": runtime_layout.kind,
             "runtime_path": "sanitized-system-only",
         },
         "environment": {
@@ -1887,12 +2100,93 @@ def _seed_profile(synthetic_home: Path) -> tuple[Path, str]:
     return profile_path, file_sha256(profile_path)
 
 
-def _reset_runtime_workspace(app_path: Path, synthetic_home: Path) -> None:
+def _reset_runtime_workspace(app_path: Path, synthetic_home: Path, installed_release: ReleaseArtifact) -> None:
     if app_path.exists():
+        verify_installed_app(app_path, installed_release)
         shutil.rmtree(app_path)
     if synthetic_home.exists():
         shutil.rmtree(synthetic_home)
     synthetic_home.mkdir(parents=True)
+
+
+def _diagnostic_app_state(app_path: Path, prior: ReleaseArtifact, candidate: ReleaseArtifact) -> str:
+    if not app_path.exists():
+        return "missing"
+    try:
+        identity = read_bundle_identity(app_path)
+    except CleanMachineError:
+        return "unreadable"
+    if identity.package_version == candidate.package_version and identity.build_version == candidate.build_version:
+        return "candidate"
+    if identity.package_version == prior.package_version and identity.build_version == prior.build_version:
+        return "prior"
+    if identity.bundle_identifier == BUNDLE_IDENTIFIER:
+        return "other-production-build"
+    return "unexpected-bundle"
+
+
+def _record_sparkle_failure_diagnostics(
+    *,
+    config: QualificationConfig,
+    operations: QualificationOperations,
+    runtime_layout: RuntimeLayout,
+    prior: ReleaseArtifact,
+    candidate: ReleaseArtifact,
+    failure_stage: str,
+    reason_code: str,
+) -> str:
+    try:
+        facts = operations.collect_sparkle_diagnostics(runtime_layout.home)
+    except (CleanMachineError, OSError, subprocess.TimeoutExpired):
+        facts = SparkleDiagnosticFacts(
+            cache_root_state="unknown",
+            classifications=("diagnostic-collection-failed",),
+            home_library_state="unknown",
+            log_event_count=0,
+            log_query_status="failed",
+        )
+    payload: Mapping[str, Any] = {
+        "app_state": _diagnostic_app_state(runtime_layout.app_path, prior, candidate),
+        "cache_root_state": facts.cache_root_state,
+        "classifications": list(facts.classifications),
+        "environment_class": config.environment_class,
+        "failure_stage": failure_stage,
+        "home_library_state": facts.home_library_state,
+        "log_event_count": facts.log_event_count,
+        "log_query_status": facts.log_query_status,
+        "process_state": "running" if operations.app_running(runtime_layout.app_path) else "not-running",
+        "reason_code": reason_code,
+        "runtime_layout": runtime_layout.kind,
+        "schema_version": 1,
+        "status": "failed",
+    }
+    if config.diagnostics_output is not None:
+        _write_json(config.diagnostics_output.resolve(), payload)
+    return (
+        "Sparkle diagnostics: "
+        f"stage={failure_stage}, reason={reason_code}, app_state={payload['app_state']}, "
+        f"process_state={payload['process_state']}, home_library={facts.home_library_state}, "
+        f"cache_root={facts.cache_root_state}, log_query={facts.log_query_status}, "
+        f"classifications={','.join(facts.classifications)}."
+    )
+
+
+def _remove_resettable_vm_app(
+    app_path: Path,
+    prior: ReleaseArtifact,
+    candidate: ReleaseArtifact,
+) -> None:
+    if not app_path.exists():
+        return
+    for release in (prior, candidate):
+        try:
+            verify_installed_app(app_path, release)
+        except CleanMachineError:
+            continue
+        break
+    else:
+        raise CleanMachineError("Refusing to remove an unverified bundle from the system Applications directory.")
+    shutil.rmtree(app_path)
 
 
 def _load_ui_json(path: Path, expected_keys: set[str]) -> Mapping[str, Any]:
@@ -2169,8 +2463,9 @@ def _run_qualification(
     )
     started_at = _utc_timestamp()
     qualification_root = config.qualification_root.resolve()
-    synthetic_home = qualification_root / "Home"
-    app_path = qualification_root / "Applications" / APP_NAME
+    runtime_layout = _runtime_layout(config)
+    synthetic_home = runtime_layout.home
+    app_path = runtime_layout.app_path
     log_path = qualification_root / "Logs" / "package-smoke.log"
     raw_ui_directory = qualification_root / "InstalledUIEvidence"
     marker_path = qualification_root / ".bd-to-avp-tier3-owned.json"
@@ -2178,16 +2473,17 @@ def _run_qualification(
     marker = {"owner": "bd-to-avp-tier3-clean-machine", "run_id": str(uuid.uuid4())}
     marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
     try:
-        synthetic_home.mkdir(parents=True)
-        operations.install_app(candidate.dmg_path, app_path)
+        runtime_layout.smoke_home.mkdir(parents=True)
+        operations.install_app(candidate.dmg_path, app_path, qualification_root / "Mount")
         candidate_install_identity = verify_installed_app(app_path, candidate)
-        package_smoke_log_sha256 = operations.smoke_app(app_path, synthetic_home, log_path)
+        package_smoke_log_sha256 = operations.smoke_app(app_path, runtime_layout.smoke_home, log_path)
         operations.quit_app()
         if operations.app_running():
             raise CleanMachineError("Candidate package smoke left the production app running.")
 
-        _reset_runtime_workspace(app_path, synthetic_home)
-        operations.install_app(prior.dmg_path, app_path)
+        _reset_runtime_workspace(app_path, runtime_layout.smoke_home, candidate)
+        synthetic_home.mkdir(parents=True, exist_ok=True)
+        operations.install_app(prior.dmg_path, app_path, qualification_root / "Mount")
         prior_identity = verify_installed_app(app_path, prior)
         profile_path, profile_before_sha256 = _seed_profile(synthetic_home)
         operations.write_preferences(synthetic_home, config.route)
@@ -2208,29 +2504,60 @@ def _run_qualification(
         if operations.app_running():
             raise CleanMachineError("Installed UI updater inspection left the production app running.")
 
-        interaction = _perform_sparkle_update(
-            app_path=app_path,
-            synthetic_home=synthetic_home,
-            prior=prior,
-            candidate=candidate,
-            operations=operations,
-            checkpoint_path=qualification_root / ".bd-to-avp-sparkle-update.json",
-            run_id=marker["run_id"],
-            attempt=attempt,
-            retry_reason_code=retry_reason_code,
-        )
-        if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT or (
-            interaction.outcome == SparkleUpdateOutcome.STAGED and not operations.app_running(app_path)
-        ):
-            operations.quit_app()
-            _wait_for_candidate_on_disk(app_path, candidate)
-            operations.launch_app(app_path, synthetic_home)
-        candidate_identity = _wait_for_candidate(
-            app_path,
-            candidate,
-            operations,
-            interaction.prior_process_id,
-        )
+        failure_stage = "updater-state-machine"
+        try:
+            interaction = _perform_sparkle_update(
+                app_path=app_path,
+                synthetic_home=synthetic_home,
+                prior=prior,
+                candidate=candidate,
+                operations=operations,
+                checkpoint_path=qualification_root / ".bd-to-avp-sparkle-update.json",
+                run_id=marker["run_id"],
+                attempt=attempt,
+                retry_reason_code=retry_reason_code,
+            )
+            if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT or (
+                interaction.outcome == SparkleUpdateOutcome.STAGED and not operations.app_running(app_path)
+            ):
+                failure_stage = "install-on-quit-wait"
+                operations.quit_app()
+                _wait_for_candidate_on_disk(app_path, candidate)
+                operations.launch_app(app_path, synthetic_home)
+            failure_stage = "candidate-relaunch-wait"
+            candidate_identity = _wait_for_candidate(
+                app_path,
+                candidate,
+                operations,
+                interaction.prior_process_id,
+            )
+        except SparkleUpdateFailure as error:
+            diagnostic_summary = _record_sparkle_failure_diagnostics(
+                config=config,
+                operations=operations,
+                runtime_layout=runtime_layout,
+                prior=prior,
+                candidate=candidate,
+                failure_stage=failure_stage,
+                reason_code=error.reason_code,
+            )
+            raise SparkleUpdateFailure(
+                f"{error} {diagnostic_summary}",
+                reason_code=error.reason_code,
+                state=error.state,
+                action_pressed=error.action_pressed,
+            ) from error
+        except (CleanMachineError, OSError, subprocess.TimeoutExpired) as error:
+            diagnostic_summary = _record_sparkle_failure_diagnostics(
+                config=config,
+                operations=operations,
+                runtime_layout=runtime_layout,
+                prior=prior,
+                candidate=candidate,
+                failure_stage=failure_stage,
+                reason_code="post-action-verification-failed",
+            )
+            raise CleanMachineError(f"{error} {diagnostic_summary}") from error
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
         sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
         profile_after_sha256 = file_sha256(profile_path)
@@ -2315,23 +2642,39 @@ def _run_qualification(
         try:
             operations.quit_app()
         finally:
-            if qualification_root.exists():
-                try:
-                    observed_marker = json.loads(marker_path.read_text(encoding="utf-8"))
-                except (OSError, json.JSONDecodeError) as error:
-                    raise CleanMachineError("Qualification cleanup ownership marker is missing or invalid.") from error
-                if observed_marker != marker:
-                    raise CleanMachineError("Qualification cleanup ownership marker changed during the run.")
-                shutil.rmtree(qualification_root)
-            cleanup_status = "disposed"
+            try:
+                if config.environment_class == RESETTABLE_VM_ENVIRONMENT_CLASS:
+                    try:
+                        _remove_resettable_vm_app(app_path, prior, candidate)
+                    finally:
+                        operations.clear_preferences(synthetic_home)
+                        _remove_managed_real_home_state(synthetic_home)
+            finally:
+                if qualification_root.exists():
+                    try:
+                        observed_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+                    except (OSError, json.JSONDecodeError) as error:
+                        raise CleanMachineError(
+                            "Qualification cleanup ownership marker is missing or invalid."
+                        ) from error
+                    if observed_marker != marker:
+                        raise CleanMachineError("Qualification cleanup ownership marker changed during the run.")
+                    shutil.rmtree(qualification_root)
+                cleanup_status = "disposed"
 
-    if operations.app_running() or qualification_root.exists():
-        raise CleanMachineError("Qualification cleanup did not remove the app process and disposable location.")
+    managed_state_exists = config.environment_class == RESETTABLE_VM_ENVIRONMENT_CLASS and any(
+        path.exists() or path.is_symlink() for path in _managed_real_home_paths(synthetic_home)
+    )
+    if operations.app_running() or app_path.exists() or managed_state_exists or qualification_root.exists():
+        raise CleanMachineError("Qualification cleanup did not remove every runner-owned runtime surface.")
     cleanup_digest = _write_json(
         evidence_directory / "cleanup.json",
         {
             "app_running": False,
+            "app_target_exists": False,
+            "managed_home_state_exists": False,
             "qualification_root_exists": False,
+            "runtime_layout": runtime_layout.kind,
             "status": cleanup_status,
         },
     )
@@ -2402,6 +2745,9 @@ def run_qualification(
         if config.evidence_directory is not None and config.evidence_directory.exists():
             shutil.rmtree(config.evidence_directory)
 
+    if config.diagnostics_output is not None and config.diagnostics_output.exists():
+        raise CleanMachineError("Diagnostics output must not already exist.")
+
     retry_reason_code: str | None = None
     for attempt in (1, 2):
         try:
@@ -2413,8 +2759,19 @@ def run_qualification(
             )
         except SparkleUpdateFailure as error:
             remove_partial_outputs()
-            clean_retry_environment = not config.qualification_root.resolve().exists() and not operations.app_running()
+            runtime_layout = _runtime_layout(config)
+            managed_state_exists = config.environment_class == RESETTABLE_VM_ENVIRONMENT_CLASS and any(
+                path.exists() or path.is_symlink() for path in _managed_real_home_paths(runtime_layout.home)
+            )
+            clean_retry_environment = (
+                not config.qualification_root.resolve().exists()
+                and not runtime_layout.app_path.exists()
+                and not managed_state_exists
+                and not operations.app_running()
+            )
             if attempt == 1 and error.retryable and clean_retry_environment:
+                if config.diagnostics_output is not None:
+                    config.diagnostics_output.unlink(missing_ok=True)
                 retry_reason_code = error.reason_code
                 continue
             raise
@@ -2436,11 +2793,16 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--prior-dmg", type=Path, required=True)
         subparser.add_argument("--qualification-root", type=Path, required=True)
         subparser.add_argument("--route", choices=tuple(ROUTE_CHANNELS), required=True)
-        subparser.add_argument("--environment-class", choices=("restorable-location",), required=True)
+        subparser.add_argument(
+            "--environment-class",
+            choices=(RESTORABLE_LOCATION_ENVIRONMENT_CLASS, RESETTABLE_VM_ENVIRONMENT_CLASS),
+            required=True,
+        )
         if command == "run":
             subparser.add_argument("--output-receipt", type=Path, required=True)
             subparser.add_argument("--ui-output-receipt", type=Path, required=True)
             subparser.add_argument("--evidence-directory", type=Path, required=True)
+            subparser.add_argument("--diagnostics-output", type=Path)
     return parser
 
 
@@ -2457,6 +2819,7 @@ def _config_from_args(args: argparse.Namespace) -> QualificationConfig:
         output_receipt=getattr(args, "output_receipt", None),
         ui_output_receipt=getattr(args, "ui_output_receipt", None),
         evidence_directory=getattr(args, "evidence_directory", None),
+        diagnostics_output=getattr(args, "diagnostics_output", None),
     )
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1184,6 +1184,8 @@ fi
         steps = qualify["steps"]
         checkout = steps[0]
         upload = steps[-1]
+        by_name = {step["name"]: step for step in steps}
+        diagnostics_upload = by_name["Retain bounded Sparkle installer diagnostics"]
         workflow_text = str(workflow)
 
         self.assertEqual(
@@ -1214,6 +1216,12 @@ fi
         self.assertIn("scripts.signed_artifact_receipt validate", workflow_text)
         self.assertIn("scripts.tier3_clean_machine preflight", workflow_text)
         self.assertIn("scripts.tier3_clean_machine run", workflow_text)
+        self.assertIn("BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT", workflow_text)
+        self.assertIn("runner.environment", workflow_text)
+        self.assertIn("$RUNNER_TEMP/Tier3-BD-to-AVP-Qualification", workflow_text)
+        self.assertNotIn("$HOME/Tier3-BD-to-AVP-Qualification", workflow_text)
+        self.assertEqual(workflow_text.count("--environment-class resettable-vm"), 2)
+        self.assertIn("--diagnostics-output qualification-output/sparkle-install-diagnostics.json", workflow_text)
         self.assertIn("scripts.tier3_receipt", workflow_text)
         self.assertIn("Blocking automated milestone qualification", workflow_text)
         self.assertIn("Qualification manifest", workflow_text)
@@ -1226,6 +1234,16 @@ fi
         self.assertNotRegex(workflow_text, r"\b(git push|git commit|gh release (upload|edit|delete))\b")
         self.assertRegex(upload["uses"], r"^actions/upload-artifact@[0-9a-f]{40}$")
         self.assertEqual(upload["with"]["retention-days"], "30")
+        self.assertRegex(diagnostics_upload["uses"], r"^actions/upload-artifact@[0-9a-f]{40}$")
+        self.assertEqual(
+            diagnostics_upload["if"],
+            "${{ failure() && hashFiles('qualification-output/sparkle-install-diagnostics.json') != '' }}",
+        )
+        self.assertEqual(
+            diagnostics_upload["with"]["path"],
+            "qualification-output/sparkle-install-diagnostics.json",
+        )
+        self.assertEqual(diagnostics_upload["with"]["retention-days"], "30")
 
         config = load_github_config()
         self.assertIn("Milestone Qualification", config["importantWorkflows"])

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import os
 import platform
 import plistlib
 import shutil
@@ -27,10 +28,14 @@ from scripts.tier3_clean_machine import (
     QualificationOperations,
     RELEASES_URL,
     ReleaseArtifact,
+    RESETTABLE_VM_ENVIRONMENT_CLASS,
+    RuntimeLayout,
+    SparkleDiagnosticFacts,
     SparkleUpdateFailure,
     SparkleUpdateState,
     SPARKLE_INSTALL_ACTIONS,
     UpdateObservation,
+    classify_sparkle_log_output,
     file_sha256,
     parse_feed_candidate,
     preflight_report,
@@ -113,6 +118,7 @@ class FakeOperations(QualificationOperations):
         self.post_staged_observations = 0
         self.observation_calls = 0
         self.staged_quit_triggered = False
+        self.checkpoint_root: Path | None = None
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
         return EnvironmentFacts(
@@ -130,7 +136,8 @@ class FakeOperations(QualificationOperations):
     def fetch_live_feed(self) -> bytes:
         return self.feed_bytes
 
-    def install_app(self, dmg_path: Path, destination: Path) -> None:
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        del mount_point
         shutil.copytree(self.app_sources[dmg_path], destination, symlinks=True)
 
     def smoke_app(self, app_path: Path, synthetic_home: Path, log_path: Path) -> str:
@@ -147,6 +154,10 @@ class FakeOperations(QualificationOperations):
 
     def read_preference(self, synthetic_home: Path, key: str) -> str:
         return self.preferences[key]
+
+    def clear_preferences(self, runtime_home: Path) -> None:
+        del runtime_home
+        self.preferences.clear()
 
     def launch_app(self, app_path: Path, synthetic_home: Path) -> None:
         self.launch_calls += 1
@@ -287,7 +298,8 @@ class FakeOperations(QualificationOperations):
     def press_updater_action(self, observation: UpdateObservation) -> None:
         if self.current_app_path is None or self.current_synthetic_home is None:
             raise AssertionError("fake updater was pressed before it was opened")
-        checkpoint_path = self.current_synthetic_home.parent / ".bd-to-avp-sparkle-update.json"
+        checkpoint_root = self.checkpoint_root or self.current_synthetic_home.parent
+        checkpoint_path = checkpoint_root / ".bd-to-avp-sparkle-update.json"
         checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
         transitions = checkpoint["transitions"]
         self.intent_seen_before_press = bool(transitions and transitions[-1]["phase"] == "intent")
@@ -442,8 +454,96 @@ class FakeOperations(QualificationOperations):
         self.running_app_path = None
         self.running_process_id = None
 
+    def collect_sparkle_diagnostics(self, runtime_home: Path) -> SparkleDiagnosticFacts:
+        del runtime_home
+        return SparkleDiagnosticFacts(
+            cache_root_state="writable",
+            classifications=("installation-cache-create-failed",),
+            home_library_state="writable",
+            log_event_count=1,
+            log_query_status="passed",
+        )
+
 
 class Tier3CleanMachineTests(unittest.TestCase):
+    def test_classify_sparkle_log_output_is_bounded_to_public_categories(self) -> None:
+        output = (
+            "Failed to create installation cache directory: Operation not permitted\n"
+            "Couldn't access its bundle info for app-bound domains"
+        )
+
+        self.assertEqual(
+            classify_sparkle_log_output(output),
+            (
+                "app-bound-domain-provenance-failed",
+                "installation-cache-create-failed",
+                "permission-denied",
+            ),
+        )
+
+    def test_install_app_refuses_to_replace_existing_destination(self) -> None:
+        operations = MacOSOperations()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            destination = root / "Install" / "Applications" / APP_NAME
+            destination.mkdir(parents=True)
+            mount_point = root / "SourceMount"
+            candidate = mount_point / APP_NAME
+            (candidate / "Contents").mkdir(parents=True)
+            (candidate / "Contents" / "Info.plist").write_bytes(
+                plistlib.dumps(
+                    {
+                        "BDToAVPDistributionChannel": "direct",
+                        "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+                        "CFBundleShortVersionString": "1.0",
+                        "CFBundleVersion": "1",
+                        "SUFeedURL": "https://example.test/appcast.xml",
+                    }
+                )
+            )
+            with (
+                patch.object(MacOSOperations, "_mount_dmg", return_value=mount_point),
+                patch.object(MacOSOperations, "_detach_mounts"),
+            ):
+                with self.assertRaisesRegex(CleanMachineError, "destination already exists"):
+                    operations.install_app(root / "release.dmg", destination, root / "Mount")
+
+    def test_install_app_uses_explicit_owned_mount_point(self) -> None:
+        operations = MacOSOperations()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            destination = root / "Applications" / APP_NAME
+            mount_point = root / "Qualification" / "Mount"
+
+            def mount(dmg_path: Path, requested_mount_point: Path) -> Path:
+                del dmg_path
+                self.assertEqual(requested_mount_point, mount_point)
+                candidate = requested_mount_point / APP_NAME
+                (candidate / "Contents").mkdir(parents=True)
+                (candidate / "Contents" / "Info.plist").write_bytes(
+                    plistlib.dumps(
+                        {
+                            "BDToAVPDistributionChannel": "direct",
+                            "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+                            "CFBundleShortVersionString": "1.0",
+                            "CFBundleVersion": "1",
+                            "SUFeedURL": "https://example.test/appcast.xml",
+                        }
+                    )
+                )
+                return requested_mount_point
+
+            with (
+                patch.object(MacOSOperations, "_mount_dmg", side_effect=mount),
+                patch.object(MacOSOperations, "_detach_mounts"),
+                patch.object(
+                    MacOSOperations,
+                    "_run",
+                    return_value=subprocess.CompletedProcess([], 0, "", ""),
+                ),
+            ):
+                operations.install_app(root / "release.dmg", destination, mount_point)
+
     def test_extract_ui_attachments_accepts_xcresult_generated_names(self) -> None:
         operations = MacOSOperations()
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -860,6 +960,119 @@ class Tier3CleanMachineTests(unittest.TestCase):
         self.assertEqual(report["feed"]["route"], "rc")
         self.assertNotIn("hostname", json.dumps(report).lower())
 
+    def test_resettable_vm_preflight_requires_github_hosted_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            runner_temp = root / "RunnerTemp"
+            runner_temp.mkdir()
+            applications = root / "Applications"
+            applications.mkdir()
+            config = replace(
+                config,
+                environment_class=RESETTABLE_VM_ENVIRONMENT_CLASS,
+                qualification_root=runner_temp / "Qualification",
+            )
+            with (
+                patch.dict(os.environ, {"RUNNER_TEMP": str(runner_temp)}, clear=False),
+                patch("scripts.tier3_clean_machine.SYSTEM_APPLICATIONS_DIRECTORY", applications),
+            ):
+                with self.assertRaisesRegex(CleanMachineError, "requires an ephemeral GitHub-hosted"):
+                    preflight_report(config, operations)
+
+    def test_resettable_vm_preflight_uses_real_home_and_system_applications(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            runner_temp = root / "RunnerTemp"
+            runner_temp.mkdir()
+            applications = root / "Applications"
+            applications.mkdir()
+            config = replace(
+                config,
+                environment_class=RESETTABLE_VM_ENVIRONMENT_CLASS,
+                qualification_root=runner_temp / "Qualification",
+            )
+            runner_environment = {
+                "BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT": "github-hosted",
+                "CI": "true",
+                "GITHUB_ACTIONS": "true",
+                "HOME": str(Path.home()),
+                "RUNNER_OS": "macOS",
+                "RUNNER_TEMP": str(runner_temp),
+            }
+            with (
+                patch.dict(os.environ, runner_environment, clear=False),
+                patch("scripts.tier3_clean_machine.SYSTEM_APPLICATIONS_DIRECTORY", applications),
+                patch("scripts.tier3_clean_machine._managed_real_home_paths", return_value=()),
+            ):
+                report = preflight_report(config, operations)
+
+        self.assertEqual(report["environment"]["environment_class"], RESETTABLE_VM_ENVIRONMENT_CLASS)
+        self.assertEqual(report["developer_state"]["runtime_layout"], "system-applications-real-home")
+
+    def test_resettable_vm_preflight_rejects_overridden_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            runner_temp = root / "RunnerTemp"
+            runner_temp.mkdir()
+            applications = root / "Applications"
+            applications.mkdir()
+            config = replace(
+                config,
+                environment_class=RESETTABLE_VM_ENVIRONMENT_CLASS,
+                qualification_root=runner_temp / "Qualification",
+            )
+            runner_environment = {
+                "BD_TO_AVP_TIER3_RUNNER_ENVIRONMENT": "github-hosted",
+                "CI": "true",
+                "GITHUB_ACTIONS": "true",
+                "HOME": str(root / "SyntheticHome"),
+                "RUNNER_OS": "macOS",
+                "RUNNER_TEMP": str(runner_temp),
+            }
+            with (
+                patch.dict(os.environ, runner_environment, clear=False),
+                patch("scripts.tier3_clean_machine.SYSTEM_APPLICATIONS_DIRECTORY", applications),
+            ):
+                with self.assertRaisesRegex(CleanMachineError, "unchanged real home"):
+                    preflight_report(config, operations)
+
+    def test_preflight_rejects_diagnostics_inside_evidence_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            config = replace(config, diagnostics_output=config.evidence_directory / "diagnostics.json")
+
+            with self.assertRaisesRegex(CleanMachineError, "outside the evidence directory"):
+                preflight_report(config, operations)
+
+    def test_resettable_vm_run_preserves_unrelated_home_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            config = replace(config, environment_class=RESETTABLE_VM_ENVIRONMENT_CLASS)
+            operations.checkpoint_root = config.qualification_root
+            runner_home = root / "RunnerHome"
+            runner_home.mkdir()
+            unrelated = runner_home / "unrelated.txt"
+            unrelated.write_text("preserve\n", encoding="utf-8")
+            system_applications = root / "SystemApplications"
+            system_applications.mkdir()
+            layout = RuntimeLayout(
+                app_path=system_applications / APP_NAME,
+                home=runner_home,
+                kind="system-applications-real-home",
+                smoke_home=config.qualification_root / "SmokeHome",
+            )
+            with patch("scripts.tier3_clean_machine._runtime_layout", return_value=layout):
+                run_qualification(config, operations)
+
+            self.assertEqual(unrelated.read_text(encoding="utf-8"), "preserve\n")
+            self.assertFalse(layout.app_path.exists())
+            self.assertFalse(config.qualification_root.exists())
+
     def test_run_emits_valid_receipt_and_disposes_owned_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -1128,6 +1341,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
+            config = replace(config, diagnostics_output=root / "sparkle-install-diagnostics.json")
             operations.install_action = "Install Update"
             operations.post_press_failure = True
 
@@ -1137,6 +1351,11 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertEqual(operations.update_attempts, 1)
             self.assertEqual(len(operations.pressed_actions), 1)
             self.assertFalse(config.evidence_directory.exists())
+            diagnostics = json.loads(config.diagnostics_output.read_text(encoding="utf-8"))
+            self.assertEqual(diagnostics["failure_stage"], "updater-state-machine")
+            self.assertEqual(diagnostics["reason_code"], "updater-script-failure")
+            self.assertEqual(diagnostics["classifications"], ["installation-cache-create-failed"])
+            self.assertNotIn(str(root), json.dumps(diagnostics))
 
     def test_run_retries_when_updater_changes_after_intent_recording(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
Refs #593

## Summary
- run Milestone Qualification as policy-approved `resettable-vm` on GitHub-hosted macOS 26
- use the runner account home and normal `/Applications` with fail-closed clean-state and exact-bundle cleanup guards
- retain bounded classified Sparkle/unified-log diagnostics on installation failure without raw paths, PIDs, usernames, hostnames, or AX output
- keep the existing local `restorable-location` synthetic-home lane

## Validation
- `uv run python -m unittest` across 230 release, receipt, qualification, Tier 3, and workflow tests
- `uv run ruff check` on changed Python files
- `uv run ruff format --check` on changed Python files
- `uv run mypy scripts/tier3_clean_machine.py`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- independent two-model release-safety review; all actionable findings resolved

JetBrains inspection was inconclusive because the selected project route lacks a configured Python SDK; it reported no actionable code finding and its generated `.idea` artifacts were removed.