### PR TITLE
Validate profile migration during Sparkle qualification

### DIFF
--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -152,8 +152,11 @@ The runner performs this bounded sequence:
    candidate. The harness never quits the app merely because the initial alert
    disappeared.
 6. Verify the final candidate bundle, build, signed app tree, and replacement
-   running process, then verify the selected route, unrelated preference, and
-   byte-for-byte profile library are preserved.
+   running process, then verify the selected route and unrelated preference are
+   preserved and the seeded profile library matches the exact expected
+   semantic migration from schema version 5 to version 6. The migration must
+   preserve profile identity, encoding options, and safe pipeline defaults while
+   removing legacy per-run defaults that version 6 intentionally no longer stores.
 7. Run the candidate installed-app XCUITest lane. It verifies main-window
    readiness, profile-save accessibility and success, updater settings, the
    public releases link, and cropped light/dark app-window screenshots.

--- a/macos/BluRayToVisionProTests/ProfileStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ProfileStoreTests.swift
@@ -452,6 +452,31 @@ final class ProfileStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testQualificationProfileFixtureMigratesToExpectedVersionSixDocument() throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("profiles.json")
+        try qualificationFixtureData("profile_library_v5.json").write(to: fileURL)
+
+        let store = ProfileStore(fileURL: fileURL)
+
+        XCTAssertEqual(store.customProfiles.count, 1)
+        let actualDocument = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        )
+        let expectedDocument = try XCTUnwrap(
+            try JSONSerialization.jsonObject(
+                with: qualificationFixtureData("profile_library_v6.json")
+            ) as? [String: Any]
+        )
+        XCTAssertEqual(
+            try JSONSerialization.data(withJSONObject: actualDocument, options: [.sortedKeys]),
+            try JSONSerialization.data(withJSONObject: expectedDocument, options: [.sortedKeys])
+        )
+    }
+
+    @MainActor
     func testVersionFiveMigrationWriteFailureKeepsOriginalAndSafeInMemoryProfiles() throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
@@ -951,6 +976,15 @@ final class ProfileStoreTests: XCTestCase {
 
     private func temporaryProfileURL() -> URL {
         temporaryDirectoryURL().appendingPathComponent("profiles.json")
+    }
+
+    private func qualificationFixtureData(_ name: String) throws -> Data {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/\(name)")
+        return try Data(contentsOf: fixtureURL)
     }
 
     private func legacyDocument(profiles: [[String: Any]]) throws -> Data {

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -50,7 +50,8 @@ AUTOMATIC_CHECKS_KEY = "SUEnableAutomaticChecks"
 SENTINEL_VALUE = "tier3-preserve"
 LIVE_FEED_URL = "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
 RELEASES_URL = "https://github.com/cbusillo/BD_to_AVP/releases"
-PROFILE_DOCUMENT = {"version": 5, "profiles": []}
+PROFILE_FIXTURE_V5_PATH = REPO_ROOT / "tests/fixtures/profile_library_v5.json"
+PROFILE_FIXTURE_V6_PATH = REPO_ROOT / "tests/fixtures/profile_library_v6.json"
 PROFILE_RELATIVE_PATH = Path("Library/Application Support/3D Blu-ray to Vision Pro/profiles.json")
 MAX_FEED_BYTES = 5 * 1024 * 1024
 BASE_FREE_SPACE_BYTES = 2 * 1024 * 1024 * 1024
@@ -2052,11 +2053,47 @@ def _wait_for_candidate_on_disk(app_path: Path, candidate: ReleaseArtifact) -> B
     raise CleanMachineError(f"Sparkle did not install the exact candidate before timeout.{detail}")
 
 
-def _seed_profile(synthetic_home: Path) -> tuple[Path, str]:
+def _load_profile_document(path: Path, description: str) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CleanMachineError(f"{description} is missing or invalid JSON.") from error
+    if not isinstance(document, dict):
+        raise CleanMachineError(f"{description} must be a JSON object.")
+    if set(document) != {"profiles", "version"}:
+        raise CleanMachineError(f"{description} has unexpected top-level fields.")
+    if isinstance(document["version"], bool) or not isinstance(document["version"], int):
+        raise CleanMachineError(f"{description} has an invalid version.")
+    if not isinstance(document["profiles"], list):
+        raise CleanMachineError(f"{description} has an invalid profile list.")
+    return document
+
+
+def _semantic_json_sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _seed_profile(synthetic_home: Path) -> tuple[Path, dict[str, Any]]:
+    profile_document = _load_profile_document(PROFILE_FIXTURE_V5_PATH, "Seed profile fixture")
     profile_path = synthetic_home / PROFILE_RELATIVE_PATH
     profile_path.parent.mkdir(parents=True, exist_ok=True)
-    profile_path.write_bytes(_canonical_json_bytes(PROFILE_DOCUMENT))
-    return profile_path, file_sha256(profile_path)
+    profile_path.write_bytes(PROFILE_FIXTURE_V5_PATH.read_bytes())
+    return profile_path, profile_document
+
+
+def _validate_profile_migration(
+    profile_path: Path,
+    profile_before: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    expected_after = _load_profile_document(PROFILE_FIXTURE_V6_PATH, "Expected migrated profile fixture")
+    profile_after = _load_profile_document(profile_path, "Profile library after Sparkle relaunch")
+    if profile_before.get("version") != 5 or expected_after.get("version") != 6:
+        raise CleanMachineError("Profile migration fixtures do not describe the expected version 5-to-6 transition.")
+    if profile_after != expected_after:
+        raise CleanMachineError(
+            "Profile library did not match the expected version 5-to-6 migration across Sparkle relaunch."
+        )
+    return file_sha256(profile_path), profile_after
 
 
 def _reset_runtime_workspace(app_path: Path, synthetic_home: Path, installed_release: ReleaseArtifact) -> None:
@@ -2444,7 +2481,7 @@ def _run_qualification(
         synthetic_home.mkdir(parents=True, exist_ok=True)
         operations.install_app(prior.dmg_path, app_path, qualification_root / "Mount")
         prior_identity = verify_installed_app(app_path, prior)
-        profile_path, profile_before_sha256 = _seed_profile(synthetic_home)
+        profile_path, seeded_profile = _seed_profile(synthetic_home)
         operations.write_preferences(synthetic_home, config.route)
         if operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY) != config.route:
             raise CleanMachineError("Update route did not persist before launching the prior release.")
@@ -2462,6 +2499,10 @@ def _run_qualification(
         operations.quit_app()
         if operations.app_running():
             raise CleanMachineError("Installed UI updater inspection left the production app running.")
+        profile_before = _load_profile_document(profile_path, "Profile library before Sparkle update")
+        if profile_before != seeded_profile:
+            raise CleanMachineError("Profile library changed before the Sparkle update began.")
+        profile_before_sha256 = file_sha256(profile_path)
 
         failure_stage = "updater-state-machine"
         try:
@@ -2517,11 +2558,9 @@ def _run_qualification(
             raise CleanMachineError(f"{error} {diagnostic_summary}") from error
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
         sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
-        profile_after_sha256 = file_sha256(profile_path)
+        profile_after_sha256, profile_after = _validate_profile_migration(profile_path, profile_before)
         if route_after != config.route or sentinel_after != SENTINEL_VALUE:
             raise CleanMachineError("Update route or unrelated preference changed across Sparkle relaunch.")
-        if profile_after_sha256 != profile_before_sha256:
-            raise CleanMachineError("Profile library changed across Sparkle relaunch.")
 
         operations.quit_app()
         operations.collect_ui_evidence(
@@ -2587,11 +2626,20 @@ def _run_qualification(
             evidence_directory / "profile-snapshot.json",
             {
                 "profile_after_sha256": profile_after_sha256,
+                "profile_after_semantic_sha256": _semantic_json_sha256(profile_after),
                 "profile_before_sha256": profile_before_sha256,
-                "profile_preserved": True,
+                "profile_before_semantic_sha256": _semantic_json_sha256(profile_before),
+                "profile_encoding_options_preserved": True,
+                "profile_identity_preserved": True,
+                "profile_migration": "v5-to-v6",
+                "profile_migration_matched": True,
+                "profile_safe_pipeline_defaults_preserved": True,
+                "profile_version_after": profile_after["version"],
+                "profile_version_before": profile_before["version"],
                 "route_after": route_after,
                 "route_preserved": True,
                 "sentinel_preserved": sentinel_after == SENTINEL_VALUE,
+                "unsafe_legacy_run_defaults_removed": True,
             },
         )
         ui_evidence_digests = _normalize_installed_ui_evidence(raw_ui_directory, evidence_directory, feed)

--- a/tests/fixtures/profile_library_v5.json
+++ b/tests/fixtures/profile_library_v5.json
@@ -1,0 +1,71 @@
+{
+  "profiles": [
+    {
+      "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+      "jobDefaults": {
+        "continueOnError": true,
+        "intermediatePolicy": "reusable",
+        "outputCommands": true,
+        "overwriteExisting": true,
+        "removeOriginalAfterSuccess": true,
+        "softwareEncoder": true,
+        "startStage": 2
+      },
+      "name": "Qualification Sentinel",
+      "options": {
+        "audioBitrate": 384,
+        "audioHandling": "automatic",
+        "audioLanguages": {
+          "mode": "preferred_only",
+          "preferredLanguage": "eng"
+        },
+        "av1CRF": 32,
+        "cropBlackBars": false,
+        "fieldOfView": 90,
+        "frameRateOverride": "",
+        "hevcQuality": 75,
+        "leftRightBitrate": 20,
+        "linkQuality": true,
+        "mvHEVC": {
+          "directFinalBitrate": {
+            "customMbps": 40,
+            "mode": "automatic"
+          },
+          "generatedEyeBitrate": {
+            "customMbps": 20,
+            "mode": "automatic"
+          },
+          "generatedMergeQuality": 75,
+          "linkGeneratedAndUpscaleQuality": true
+        },
+        "resolutionOverride": "",
+        "subtitles": {
+          "mode": "preferred_plus_others",
+          "preferredLanguage": "eng"
+        },
+        "swapEyes": false,
+        "upscaleEnabled": false,
+        "upscaleQuality": 75,
+        "videoOutputMode": "mv_hevc",
+        "videoQuality": {
+          "custom": {
+            "av1CRF": 32,
+            "directFinalBitrate": {
+              "customMbps": 40,
+              "mode": "automatic"
+            },
+            "generatedEyeBitrate": {
+              "customMbps": 20,
+              "mode": "automatic"
+            },
+            "generatedMergeQuality": 75,
+            "upscaleQuality": 75
+          },
+          "lastLadderStep": "balanced",
+          "mode": "ladder"
+        }
+      }
+    }
+  ],
+  "version": 5
+}

--- a/tests/fixtures/profile_library_v6.json
+++ b/tests/fixtures/profile_library_v6.json
@@ -1,0 +1,66 @@
+{
+  "profiles": [
+    {
+      "id": "A4CC523E-72FA-4F36-A38D-1FB0D6A84742",
+      "name": "Qualification Sentinel",
+      "options": {
+        "audioBitrate": 384,
+        "audioHandling": "automatic",
+        "audioLanguages": {
+          "mode": "preferred_only",
+          "preferredLanguage": "eng"
+        },
+        "av1CRF": 32,
+        "cropBlackBars": false,
+        "fieldOfView": 90,
+        "frameRateOverride": "",
+        "hevcQuality": 75,
+        "leftRightBitrate": 20,
+        "linkQuality": true,
+        "mvHEVC": {
+          "directFinalBitrate": {
+            "customMbps": 40,
+            "mode": "automatic"
+          },
+          "generatedEyeBitrate": {
+            "customMbps": 20,
+            "mode": "automatic"
+          },
+          "generatedMergeQuality": 75,
+          "linkGeneratedAndUpscaleQuality": true
+        },
+        "resolutionOverride": "",
+        "subtitles": {
+          "mode": "preferred_plus_others",
+          "preferredLanguage": "eng"
+        },
+        "swapEyes": false,
+        "upscaleEnabled": false,
+        "upscaleQuality": 75,
+        "videoOutputMode": "mv_hevc",
+        "videoQuality": {
+          "custom": {
+            "av1CRF": 32,
+            "directFinalBitrate": {
+              "customMbps": 40,
+              "mode": "automatic"
+            },
+            "generatedEyeBitrate": {
+              "customMbps": 20,
+              "mode": "automatic"
+            },
+            "generatedMergeQuality": 75,
+            "upscaleQuality": 75
+          },
+          "lastLadderStep": "balanced",
+          "mode": "ladder"
+        }
+      },
+      "pipelineDefaults": {
+        "intermediatePolicy": "reusable",
+        "softwareEncoder": true
+      }
+    }
+  ],
+  "version": 6
+}

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -24,6 +24,8 @@ from scripts.tier3_clean_machine import (
     CleanMachineError,
     EnvironmentFacts,
     MacOSOperations,
+    PROFILE_FIXTURE_V6_PATH,
+    PROFILE_RELATIVE_PATH,
     QualificationConfig,
     QualificationOperations,
     RELEASES_URL,
@@ -107,6 +109,8 @@ class FakeOperations(QualificationOperations):
         self.observation_calls = 0
         self.post_install_update_observations = 0
         self.checkpoint_root: Path | None = None
+        self.profile_after_relaunch = PROFILE_FIXTURE_V6_PATH.read_bytes()
+        self.tamper_profile_before_update = False
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
         return EnvironmentFacts(
@@ -299,6 +303,8 @@ class FakeOperations(QualificationOperations):
         self.running_app_path = self.candidate_source if self.wrong_running_path else app_path
         self.running_process_id = self.next_process_id
         self.next_process_id += 1
+        profile_path = self.current_synthetic_home / PROFILE_RELATIVE_PATH
+        profile_path.write_bytes(self.profile_after_relaunch)
 
     def collect_ui_evidence(
         self,
@@ -312,6 +318,11 @@ class FakeOperations(QualificationOperations):
     ) -> None:
         if phase == "updater" and self.tamper_prior_before_update:
             (app_path / "tampered-before-updater").write_text("changed\n", encoding="utf-8")
+        if phase == "updater" and self.tamper_profile_before_update:
+            profile_path = synthetic_home / PROFILE_RELATIVE_PATH
+            profile_document = json.loads(profile_path.read_text(encoding="utf-8"))
+            profile_document["profiles"][0]["name"] = "Changed Before Update"
+            profile_path.write_text(json.dumps(profile_document, sort_keys=True), encoding="utf-8")
         del repo, app_path, synthetic_home
         output_directory.mkdir(parents=True, exist_ok=True)
         if phase == "updater":
@@ -1065,8 +1076,70 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertIn("ready-install-relaunch", update_evidence["states_observed"])
             self.assertRegex(update_evidence["intent_checkpoint_sha256"], r"^[0-9a-f]{64}$")
             self.assertRegex(update_evidence["journal_sha256"], r"^[0-9a-f]{64}$")
+            profile_evidence = json.loads(
+                (config.evidence_directory / "profile-snapshot.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(profile_evidence["profile_migration"], "v5-to-v6")
+            self.assertTrue(profile_evidence["profile_migration_matched"])
+            self.assertTrue(profile_evidence["profile_identity_preserved"])
+            self.assertTrue(profile_evidence["profile_encoding_options_preserved"])
+            self.assertTrue(profile_evidence["profile_safe_pipeline_defaults_preserved"])
+            self.assertTrue(profile_evidence["unsafe_legacy_run_defaults_removed"])
+            self.assertEqual(profile_evidence["profile_version_before"], 5)
+            self.assertEqual(profile_evidence["profile_version_after"], 6)
+            self.assertNotEqual(
+                profile_evidence["profile_before_sha256"],
+                profile_evidence["profile_after_sha256"],
+            )
+            self.assertRegex(profile_evidence["profile_before_semantic_sha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(profile_evidence["profile_after_semantic_sha256"], r"^[0-9a-f]{64}$")
             self.assertTrue(operations.intent_seen_before_press)
             self.assertFalse(operations.app_running())
+
+    def test_run_rejects_profile_mutation_beyond_expected_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            mutated_document = json.loads(PROFILE_FIXTURE_V6_PATH.read_text(encoding="utf-8"))
+            mutated_document["profiles"][0]["name"] = "Changed"
+            operations.profile_after_relaunch = json.dumps(mutated_document, sort_keys=True).encode()
+
+            with self.assertRaisesRegex(
+                CleanMachineError,
+                "did not match the expected version 5-to-6 migration",
+            ):
+                run_qualification(config, operations)
+
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_rejects_profile_mutation_before_sparkle_update(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.tamper_profile_before_update = True
+
+            with self.assertRaisesRegex(
+                CleanMachineError,
+                "Profile library changed before the Sparkle update began",
+            ):
+                run_qualification(config, operations)
+
+            self.assertFalse(operations.pressed_actions)
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_run_rejects_invalid_profile_document_after_relaunch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.profile_after_relaunch = b"not-json\n"
+
+            with self.assertRaisesRegex(
+                CleanMachineError,
+                "Profile library after Sparkle relaunch is missing or invalid JSON",
+            ):
+                run_qualification(config, operations)
+
+            self.assertFalse(config.evidence_directory.exists())
 
     def test_run_accepts_supported_sparkle_install_actions(self) -> None:
         for install_action in SPARKLE_INSTALL_ACTIONS:


### PR DESCRIPTION
## Summary

- replace the stale byte-for-byte profile check with an exact v5-to-v6 semantic migration contract
- seed a deterministic non-empty legacy profile and require identity, encoding options, and safe pipeline defaults to survive while unsafe run defaults are removed
- share the fixtures with `ProfileStoreTests` so the qualification harness stays pinned to product behavior
- record explicit migration evidence in the Tier 3 profile snapshot

## Validation

- `uv run python -m unittest tests.test_tier3_clean_machine` — 42 passed
- focused release/qualification suite — 162 passed
- `uv run python scripts/native_app.py test` — 478 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy bd_to_avp`
- `uv run mypy scripts/tier3_clean_machine.py`

The whole Python discovery suite reached 1,781 tests; three unrelated local integration errors remain because Homebrew `ffprobe` has a dylib mismatch and the installed `libbluray` is 1.5.0 instead of the pinned 1.4.1.

JetBrains inspection was inconclusive because the selected project lacked a configured language SDK; helper-generated IDE metadata was removed.

Refs #593
