### PR TITLE
Prepare v0.3.2-beta.4 recovery

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -80,7 +80,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.2-beta.3-cut-packet.md
+++ b/docs/0.3.2-beta.3-cut-packet.md
@@ -1,13 +1,12 @@
 # 0.3.2 Beta 3 Cut Packet
 
-> **Prepared metadata; publication pending.**
-> Release dispatch is not authorized by this preparation. A future guarded
-> Prerelease run must use the exact merged protected-`main` SHA under a temporary
-> merge hold, and `macos-signing` approval requires separate explicit run-bound
-> authorization in the active conversation.
+> **Failed and unpublished.**
+> Beta 3 reached production signing but failed before publication. Internal
+> version `0.3.2b3`, public identity `v0.3.2-beta.3`, and build `165` are burned
+> and must not be rebuilt, retagged, or published.
 
-Beta `0.3.2b3` is the scope-frozen successor to immutable Beta `0.3.2b2`.
-Issue #609 owns preparation, qualification, publication, and closeout. Product
+Beta `0.3.2b3` was the scope-frozen successor to immutable Beta `0.3.2b2`.
+Issue #609 owns its failed-attempt recovery and successor release. Product
 scope is limited to PR #611 and PR #612: deterministic coordination for the
 known timing-sensitive tests, plus batch-folder Main Feature versus All 3D
 Videos selection and durable sequential per-title fan-out. No other feature or
@@ -30,11 +29,32 @@ Beta 2 tester-feedback fix is admitted to this candidate.
 | Bundle identifier | `com.shinycomputers.bd-to-avp` |
 | Privacy contract | Privacy rules version `5` |
 
-Build `165` is globally newer than immutable Beta 2 build `164`, Beta 1 build
-`163`, Stable `0.3.1` build `162`, and all earlier production history. Burned
-builds `147` and `154` and abandoned metadata build `157` remain unavailable.
-Live state was checked on August 21, 2026: no `v0.3.2-beta.3` tag, release,
-draft, PyPI version, Homebrew pull request, or appcast item exists.
+Build `165` was globally newer than immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier production history. It joins
+burned builds `147` and `154`; abandoned metadata build `157` remains
+unavailable. No published `v0.3.2-beta.3` tag, release, appcast item, Pages
+state, PyPI version, or Homebrew change exists.
+
+## Failed Attempt Receipt
+
+- Guarded Prerelease run `32446869702`, attempt `1`.
+- Exact source SHA `d2d455fdbedfde19b40a3be9c86e98997ec42981`.
+- Production signing and notarization completed after explicit run-bound
+  approval.
+- Signed-artifact UI job `96670916278` failed because
+  `MacOSOperations.install_app()` was called without its required `mount_point`.
+- Unpublished draft release ID `374173827` was created and later deleted after
+  its identities were durably recorded and recovery was explicitly authorized.
+- Draft DMG asset `523237480` had SHA-256
+  `a3d8398c565c7bb9771eb5eca772307b6d028eec32ad8a1dcc7fa7ee5efa3c11`.
+- Draft appcast asset `523238130` had SHA-256
+  `87c9b42a8423ab483dda77ab353fe91eaa5e81545c11c7f3caf0a9160defefeb`.
+- Draft release receipt asset `523238644` had SHA-256
+  `7c178d1f0bd42c938adde01793f23ff8f2dd1afae0bebcf07e5a551c6ec6be2b`.
+- Draft checksum asset `523237529` had SHA-256
+  `35201ee40eff92f7800061b8cf851d24d13068795903d418f70fd30ca2b5a1f2`.
+- PR #617 fixed the installer contract and merged at
+  `02baeb08342ca6e5f8e132f85fe7a5a470853be6` with passing CI and CodeQL.
 
 ## Frozen Product Scope
 
@@ -104,6 +124,6 @@ signed-artifact, installed UI, live Sparkle, clean-machine, and post-publication
 evidence remain owned by the guarded artifact and milestone phases; no unsigned
 local package can satisfy those boundaries.
 
-This preparation does not create a tag, release, signed artifact, appcast item,
-PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
-approve `macos-signing` without a separate explicit authorization.
+This failed attempt did not publish a tag, release, appcast item, Pages state,
+PyPI version, or Homebrew change. The corrected source advances to Beta 4 build
+`166`; do not recreate or publish Beta 3.

--- a/docs/0.3.2-beta.4-cut-packet.md
+++ b/docs/0.3.2-beta.4-cut-packet.md
@@ -1,0 +1,96 @@
+# 0.3.2 Beta 4 Cut Packet
+
+> **Prepared metadata; publication pending.**
+> Release dispatch is not authorized by this preparation. A future guarded
+> Prerelease run must use the exact merged protected-`main` SHA under a temporary
+> merge hold, and `macos-signing` approval requires separate explicit run-bound
+> authorization in the active conversation.
+
+Beta `0.3.2b4` is the recovery successor to failed unpublished Beta
+`0.3.2b3`. Issue #609 owns preparation, qualification, publication, and
+closeout. Product scope remains limited to PR #611 and PR #612; PR #617 only
+repairs the signed-artifact UI installer contract that stopped Beta 3 before
+publication.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2b4` |
+| Public version | `0.3.2-beta.4` |
+| Bundle and Sparkle build | `166` |
+| GitHub tag and release title | `v0.3.2-beta.4` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `166` is globally newer than immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier published production
+history. Failed signed Beta 3 build `165`, burned builds `147` and `154`, and
+abandoned metadata build `157` remain unavailable. Live state was checked on
+August 21, 2026: no `v0.3.2-beta.4` tag, release, draft, PyPI version, Homebrew
+pull request, or appcast item exists.
+
+## Frozen Product Scope
+
+- PR #611 replaces scheduler timing assumptions in process-runner heartbeat,
+  broken-pipe cleanup, cancellation, and resource-sampler tests with observable
+  coordination.
+- PR #612 adds Main Feature / All 3D Videos selection for source folders
+  containing Blu-ray ISO images, with durable sequential per-title fan-out,
+  stable retry identity, collision checks, and final-title source removal.
+- PR #617 passes a bounded DMG mount point into the signed-artifact UI installer
+  and regression-covers the production method contract.
+
+Beta 2 feedback fixes, broad test audit #554, persistent queue roadmap #501,
+MakeMKV-free SSIF streaming #209, live processed-frame monitor #356, and Vision
+Pro companion/productization work #436–#439 remain excluded.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2-beta.4` adds explicit Main Feature or All 3D Videos
+> selection for folders containing Blu-ray ISO images. Selected disc titles are
+> converted sequentially with distinct output identities, safer retries, and
+> source cleanup only after the selected title set completes. It also includes
+> the release qualification installer fix required after the unpublished Beta 3
+> attempt.
+
+GitHub-generated notes compare with immutable Beta `v0.3.2-beta.2`. Failed
+unpublished Beta 3 is not a release-note base or appcast item.
+
+## Recovery Evidence
+
+- Beta 3 run `32446869702` signed and notarized build `165`, then failed before
+  publication in signed-artifact UI qualification.
+- Draft release `374173827` and all asset identities were recorded before the
+  unpublished draft was deleted under explicit authorization.
+- PR #617 fixed the exact installer contract failure and passed PR plus
+  post-merge CI and CodeQL at
+  `02baeb08342ca6e5f8e132f85fe7a5a470853be6`.
+- `scripts.release prepare` derived Beta 4 metadata from internal version
+  `0.3.2b4` and global build `166` without changing product identity or
+  publication effects.
+- Release metadata and qualification-policy validation, Ruff lint and format
+  checks, mypy, observability migration validation, 181 focused release and
+  packaging tests, 484 native tests, and `uv build` passed on the preparation
+  worktree.
+- `scripts/native_app.py package` passed with the approved diagnostics endpoint
+  and verified package version `0.3.2b4`, build `166`, app bundle integrity,
+  worker cancellation, and preview presentation.
+
+## Qualification And Authorization
+
+Immutable Beta `v0.3.2-beta.2` remains the prior published artifact,
+release-note base, and Sparkle update-route input. Failed Beta 3 evidence is
+historical recovery context only. Candidate-specific release-run, signed
+artifact, installed UI, live Sparkle, clean-machine, and post-publication
+evidence remain owned by the guarded artifact and milestone phases.
+
+This preparation does not create a tag, release, signed artifact, appcast item,
+PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
+approve `macos-signing` without a separate explicit authorization.

--- a/docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json
@@ -1,0 +1,250 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+      "native-sparkle-notes-beta4",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "166",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2b4",
+    "public_version": "0.3.2-beta.4",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2-beta.4",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "beta",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154,
+      165
+    ],
+    "previous_beta": {
+      "appcast_sha256": "d9e589452cbcc0147170dcdfa0cfdc520b761075ccde929fec64dee82c528073",
+      "build_version": "164",
+      "dmg_sha256": "72b7cba55948804724eca39f67359ee1f295fc57c9640f4c4f1a9fd1006bb774",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2b2",
+      "published_at": "2026-08-19T17:04:11Z",
+      "release_id": 373212973,
+      "release_run_id": 32277548249,
+      "release_tag": "v0.3.2-beta.2",
+      "signed_app_tree_sha256": "87a36f1a7c474fd408c0569afc4430e5cea79387f40b67e08ada65780c2dd24f",
+      "source_git_sha": "da307689f38ee696c872b98c7c784a17e9fe9d19"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#617",
+    "#609"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-beta4",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-beta.3-change-scoped-evidence-v1",
+      "scope": "immutable change-scoped preparation evidence carried from the failed unpublished Beta 3 attempt"
+    }
+  ],
+  "qualification_id": "v0.3.2-beta.4-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage beta --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-attempts/v0.3.2-beta.3/failed-attempt-v1.json
+++ b/docs/release-attempts/v0.3.2-beta.3/failed-attempt-v1.json
@@ -1,0 +1,23 @@
+{
+  "build_version": "165",
+  "draft_deleted": true,
+  "draft_release_id": 374173827,
+  "failed_job": "Prove signed artifact UI accessibility",
+  "failed_job_id": 96670916278,
+  "failed_step": "Run installed candidate UI accessibility lane",
+  "must_not_rebuild": true,
+  "package_version": "0.3.2b3",
+  "public_version": "0.3.2-beta.3",
+  "published_at": null,
+  "recorded_at": "2026-08-21T05:10:18Z",
+  "release_receipt_file_sha256": "7c178d1f0bd42c938adde01793f23ff8f2dd1afae0bebcf07e5a551c6ec6be2b",
+  "release_receipt_path": "docs/release-attempts/v0.3.2-beta.3/release-receipt.json",
+  "release_receipt_sha256": "ce96bac4203b6621fe33b77ba5d828ba0afd5ebd8268f3da5294ae8d42dfbffb",
+  "release_tag": "v0.3.2-beta.3",
+  "schema_version": 1,
+  "source_sha": "d2d455fdbedfde19b40a3be9c86e98997ec42981",
+  "status": "failed_unpublished_signed_candidate",
+  "workflow_conclusion": "failure",
+  "workflow_run_attempt": 1,
+  "workflow_run_id": 32446869702
+}

--- a/docs/release-attempts/v0.3.2-beta.3/release-receipt.json
+++ b/docs/release-attempts/v0.3.2-beta.3/release-receipt.json
@@ -1,0 +1,75 @@
+{
+  "appcast": {
+    "live_pages_sha256": "87c9b42a8423ab483dda77ab353fe91eaa5e81545c11c7f3caf0a9160defefeb",
+    "live_pages_state": "pending_release_deploy",
+    "live_pages_url": "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+  },
+  "artifacts": [
+    {
+      "asset_id": 523238130,
+      "kind": "appcast",
+      "name": "appcast.xml",
+      "sha256": "87c9b42a8423ab483dda77ab353fe91eaa5e81545c11c7f3caf0a9160defefeb",
+      "size_bytes": 82748
+    },
+    {
+      "asset_id": 523237529,
+      "kind": "checksum",
+      "name": "SHA256SUMS",
+      "sha256": "35201ee40eff92f7800061b8cf851d24d13068795903d418f70fd30ca2b5a1f2",
+      "size_bytes": 108
+    },
+    {
+      "asset_id": 523237480,
+      "kind": "dmg",
+      "name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg",
+      "sha256": "a3d8398c565c7bb9771eb5eca772307b6d028eec32ad8a1dcc7fa7ee5efa3c11",
+      "size_bytes": 166824307
+    }
+  ],
+  "protected_branch": "main",
+  "receipt_sha256": "ce96bac4203b6621fe33b77ba5d828ba0afd5ebd8268f3da5294ae8d42dfbffb",
+  "receipt_type": "bd-to-avp-release-engine",
+  "release": {
+    "created_at": "2026-08-21T04:42:03Z",
+    "id": 374173827,
+    "make_latest": false,
+    "name": "v0.3.2-beta.3",
+    "prerelease": true,
+    "tag": "v0.3.2-beta.3",
+    "target_sha": "d2d455fdbedfde19b40a3be9c86e98997ec42981"
+  },
+  "release_route": "prerelease",
+  "repository": "cbusillo/BD_to_AVP",
+  "schema_version": 1,
+  "signed_app_tree_sha256": "52701aa8f9f5c07ab07a8ddc374aead89f640a69cc8d328894064aa274b3e1a6",
+  "source_sha": "d2d455fdbedfde19b40a3be9c86e98997ec42981",
+  "tier1_case_references": [
+    "release-workflow-identity",
+    "signed-packaged-route-parity"
+  ],
+  "verification": {
+    "app_notarization": "passed",
+    "app_staple": "passed",
+    "appcast": "passed",
+    "asset_redownload": "passed",
+    "attestation": "passed",
+    "dmg_notarization": "passed",
+    "dmg_staple": "passed",
+    "gatekeeper": "passed",
+    "package_smoke": "passed"
+  },
+  "versions": {
+    "build": "165",
+    "package": "0.3.2b3",
+    "public": "0.3.2-beta.3"
+  },
+  "workflow": {
+    "actor": "shiny-code-bot",
+    "engine_path": ".github/workflows/release-engine.yml",
+    "name": "Prerelease",
+    "path": ".github/workflows/prerelease.yml",
+    "run_attempt": 1,
+    "run_id": 32446869702
+  }
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,8 +25,11 @@ recorded in [the 0.3.1 cut packet](0.3.1-cut-packet.md). Beta `0.3.2b1` build
 `163` and Beta `0.3.2b2` build `164` are published and immutable, tracked in
 [the 0.3.2 Beta 1 cut packet](0.3.2-beta.1-cut-packet.md),
 [the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md), issues #584 and #593.
-The next prepared identity is Beta `0.3.2b3` build `165`, tracked in
-[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md) and issue #609.
+Beta `0.3.2b3` build `165` is a failed unpublished signed attempt and its
+identity is permanently burned, as recorded in
+[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md). The next prepared
+identity is Beta `0.3.2b4` build `166`, tracked in
+[the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md) and issue #609.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -13,9 +13,10 @@ burned builds `147`, `154`, and abandoned metadata build `157`. Failed Beta 9
 RC 2 (`0.3.0rc2`, build `159`), and RC 3 (`0.3.0rc3`, build `160`) are
 published and immutable. Stable `0.3.0` build `161` is also published and
 immutable. Stable `0.3.1` build `162`, Beta `0.3.2b1` build `163`, and Beta
-`0.3.2b2` build `164` are published and immutable. The next prepared target is
-Beta `0.3.2b3` build `165`; issue #609 owns publication and exact-artifact
-qualification.
+`0.3.2b2` build `164` are published and immutable. Beta `0.3.2b3` build `165`
+is a failed unpublished signed attempt and both identities are burned. The next
+prepared target is Beta `0.3.2b4` build `166`; issue #609 owns publication and
+exact-artifact qualification.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -389,10 +390,9 @@ The reviewed metadata, release-note seed, scope freeze, and qualification
 evidence are in
 [the 0.3.2 Beta 2 cut packet](0.3.2-beta.2-cut-packet.md).
 
-## 0.3.2 Beta 3 Prepared Target
+## 0.3.2 Beta 3 Failed Attempt
 
-The repository is prepared for review of guarded Prerelease dispatch for
-`v0.3.2-beta.3`:
+Beta 3 is failed, unpublished, and permanently burned:
 
 - internal version `0.3.2b3` and public version `0.3.2-beta.3`;
 - public tag and title `v0.3.2-beta.3`;
@@ -402,16 +402,43 @@ The repository is prepared for review of guarded Prerelease dispatch for
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as Beta `0.3.2b2`.
 
-Publication must place Beta 3 above immutable Beta 2 build `164`, Beta 1 build
-`163`, Stable `0.3.1` build `162`, and all earlier history. Stable and RC
-clients exclude the Beta item; Beta and Alpha clients can select it because
-build `165` is newer.
+Guarded Prerelease run `32446869702` built, Developer ID signed, notarized, and
+packaged build `165` from source SHA
+`d2d455fdbedfde19b40a3be9c86e98997ec42981`. The run failed before publication
+in the signed-artifact UI accessibility lane because the installer call omitted
+its required DMG mount point. No public tag, release, appcast item, Pages state,
+PyPI version, or Homebrew change was created.
 
-As checked on August 21, 2026, no `v0.3.2-beta.3` tag, release, draft, PyPI
+The unpublished draft and its asset identities were recorded, then the draft
+was deleted after explicit recovery authorization. The corrected source
+advances to Beta 4 build `166` rather than reusing either Beta 3 identity. The
+failed-attempt details are in
+[the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md).
+
+## 0.3.2 Beta 4 Prepared Target
+
+The repository is prepared for review of guarded Prerelease dispatch for
+`v0.3.2-beta.4`:
+
+- internal version `0.3.2b4` and public version `0.3.2-beta.4`;
+- public tag and title `v0.3.2-beta.4`;
+- global build `166`;
+- Sparkle channel `beta`, making the item eligible only on Beta and Alpha;
+- GitHub prerelease, never Latest, PyPI, or Homebrew; and
+- the same production product, bundle, feed, key, signing team, and diagnostics
+  endpoint as Beta `0.3.2b2`.
+
+Publication must place Beta 4 above immutable Beta 2 build `164`, Beta 1 build
+`163`, Stable `0.3.1` build `162`, and all earlier published history, with
+failed Beta 3 build `165` absent. Stable and RC clients exclude the Beta item;
+Beta and Alpha clients can select it because build `166` is newer.
+
+As checked on August 21, 2026, no `v0.3.2-beta.4` tag, release, draft, PyPI
 version, Homebrew pull request, or appcast item exists. Dispatch requires
 separate explicit release authorization under a fixed-`main` merge hold. The
-reviewed metadata, release-note seed, scope freeze, and qualification boundary
-are in [the 0.3.2 Beta 3 cut packet](0.3.2-beta.3-cut-packet.md).
+reviewed metadata, release-note seed, scope freeze, recovery evidence, and
+qualification boundary are in
+[the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 165
+        CURRENT_PROJECT_VERSION: 166
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2b3
+        MARKETING_VERSION: 0.3.2b4
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2b3"
+version = "0.3.2b4"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "165"
+build_version = "166"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -34,6 +34,9 @@ RUNNER_BOUND_QUALIFICATION_PATHS = {
 RECEIPT_PATH_PATTERN = re.compile(r"^docs/release-evidence/(v[^/]+)/release-receipt\.json$")
 MANIFEST_PATH_PATTERN = re.compile(rf"^docs/release-evidence/(v[^/]+)/{re.escape(MANIFEST_NAME)}$")
 CHANGE_SCOPED_EVIDENCE_PATH_PATTERN = re.compile(r"^docs/qualification/(v[^/]+)-change-scoped-evidence-v1\.json$")
+FAILED_ATTEMPT_ROOT = Path("docs/release-attempts")
+FAILED_ATTEMPT_RECORD_NAME = "failed-attempt-v1.json"
+FAILED_ATTEMPT_RECEIPT_NAME = "release-receipt.json"
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
@@ -44,6 +47,31 @@ IMMUTABLE_CANDIDATE_FIELDS = (
     "dmg_sha256",
     "appcast_sha256",
     "signed_app_tree_sha256",
+)
+FAILED_ATTEMPT_RECORD_KEYS = frozenset(
+    {
+        "build_version",
+        "draft_deleted",
+        "draft_release_id",
+        "failed_job",
+        "failed_job_id",
+        "failed_step",
+        "must_not_rebuild",
+        "package_version",
+        "public_version",
+        "published_at",
+        "recorded_at",
+        "release_receipt_file_sha256",
+        "release_receipt_path",
+        "release_receipt_sha256",
+        "release_tag",
+        "schema_version",
+        "source_sha",
+        "status",
+        "workflow_conclusion",
+        "workflow_run_attempt",
+        "workflow_run_id",
+    }
 )
 
 
@@ -149,10 +177,107 @@ def _sequence(value: object, description: str) -> Sequence[Any]:
     return cast(Sequence[Any], value)
 
 
+def _validate_failed_unpublished_candidate(
+    repo_root: Path,
+    *,
+    base_sha: str,
+    base_qualification: Mapping[str, Any],
+    base_candidate: Mapping[str, Any],
+) -> int:
+    release_tag = _string(base_candidate.get("release_tag"), "failed candidate release tag")
+    attempt_root = FAILED_ATTEMPT_ROOT / release_tag
+    record_relative = attempt_root / FAILED_ATTEMPT_RECORD_NAME
+    receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
+    for relative in (record_relative, receipt_relative):
+        tracked_in_base = subprocess.run(
+            ["git", "cat-file", "-e", f"{base_sha}:{relative.as_posix()}"],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+        if tracked_in_base.returncode == 0:
+            raise ReleaseMilestoneContextError("Failed release-attempt recovery records must be new and immutable.")
+
+    record = _load_json(repo_root / record_relative, "failed release-attempt record")
+    if set(record) != FAILED_ATTEMPT_RECORD_KEYS:
+        raise ReleaseMilestoneContextError("Failed release-attempt record keys do not match the required schema.")
+    if (
+        record.get("schema_version") != 1
+        or record.get("status") != "failed_unpublished_signed_candidate"
+        or record.get("workflow_conclusion") != "failure"
+        or record.get("published_at") is not None
+        or record.get("draft_deleted") is not True
+        or record.get("must_not_rebuild") is not True
+        or base_qualification.get("status") != "preregistered_pending_exact_candidate"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed release-attempt record must prove an unpublished, deleted-draft, permanently burned candidate."
+        )
+    if record.get("release_receipt_path") != receipt_relative.as_posix():
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt path is not canonical.")
+
+    try:
+        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
+    except ReleaseReceiptError as error:
+        raise ReleaseMilestoneContextError(f"Failed release-attempt receipt is invalid: {error}") from error
+    if record.get("release_receipt_file_sha256") != receipt_file_sha256:
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt file digest does not match the record.")
+    if record.get("release_receipt_sha256") != receipt.get("receipt_sha256"):
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt self-digest does not match the record.")
+
+    release = _mapping(receipt.get("release"), "failed release-attempt receipt release")
+    versions = _mapping(receipt.get("versions"), "failed release-attempt receipt versions")
+    workflow = _mapping(receipt.get("workflow"), "failed release-attempt receipt workflow")
+    identity_pairs = {
+        "package_version": versions.get("package"),
+        "public_version": versions.get("public"),
+        "build_version": versions.get("build"),
+        "release_tag": release.get("tag"),
+        "source_sha": receipt.get("source_sha"),
+        "workflow_run_id": workflow.get("run_id"),
+        "workflow_run_attempt": workflow.get("run_attempt"),
+        "draft_release_id": release.get("id"),
+    }
+    if any(record.get(field) != value for field, value in identity_pairs.items()):
+        raise ReleaseMilestoneContextError("Failed release-attempt record identity differs from its checked receipt.")
+    expected_candidate = {
+        "package_version": versions.get("package"),
+        "public_version": versions.get("public"),
+        "build_version": versions.get("build"),
+        "release_tag": release.get("tag"),
+        "dmg_name": next(
+            (
+                artifact.get("name")
+                for artifact in _sequence(receipt.get("artifacts"), "failed release-attempt receipt artifacts")
+                if _mapping(artifact, "failed release-attempt receipt artifact").get("kind") == "dmg"
+            ),
+            None,
+        ),
+        "workflow": workflow.get("name"),
+    }
+    if any(base_candidate.get(field) != value for field, value in expected_candidate.items()):
+        raise ReleaseMilestoneContextError(
+            "Failed release-attempt receipt does not bind the base qualification candidate."
+        )
+    if (
+        release.get("target_sha") != record.get("source_sha")
+        or release.get("prerelease") is not True
+        or workflow.get("actor") != "shiny-code-bot"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed release-attempt receipt does not preserve guarded prerelease identity."
+        )
+    try:
+        return parse_build_version(_string(record.get("build_version"), "failed candidate build version"))
+    except ReleaseError as error:
+        raise ReleaseMilestoneContextError(f"Failed release-attempt build identity is invalid: {error}") from error
+
+
 def _validate_prepublication_candidate_transition(
     repo_root: Path,
     *,
     base_sha: str,
+    qualification: Mapping[str, Any],
     candidate: Mapping[str, Any],
 ) -> None:
     base_config = _load_json_at_revision(
@@ -180,9 +305,18 @@ def _validate_prepublication_candidate_transition(
     )
     base_candidate = _mapping(base_qualification.get("candidate"), "base qualification candidate")
     if any(field not in base_candidate or base_candidate[field] is None for field in IMMUTABLE_CANDIDATE_FIELDS):
-        raise ReleaseMilestoneContextError(
-            "Prepublication qualification must advance from a bound published candidate."
+        failed_build = _validate_failed_unpublished_candidate(
+            repo_root,
+            base_sha=base_sha,
+            base_qualification=base_qualification,
+            base_candidate=base_candidate,
         )
+        immutable_history = _mapping(qualification.get("immutable_history"), "qualification immutable_history")
+        burned_builds = _sequence(immutable_history.get("burned_builds"), "qualification burned_builds")
+        if failed_build not in burned_builds:
+            raise ReleaseMilestoneContextError(
+                "The successor qualification must permanently burn the failed candidate build."
+            )
     try:
         base_version = parse_release_version(cast(str, base_candidate.get("package_version")))
         next_version = parse_release_version(cast(str, candidate.get("package_version")))
@@ -594,6 +728,7 @@ def discover_milestone_receipt(
             _validate_prepublication_candidate_transition(
                 repo_root,
                 base_sha=base_sha,
+                qualification=qualification,
                 candidate=candidate,
             )
             unbound_candidate = True

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -129,8 +129,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b3")
-        self.assertEqual(NATIVE_BUILD_VERSION, "165")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b4")
+        self.assertEqual(NATIVE_BUILD_VERSION, "166")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -202,12 +202,12 @@ class ReleaseMetadataTests(unittest.TestCase):
     def test_repository_is_prepared_for_beta(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2b3")
-        self.assertEqual(metadata.public_version, "0.3.2-beta.3")
-        self.assertEqual(metadata.build_version, "165")
-        self.assertEqual(metadata.release_tag, "v0.3.2-beta.3")
-        self.assertEqual(metadata.release_name, "v0.3.2-beta.3")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.3.dmg")
+        self.assertEqual(metadata.package_version, "0.3.2b4")
+        self.assertEqual(metadata.public_version, "0.3.2-beta.4")
+        self.assertEqual(metadata.build_version, "166")
+        self.assertEqual(metadata.release_tag, "v0.3.2-beta.4")
+        self.assertEqual(metadata.release_name, "v0.3.2-beta.4")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.4.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.first_candidate_of_cycle)
@@ -215,11 +215,11 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.2-beta.3", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.2-beta.4", freeze_policy["frozen_release_tags"])
 
-        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.3-cut-packet.md").read_text(encoding="utf-8")
-        self.assertIn("`0.3.2b3`", cut_packet)
-        self.assertIn("Build `165`", cut_packet)
+        cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.4-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2b4`", cut_packet)
+        self.assertIn("Build `166`", cut_packet)
         self.assertIn("#609", cut_packet)
         self.assertIn("PR #611", cut_packet)
         self.assertIn("PR #612", cut_packet)
@@ -233,14 +233,14 @@ class ReleaseMetadataTests(unittest.TestCase):
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b3")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.3")
-        self.assertEqual(qualification["candidate"]["build_version"], "165")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.3")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b4")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.4")
+        self.assertEqual(qualification["candidate"]["build_version"], "166")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.4")
         self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
@@ -250,8 +250,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.3",
-            "native-sparkle-notes-beta3",
+            "updater-route-v0.3.2-beta.2-to-v0.3.2-beta.4",
+            "native-sparkle-notes-beta4",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -260,6 +260,139 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         return record
 
     @staticmethod
+    def prepare_failed_candidate_transition(
+        root: Path,
+        *,
+        include_burned_build: bool = True,
+        receipt_digest_override: str | None = None,
+    ) -> tuple[str, str]:
+        base_qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
+        base_qualification = json.loads(base_qualification_path.read_text(encoding="utf-8"))
+        base_qualification["status"] = "preregistered_pending_exact_candidate"
+        base_qualification["candidate"].update(
+            {
+                "package_version": "0.3.1b1",
+                "public_version": "0.3.1-beta.1",
+                "build_version": "162",
+                "release_tag": "v0.3.1-beta.1",
+                "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1-beta.1.dmg",
+                "workflow": "Prerelease",
+            }
+        )
+        for field in (
+            "source_git_sha",
+            "release_run_id",
+            "release_id",
+            "dmg_sha256",
+            "appcast_sha256",
+            "signed_app_tree_sha256",
+        ):
+            base_qualification["candidate"][field] = None
+        base_qualification_path.write_text(json.dumps(base_qualification) + "\n", encoding="utf-8")
+        subprocess.run(["git", "add", base_qualification_path], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "prepare failed beta"], cwd=root, check=True)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+        release_tag = "v0.3.1-beta.1"
+        attempt_root = root / "docs/release-attempts" / release_tag
+        attempt_root.mkdir(parents=True)
+        receipt_path = attempt_root / "release-receipt.json"
+        receipt = build_receipt(
+            {
+                "release_route": "prerelease",
+                "source_sha": base_sha,
+                "workflow_actor": "shiny-code-bot",
+                "workflow_run_id": 22222,
+                "workflow_run_attempt": 1,
+                "package_version": "0.3.1b1",
+                "public_version": "0.3.1-beta.1",
+                "build_version": "162",
+                "release_tag": release_tag,
+                "release_name": release_tag,
+                "release_id": 33333,
+                "release_created_at": "2026-08-21T01:00:00Z",
+                "prerelease": True,
+                "make_latest": False,
+                "signed_app_tree_sha256": APP_TREE_SHA256,
+                "artifacts": [
+                    {
+                        "kind": "dmg",
+                        "name": "3D-Blu-ray-to-Vision-Pro-0.3.1-beta.1.dmg",
+                        "sha256": DMG_SHA256,
+                        "size_bytes": 1000,
+                        "asset_id": 1,
+                    },
+                    {
+                        "kind": "checksum",
+                        "name": "SHA256SUMS",
+                        "sha256": CHECKSUM_SHA256,
+                        "size_bytes": 100,
+                        "asset_id": 2,
+                    },
+                    {
+                        "kind": "appcast",
+                        "name": "appcast.xml",
+                        "sha256": APPCAST_SHA256,
+                        "size_bytes": 500,
+                        "asset_id": 3,
+                    },
+                ],
+            }
+        )
+        write_receipt(receipt, receipt_path)
+        record = {
+            "build_version": "162",
+            "draft_deleted": True,
+            "draft_release_id": 33333,
+            "failed_job": "Prove signed artifact UI accessibility",
+            "failed_job_id": 44444,
+            "failed_step": "Run installed candidate UI accessibility lane",
+            "must_not_rebuild": True,
+            "package_version": "0.3.1b1",
+            "public_version": "0.3.1-beta.1",
+            "published_at": None,
+            "recorded_at": "2026-08-21T02:00:00Z",
+            "release_receipt_file_sha256": receipt_digest_override
+            or hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+            "release_receipt_path": receipt_path.relative_to(root).as_posix(),
+            "release_receipt_sha256": receipt["receipt_sha256"],
+            "release_tag": release_tag,
+            "schema_version": 1,
+            "source_sha": base_sha,
+            "status": "failed_unpublished_signed_candidate",
+            "workflow_conclusion": "failure",
+            "workflow_run_attempt": 1,
+            "workflow_run_id": 22222,
+        }
+        (attempt_root / "failed-attempt-v1.json").write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+        next_qualification = json.loads(json.dumps(base_qualification))
+        next_qualification["candidate"].update(
+            {
+                "package_version": "0.3.1b2",
+                "public_version": "0.3.1-beta.2",
+                "build_version": "163",
+                "release_tag": "v0.3.1-beta.2",
+                "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.1-beta.2.dmg",
+            }
+        )
+        next_qualification["immutable_history"] = {"burned_builds": [162] if include_burned_build else []}
+        next_path = root / "docs/qualification/v0.3.1-beta.2-signed-qualification-v1.json"
+        next_path.write_text(json.dumps(next_qualification) + "\n", encoding="utf-8")
+        config_path = root / ".github/github.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["releaseOperations"]["qualificationRecordPath"] = next_path.relative_to(root).as_posix()
+        config_path.write_text(json.dumps(config) + "\n", encoding="utf-8")
+        subprocess.run(["git", "add", attempt_root, next_path, config_path], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "prepare successor beta"], cwd=root, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        return base_sha, head_sha
+
+    @staticmethod
     def append_beta_change_scoped_evidence(
         root: Path,
         *,
@@ -958,6 +1091,61 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             )
 
         self.assertIsNone(discovered)
+
+    def test_allows_failed_unpublished_signed_candidate_to_advance(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.prepare_failed_candidate_transition(root)
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="prepare/v0.3.1-beta.2",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(discovered)
+
+    def test_rejects_failed_candidate_with_wrong_receipt_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.prepare_failed_candidate_transition(
+                root,
+                receipt_digest_override="0" * 64,
+            )
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "file digest"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="prepare/v0.3.1-beta.2",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
+
+    def test_rejects_successor_that_does_not_burn_failed_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.prepare_failed_candidate_transition(root, include_burned_build=False)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "permanently burn"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="prepare/v0.3.1-beta.2",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
 
     def test_allows_beta_change_scoped_evidence_append_without_checked_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "165")
+        self.assertEqual(info["CFBundleVersion"], "166")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -973,7 +973,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-beta.3-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-beta.4-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2b3"
+version = "0.3.2b4"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary
- record failed unpublished Beta 3 build `165` with its exact checked release receipt and failed-attempt envelope
- teach release milestone validation to allow only a proven, deleted-draft, permanently burned signed candidate to advance
- prepare recovery identity `0.3.2b4` / `v0.3.2-beta.4` / build `166`
- keep all Beta 4 candidate artifact/run identities null until a fresh guarded run exists

## Safety invariants
- the failed-attempt receipt must be new, exact, self-validating, and file-digest bound
- the failure record must prove workflow failure, no publication, deleted draft, and `must_not_rebuild: true`
- the successor qualification must include failed build `165` in `burned_builds`
- normal published-candidate transitions remain unchanged; arbitrary unbound predecessors still fail closed

## Validation
- `uv run python -m scripts.release validate`
- release milestone context passes for exact base `02baeb08342ca6e5f8e132f85fe7a5a470853be6` and head `d227eadcb4b3a6c57a9db322789ef7fc6ca284e0`
- 38 release milestone context tests passed, including failed-candidate acceptance, wrong receipt digest rejection, and missing burned-build rejection
- 181 focused release/packaging tests passed
- 484 native tests passed
- Ruff, format, mypy, policy, observability, `uv build`, and native package verification passed

## Recovery boundary
- failed run `32446869702`, draft `374173827`, and all draft asset identities remain recorded
- only the unpublished draft was deleted after explicit authorization
- this PR does not dispatch Beta 4 or approve signing

Supersedes #618.
Refs #609
