### PR TITLE
Prepare v0.3.2-beta.3

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -80,7 +80,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.2-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.2-beta.3-cut-packet.md
+++ b/docs/0.3.2-beta.3-cut-packet.md
@@ -1,0 +1,109 @@
+# 0.3.2 Beta 3 Cut Packet
+
+> **Prepared metadata; publication pending.**
+> Release dispatch is not authorized by this preparation. A future guarded
+> Prerelease run must use the exact merged protected-`main` SHA under a temporary
+> merge hold, and `macos-signing` approval requires separate explicit run-bound
+> authorization in the active conversation.
+
+Beta `0.3.2b3` is the scope-frozen successor to immutable Beta `0.3.2b2`.
+Issue #609 owns preparation, qualification, publication, and closeout. Product
+scope is limited to PR #611 and PR #612: deterministic coordination for the
+known timing-sensitive tests, plus batch-folder Main Feature versus All 3D
+Videos selection and durable sequential per-title fan-out. No other feature or
+Beta 2 tester-feedback fix is admitted to this candidate.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2b3` |
+| Public version | `0.3.2-beta.3` |
+| Bundle and Sparkle build | `165` |
+| GitHub tag and release title | `v0.3.2-beta.3` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `165` is globally newer than immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier production history. Burned
+builds `147` and `154` and abandoned metadata build `157` remain unavailable.
+Live state was checked on August 21, 2026: no `v0.3.2-beta.3` tag, release,
+draft, PyPI version, Homebrew pull request, or appcast item exists.
+
+## Frozen Product Scope
+
+- PR #611 replaces scheduler timing assumptions in process-runner heartbeat,
+  broken-pipe cleanup, cancellation, and resource-sampler tests with observable
+  coordination.
+- PR #612 adds Main Feature / All 3D Videos selection when a source folder
+  contains Blu-ray ISO images.
+- Selected disc titles become durable sequential queue items with stable retry
+  identities, collision checks, distinct labels, and safe source removal only
+  after the selected title set completes.
+- Main Feature remains the default; ordinary non-disc files in the same folder
+  continue to convert once.
+
+Beta 2 feedback fixes, the broad test audit #554, persistent queue roadmap #501,
+MakeMKV-free SSIF streaming #209, live processed-frame monitor #356, and Vision
+Pro companion/productization work #436–#439 remain excluded.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2-beta.3` adds explicit Main Feature or All 3D Videos
+> selection for folders containing Blu-ray ISO images. Selected disc titles are
+> queued and converted sequentially with distinct status and output identities,
+> safer retries, and source cleanup only after the selected title set finishes.
+> The release also removes known timing assumptions from the process-runner test
+> coverage. This Beta is intentionally limited to PRs #611 and #612.
+
+GitHub-generated notes compare with immutable Beta `v0.3.2-beta.2`. The
+generated history may include release-infrastructure merges completed after the
+Beta 2 tag; this reviewed seed defines the intended Beta 3 product scope.
+
+## Preparation Evidence
+
+- PR #611 merged to protected `main` at
+  `06dd3cd84c62e9eaa409da49de0a76452b6bc75d`; post-merge CI and CodeQL passed
+  on that exact commit.
+- PR #612 merged to protected `main` at
+  `9d5d01bdcb756f1cde5eb1c3232b4e6f4777bd3a`; post-merge CI and CodeQL passed
+  on that exact commit.
+- `scripts.release prepare` derived `0.3.2-beta.3`, tag/title
+  `v0.3.2-beta.3`, DMG name
+  `3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg`, Beta channel, prerelease state,
+  and no PyPI or Homebrew publication from internal version `0.3.2b3` and build
+  `165`.
+- Candidate-specific qualification is preregistered with artifact, run,
+  release, and source identities left null until an authorized exact candidate
+  exists.
+- Release metadata validation, qualification-policy validation, Ruff lint and
+  format checks, mypy, observability migration validation, import/CLI smoke,
+  181 focused release and packaging tests, 484 native tests, and `uv build`
+  passed on the preparation worktree.
+- `scripts/native_app.py package` passed with the approved diagnostics endpoint
+  and verified package version `0.3.2b3`, build `165`, app bundle integrity,
+  worker cancellation, and preview presentation.
+- Full Python discovery ran 1,785 tests with 3 skipped and reached only four
+  known local toolchain errors: the installed Homebrew `ffmpeg-full` binaries
+  resolve incompatible `ffmpeg` dylibs, and installed `libbluray` 1.5.0 differs
+  from the fixture-required 1.4.1. The same environment-only failures were
+  recorded before PR #611 merged; repository CI remains the clean broad gate.
+
+## Qualification And Authorization
+
+Immutable Beta `v0.3.2-beta.2` is the prior artifact, release-note base, and
+Sparkle update-route input. The batch title workflow requires fresh
+change-scoped preparation evidence on the exact merged preparation SHA. Same-run
+signed-artifact, installed UI, live Sparkle, clean-machine, and post-publication
+evidence remain owned by the guarded artifact and milestone phases; no unsigned
+local package can satisfy those boundaries.
+
+This preparation does not create a tag, release, signed artifact, appcast item,
+PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
+approve `macos-signing` without a separate explicit authorization.

--- a/docs/conversion-setup-beta-test-guide.md
+++ b/docs/conversion-setup-beta-test-guide.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-This Beta is a focused test of the source-first Conversion Setup experience. It
-asks whether adding one movie or a folder is obvious, the selected Result makes
-sense, Advanced Settings remain understandable, and the same movie cannot be
-queued accidentally more than once. It is not a test of the future first-class
-persistent queue.
+This Beta keeps the source-first Conversion Setup checks and adds focused
+coverage for folders containing Blu-ray ISO images. It asks whether Main
+Feature versus All 3D Videos is clear, selected disc titles become distinct
+sequential conversions, retries remain safe, and non-disc files still convert
+exactly once. It is not a test of the future first-class persistent queue.
 
 Recruit three to five testers when possible:
 
@@ -107,6 +107,24 @@ made it obvious which item needed attention.
    reachable without horizontal scrolling.
 3. Repeat one Ready or Editor check in both light and dark appearance.
 
+### 6. Batch Folder Disc Titles
+
+1. Choose **Add Folder of Movies…** with a folder containing at least one
+   Blu-ray ISO and one ordinary supported movie file.
+2. Confirm the setup offers **Main Feature** and **All 3D Videos**, with Main
+   Feature selected by default.
+3. Run Main Feature and confirm each ISO contributes only its selected main
+   title while the ordinary movie is queued once.
+4. Repeat with All 3D Videos and confirm every eligible stereoscopic title is
+   represented by a distinct queue label and output identity.
+5. Confirm selected titles run sequentially and the source is not removed until
+   all selected titles from that source finish.
+6. Retry one failed title or rerun a completed batch and confirm existing
+   successful outputs are not silently duplicated or overwritten.
+
+Record whether title selection, queue labels, ordering, and retry behavior made
+the batch outcome predictable before conversion started.
+
 ## Playback Check
 
 Play at least one Beta-produced movie on Apple Vision Pro when available. Record:
@@ -151,10 +169,9 @@ written by the Beta. Restoring the backup is part of rollback.
 
 ## Deliberate Non-Goals
 
-The following work remains separate so feedback stays attributable to Conversion
-Setup:
+The following work remains separate so feedback stays attributable to the
+prepared Beta 3 scope:
 
-- batch-folder **Main Feature** versus **All 3D Titles** selection;
 - the first-class persistent queue workspace, scheduling, notifications,
   storage forecasting, history, unattended policies, and watch-folder intake;
 - the guided Vision Pro playback companion;

--- a/docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json
@@ -1,0 +1,248 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.3",
+      "native-sparkle-notes-beta3",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "165",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2b3",
+    "public_version": "0.3.2-beta.3",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2-beta.3",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "beta",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154
+    ],
+    "previous_beta": {
+      "appcast_sha256": "d9e589452cbcc0147170dcdfa0cfdc520b761075ccde929fec64dee82c528073",
+      "build_version": "164",
+      "dmg_sha256": "72b7cba55948804724eca39f67359ee1f295fc57c9640f4c4f1a9fd1006bb774",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2b2",
+      "published_at": "2026-08-19T17:04:11Z",
+      "release_id": 373212973,
+      "release_run_id": 32277548249,
+      "release_tag": "v0.3.2-beta.2",
+      "signed_app_tree_sha256": "87a36f1a7c474fd408c0569afc4430e5cea79387f40b67e08ada65780c2dd24f",
+      "source_git_sha": "da307689f38ee696c872b98c7c784a17e9fe9d19"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#609"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.3",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-beta3",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-beta.2-change-scoped-evidence-v1",
+      "scope": "immutable prior preparation and signed-artifact qualification inputs for Beta 3"
+    }
+  ],
+  "qualification_id": "v0.3.2-beta.3-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage beta --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -22,10 +22,11 @@ records immutable publication plus its targeted qualification result. Stable
 PyPI recovery are recorded in [the Stable cut packet](0.3.0-cut-packet.md).
 Stable `0.3.1` build `162` is published and immutable; its publication is
 recorded in [the 0.3.1 cut packet](0.3.1-cut-packet.md). Beta `0.3.2b1` build
-`163` is published and immutable, tracked in
-[the 0.3.2 Beta 1 cut packet](0.3.2-beta.1-cut-packet.md) and issue #584. The
-next prepared identity is Beta `0.3.2b2` build `164`, tracked in
-[the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md) and issue #593.
+`163` and Beta `0.3.2b2` build `164` are published and immutable, tracked in
+[the 0.3.2 Beta 1 cut packet](0.3.2-beta.1-cut-packet.md),
+[the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md), issues #584 and #593.
+The next prepared identity is Beta `0.3.2b3` build `165`, tracked in
+[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md) and issue #609.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -12,9 +12,10 @@ burned builds `147`, `154`, and abandoned metadata build `157`. Failed Beta 9
 (`0.3.0b9`, build `154`) was never published. RC 1 (`0.3.0rc1`, build `158`),
 RC 2 (`0.3.0rc2`, build `159`), and RC 3 (`0.3.0rc3`, build `160`) are
 published and immutable. Stable `0.3.0` build `161` is also published and
-immutable. Stable `0.3.1` build `162` and Beta `0.3.2b1` build `163` are
-published and immutable. The next prepared target is Beta `0.3.2b2` build
-`164`; issue #593 owns publication and exact-artifact qualification.
+immutable. Stable `0.3.1` build `162`, Beta `0.3.2b1` build `163`, and Beta
+`0.3.2b2` build `164` are published and immutable. The next prepared target is
+Beta `0.3.2b3` build `165`; issue #609 owns publication and exact-artifact
+qualification.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -366,10 +367,9 @@ The reviewed metadata, release-note seed, focused Beta scope, and qualification
 boundary are in
 [the 0.3.2 Beta 1 cut packet](0.3.2-beta.1-cut-packet.md).
 
-## 0.3.2 Beta 2 Prepared Target
+## 0.3.2 Beta 2 Published History
 
-The repository is prepared for review of guarded Prerelease dispatch for
-`v0.3.2-beta.2`:
+Published `v0.3.2-beta.2` has:
 
 - internal version `0.3.2b2` and public version `0.3.2-beta.2`;
 - public tag and title `v0.3.2-beta.2`;
@@ -379,15 +379,39 @@ The repository is prepared for review of guarded Prerelease dispatch for
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta `0.3.2b1`.
 
-Publication must place Beta 2 above immutable Beta 1 build `163`, Stable
-`0.3.1` build `162`, and all earlier history. Stable and RC clients exclude the
-Beta item; Beta and Alpha clients can select it because build `164` is newer.
+Publication placed Beta 2 above immutable Beta 1 build `163`, Stable `0.3.1`
+build `162`, and all earlier history. Stable and RC clients exclude the Beta
+item; Beta and Alpha clients can select it because build `164` is newer. The
+release targets exact source SHA
+`da307689f38ee696c872b98c7c784a17e9fe9d19` and remains immutable.
 
-As checked on August 19, 2026, no `v0.3.2-beta.2` tag, release, draft, PyPI
-version, Homebrew pull request, or appcast item exists. Dispatch requires
-explicit release authorization under a fixed-`main` merge hold. The reviewed
-metadata, release-note seed, scope freeze, and qualification boundary are in
+The reviewed metadata, release-note seed, scope freeze, and qualification
+evidence are in
 [the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md).
+
+## 0.3.2 Beta 3 Prepared Target
+
+The repository is prepared for review of guarded Prerelease dispatch for
+`v0.3.2-beta.3`:
+
+- internal version `0.3.2b3` and public version `0.3.2-beta.3`;
+- public tag and title `v0.3.2-beta.3`;
+- global build `165`;
+- Sparkle channel `beta`, making the item eligible only on Beta and Alpha;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta `0.3.2b2`.
+
+Publication must place Beta 3 above immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier history. Stable and RC
+clients exclude the Beta item; Beta and Alpha clients can select it because
+build `165` is newer.
+
+As checked on August 21, 2026, no `v0.3.2-beta.3` tag, release, draft, PyPI
+version, Homebrew pull request, or appcast item exists. Dispatch requires
+separate explicit release authorization under a fixed-`main` merge hold. The
+reviewed metadata, release-note seed, scope freeze, and qualification boundary
+are in [the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 164
+        CURRENT_PROJECT_VERSION: 165
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2b2
+        MARKETING_VERSION: 0.3.2b3
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2b2"
+version = "0.3.2b3"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "164"
+build_version = "165"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b2")
-        self.assertEqual(NATIVE_BUILD_VERSION, "164")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b3")
+        self.assertEqual(NATIVE_BUILD_VERSION, "165")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -202,12 +202,12 @@ class ReleaseMetadataTests(unittest.TestCase):
     def test_repository_is_prepared_for_beta(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2b2")
-        self.assertEqual(metadata.public_version, "0.3.2-beta.2")
-        self.assertEqual(metadata.build_version, "164")
-        self.assertEqual(metadata.release_tag, "v0.3.2-beta.2")
-        self.assertEqual(metadata.release_name, "v0.3.2-beta.2")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.2.dmg")
+        self.assertEqual(metadata.package_version, "0.3.2b3")
+        self.assertEqual(metadata.public_version, "0.3.2-beta.3")
+        self.assertEqual(metadata.build_version, "165")
+        self.assertEqual(metadata.release_tag, "v0.3.2-beta.3")
+        self.assertEqual(metadata.release_name, "v0.3.2-beta.3")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.first_candidate_of_cycle)
@@ -215,15 +215,17 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.2-beta.2", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.2-beta.3", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.2-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.2b2`", cut_packet)
-        self.assertIn("Build `164`", cut_packet)
-        self.assertIn("#593", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.3-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2b3`", cut_packet)
+        self.assertIn("Build `165`", cut_packet)
+        self.assertIn("#609", cut_packet)
+        self.assertIn("PR #611", cut_packet)
+        self.assertIn("PR #612", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertIn("Published and immutable.", cut_packet)
-        self.assertIn("post-publication", cut_packet)
+        self.assertIn("Prepared metadata; publication pending.", cut_packet)
+        self.assertIn("Release dispatch is not authorized", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)
 
@@ -231,14 +233,14 @@ class ReleaseMetadataTests(unittest.TestCase):
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-beta.2-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b2")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.2")
-        self.assertEqual(qualification["candidate"]["build_version"], "164")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.2")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b3")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.3")
+        self.assertEqual(qualification["candidate"]["build_version"], "165")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.3")
         self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
@@ -248,8 +250,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.1-to-v0.3.2-beta.2",
-            "native-sparkle-notes-beta2",
+            "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.3",
+            "native-sparkle-notes-beta3",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "164")
+        self.assertEqual(info["CFBundleVersion"], "165")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -973,7 +973,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-beta.2-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2b2"
+version = "0.3.2b3"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- freeze Beta 3 product scope to merged PRs #611 and #612
- prepare `0.3.2b3` / `v0.3.2-beta.3` / build `165`
- add the Beta 3 cut packet, release-history updates, tester guidance, and preregistered qualification record
- keep candidate source, run, release, signing, and artifact identities null before authorized release orchestration

## Validation
- `uv run python -m scripts.release validate`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy bd_to_avp`
- `uv run python scripts/validate_observability_migration.py`
- 181 focused release/packaging tests passed
- 484 native tests passed
- `uv build` passed
- import and CLI smoke passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` passed for version `0.3.2b3`, build `165`

Full Python discovery ran 1,785 tests with 3 skipped and reached four known local toolchain errors only: Homebrew `ffmpeg-full` resolving incompatible `ffmpeg` dylibs, plus installed `libbluray` 1.5.0 versus the fixture-required 1.4.1. These are the same environment-only failures recorded before PR #611 merged; GitHub CI remains the clean broad gate.

JetBrains inspection was inconclusive because IntelliJ rewrote tracked project metadata while opening the isolated worktree. Those generated changes were removed; no actionable finding tied to this release metadata change was identified.

## Authorization Boundary
This PR does not dispatch Prerelease, request or approve `macos-signing`, create a tag or release, or publish any artifact. Release dispatch and signing approval remain separately authorized operations.

Refs #542
Refs #610
Refs #609
