### PR TITLE
Correct Sparkle install confirmation flow

### DIFF
--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -138,18 +138,19 @@ The runner performs this bounded sequence:
 4. Revalidate the exact prior bundle and signed app tree immediately before
    updater interaction, invoke `Check for Updates…`, and drive Sparkle through
    an explicit bounded state machine. Identifier-scoped observations distinguish
-   downloading, staged install, install-and-relaunch, install-on-quit,
-   cancellation, terminal failure, and unknown states.
+   downloading, install-and-relaunch, install-on-quit, cancellation, terminal
+   failure, and unknown states. Sparkle 2.9.4's initial `Install Update` action
+   begins download/extraction and must not be mistaken for an already-staged
+   install or the final relaunch confirmation.
 5. Durably record each selected action inside the owned qualification root
-   before pressing it. Install-on-quit explicitly terminates the prior app,
-   waits for the exact candidate on disk, and launches that candidate; staged
-   installs remain bounded until Sparkle exposes the final action or the exact
-   candidate appears on disk with a replacement application process, including
-   relaunches completed between UI polls while Accessibility still reports a
-   stale downloading, installing, or staged state. If Sparkle closes the updater
-   window after `Install Update` while the exact prior process remains active,
-   the runner gracefully quits that process to trigger the staged installation,
-   waits for the exact candidate on disk, and launches it.
+   before pressing it. After the initial `Install Update`, tolerate the alert
+   closing while the exact prior app remains running, wait through download and
+   extraction, then require and press Sparkle's
+   `SUStatusInstallAndRelaunch` final action. Only then wait for the exact
+   candidate and replacement process. Install-on-quit explicitly terminates the
+   prior app, waits for the exact candidate on disk, and launches that
+   candidate. The harness never quits the app merely because the initial alert
+   disappeared.
 6. Verify the final candidate bundle, build, signed app tree, and replacement
    running process, then verify the selected route, unrelated preference, and
    byte-for-byte profile library are preserved.
@@ -172,13 +173,14 @@ are deleted. Retained screenshots contain only the app window. A failed run
 does not emit either accepted receipt.
 
 Timeout failures include only bounded public-safe state context: the final
-state, staged/quit/action counts, process relation, exact-candidate result, and
-the ordered state enum history. They do not retain raw Accessibility output,
-paths, process IDs, usernames, or hostnames.
+state, action count, process relation, and ordered state enum history. They do
+not retain raw Accessibility output, paths, process IDs, usernames, or
+hostnames.
 
-The updater state machine prefers the Sparkle `SUUpdateAlert` window and
-`SPUUserUpdateChoiceInstall` action identifiers. A title fallback is permitted
-only inside the single owned updater window and is recorded in evidence. The
+The updater state machine prefers Sparkle's `SUUpdateAlert`,
+`SPUUserUpdateChoiceInstall`, and `SUStatusInstallAndRelaunch` identifiers. A
+title fallback is permitted only inside the single owned updater window and is
+recorded in evidence. The
 selected action, state, exact prior/candidate identities, attempt number, and
 transition history are atomically written and synced before an asynchronous
 press. That journal remains disposable; normalized `sparkle-update.json`

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -63,6 +63,7 @@ UI_TEST_TIMEOUT_SECONDS = 15 * 60
 ACCESSIBILITY_COLLECTOR_FINISH_TIMEOUT_SECONDS = 15
 MAX_UI_SCREENSHOT_BYTES = 20 * 1024 * 1024
 SPARKLE_INSTALL_IDENTIFIER = "SPUUserUpdateChoiceInstall"
+SPARKLE_STATUS_INSTALL_IDENTIFIER = "SUStatusInstallAndRelaunch"
 SPARKLE_INSTALL_ACTIONS = (
     SPARKLE_INSTALL_IDENTIFIER,
     "Install Update",
@@ -127,7 +128,7 @@ class SparkleUpdateFailure(CleanMachineError):
 class SparkleUpdateState(str, enum.Enum):
     WAITING_FOR_WINDOW = "waiting-for-window"
     DOWNLOADING = "downloading"
-    STAGED_INSTALL = "staged-install"
+    READY_INSTALL_UPDATE = "ready-install-update"
     READY_INSTALL_RELAUNCH = "ready-install-relaunch"
     READY_INSTALL_ON_QUIT = "ready-install-on-quit"
     INSTALLING = "installing"
@@ -139,7 +140,6 @@ class SparkleUpdateState(str, enum.Enum):
 class SparkleUpdateOutcome(str, enum.Enum):
     INSTALL_AND_RELAUNCH = "install-and-relaunch"
     INSTALL_ON_QUIT = "install-on-quit"
-    STAGED = "staged"
 
 
 @dataclass(frozen=True)
@@ -1469,7 +1469,9 @@ end run"""
                     repeat with candidateButton in buttons of candidateWindow
                         try
                             set candidateIdentifier to value of attribute "AXIdentifier" of candidateButton
-                            if candidateIdentifier is "SPUUserUpdateChoiceInstall" then
+                            set isInstallChoice to candidateIdentifier is "SPUUserUpdateChoiceInstall"
+                            set isFinalInstallChoice to candidateIdentifier is "SUStatusInstallAndRelaunch"
+                            if isInstallChoice or isFinalInstallChoice then
                                 set end of fallbackWindows to candidateWindow
                                 exit repeat
                             end if
@@ -1501,7 +1503,9 @@ end run"""
             repeat with candidateButton in buttons of targetWindow
                 try
                     set buttonIdentifier to value of attribute "AXIdentifier" of candidateButton
-                    if buttonIdentifier is "SPUUserUpdateChoiceInstall" then
+                    set isInstallChoice to buttonIdentifier is "SPUUserUpdateChoiceInstall"
+                    set isFinalInstallChoice to buttonIdentifier is "SUStatusInstallAndRelaunch"
+                    if isInstallChoice or isFinalInstallChoice then
                         set selectedButton to candidateButton
                         set selectedIdentifier to buttonIdentifier
                         exit repeat
@@ -1529,7 +1533,7 @@ end run"""
                 return "downloading" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
             end if
             if selectedTitle is "Install Update" then
-                return "staged-install" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
+                return "ready-install-update" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
             else if selectedTitle is "Install on Quit" then
                 return "ready-install-on-quit" & tab & windowMatch & tab & selectedIdentifier & tab & selectedTitle
             else if selectedTitle is "Install and Relaunch" then
@@ -1572,7 +1576,9 @@ end run"""
                     repeat with candidateButton in buttons of candidateWindow
                         try
                             set candidateIdentifier to value of attribute "AXIdentifier" of candidateButton
-                            if candidateIdentifier is "SPUUserUpdateChoiceInstall" then
+                            set isInstallChoice to candidateIdentifier is "SPUUserUpdateChoiceInstall"
+                            set isFinalInstallChoice to candidateIdentifier is "SUStatusInstallAndRelaunch"
+                            if isInstallChoice or isFinalInstallChoice then
                                 if targetWindow is not missing value then
                                     error "Updater state changed before the guarded press."
                                 end if
@@ -1799,10 +1805,8 @@ def _perform_sparkle_update(
     states_observed: list[str] = []
     last_recorded_state: SparkleUpdateState | None = None
     saw_owned_window = False
-    staged_pressed = False
-    staged_quit_requested = False
+    install_update_pressed = False
     action_count = 0
-    last_pressed: UpdateObservation | None = None
     intent_checkpoint_sha256 = ""
 
     def record_transition(phase: str, observation: UpdateObservation) -> str:
@@ -1827,50 +1831,6 @@ def _perform_sparkle_update(
         )
         return _write_durable_json(checkpoint_path, journal)
 
-    def exact_candidate_installed() -> bool:
-        if not staged_pressed or not app_path.exists():
-            return False
-        try:
-            identity = read_bundle_identity(app_path)
-        except CleanMachineError:
-            return False
-        if (
-            identity.bundle_identifier != BUNDLE_IDENTIFIER
-            or identity.package_version != candidate.package_version
-            or identity.build_version != candidate.build_version
-        ):
-            return False
-        try:
-            verify_installed_app(app_path, candidate)
-        except CleanMachineError:
-            return False
-        return True
-
-    def staged_candidate_replacement_detected() -> bool:
-        current_process_id = operations.app_process_id(app_path)
-        return (
-            staged_pressed
-            and current_process_id is not None
-            and current_process_id != prior_process_id
-            and exact_candidate_installed()
-        )
-
-    def staged_interaction() -> UpdateInteraction:
-        if last_pressed is None:
-            raise AssertionError("staged Sparkle update lost its pressed action")
-        return UpdateInteraction(
-            clicked_button=last_pressed.action_title,
-            outcome=SparkleUpdateOutcome.STAGED,
-            action_identifier=last_pressed.action_identifier,
-            window_match=last_pressed.window_match,
-            states_observed=tuple(states_observed),
-            intent_checkpoint_sha256=intent_checkpoint_sha256,
-            journal_sha256=journal_sha256,
-            attempt=attempt,
-            retry_reason_code=retry_reason_code,
-            prior_process_id=prior_process_id,
-        )
-
     while time.monotonic() < deadline:
         observation = operations.observe_updater()
         state = observation.state
@@ -1883,18 +1843,15 @@ def _perform_sparkle_update(
             saw_owned_window = True
 
         if state == SparkleUpdateState.WAITING_FOR_WINDOW:
-            current_process_id = operations.app_process_id(app_path)
-            if staged_pressed and (current_process_id is None or staged_candidate_replacement_detected()):
-                return staged_interaction()
-            if (
-                staged_pressed
-                and not staged_quit_requested
-                and current_process_id == prior_process_id
-                and not exact_candidate_installed()
-            ):
-                journal_sha256 = record_transition("staged-quit", observation)
-                operations.quit_app()
-                staged_quit_requested = True
+            if install_update_pressed:
+                if operations.app_process_id(app_path) is None:
+                    raise SparkleUpdateFailure(
+                        "The prior application terminated before Sparkle exposed the final install action.",
+                        reason_code="application-terminated-before-install-ready",
+                        state=state,
+                        action_pressed=True,
+                    )
+                time.sleep(UPDATE_POLL_SECONDS)
                 continue
             if saw_owned_window and action_count == 0:
                 cancelled = UpdateObservation(
@@ -1915,13 +1872,9 @@ def _perform_sparkle_update(
             continue
 
         if state in {SparkleUpdateState.DOWNLOADING, SparkleUpdateState.INSTALLING}:
-            if staged_candidate_replacement_detected():
-                return staged_interaction()
             time.sleep(UPDATE_POLL_SECONDS)
             continue
-        if state == SparkleUpdateState.STAGED_INSTALL and staged_pressed:
-            if staged_candidate_replacement_detected():
-                return staged_interaction()
+        if state == SparkleUpdateState.READY_INSTALL_UPDATE and install_update_pressed:
             time.sleep(UPDATE_POLL_SECONDS)
             continue
 
@@ -1950,8 +1903,8 @@ def _perform_sparkle_update(
                 action_pressed=action_count > 0,
             )
 
-        outcomes = {
-            SparkleUpdateState.STAGED_INSTALL: SparkleUpdateOutcome.STAGED,
+        outcomes: dict[SparkleUpdateState, SparkleUpdateOutcome | None] = {
+            SparkleUpdateState.READY_INSTALL_UPDATE: None,
             SparkleUpdateState.READY_INSTALL_RELAUNCH: SparkleUpdateOutcome.INSTALL_AND_RELAUNCH,
             SparkleUpdateState.READY_INSTALL_ON_QUIT: SparkleUpdateOutcome.INSTALL_ON_QUIT,
         }
@@ -1971,7 +1924,11 @@ def _perform_sparkle_update(
                 state=SparkleUpdateState.UNKNOWN,
                 action_pressed=action_count > 0,
             )
-        if observation.action_identifier not in {"", SPARKLE_INSTALL_IDENTIFIER}:
+        if observation.action_identifier not in {
+            "",
+            SPARKLE_INSTALL_IDENTIFIER,
+            SPARKLE_STATUS_INSTALL_IDENTIFIER,
+        }:
             raise SparkleUpdateFailure(
                 f"Sparkle updater exposed an unsupported action identifier: {observation.action_identifier!r}.",
                 reason_code="updater-action-unknown",
@@ -2001,21 +1958,23 @@ def _perform_sparkle_update(
             ) from error
         journal_sha256 = record_transition("pressed", observation)
         action_count += 1
-        last_pressed = observation
 
-        if outcome == SparkleUpdateOutcome.STAGED:
-            staged_pressed = True
-            last_recorded_state = SparkleUpdateState.INSTALLING
-            states_observed.append(SparkleUpdateState.INSTALLING.value)
-            installing = UpdateObservation(
-                state=SparkleUpdateState.INSTALLING,
+        if state == SparkleUpdateState.READY_INSTALL_UPDATE:
+            install_update_pressed = True
+            downloading = UpdateObservation(
+                state=SparkleUpdateState.DOWNLOADING,
                 window_match=observation.window_match,
                 action_identifier=observation.action_identifier,
                 action_title=observation.action_title,
             )
-            journal_sha256 = record_transition("derived", installing)
+            states_observed.append(downloading.state.value)
+            journal_sha256 = record_transition("derived", downloading)
+            last_recorded_state = downloading.state
             time.sleep(UPDATE_POLL_SECONDS)
             continue
+
+        if outcome is None:
+            raise AssertionError("non-terminal Sparkle action reached terminal interaction")
 
         return UpdateInteraction(
             clicked_button=observation.action_title,
@@ -2040,9 +1999,9 @@ def _perform_sparkle_update(
     raise SparkleUpdateFailure(
         "Sparkle updater did not reach a bounded install state before timeout "
         f"(last_state={(last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW).value}, "
-        f"staged_pressed={str(staged_pressed).lower()}, staged_quit_requested={str(staged_quit_requested).lower()}, "
+        f"install_update_pressed={str(install_update_pressed).lower()}, "
         f"action_count={action_count}, "
-        f"process_relation={process_relation}, candidate_exact={str(exact_candidate_installed()).lower()}, "
+        f"process_relation={process_relation}, "
         f"states_observed={','.join(states_observed)}).",
         reason_code="update-window-timeout",
         state=last_recorded_state or SparkleUpdateState.WAITING_FOR_WINDOW,
@@ -2517,9 +2476,7 @@ def _run_qualification(
                 attempt=attempt,
                 retry_reason_code=retry_reason_code,
             )
-            if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT or (
-                interaction.outcome == SparkleUpdateOutcome.STAGED and not operations.app_running(app_path)
-            ):
+            if interaction.outcome == SparkleUpdateOutcome.INSTALL_ON_QUIT:
                 failure_stage = "install-on-quit-wait"
                 operations.quit_app()
                 _wait_for_candidate_on_disk(app_path, candidate)

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -1790,7 +1790,7 @@ def _perform_sparkle_update(
         "schema_version": 1,
         "transitions": [],
     }
-    journal_sha256 = _write_durable_json(checkpoint_path, journal)
+    _write_durable_json(checkpoint_path, journal)
     operations.open_updater(app_path, synthetic_home)
     prior_process_id = operations.app_process_id(app_path)
     if prior_process_id is None:
@@ -1836,7 +1836,7 @@ def _perform_sparkle_update(
         state = observation.state
         if state != last_recorded_state:
             states_observed.append(state.value)
-            journal_sha256 = record_transition("observed", observation)
+            record_transition("observed", observation)
             last_recorded_state = state
 
         if observation.window_match in {"identifier", "button-identifier"}:
@@ -1956,7 +1956,7 @@ def _perform_sparkle_update(
                 state=observation.state,
                 action_pressed=action_count > 0,
             ) from error
-        journal_sha256 = record_transition("pressed", observation)
+        pressed_journal_sha256 = record_transition("pressed", observation)
         action_count += 1
 
         if state == SparkleUpdateState.READY_INSTALL_UPDATE:
@@ -1968,7 +1968,7 @@ def _perform_sparkle_update(
                 action_title=observation.action_title,
             )
             states_observed.append(downloading.state.value)
-            journal_sha256 = record_transition("derived", downloading)
+            record_transition("derived", downloading)
             last_recorded_state = downloading.state
             time.sleep(UPDATE_POLL_SECONDS)
             continue
@@ -1983,7 +1983,7 @@ def _perform_sparkle_update(
             window_match=observation.window_match,
             states_observed=tuple(states_observed),
             intent_checkpoint_sha256=intent_checkpoint_sha256,
-            journal_sha256=journal_sha256,
+            journal_sha256=pressed_journal_sha256,
             attempt=attempt,
             retry_reason_code=retry_reason_code,
             prior_process_id=prior_process_id,

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -65,15 +65,9 @@ class FakeOperations(QualificationOperations):
         cancelled: bool = False,
         tamper_prior_before_update: bool = False,
         wrong_running_path: bool = False,
-        staged_repeats_after_press: int = 0,
         press_state_change_failures: int = 0,
-        press_state_change_after_actions: int = 0,
-        staged_relaunches_directly: bool = False,
-        staged_relaunch_stays_installing: bool = False,
-        staged_relaunch_repeats_action: bool = False,
-        staged_window_closes_after_press: bool = False,
-        staged_installs_on_quit: bool = False,
-        staged_candidate_installed_before_final_action: bool = False,
+        install_update_wait_observations: int = 1,
+        install_update_process_exits_before_ready: bool = False,
         oscillate_non_actionable: bool = False,
         sentinel_failure: bool = False,
         tamper_marker: bool = False,
@@ -89,15 +83,9 @@ class FakeOperations(QualificationOperations):
         self.cancelled = cancelled
         self.tamper_prior_before_update = tamper_prior_before_update
         self.wrong_running_path = wrong_running_path
-        self.staged_repeats_after_press = staged_repeats_after_press
         self.press_state_change_failures = press_state_change_failures
-        self.press_state_change_after_actions = press_state_change_after_actions
-        self.staged_relaunches_directly = staged_relaunches_directly
-        self.staged_relaunch_stays_installing = staged_relaunch_stays_installing
-        self.staged_relaunch_repeats_action = staged_relaunch_repeats_action
-        self.staged_window_closes_after_press = staged_window_closes_after_press
-        self.staged_installs_on_quit = staged_installs_on_quit
-        self.staged_candidate_installed_before_final_action = staged_candidate_installed_before_final_action
+        self.install_update_wait_observations = install_update_wait_observations
+        self.install_update_process_exits_before_ready = install_update_process_exits_before_ready
         self.oscillate_non_actionable = oscillate_non_actionable
         self.sentinel_failure = sentinel_failure
         self.tamper_marker = tamper_marker
@@ -112,12 +100,12 @@ class FakeOperations(QualificationOperations):
         self.current_synthetic_home: Path | None = None
         self.launch_calls = 0
         self.quit_calls = 0
+        self.quit_calls_at_press: list[int] = []
         self.running_app_path: Path | None = None
         self.running_process_id: int | None = None
         self.next_process_id = 1000
-        self.post_staged_observations = 0
         self.observation_calls = 0
-        self.staged_quit_triggered = False
+        self.post_install_update_observations = 0
         self.checkpoint_root: Path | None = None
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
@@ -197,13 +185,6 @@ class FakeOperations(QualificationOperations):
                 action_identifier="SPUUserUpdateChoiceInstall",
                 action_title="Install Update",
             )
-        if self.post_press_failure and self.pressed_actions:
-            raise SparkleUpdateFailure(
-                "simulated post-press failure",
-                reason_code="updater-script-failure",
-                state=SparkleUpdateState.INSTALLING,
-                action_pressed=True,
-            )
         if self.terminal_failure:
             return UpdateObservation(
                 state=SparkleUpdateState.TERMINAL_FAILURE,
@@ -236,46 +217,32 @@ class FakeOperations(QualificationOperations):
             ),
         }
         if self.install_action == "Install Update":
-            staged_observation = UpdateObservation(
-                state=SparkleUpdateState.STAGED_INSTALL,
-                window_match="identifier",
-                action_identifier="SPUUserUpdateChoiceInstall",
-                action_title="Install Update",
-            )
-            if self.staged_relaunches_directly and self.pressed_actions:
-                if self.staged_relaunch_stays_installing:
-                    observation = UpdateObservation(
-                        state=SparkleUpdateState.INSTALLING,
-                        window_match="identifier",
-                        action_identifier="SPUUserUpdateChoiceInstall",
-                        action_title="Install Update",
-                    )
-                elif self.staged_relaunch_repeats_action:
-                    observation = staged_observation
-                else:
-                    observation = UpdateObservation(
-                        state=SparkleUpdateState.WAITING_FOR_WINDOW,
-                        window_match="none",
-                        action_identifier="",
-                        action_title="",
-                    )
-            elif self.staged_window_closes_after_press and self.pressed_actions:
+            if not self.pressed_actions:
+                observation = UpdateObservation(
+                    state=SparkleUpdateState.READY_INSTALL_UPDATE,
+                    window_match="identifier",
+                    action_identifier="SPUUserUpdateChoiceInstall",
+                    action_title="Install Update",
+                )
+            elif len(self.pressed_actions) == 1 and (
+                self.post_install_update_observations < self.install_update_wait_observations
+            ):
+                self.post_install_update_observations += 1
+                if self.install_update_process_exits_before_ready:
+                    self.running = False
+                    self.running_app_path = None
+                    self.running_process_id = None
                 observation = UpdateObservation(
                     state=SparkleUpdateState.WAITING_FOR_WINDOW,
                     window_match="none",
                     action_identifier="",
                     action_title="",
                 )
-            elif not self.pressed_actions:
-                observation = staged_observation
-            elif self.post_staged_observations < self.staged_repeats_after_press:
-                self.post_staged_observations += 1
-                observation = staged_observation
             else:
                 observation = UpdateObservation(
                     state=SparkleUpdateState.READY_INSTALL_RELAUNCH,
-                    window_match="identifier",
-                    action_identifier="SPUUserUpdateChoiceInstall",
+                    window_match="button-identifier",
+                    action_identifier="SUStatusInstallAndRelaunch",
                     action_title="Install and Relaunch",
                 )
         elif self.install_action in action_states:
@@ -303,7 +270,7 @@ class FakeOperations(QualificationOperations):
         checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
         transitions = checkpoint["transitions"]
         self.intent_seen_before_press = bool(transitions and transitions[-1]["phase"] == "intent")
-        if self.press_state_change_failures > 0 and len(self.pressed_actions) >= self.press_state_change_after_actions:
+        if self.press_state_change_failures > 0:
             self.press_state_change_failures -= 1
             raise SparkleUpdateFailure(
                 "simulated updater state change",
@@ -311,16 +278,16 @@ class FakeOperations(QualificationOperations):
                 state=observation.state,
                 action_pressed=False,
             )
+        self.quit_calls_at_press.append(self.quit_calls)
         self.pressed_actions.append(observation)
-        if observation.state == SparkleUpdateState.STAGED_INSTALL:
-            if self.staged_relaunches_directly or self.staged_candidate_installed_before_final_action:
-                app_path = self.current_app_path
-                shutil.rmtree(app_path)
-                shutil.copytree(self.candidate_source, app_path, symlinks=True)
-                self.running = True
-                self.running_app_path = app_path
-                self.running_process_id = self.next_process_id
-                self.next_process_id += 1
+        if self.post_press_failure:
+            raise SparkleUpdateFailure(
+                "simulated post-press failure",
+                reason_code="updater-script-failure",
+                state=SparkleUpdateState.INSTALLING,
+                action_pressed=True,
+            )
+        if observation.state == SparkleUpdateState.READY_INSTALL_UPDATE:
             return
         if self.tamper_marker:
             marker_path = self.current_synthetic_home.parent / ".bd-to-avp-tier3-owned.json"
@@ -439,17 +406,6 @@ class FakeOperations(QualificationOperations):
 
     def quit_app(self) -> None:
         self.quit_calls += 1
-        if (
-            self.staged_installs_on_quit
-            and self.pressed_actions
-            and self.pressed_actions[-1].state == SparkleUpdateState.STAGED_INSTALL
-            and not self.staged_quit_triggered
-        ):
-            if self.current_app_path is None:
-                raise AssertionError("fake staged install was quit before the updater opened")
-            shutil.rmtree(self.current_app_path)
-            shutil.copytree(self.candidate_source, self.current_app_path, symlinks=True)
-            self.staged_quit_triggered = True
         self.running = False
         self.running_app_path = None
         self.running_process_id = None
@@ -1173,7 +1129,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertEqual(operations.launch_calls, 2)
             self.assertTrue(operations.intent_seen_before_press)
 
-    def test_run_records_staged_install_before_final_relaunch_action(self) -> None:
+    def test_run_treats_install_update_as_install_and_relaunch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
@@ -1186,140 +1142,37 @@ class Tier3CleanMachineTests(unittest.TestCase):
             )
             self.assertEqual(
                 [observation.state for observation in operations.pressed_actions],
-                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
+                [
+                    SparkleUpdateState.READY_INSTALL_UPDATE,
+                    SparkleUpdateState.READY_INSTALL_RELAUNCH,
+                ],
+            )
+            self.assertEqual(
+                [observation.action_identifier for observation in operations.pressed_actions],
+                ["SPUUserUpdateChoiceInstall", "SUStatusInstallAndRelaunch"],
             )
             self.assertEqual(update_evidence["outcome"], "install-and-relaunch")
             self.assertEqual(
                 update_evidence["states_observed"],
-                ["staged-install", "installing", "ready-install-relaunch"],
+                ["ready-install-update", "downloading", "waiting-for-window", "ready-install-relaunch"],
             )
+            self.assertEqual(operations.quit_calls_at_press, [2, 2])
 
-    def test_run_detects_candidate_relaunch_after_staged_action(self) -> None:
+    def test_run_fails_if_app_exits_before_final_install_action(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
             operations.install_action = "Install Update"
-            operations.staged_relaunches_directly = True
+            operations.install_update_process_exits_before_ready = True
 
-            run_qualification(config, operations)
-
-            update_evidence = json.loads(
-                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(
-                [observation.state for observation in operations.pressed_actions],
-                [SparkleUpdateState.STAGED_INSTALL],
-            )
-            self.assertEqual(update_evidence["outcome"], "staged")
-            self.assertEqual(
-                update_evidence["states_observed"],
-                ["staged-install", "installing", "waiting-for-window"],
-            )
-
-    def test_run_detects_candidate_relaunch_while_updater_stays_installing(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_relaunches_directly = True
-            operations.staged_relaunch_stays_installing = True
-
-            run_qualification(config, operations)
-
-            update_evidence = json.loads(
-                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(len(operations.pressed_actions), 1)
-            self.assertEqual(update_evidence["outcome"], "staged")
-            self.assertEqual(update_evidence["states_observed"], ["staged-install", "installing"])
-
-    def test_run_detects_candidate_relaunch_while_staged_action_repeats(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_relaunches_directly = True
-            operations.staged_relaunch_repeats_action = True
-
-            run_qualification(config, operations)
-
-            update_evidence = json.loads(
-                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(len(operations.pressed_actions), 1)
-            self.assertEqual(update_evidence["outcome"], "staged")
-            self.assertEqual(update_evidence["states_observed"], ["staged-install", "installing", "staged-install"])
-
-    def test_run_quits_prior_app_to_complete_staged_install(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_window_closes_after_press = True
-            operations.staged_installs_on_quit = True
-
-            run_qualification(config, operations)
-
-            update_evidence = json.loads(
-                (config.evidence_directory / "sparkle-update.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(len(operations.pressed_actions), 1)
-            self.assertTrue(operations.staged_quit_triggered)
-            self.assertEqual(operations.launch_calls, 2)
-            self.assertEqual(update_evidence["outcome"], "staged")
-            self.assertEqual(
-                update_evidence["states_observed"],
-                ["staged-install", "installing", "waiting-for-window"],
-            )
-
-    def test_run_does_not_skip_visible_final_action_when_candidate_is_on_disk(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_candidate_installed_before_final_action = True
-
-            run_qualification(config, operations)
+            with self.assertRaisesRegex(CleanMachineError, "terminated before Sparkle exposed the final install"):
+                run_qualification(config, operations)
 
             self.assertEqual(
                 [observation.state for observation in operations.pressed_actions],
-                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
+                [SparkleUpdateState.READY_INSTALL_UPDATE],
             )
-
-    def test_run_does_not_press_a_repeated_staged_action(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_repeats_after_press = 2
-
-            run_qualification(config, operations)
-
-            self.assertEqual(
-                [observation.state for observation in operations.pressed_actions],
-                [SparkleUpdateState.STAGED_INSTALL, SparkleUpdateState.READY_INSTALL_RELAUNCH],
-            )
-
-    def test_run_reports_bounded_post_press_timeout_context(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.staged_repeats_after_press = 1_000_000
-
-            with (
-                patch("scripts.tier3_clean_machine.GUI_TIMEOUT_SECONDS", 0.01),
-                patch("scripts.tier3_clean_machine.UPDATE_POLL_SECONDS", 0),
-            ):
-                with self.assertRaisesRegex(
-                    CleanMachineError,
-                    "last_state=staged-install, staged_pressed=true, staged_quit_requested=false, action_count=1, "
-                    "process_relation=same-prior, candidate_exact=false",
-                ):
-                    run_qualification(config, operations)
-
-            self.assertEqual(operations.update_attempts, 1)
-            self.assertEqual(len(operations.pressed_actions), 1)
+            self.assertEqual(operations.quit_calls_at_press, [2])
             self.assertFalse(config.evidence_directory.exists())
 
     def test_run_retries_one_clean_attempt_for_pre_press_environmental_failure(self) -> None:
@@ -1385,24 +1238,6 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertEqual(operations.update_attempts, 2)
             self.assertTrue(operations.intent_seen_before_press)
             self.assertFalse(operations.pressed_actions)
-            self.assertFalse(config.evidence_directory.exists())
-
-    def test_run_does_not_retry_state_change_after_staged_action(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            config, operations = self.fixture(root)
-            operations.install_action = "Install Update"
-            operations.press_state_change_failures = 1
-            operations.press_state_change_after_actions = 1
-
-            with self.assertRaisesRegex(CleanMachineError, "changed after intent"):
-                run_qualification(config, operations)
-
-            self.assertEqual(operations.update_attempts, 1)
-            self.assertEqual(
-                [observation.state for observation in operations.pressed_actions],
-                [SparkleUpdateState.STAGED_INSTALL],
-            )
             self.assertFalse(config.evidence_directory.exists())
 
     def test_run_classifies_terminal_failure_without_retry(self) -> None:
@@ -1599,9 +1434,12 @@ class Tier3CleanMachineTests(unittest.TestCase):
         self.assertIn('attribute "AXIdentifier"', observe_script)
         self.assertIn('"SUUpdateAlert"', observe_script)
         self.assertIn('"SPUUserUpdateChoiceInstall"', observe_script)
+        self.assertIn('"SUStatusInstallAndRelaunch"', observe_script)
         self.assertIn("enabled of selectedButton", observe_script)
         self.assertIn('selectedTitle is "Install Update"', observe_script)
+        self.assertNotIn('return "staged-install"', observe_script)
         self.assertIn('selectedTitle is "Install on Quit"', observe_script)
+        self.assertIn('"ready-install-update"', observe_script)
         self.assertIn('"ready-install-relaunch"', observe_script)
         self.assertIn('perform action "AXPress" of selectedButton', press_script)
         self.assertIn("actualWindowMatch is not expectedWindowMatch", press_script)


### PR DESCRIPTION
Refs #593

## Summary
- model Sparkle 2.9.4's initial `Install Update` as the first phase of a two-step install-now flow
- tolerate the initial alert closing while download/extraction proceeds, without quitting the app
- detect and press the final `SUStatusInstallAndRelaunch` action before waiting for exact candidate replacement
- fail closed if the prior app exits before Sparkle exposes the final install action
- remove the incorrect staged-install state and its obsolete test machinery

## Root cause
Run `32381581255` was invalidated by the harness: it treated the initial `Install Update` action as already staged and quit the app when the alert closed. Sparkle 2.9.4 instead shows a later status-controller confirmation before installation/relaunch.

## Validation
- 231 release, manifest, controller, receipt, Tier 3, and workflow tests passed
- changed-file Ruff lint and format checks passed
- direct mypy on `scripts/tier3_clean_machine.py` passed
- AppleScript compilation passed on macOS
- two-model review against pinned Sparkle 2.9.4 source; actionable two-phase and premature-exit coverage findings resolved

JetBrains inspection remained inconclusive because the IDE returned stale results; it reported no current actionable finding, and helper-generated `.idea` changes were removed.