### PR TITLE
Prepare v0.3.2-beta.4 recovery

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -80,7 +80,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.2-beta.3-cut-packet.md
+++ b/docs/0.3.2-beta.3-cut-packet.md
@@ -1,13 +1,12 @@
 # 0.3.2 Beta 3 Cut Packet
 
-> **Prepared metadata; publication pending.**
-> Release dispatch is not authorized by this preparation. A future guarded
-> Prerelease run must use the exact merged protected-`main` SHA under a temporary
-> merge hold, and `macos-signing` approval requires separate explicit run-bound
-> authorization in the active conversation.
+> **Failed and unpublished.**
+> Beta 3 reached production signing but failed before publication. Internal
+> version `0.3.2b3`, public identity `v0.3.2-beta.3`, and build `165` are burned
+> and must not be rebuilt, retagged, or published.
 
-Beta `0.3.2b3` is the scope-frozen successor to immutable Beta `0.3.2b2`.
-Issue #609 owns preparation, qualification, publication, and closeout. Product
+Beta `0.3.2b3` was the scope-frozen successor to immutable Beta `0.3.2b2`.
+Issue #609 owns its failed-attempt recovery and successor release. Product
 scope is limited to PR #611 and PR #612: deterministic coordination for the
 known timing-sensitive tests, plus batch-folder Main Feature versus All 3D
 Videos selection and durable sequential per-title fan-out. No other feature or
@@ -30,11 +29,32 @@ Beta 2 tester-feedback fix is admitted to this candidate.
 | Bundle identifier | `com.shinycomputers.bd-to-avp` |
 | Privacy contract | Privacy rules version `5` |
 
-Build `165` is globally newer than immutable Beta 2 build `164`, Beta 1 build
-`163`, Stable `0.3.1` build `162`, and all earlier production history. Burned
-builds `147` and `154` and abandoned metadata build `157` remain unavailable.
-Live state was checked on August 21, 2026: no `v0.3.2-beta.3` tag, release,
-draft, PyPI version, Homebrew pull request, or appcast item exists.
+Build `165` was globally newer than immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier production history. It joins
+burned builds `147` and `154`; abandoned metadata build `157` remains
+unavailable. No published `v0.3.2-beta.3` tag, release, appcast item, Pages
+state, PyPI version, or Homebrew change exists.
+
+## Failed Attempt Receipt
+
+- Guarded Prerelease run `32446869702`, attempt `1`.
+- Exact source SHA `d2d455fdbedfde19b40a3be9c86e98997ec42981`.
+- Production signing and notarization completed after explicit run-bound
+  approval.
+- Signed-artifact UI job `96670916278` failed because
+  `MacOSOperations.install_app()` was called without its required `mount_point`.
+- Unpublished draft release ID `374173827` was created and later deleted after
+  its identities were durably recorded and recovery was explicitly authorized.
+- Draft DMG asset `523237480` had SHA-256
+  `a3d8398c565c7bb9771eb5eca772307b6d028eec32ad8a1dcc7fa7ee5efa3c11`.
+- Draft appcast asset `523238130` had SHA-256
+  `87c9b42a8423ab483dda77ab353fe91eaa5e81545c11c7f3caf0a9160defefeb`.
+- Draft release receipt asset `523238644` had SHA-256
+  `7c178d1f0bd42c938adde01793f23ff8f2dd1afae0bebcf07e5a551c6ec6be2b`.
+- Draft checksum asset `523237529` had SHA-256
+  `35201ee40eff92f7800061b8cf851d24d13068795903d418f70fd30ca2b5a1f2`.
+- PR #617 fixed the installer contract and merged at
+  `02baeb08342ca6e5f8e132f85fe7a5a470853be6` with passing CI and CodeQL.
 
 ## Frozen Product Scope
 
@@ -104,6 +124,6 @@ signed-artifact, installed UI, live Sparkle, clean-machine, and post-publication
 evidence remain owned by the guarded artifact and milestone phases; no unsigned
 local package can satisfy those boundaries.
 
-This preparation does not create a tag, release, signed artifact, appcast item,
-PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
-approve `macos-signing` without a separate explicit authorization.
+This failed attempt did not publish a tag, release, appcast item, Pages state,
+PyPI version, or Homebrew change. The corrected source advances to Beta 4 build
+`166`; do not recreate or publish Beta 3.

--- a/docs/0.3.2-beta.4-cut-packet.md
+++ b/docs/0.3.2-beta.4-cut-packet.md
@@ -1,0 +1,96 @@
+# 0.3.2 Beta 4 Cut Packet
+
+> **Prepared metadata; publication pending.**
+> Release dispatch is not authorized by this preparation. A future guarded
+> Prerelease run must use the exact merged protected-`main` SHA under a temporary
+> merge hold, and `macos-signing` approval requires separate explicit run-bound
+> authorization in the active conversation.
+
+Beta `0.3.2b4` is the recovery successor to failed unpublished Beta
+`0.3.2b3`. Issue #609 owns preparation, qualification, publication, and
+closeout. Product scope remains limited to PR #611 and PR #612; PR #617 only
+repairs the signed-artifact UI installer contract that stopped Beta 3 before
+publication.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2b4` |
+| Public version | `0.3.2-beta.4` |
+| Bundle and Sparkle build | `166` |
+| GitHub tag and release title | `v0.3.2-beta.4` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `166` is globally newer than immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier published production
+history. Failed signed Beta 3 build `165`, burned builds `147` and `154`, and
+abandoned metadata build `157` remain unavailable. Live state was checked on
+August 21, 2026: no `v0.3.2-beta.4` tag, release, draft, PyPI version, Homebrew
+pull request, or appcast item exists.
+
+## Frozen Product Scope
+
+- PR #611 replaces scheduler timing assumptions in process-runner heartbeat,
+  broken-pipe cleanup, cancellation, and resource-sampler tests with observable
+  coordination.
+- PR #612 adds Main Feature / All 3D Videos selection for source folders
+  containing Blu-ray ISO images, with durable sequential per-title fan-out,
+  stable retry identity, collision checks, and final-title source removal.
+- PR #617 passes a bounded DMG mount point into the signed-artifact UI installer
+  and regression-covers the production method contract.
+
+Beta 2 feedback fixes, broad test audit #554, persistent queue roadmap #501,
+MakeMKV-free SSIF streaming #209, live processed-frame monitor #356, and Vision
+Pro companion/productization work #436–#439 remain excluded.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2-beta.4` adds explicit Main Feature or All 3D Videos
+> selection for folders containing Blu-ray ISO images. Selected disc titles are
+> converted sequentially with distinct output identities, safer retries, and
+> source cleanup only after the selected title set completes. It also includes
+> the release qualification installer fix required after the unpublished Beta 3
+> attempt.
+
+GitHub-generated notes compare with immutable Beta `v0.3.2-beta.2`. Failed
+unpublished Beta 3 is not a release-note base or appcast item.
+
+## Recovery Evidence
+
+- Beta 3 run `32446869702` signed and notarized build `165`, then failed before
+  publication in signed-artifact UI qualification.
+- Draft release `374173827` and all asset identities were recorded before the
+  unpublished draft was deleted under explicit authorization.
+- PR #617 fixed the exact installer contract failure and passed PR plus
+  post-merge CI and CodeQL at
+  `02baeb08342ca6e5f8e132f85fe7a5a470853be6`.
+- `scripts.release prepare` derived Beta 4 metadata from internal version
+  `0.3.2b4` and global build `166` without changing product identity or
+  publication effects.
+- Release metadata and qualification-policy validation, Ruff lint and format
+  checks, mypy, observability migration validation, 181 focused release and
+  packaging tests, 484 native tests, and `uv build` passed on the preparation
+  worktree.
+- `scripts/native_app.py package` passed with the approved diagnostics endpoint
+  and verified package version `0.3.2b4`, build `166`, app bundle integrity,
+  worker cancellation, and preview presentation.
+
+## Qualification And Authorization
+
+Immutable Beta `v0.3.2-beta.2` remains the prior published artifact,
+release-note base, and Sparkle update-route input. Failed Beta 3 evidence is
+historical recovery context only. Candidate-specific release-run, signed
+artifact, installed UI, live Sparkle, clean-machine, and post-publication
+evidence remain owned by the guarded artifact and milestone phases.
+
+This preparation does not create a tag, release, signed artifact, appcast item,
+PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
+approve `macos-signing` without a separate explicit authorization.

--- a/docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json
@@ -1,0 +1,249 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+      "native-sparkle-notes-beta4",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "166",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2b4",
+    "public_version": "0.3.2-beta.4",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2-beta.4",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "beta",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154
+    ],
+    "previous_beta": {
+      "appcast_sha256": "d9e589452cbcc0147170dcdfa0cfdc520b761075ccde929fec64dee82c528073",
+      "build_version": "164",
+      "dmg_sha256": "72b7cba55948804724eca39f67359ee1f295fc57c9640f4c4f1a9fd1006bb774",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2b2",
+      "published_at": "2026-08-19T17:04:11Z",
+      "release_id": 373212973,
+      "release_run_id": 32277548249,
+      "release_tag": "v0.3.2-beta.2",
+      "signed_app_tree_sha256": "87a36f1a7c474fd408c0569afc4430e5cea79387f40b67e08ada65780c2dd24f",
+      "source_git_sha": "da307689f38ee696c872b98c7c784a17e9fe9d19"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#617",
+    "#609"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-beta4",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-beta.3-change-scoped-evidence-v1",
+      "scope": "immutable change-scoped preparation evidence carried from the failed unpublished Beta 3 attempt"
+    }
+  ],
+  "qualification_id": "v0.3.2-beta.4-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage beta --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,8 +25,11 @@ recorded in [the 0.3.1 cut packet](0.3.1-cut-packet.md). Beta `0.3.2b1` build
 `163` and Beta `0.3.2b2` build `164` are published and immutable, tracked in
 [the 0.3.2 Beta 1 cut packet](0.3.2-beta.1-cut-packet.md),
 [the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md), issues #584 and #593.
-The next prepared identity is Beta `0.3.2b3` build `165`, tracked in
-[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md) and issue #609.
+Beta `0.3.2b3` build `165` is a failed unpublished signed attempt and its
+identity is permanently burned, as recorded in
+[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md). The next prepared
+identity is Beta `0.3.2b4` build `166`, tracked in
+[the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md) and issue #609.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -13,9 +13,10 @@ burned builds `147`, `154`, and abandoned metadata build `157`. Failed Beta 9
 RC 2 (`0.3.0rc2`, build `159`), and RC 3 (`0.3.0rc3`, build `160`) are
 published and immutable. Stable `0.3.0` build `161` is also published and
 immutable. Stable `0.3.1` build `162`, Beta `0.3.2b1` build `163`, and Beta
-`0.3.2b2` build `164` are published and immutable. The next prepared target is
-Beta `0.3.2b3` build `165`; issue #609 owns publication and exact-artifact
-qualification.
+`0.3.2b2` build `164` are published and immutable. Beta `0.3.2b3` build `165`
+is a failed unpublished signed attempt and both identities are burned. The next
+prepared target is Beta `0.3.2b4` build `166`; issue #609 owns publication and
+exact-artifact qualification.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -389,10 +390,9 @@ The reviewed metadata, release-note seed, scope freeze, and qualification
 evidence are in
 [the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md).
 
-## 0.3.2 Beta 3 Prepared Target
+## 0.3.2 Beta 3 Failed Attempt
 
-The repository is prepared for review of guarded Prerelease dispatch for
-`v0.3.2-beta.3`:
+Beta 3 is failed, unpublished, and permanently burned:
 
 - internal version `0.3.2b3` and public version `0.3.2-beta.3`;
 - public tag and title `v0.3.2-beta.3`;
@@ -402,16 +402,43 @@ The repository is prepared for review of guarded Prerelease dispatch for
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta `0.3.2b2`.
 
-Publication must place Beta 3 above immutable Beta 2 build `164`, Beta 1 build
-`163`, Stable `0.3.1` build `162`, and all earlier history. Stable and RC
-clients exclude the Beta item; Beta and Alpha clients can select it because
-build `165` is newer.
+Guarded Prerelease run `32446869702` built, Developer ID signed, notarized, and
+packaged build `165` from source SHA
+`d2d455fdbedfde19b40a3be9c86e98997ec42981`. The run failed before publication
+in the signed-artifact UI accessibility lane because the installer call omitted
+its required DMG mount point. No public tag, release, appcast item, Pages state,
+PyPI version, or Homebrew change was created.
 
-As checked on August 21, 2026, no `v0.3.2-beta.3` tag, release, draft, PyPI
+The unpublished draft and its asset identities were recorded, then the draft
+was deleted after explicit recovery authorization. The corrected source
+advances to Beta 4 build `166` rather than reusing either Beta 3 identity. The
+failed-attempt details are in
+[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md).
+
+## 0.3.2 Beta 4 Prepared Target
+
+The repository is prepared for review of guarded Prerelease dispatch for
+`v0.3.2-beta.4`:
+
+- internal version `0.3.2b4` and public version `0.3.2-beta.4`;
+- public tag and title `v0.3.2-beta.4`;
+- global build `166`;
+- Sparkle channel `beta`, making the item eligible only on Beta and Alpha;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta `0.3.2b2`.
+
+Publication must place Beta 4 above immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier published history, with
+failed Beta 3 build `165` absent. Stable and RC clients exclude the Beta item;
+Beta and Alpha clients can select it because build `166` is newer.
+
+As checked on August 21, 2026, no `v0.3.2-beta.4` tag, release, draft, PyPI
 version, Homebrew pull request, or appcast item exists. Dispatch requires
 separate explicit release authorization under a fixed-`main` merge hold. The
-reviewed metadata, release-note seed, scope freeze, and qualification boundary
-are in [the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md).
+reviewed metadata, release-note seed, scope freeze, recovery evidence, and
+qualification boundary are in
+[the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 165
+        CURRENT_PROJECT_VERSION: 166
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2b3
+        MARKETING_VERSION: 0.3.2b4
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2b3"
+version = "0.3.2b4"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "165"
+build_version = "166"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b3")
-        self.assertEqual(NATIVE_BUILD_VERSION, "165")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b4")
+        self.assertEqual(NATIVE_BUILD_VERSION, "166")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -202,12 +202,12 @@ class ReleaseMetadataTests(unittest.TestCase):
     def test_repository_is_prepared_for_beta(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2b3")
-        self.assertEqual(metadata.public_version, "0.3.2-beta.3")
-        self.assertEqual(metadata.build_version, "165")
-        self.assertEqual(metadata.release_tag, "v0.3.2-beta.3")
-        self.assertEqual(metadata.release_name, "v0.3.2-beta.3")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg")
+        self.assertEqual(metadata.package_version, "0.3.2b4")
+        self.assertEqual(metadata.public_version, "0.3.2-beta.4")
+        self.assertEqual(metadata.build_version, "166")
+        self.assertEqual(metadata.release_tag, "v0.3.2-beta.4")
+        self.assertEqual(metadata.release_name, "v0.3.2-beta.4")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.first_candidate_of_cycle)
@@ -215,11 +215,11 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.2-beta.3", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.2-beta.4", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.3-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.2b3`", cut_packet)
-        self.assertIn("Build `165`", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.4-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2b4`", cut_packet)
+        self.assertIn("Build `166`", cut_packet)
         self.assertIn("#609", cut_packet)
         self.assertIn("PR #611", cut_packet)
         self.assertIn("PR #612", cut_packet)
@@ -233,14 +233,14 @@ class ReleaseMetadataTests(unittest.TestCase):
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b3")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.3")
-        self.assertEqual(qualification["candidate"]["build_version"], "165")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.3")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b4")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.4")
+        self.assertEqual(qualification["candidate"]["build_version"], "166")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.4")
         self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
@@ -250,8 +250,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.3",
-            "native-sparkle-notes-beta3",
+            "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+            "native-sparkle-notes-beta4",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "165")
+        self.assertEqual(info["CFBundleVersion"], "166")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -973,7 +973,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2b3"
+version = "0.3.2b4"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- record failed unpublished Beta 3 build `165` and its deleted draft/asset identities
- prepare recovery identity `0.3.2b4` / `v0.3.2-beta.4` / build `166`
- preregister the Beta 4 qualification record while preserving Beta 2 as the last published update base
- keep product scope frozen to PRs #611 and #612; PR #617 is release qualification recovery only

## Validation
- `uv run python -m scripts.release validate`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- Ruff lint and format checks passed
- mypy and observability migration validation passed
- 181 focused release/packaging tests passed
- 484 native tests passed
- `uv build` passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` passed for version `0.3.2b4`, build `166`

## Recovery boundary
- failed Prerelease run `32446869702` and draft release `374173827` identities are recorded in the Beta 3 cut packet and plan #609
- only the unpublished draft was deleted after explicit authorization
- this PR does not dispatch Beta 4, approve signing, create a tag, or publish an artifact

Refs #609
