### PR TITLE
Allow validated release ledger appends

### DIFF
--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -26,6 +26,7 @@ from scripts.release_receipt import ReleaseReceiptError, load_validated_checked_
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GITHUB_CONFIG_PATH = Path(".github/github.json")
 EVIDENCE_INDEX_PATH = "docs/qualification/release-evidence-v1.json"
+RELEASE_LEDGER_PATH = "docs/release-evidence/index-v1.json"
 RUNNER_BOUND_QUALIFICATION_PATHS = {
     "docs/qualification/release-qualification-policy-v1.json",
     "docs/qualification/video-quality-route-table-v2.json",
@@ -383,12 +384,47 @@ def _validate_release_evidence_tag_scope(changed_paths: Sequence[str], release_t
         for path in changed_paths
         if path.startswith("docs/release-evidence/")
         and not path.startswith(expected_prefix)
+        and path != RELEASE_LEDGER_PATH
         and not _is_recovery_authorization_path(path)
     )
     if unrelated_paths:
         raise ReleaseMilestoneContextError(
             "Release evidence pull requests may change only one release tag: "
             f"expected {release_tag!r}, unrelated={unrelated_paths!r}."
+        )
+
+
+def _validate_append_only_release_ledger(repo_root: Path, *, base_sha: str, release_tag: str) -> None:
+    base_ledger = _load_json_at_revision(repo_root, base_sha, RELEASE_LEDGER_PATH, "base release evidence ledger")
+    head_ledger = _load_json(repo_root / RELEASE_LEDGER_PATH, "release evidence ledger")
+    if base_ledger.get("schema_version") != 1 or head_ledger.get("schema_version") != 1:
+        raise ReleaseMilestoneContextError("Release evidence ledger schema_version must remain 1.")
+    if {key: value for key, value in base_ledger.items() if key != "releases"} != {
+        key: value for key, value in head_ledger.items() if key != "releases"
+    }:
+        raise ReleaseMilestoneContextError("Release evidence ledger metadata may not change.")
+
+    def records_by_tag(ledger: Mapping[str, Any], description: str) -> dict[str, Mapping[str, Any]]:
+        records: dict[str, Mapping[str, Any]] = {}
+        for index, raw_record in enumerate(_sequence(ledger.get("releases"), f"{description} releases")):
+            record = _mapping(raw_record, f"{description} release {index}")
+            tag = _string(record.get("tag"), f"{description} release tag")
+            if tag in records:
+                raise ReleaseMilestoneContextError(f"{description.capitalize()} may not contain duplicate tags.")
+            records[tag] = record
+        return records
+
+    base_records = records_by_tag(base_ledger, "base release evidence ledger")
+    head_records = records_by_tag(head_ledger, "release evidence ledger")
+    if any(head_records.get(tag) != record for tag, record in base_records.items()):
+        raise ReleaseMilestoneContextError(
+            "Release evidence ledger may only append a release without changing accepted history."
+        )
+    added_tags = set(head_records) - set(base_records)
+    if added_tags != {release_tag}:
+        raise ReleaseMilestoneContextError(
+            "Release evidence ledger must append exactly the pull request release tag: "
+            f"expected {release_tag!r}, added={sorted(added_tags)!r}."
         )
 
 
@@ -553,6 +589,8 @@ def discover_milestone_receipt(
         )
     if evidence_index_mutation:
         _validate_append_only_evidence_index(repo_root, base_sha=base_sha)
+    if RELEASE_LEDGER_PATH in changed_paths:
+        _validate_append_only_release_ledger(repo_root, base_sha=base_sha, release_tag=release_tag)
     return repo_root / receipt_relative
 
 
@@ -616,6 +654,8 @@ def discover_milestone_manifest(
         )
     if EVIDENCE_INDEX_PATH in changed_paths:
         _validate_append_only_evidence_index(repo_root, base_sha=base_sha)
+    if RELEASE_LEDGER_PATH in changed_paths:
+        _validate_append_only_release_ledger(repo_root, base_sha=base_sha, release_tag=release_tag)
     return repo_root / manifest_relative
 
 

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -406,12 +406,17 @@ def _validate_append_only_release_ledger(repo_root: Path, *, base_sha: str, rele
 
     def records_by_tag(ledger: Mapping[str, Any], description: str) -> dict[str, Mapping[str, Any]]:
         records: dict[str, Mapping[str, Any]] = {}
-        for index, raw_record in enumerate(_sequence(ledger.get("releases"), f"{description} releases")):
+        raw_records = _sequence(ledger.get("releases"), f"{description} releases")
+        tags: list[str] = []
+        for index, raw_record in enumerate(raw_records):
             record = _mapping(raw_record, f"{description} release {index}")
             tag = _string(record.get("tag"), f"{description} release tag")
             if tag in records:
                 raise ReleaseMilestoneContextError(f"{description.capitalize()} may not contain duplicate tags.")
             records[tag] = record
+            tags.append(tag)
+        if tags != sorted(tags):
+            raise ReleaseMilestoneContextError(f"{description.capitalize()} releases must remain sorted by tag.")
         return records
 
     base_records = records_by_tag(base_ledger, "base release evidence ledger")
@@ -425,6 +430,44 @@ def _validate_append_only_release_ledger(repo_root: Path, *, base_sha: str, rele
         raise ReleaseMilestoneContextError(
             "Release evidence ledger must append exactly the pull request release tag: "
             f"expected {release_tag!r}, added={sorted(added_tags)!r}."
+        )
+    receipt_relative = f"docs/release-evidence/{release_tag}/release-receipt.json"
+    publication_relative = f"docs/release-evidence/{release_tag}/publication-record.json"
+    try:
+        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
+    except ReleaseReceiptError as error:
+        raise ReleaseMilestoneContextError(f"Release evidence ledger receipt is invalid: {error}") from error
+    release = _mapping(receipt.get("release"), "release evidence ledger receipt release")
+    workflow = _mapping(receipt.get("workflow"), "release evidence ledger receipt workflow")
+    publication = _load_json(repo_root / publication_relative, "release evidence ledger publication record")
+    expected_publication = {
+        "receipt_file_sha256": receipt_file_sha256,
+        "release_id": release.get("id"),
+        "release_tag": release_tag,
+        "source_sha": receipt.get("source_sha"),
+        "workflow_conclusion": "success",
+        "workflow_run_id": workflow.get("run_id"),
+    }
+    for field, expected in expected_publication.items():
+        if publication.get(field) != expected:
+            raise ReleaseMilestoneContextError(
+                f"Release evidence ledger publication record {field} must match the checked release receipt."
+            )
+    expected_record: dict[str, Any] = {
+        "publication_record": publication_relative,
+        "published_at": _string(publication.get("published_at"), "release publication timestamp"),
+        "receipt": receipt_relative,
+        "receipt_file_sha256": receipt_file_sha256,
+        "release_id": release.get("id"),
+        "source_sha": receipt.get("source_sha"),
+        "tag": release_tag,
+        "workflow_run_id": workflow.get("run_id"),
+    }
+    if "recovery_workflow_run" in publication:
+        expected_record["recovery_workflow_run"] = publication["recovery_workflow_run"]
+    if head_records[release_tag] != expected_record:
+        raise ReleaseMilestoneContextError(
+            "Release evidence ledger record must match the checked release receipt and publication record."
         )
 
 

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -445,7 +445,6 @@ def _validate_append_only_release_ledger(repo_root: Path, *, base_sha: str, rele
         "release_id": release.get("id"),
         "release_tag": release_tag,
         "source_sha": receipt.get("source_sha"),
-        "workflow_conclusion": "success",
         "workflow_run_id": workflow.get("run_id"),
     }
     for field, expected in expected_publication.items():
@@ -453,6 +452,10 @@ def _validate_append_only_release_ledger(repo_root: Path, *, base_sha: str, rele
             raise ReleaseMilestoneContextError(
                 f"Release evidence ledger publication record {field} must match the checked release receipt."
             )
+    if effective_successful_workflow_run_id(publication) is None:
+        raise ReleaseMilestoneContextError(
+            "Release evidence ledger publication record must identify a successful publication workflow."
+        )
     expected_record: dict[str, Any] = {
         "publication_record": publication_relative,
         "published_at": _string(publication.get("published_at"), "release publication timestamp"),

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from scripts.release_milestone_context import (
     EVIDENCE_INDEX_PATH,
+    RELEASE_LEDGER_PATH,
     ReleaseMilestoneContextError,
     discover_milestone_manifest,
     discover_milestone_receipt,
@@ -47,6 +48,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         route_table_path = root / "docs/qualification/video-quality-route-table-v2.json"
         receipt_path = root / "docs/release-evidence/v0.3.0/release-receipt.json"
         publication_path = root / "docs/release-evidence/v0.3.0/publication-record.json"
+        release_ledger_path = root / RELEASE_LEDGER_PATH
         config_path = root / ".github/github.json"
         controller_path = root / ".github/workflows/milestone-qualification.yml"
         for path in (
@@ -56,6 +58,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             route_table_path,
             receipt_path,
             publication_path,
+            release_ledger_path,
             config_path,
             controller_path,
         ):
@@ -91,6 +94,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             encoding="utf-8",
         )
         evidence_path.write_text('{"schema_version": 1, "receipts": []}\n', encoding="utf-8")
+        release_ledger_path.write_text('{"schema_version": 1, "releases": []}\n', encoding="utf-8")
         route_table_path.write_text('{"schema_version": 1, "routes": []}\n', encoding="utf-8")
         controller_path.write_text("name: Milestone Qualification\n", encoding="utf-8")
         config_path.write_text(
@@ -1331,6 +1335,139 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     base_sha=base_sha,
                     head_sha=head_sha,
                     head_branch="fix/stable-pypi-recovery",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_manifest_discovery_allows_release_ledger_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            manifest_path = root / "docs/release-evidence/v0.3.0/qualification-manifest.json"
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [{"tag": "v0.3.0"}]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", manifest_path, ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "append release ledger"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_manifest(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="automation/release-evidence-v0.3.0",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertEqual(discovered, manifest_path)
+
+    def test_manifest_discovery_rejects_release_ledger_history_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [{"tag": "v0.2.9", "release_id": 1}]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "record prior release"], cwd=root, check=True)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            manifest_path = root / "docs/release-evidence/v0.3.0/qualification-manifest.json"
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            ledger_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "releases": [
+                            {"tag": "v0.2.9", "release_id": 2},
+                            {"tag": "v0.3.0", "release_id": 3},
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", manifest_path, ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "rewrite release ledger"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "changing accepted history"):
+                discover_milestone_manifest(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="automation/release-evidence-v0.3.0",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_manifest_discovery_rejects_release_ledger_foreign_tag_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            manifest_path = root / "docs/release-evidence/v0.3.0/qualification-manifest.json"
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [{"tag": "v0.3.1"}]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", manifest_path, ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "append foreign release"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "pull request release tag"):
+                discover_milestone_manifest(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="automation/release-evidence-v0.3.0",
                     base_repo="cbusillo/BD_to_AVP",
                     head_repo="cbusillo/BD_to_AVP",
                     base_branch="main",

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -245,7 +245,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         publication_path = root / "docs/release-evidence/v0.3.0/publication-record.json"
         receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
         publication = json.loads(publication_path.read_text(encoding="utf-8"))
-        return {
+        record = {
             "publication_record": publication_path.relative_to(root).as_posix(),
             "published_at": publication["published_at"],
             "receipt": receipt_path.relative_to(root).as_posix(),
@@ -255,6 +255,9 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             "tag": receipt["release"]["tag"],
             "workflow_run_id": receipt["workflow"]["run_id"],
         }
+        if "recovery_workflow_run" in publication:
+            record["recovery_workflow_run"] = publication["recovery_workflow_run"]
+        return record
 
     @staticmethod
     def append_beta_change_scoped_evidence(
@@ -1530,6 +1533,55 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     head_repo="cbusillo/BD_to_AVP",
                     base_branch="main",
                 )
+
+    def test_manifest_discovery_allows_recovered_release_ledger_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            publication_path = root / "docs/release-evidence/v0.3.0/publication-record.json"
+            publication = json.loads(publication_path.read_text(encoding="utf-8"))
+            publication["workflow_conclusion"] = "failure"
+            publication["recovery_workflow_run"] = {
+                "operation": "pypi_recovery",
+                "workflow_conclusion": "success",
+                "workflow_run_id": 12346,
+            }
+            publication_path.write_text(json.dumps(publication) + "\n", encoding="utf-8")
+            manifest_path = root / "docs/release-evidence/v0.3.0/qualification-manifest.json"
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [self.release_ledger_record(root)]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", manifest_path, publication_path, ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "append recovered release ledger"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_manifest(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="automation/release-evidence-v0.3.0",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertEqual(discovered, manifest_path)
 
     def test_receipt_discovery_validates_release_ledger_append(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -240,6 +240,23 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         return receipt_path
 
     @staticmethod
+    def release_ledger_record(root: Path) -> dict[str, object]:
+        receipt_path = root / "docs/release-evidence/v0.3.0/release-receipt.json"
+        publication_path = root / "docs/release-evidence/v0.3.0/publication-record.json"
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        publication = json.loads(publication_path.read_text(encoding="utf-8"))
+        return {
+            "publication_record": publication_path.relative_to(root).as_posix(),
+            "published_at": publication["published_at"],
+            "receipt": receipt_path.relative_to(root).as_posix(),
+            "receipt_file_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+            "release_id": receipt["release"]["id"],
+            "source_sha": receipt["source_sha"],
+            "tag": receipt["release"]["tag"],
+            "workflow_run_id": receipt["workflow"]["run_id"],
+        }
+
+    @staticmethod
     def append_beta_change_scoped_evidence(
         root: Path,
         *,
@@ -1355,7 +1372,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             manifest_path.write_text("{}\n", encoding="utf-8")
             ledger_path = root / RELEASE_LEDGER_PATH
             ledger_path.write_text(
-                json.dumps({"schema_version": 1, "releases": [{"tag": "v0.3.0"}]}) + "\n",
+                json.dumps({"schema_version": 1, "releases": [self.release_ledger_record(root)]}) + "\n",
                 encoding="utf-8",
             )
             subprocess.run(["git", "add", manifest_path, ledger_path], cwd=root, check=True)
@@ -1406,7 +1423,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                         "schema_version": 1,
                         "releases": [
                             {"tag": "v0.2.9", "release_id": 2},
-                            {"tag": "v0.3.0", "release_id": 3},
+                            self.release_ledger_record(root),
                         ],
                     }
                 )
@@ -1472,6 +1489,85 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     head_repo="cbusillo/BD_to_AVP",
                     base_branch="main",
                 )
+
+    def test_manifest_discovery_rejects_release_ledger_record_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            manifest_path = root / "docs/release-evidence/v0.3.0/qualification-manifest.json"
+            manifest_path.write_text("{}\n", encoding="utf-8")
+            record = self.release_ledger_record(root)
+            record["receipt"] = "docs/release-evidence/v0.2.9/release-receipt.json"
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [record]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", manifest_path, ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "forge release ledger"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "checked release receipt"):
+                discover_milestone_manifest(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="automation/release-evidence-v0.3.0",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_receipt_discovery_validates_release_ledger_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            receipt_path = self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-list", "--reverse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.splitlines()[0]
+            ledger_path = root / RELEASE_LEDGER_PATH
+            ledger_path.write_text(
+                json.dumps({"schema_version": 1, "releases": [self.release_ledger_record(root)]}) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", ledger_path], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "append release ledger"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="automation/release-evidence-v0.3.0",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertEqual(discovered, receipt_path)
 
     def test_manifest_discovery_rejects_changed_receipt_for_another_release(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- recognize the canonical release evidence ledger as a shared evidence path
- require ledger changes to preserve all accepted records and metadata
- allow exactly one newly indexed tag matching the evidence pull request

## Validation
- `uv run python -m unittest tests.test_release_milestone_context` (32 passed)
- exact PR #598 milestone-context resolution passed against `808156f6...cdc5ef2`
- `uv run ruff check scripts/release_milestone_context.py tests/test_release_milestone_context.py`
- `uv run ruff format --check scripts/release_milestone_context.py tests/test_release_milestone_context.py`
- full unit discovery reached 1,786 tests; 4 environment/toolchain errors remain unrelated (local ffmpeg dylib mismatch and libbluray 1.5.0 vs required 1.4.1)

Refs #593