### PR TITLE
Fix signed artifact UI installation

### DIFF
--- a/scripts/signed_artifact_ui.py
+++ b/scripts/signed_artifact_ui.py
@@ -141,6 +141,7 @@ def _run(config: SignedArtifactUIConfig, operations: MacOSOperations) -> Mapping
 
     synthetic_home = config.qualification_root / "Home"
     app_path = config.qualification_root / "Applications" / APP_NAME
+    mount_point = config.qualification_root / "Mount"
     raw_ui_directory = config.qualification_root / "InstalledUIEvidence"
     marker_path = config.qualification_root / ".bd-to-avp-signed-artifact-ui.json"
     marker = {"owner": "bd-to-avp-signed-artifact-ui", "run_id": str(uuid.uuid4())}
@@ -148,7 +149,7 @@ def _run(config: SignedArtifactUIConfig, operations: MacOSOperations) -> Mapping
     marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
     try:
         synthetic_home.mkdir(parents=True)
-        operations.install_app(config.dmg, app_path)
+        operations.install_app(config.dmg, app_path, mount_point)
         installed_app_tree_sha256 = app_tree_sha256(app_path)
         if installed_app_tree_sha256 != expectation.signed_app_tree_sha256:
             raise SignedArtifactUIError("Installed app tree digest does not match the signed package receipt.")

--- a/tests/test_signed_artifact_ui.py
+++ b/tests/test_signed_artifact_ui.py
@@ -22,8 +22,10 @@ class FakeOperations:
         self.profiles_after = 1
         self.profiles_before = 0
         self.running = False
+        self.install_mount_point: Path | None = None
 
-    def install_app(self, _dmg_path: Path, destination: Path) -> None:
+    def install_app(self, _dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        self.install_mount_point = mount_point
         destination.parent.mkdir(parents=True, exist_ok=True)
         if destination.exists():
             raise AssertionError("test destination should start empty")
@@ -270,10 +272,12 @@ class SignedArtifactUITests(unittest.TestCase):
                 release_receipt_file_sha256=release_receipt_sha256,
             )
 
-            receipt = run(config, FakeOperations(app))
+            operations = FakeOperations(app)
+            receipt = run(config, operations)
 
             self.assertTrue(output_receipt.exists())
             self.assertFalse(config.qualification_root.exists())
+            self.assertEqual(operations.install_mount_point, config.qualification_root / "Mount")
             self.assertEqual(receipt["case_id"], "profile-save-action-accessibility")
             self.assertEqual(receipt["release_receipt"]["asset_id"], 4)
             self.assertEqual(receipt["dmg"]["name"], dmg.name)


### PR DESCRIPTION
## Summary
- pass the qualification workspace mount point to `MacOSOperations.install_app`
- update the signed-artifact UI test double to match the production method contract
- assert the exact bounded mount path used by the runner

## Release failure
Guarded Prerelease run `32446869702` failed before publication in `Prove signed artifact UI accessibility` with:

`TypeError: MacOSOperations.install_app() missing 1 required positional argument: 'mount_point'`

The signed package was produced, but the artifact UI gate failed closed and downstream publication did not complete.

## Validation
- `uv run python -m unittest tests.test_signed_artifact_ui tests.test_tier3_clean_machine` — 47 passed
- `uv run python -m unittest tests.test_sparkle_workflows` — 32 passed
- changed-file Ruff lint and format checks passed

Refs #609
