### PR TITLE
Harden release fixtures before production signing

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -142,6 +142,7 @@
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",
+      "preSigningUi": "uv run python -m unittest tests.test_installed_ui_qualification tests.test_pre_signing_ui tests.test_signed_artifact_ui",
       "tier3Receipt": "uv run python -m unittest tests.test_tier3_receipt",
       "tier3CleanMachine": "uv run python -m unittest tests.test_tier3_clean_machine",
       "tier3OperatorCollection": "uv run python -m unittest tests.test_tier3_operator_collect",

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -606,12 +606,154 @@ jobs:
             exit "$QUALIFICATION_EXIT_CODE"
           fi
 
+  pre-signing-package:
+    name: Qualify production package before signing
+    needs:
+      - policy
+      - prepare
+      - qualify-preparation
+    runs-on: macos-26
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout validated main commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify pre-signing runner and checkout
+        env:
+          EXPECTED_POLICY_FINGERPRINT: ${{ needs.policy.outputs.policy_fingerprint }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_REF: ${{ github.ref }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_OPERATOR_WORKFLOW_REF: ${{ github.workflow_ref }}
+          RELEASE_OPERATOR_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RELEASE_ENGINE_WORKFLOW_REF: ${{ needs.policy.outputs.engine_workflow_ref }}
+          RELEASE_ENGINE_WORKFLOW_SHA: ${{ needs.policy.outputs.engine_workflow_sha }}
+          RELEASE_ENGINE_WORKFLOW_REPOSITORY: ${{ github.repository }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          INPUT_RELEASE_SHA: ${{ inputs.release_sha }}
+          INPUT_OPERATOR_WORKFLOW_REF: ${{ inputs.operator_workflow_ref }}
+          INPUT_OPERATOR_WORKFLOW_SHA: ${{ inputs.operator_workflow_sha }}
+          INPUT_OPERATOR_RUN_ID: ${{ inputs.operator_run_id }}
+          INPUT_OPERATOR_RUN_ATTEMPT: ${{ inputs.operator_run_attempt }}
+          INPUT_OPERATOR_ACTOR: ${{ inputs.operator_actor }}
+          INPUT_OPERATOR_TRIGGERING_ACTOR: ${{ inputs.operator_triggering_actor }}
+        run: |
+          set -euo pipefail
+          python3 scripts/release_workflow_policy.py engine \
+            --expected-fingerprint "$EXPECTED_POLICY_FINGERPRINT"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]; then
+            echo "Protected main moved before pre-signing qualification." >&2
+            exit 1
+          fi
+          test "$(uname -m)" = "arm64"
+          test "$(sw_vers -productVersion | cut -d. -f1)" = "26"
+          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
+          if [ ! -d "$XCODE_PATH" ]; then
+            echo "Pinned Xcode path is unavailable: $XCODE_PATH" >&2
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_PATH"
+          test "$(xcodebuild -version | sed -n '1p')" = "Xcode $XCODE_VERSION"
+          test "$(xcodebuild -version | sed -n '2p')" = "Build version $XCODE_BUILD_VERSION"
+          if [ -n "${BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE:-}" ]; then
+            echo "Release builds must not override the macOS 26 deployment target." >&2
+            exit 1
+          fi
+
+      - name: Install pinned XcodeGen
+        run: |
+          set -euo pipefail
+          ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
+          curl --fail --location --silent --show-error \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/$XCODEGEN_VERSION/xcodegen.zip" \
+            --output "$ARCHIVE"
+          printf '%s  %s\n' "$XCODEGEN_SHA256" "$ARCHIVE" | shasum -a 256 --check
+          ditto -x -k "$ARCHIVE" "$RUNNER_TEMP"
+          test "$("$RUNNER_TEMP/xcodegen/bin/xcodegen" --version)" = "Version: $XCODEGEN_VERSION"
+          echo "$RUNNER_TEMP/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install Python and locked dependencies
+        run: |
+          uv python install 3.12
+          uv sync --locked --all-groups --python 3.12
+
+      - name: Build and smoke the production-shaped package
+        env:
+          BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE: ""
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          APP_PATH="macos/build/package/3D Blu-ray to Vision Pro.app"
+          echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
+          uv run python scripts/native_app.py package --sign-identity -
+          test -d "$APP_PATH"
+          uv run python scripts/smoke_release_app.py \
+            --app-path "$APP_PATH" \
+            --skip-spctl \
+            | tee pre-signing-smoke.log
+
+      - name: Run installed UI qualification before signing
+        run: |
+          set -euo pipefail
+          uv run python -m scripts.pre_signing_ui \
+            --app "$APP_PATH" \
+            --dmg "$RUNNER_TEMP/pre-signing-package.dmg" \
+            --qualification-root "$RUNNER_TEMP/pre-signing-installed-ui" \
+            --evidence-directory pre-signing-installed-ui-evidence \
+            --output-report pre-signing-installed-ui-report.json \
+            --failure-diagnostics-directory pre-signing-installed-ui-diagnostics \
+            --source-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT"
+
+      - name: Retain pre-signing failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pre-signing-package-diagnostics-${{ github.run_attempt }}
+          path: |
+            pre-signing-smoke.log
+            pre-signing-installed-ui-diagnostics
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Retain pre-signing qualification report
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pre-signing-package-${{ github.run_attempt }}
+          path: |
+            pre-signing-smoke.log
+            pre-signing-installed-ui-evidence
+            pre-signing-installed-ui-report.json
+          if-no-files-found: error
+          retention-days: 7
+
   package:
     name: Build, sign, notarize, and validate DMG
     needs:
       - policy
       - prepare
       - qualify-preparation
+      - pre-signing-package
     runs-on: macos-26
     timeout-minutes: 180
     environment: macos-signing

--- a/docs/direct-ssif-prototype.md
+++ b/docs/direct-ssif-prototype.md
@@ -21,17 +21,19 @@ The prototype proves a narrower source contract:
 
 ## Build
 
-The development build requires Apple Silicon macOS, `pkg-config`, libbluray
-`1.4.1`, and libudfread `1.2.0`:
+The development build requires Apple Silicon macOS, `pkg-config`, libbluray,
+and libudfread:
 
 ```bash
 brew install libbluray pkgconf
 uv run python scripts/build_ssif_probe_macos.py
 ```
 
-The build intentionally enforces those exact development-library versions. A
-Homebrew formula update therefore fails CI until the recorded compatibility
-baseline is reviewed and updated.
+The dynamic development build accepts the installed Homebrew libraries when the
+probe compiles, links, and passes its synthetic and real-media behavior checks.
+The manifest records checksum-pinned known-good source archives for a future
+hermetic distributable build; those source versions are provenance, not a
+requirement imposed on the host package manager.
 
 The binary is written to `build/ssif-probe/ssif_probe`, which is ignored and is
 not included in wheels, embedded-runtime staging, or the production macOS app.
@@ -145,8 +147,8 @@ Ordinary CI uses synthetic M2TS packets and does not require copyrighted media.
 ## Packaging And Licensing
 
 The tested development binary dynamically links Homebrew libraries and must not
-be distributed. libbluray and libudfread are LGPL-2.1-or-later; their tested
-versions, source URLs, and source-archive checksums are recorded in
+be distributed. libbluray and libudfread are LGPL-2.1-or-later; known-good
+source versions, URLs, and source-archive checksums are recorded in
 `vendor/ssif-probe-macos-arm64.toml`.
 
 A distributable implementation must build arm64 dylibs from the pinned sources,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -47,6 +47,16 @@ category is explicitly not applicable rather than failed. Metadata
 preparation and review do not authorize dispatch; run-bound signing approval
 remains a separate verified boundary.
 
+Before the `macos-signing` environment can request approval, the reusable
+release engine runs a secret-free macOS pre-signing package gate. That job
+builds the production package with ad-hoc signing, runs the complete maintained
+release-app smoke, creates a production-shaped DMG, and exercises the same
+installed UI accessibility fixture used by the signed-artifact lane. Failure,
+cancellation, or skipped execution prevents the signing job from starting. The
+later Developer ID, notarization, signed-DMG, exact-artifact UI, appcast, and
+post-publication gates remain mandatory; pre-signing qualification moves fixture
+and packaged-runtime feedback earlier without substituting for release evidence.
+
 ## Release Preparation
 
 Every release version and Sparkle build number is committed through a normal

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -71,6 +71,15 @@ installed UI receipts. Other Tier 2 invalidations continue to block preparation
 and require another reviewed candidate rather than being deferred through
 publication.
 
+The release engine also runs a secret-free macOS package/UI qualification after
+preparation classification and before the `macos-signing` environment job. It
+uses an ad-hoc signed production package and production-shaped DMG to exercise
+worker identity, startup, cancellation, preview, bundled tools, clean-library
+profile creation, DMG installation, and installed accessibility behavior. This
+gate is preventive rather than evidentiary: it must pass before signing can
+begin, while the exact Developer ID signed artifact still requires fresh
+artifact and milestone receipts.
+
 ```sh
 uv run python -m scripts.qualify_release_scope \
   --candidate-sha "$CANDIDATE_SHA" \

--- a/scripts/build_ssif_probe_macos.py
+++ b/scripts/build_ssif_probe_macos.py
@@ -20,12 +20,17 @@ COMMAND_TIMEOUT_SECONDS = 120
 
 
 @dataclass(frozen=True)
-class NativeDependency:
+class SourceProvenance:
     version: str
+    url: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class NativeDependency:
     pkg_config: str
-    source_url: str
-    source_sha256: str
     license: str
+    known_good_source: SourceProvenance
 
 
 @dataclass(frozen=True)
@@ -38,17 +43,34 @@ class SsifProbeManifest:
     libudfread: NativeDependency
 
 
+def parse_source_provenance(value: object, name: str) -> SourceProvenance:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{name} known-good source must be a table")
+    expected_fields = {"version", "url", "sha256"}
+    unexpected_fields = sorted(set(value) - expected_fields)
+    if unexpected_fields:
+        raise RuntimeError(f"unexpected {name} known-good source fields: {', '.join(unexpected_fields)}")
+    for field in expected_fields:
+        if not isinstance(value.get(field), str) or not value[field]:
+            raise RuntimeError(f"{name} known-good source field is missing or invalid: {field}")
+    return SourceProvenance(**{field: value[field] for field in expected_fields})
+
+
 def parse_dependency(value: object, name: str) -> NativeDependency:
     if not isinstance(value, dict):
         raise RuntimeError(f"{name} manifest section must be a table")
-    expected_fields = {"version", "pkg_config", "source_url", "source_sha256", "license"}
+    expected_fields = {"pkg_config", "license", "known_good_source"}
     unexpected_fields = sorted(set(value) - expected_fields)
     if unexpected_fields:
         raise RuntimeError(f"unexpected {name} manifest fields: {', '.join(unexpected_fields)}")
-    for field in expected_fields:
+    for field in ("pkg_config", "license"):
         if not isinstance(value.get(field), str) or not value[field]:
             raise RuntimeError(f"{name} manifest field is missing or invalid: {field}")
-    return NativeDependency(**{field: value[field] for field in expected_fields})
+    return NativeDependency(
+        pkg_config=value["pkg_config"],
+        license=value["license"],
+        known_good_source=parse_source_provenance(value.get("known_good_source"), name),
+    )
 
 
 def load_manifest(path: Path) -> SsifProbeManifest:
@@ -64,7 +86,7 @@ def load_manifest(path: Path) -> SsifProbeManifest:
     unexpected_fields = sorted(set(data) - expected_fields)
     if unexpected_fields:
         raise RuntimeError(f"unexpected SSIF probe manifest fields: {', '.join(unexpected_fields)}")
-    if data.get("schema_version") != 1:
+    if data.get("schema_version") != 2:
         raise RuntimeError("unsupported SSIF probe manifest schema")
     for field in ("platform", "minimum_macos", "linkage"):
         if not isinstance(data.get(field), str) or not data[field]:
@@ -87,12 +109,14 @@ def pkg_config(arguments: list[str]) -> str:
     ).strip()
 
 
-def verify_dependency(dependency: NativeDependency) -> None:
-    installed_version = pkg_config(["--modversion", dependency.pkg_config])
-    if installed_version != dependency.version:
-        raise RuntimeError(
-            f"{dependency.pkg_config} {dependency.version} is required; found {installed_version or 'nothing'}"
-        )
+def verify_dependency(dependency: NativeDependency) -> str:
+    try:
+        installed_version = pkg_config(["--modversion", dependency.pkg_config])
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(f"{dependency.pkg_config} is required via pkg-config") from error
+    if not installed_version:
+        raise RuntimeError(f"{dependency.pkg_config} did not report an installed version")
+    return installed_version
 
 
 def build_command(
@@ -122,8 +146,8 @@ def build_command(
 def build_ssif_probe(output_path: Path, manifest: SsifProbeManifest) -> None:
     if manifest.linkage != "dynamic-development-only":
         raise RuntimeError(f"unsupported SSIF probe linkage: {manifest.linkage}")
-    verify_dependency(manifest.libbluray)
-    verify_dependency(manifest.libudfread)
+    libbluray_version = verify_dependency(manifest.libbluray)
+    libudfread_version = verify_dependency(manifest.libudfread)
     compiler = os.environ.get("CC") or shutil.which("clang")
     if compiler is None:
         raise RuntimeError("clang is required to build the SSIF probe")
@@ -158,6 +182,7 @@ def build_ssif_probe(output_path: Path, manifest: SsifProbeManifest) -> None:
     )
     if "libbluray" not in linked_libraries:
         raise RuntimeError("SSIF probe is not dynamically linked to libbluray")
+    print(f"Built against host libbluray {libbluray_version} and libudfread {libudfread_version}")
 
 
 def main() -> int:

--- a/scripts/installed_ui_qualification.py
+++ b/scripts/installed_ui_qualification.py
@@ -80,13 +80,13 @@ def _cleanup_qualification_workspace(
     operations: MacOSOperations,
     marker_path: Path,
     marker: Mapping[str, str],
-) -> list[BaseException]:
-    errors: list[BaseException] = []
+) -> list[Exception]:
+    errors: list[Exception] = []
     try:
         operations.quit_app()
         if operations.app_running():
             raise InstalledUIQualificationError("Installed UI qualification left the production app running.")
-    except BaseException as error:
+    except Exception as error:
         errors.append(error)
 
     if not config.qualification_root.exists():
@@ -101,7 +101,7 @@ def _cleanup_qualification_workspace(
         return errors
     try:
         shutil.rmtree(config.qualification_root)
-    except BaseException as error:
+    except Exception as error:
         errors.append(error)
     return errors
 
@@ -122,7 +122,7 @@ def _run(
     marker = {"owner": config.owner, "run_id": str(uuid.uuid4())}
     config.qualification_root.mkdir(parents=True)
     marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-    primary_error: BaseException | None = None
+    primary_error: Exception | None = None
     try:
         synthetic_home.mkdir(parents=True)
         operations.install_app(config.dmg, app_path, mount_point)
@@ -145,11 +145,11 @@ def _run(
             config.evidence_directory,
             release_notes_url=config.release_notes_url,
         )
-    except BaseException as error:
+    except Exception as error:
         primary_error = error
         try:
             _preserve_failure_diagnostics(config, raw_ui_directory, error)
-        except BaseException as diagnostics_error:
+        except Exception as diagnostics_error:
             error.add_note(
                 "Installed UI failure diagnostics could not be preserved: "
                 f"{type(diagnostics_error).__name__}: {diagnostics_error}"
@@ -172,7 +172,7 @@ def run(
     operations = operations or MacOSOperations()
     try:
         return _run(config, operations)
-    except BaseException:
+    except Exception:
         if config.evidence_directory.exists():
             shutil.rmtree(config.evidence_directory)
         raise

--- a/scripts/installed_ui_qualification.py
+++ b/scripts/installed_ui_qualification.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.artifact_identity import app_tree_sha256
+from scripts.tier3_clean_machine import (
+    APP_NAME,
+    MacOSOperations,
+    normalize_installed_ui_candidate_evidence,
+)
+
+
+class InstalledUIQualificationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class InstalledUIQualificationConfig:
+    repo: Path
+    dmg: Path
+    qualification_root: Path
+    evidence_directory: Path
+    release_notes_url: str
+    expected_app_tree_sha256: str
+    owner: str
+    failure_diagnostics_directory: Path | None = None
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    resolved_left = left.resolve()
+    resolved_right = right.resolve()
+    return (
+        resolved_left == resolved_right
+        or resolved_left in resolved_right.parents
+        or resolved_right in resolved_left.parents
+    )
+
+
+def validate_installed_ui_output_paths(config: InstalledUIQualificationConfig) -> None:
+    directories = [
+        ("qualification root", config.qualification_root),
+        ("evidence directory", config.evidence_directory),
+    ]
+    if config.failure_diagnostics_directory is not None:
+        directories.append(("failure diagnostics directory", config.failure_diagnostics_directory))
+    for index, (left_name, left_path) in enumerate(directories):
+        for right_name, right_path in directories[index + 1 :]:
+            if _paths_overlap(left_path, right_path):
+                raise InstalledUIQualificationError(f"Installed UI {left_name} and {right_name} must not overlap.")
+    if any(path.exists() or path.is_symlink() for _, path in directories):
+        raise InstalledUIQualificationError("Installed UI outputs and workspace must not already exist.")
+
+
+def _preserve_failure_diagnostics(
+    config: InstalledUIQualificationConfig,
+    raw_ui_directory: Path,
+    error: BaseException,
+) -> None:
+    destination = config.failure_diagnostics_directory
+    if destination is None:
+        return
+    destination.mkdir(parents=True)
+    (destination / "failure.txt").write_text(f"{type(error).__name__}: {error}\n", encoding="utf-8")
+    result_bundle = config.qualification_root / "InstalledUI-candidate.xcresult"
+    if result_bundle.is_dir():
+        shutil.copytree(result_bundle, destination / result_bundle.name)
+    if raw_ui_directory.is_dir():
+        shutil.copytree(raw_ui_directory, destination / raw_ui_directory.name)
+
+
+def _cleanup_qualification_workspace(
+    config: InstalledUIQualificationConfig,
+    operations: MacOSOperations,
+    marker_path: Path,
+    marker: Mapping[str, str],
+) -> list[BaseException]:
+    errors: list[BaseException] = []
+    try:
+        operations.quit_app()
+        if operations.app_running():
+            raise InstalledUIQualificationError("Installed UI qualification left the production app running.")
+    except BaseException as error:
+        errors.append(error)
+
+    if not config.qualification_root.exists():
+        return errors
+    try:
+        observed_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        errors.append(InstalledUIQualificationError("Installed UI cleanup marker is missing or invalid."))
+        return errors
+    if observed_marker != marker:
+        errors.append(InstalledUIQualificationError("Installed UI cleanup marker changed during the run."))
+        return errors
+    try:
+        shutil.rmtree(config.qualification_root)
+    except BaseException as error:
+        errors.append(error)
+    return errors
+
+
+def _run(
+    config: InstalledUIQualificationConfig,
+    operations: MacOSOperations,
+) -> Mapping[str, Any]:
+    validate_installed_ui_output_paths(config)
+    if operations.app_running():
+        raise InstalledUIQualificationError("The production app must not be running before installed UI qualification.")
+
+    synthetic_home = config.qualification_root / "Home"
+    app_path = config.qualification_root / "Applications" / APP_NAME
+    mount_point = config.qualification_root / "Mount"
+    raw_ui_directory = config.qualification_root / "InstalledUIEvidence"
+    marker_path = config.qualification_root / ".bd-to-avp-installed-ui.json"
+    marker = {"owner": config.owner, "run_id": str(uuid.uuid4())}
+    config.qualification_root.mkdir(parents=True)
+    marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+    primary_error: BaseException | None = None
+    try:
+        synthetic_home.mkdir(parents=True)
+        operations.install_app(config.dmg, app_path, mount_point)
+        installed_app_tree_sha256 = app_tree_sha256(app_path)
+        if installed_app_tree_sha256 != config.expected_app_tree_sha256:
+            raise InstalledUIQualificationError("Installed app tree digest does not match the packaged app.")
+        operations.collect_ui_evidence(
+            repo=config.repo.resolve(),
+            phase="candidate",
+            app_path=app_path,
+            synthetic_home=synthetic_home,
+            output_directory=raw_ui_directory,
+            release_notes_url=config.release_notes_url,
+        )
+        operations.quit_app()
+        if operations.app_running():
+            raise InstalledUIQualificationError("Installed UI qualification left the production app running.")
+        return normalize_installed_ui_candidate_evidence(
+            raw_ui_directory,
+            config.evidence_directory,
+            release_notes_url=config.release_notes_url,
+        )
+    except BaseException as error:
+        primary_error = error
+        try:
+            _preserve_failure_diagnostics(config, raw_ui_directory, error)
+        except BaseException as diagnostics_error:
+            error.add_note(
+                "Installed UI failure diagnostics could not be preserved: "
+                f"{type(diagnostics_error).__name__}: {diagnostics_error}"
+            )
+        raise
+    finally:
+        cleanup_errors = _cleanup_qualification_workspace(config, operations, marker_path, marker)
+        if cleanup_errors:
+            summary = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            if primary_error is not None:
+                primary_error.add_note(f"Installed UI cleanup also failed: {summary}")
+            else:
+                raise InstalledUIQualificationError(f"Installed UI cleanup failed: {summary}") from cleanup_errors[0]
+
+
+def run(
+    config: InstalledUIQualificationConfig,
+    operations: MacOSOperations | None = None,
+) -> Mapping[str, Any]:
+    operations = operations or MacOSOperations()
+    try:
+        return _run(config, operations)
+    except BaseException:
+        if config.evidence_directory.exists():
+            shutil.rmtree(config.evidence_directory)
+        raise

--- a/scripts/macos_release.py
+++ b/scripts/macos_release.py
@@ -81,12 +81,13 @@ def smoke_packaged_tools(app_path: Path) -> None:
         raise MacOSReleaseError(f"macOS bundled-tool smoke failed: {error}") from error
 
 
-def create_release_dmg(app_path: Path, output_path: Path) -> Path:
+def create_release_dmg(app_path: Path, output_path: Path, *, verify_signatures: bool = True) -> Path:
+    """Create the release DMG; unsigned verification is reserved for the preventive pre-signing fixture."""
     if output_path.suffix.lower() != ".dmg":
         raise MacOSReleaseError("Release output must use the .dmg extension.")
     if output_path.exists():
         raise MacOSReleaseError(f"Refusing to replace existing release DMG: {output_path}")
-    verify_release_app(app_path, verify_signatures=True)
+    verify_release_app(app_path, verify_signatures=verify_signatures)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="macos-release-dmg-", dir=output_path.parent) as temporary_directory:

--- a/scripts/pre_signing_ui.py
+++ b/scripts/pre_signing_ui.py
@@ -129,11 +129,11 @@ def run(config: PreSigningUIConfig) -> Mapping[str, object]:
         }
         _write_report(config.output_report, report)
         return report
-    except BaseException as error:
+    except Exception as error:
         for path in (config.output_report, config.evidence_directory, config.dmg):
             try:
                 _remove_owned_output(path)
-            except BaseException as cleanup_error:
+            except Exception as cleanup_error:
                 error.add_note(
                     f"Pre-signing output cleanup failed for {path}: {type(cleanup_error).__name__}: {cleanup_error}"
                 )

--- a/scripts/pre_signing_ui.py
+++ b/scripts/pre_signing_ui.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.artifact_identity import app_tree_sha256
+from scripts.installed_ui_qualification import (
+    InstalledUIQualificationConfig,
+    InstalledUIQualificationError,
+    run as run_installed_ui_qualification,
+    validate_installed_ui_output_paths,
+)
+from scripts.macos_release import MacOSReleaseError, create_release_dmg
+from scripts.tier3_clean_machine import CleanMachineError, RELEASES_URL
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class PreSigningUIError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PreSigningUIConfig:
+    repo: Path
+    app: Path
+    dmg: Path
+    qualification_root: Path
+    evidence_directory: Path
+    output_report: Path
+    failure_diagnostics_directory: Path | None
+    release_notes_url: str
+    source_sha: str
+    workflow_run_id: int
+    workflow_run_attempt: int
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _path_is_within(path: Path, directory: Path) -> bool:
+    resolved_path = path.resolve()
+    resolved_directory = directory.resolve()
+    return resolved_path == resolved_directory or resolved_directory in resolved_path.parents
+
+
+def _write_report(path: Path, report: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(report, temporary, indent=2, sort_keys=True)
+            temporary.write("\n")
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _remove_owned_output(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def run(config: PreSigningUIConfig) -> Mapping[str, object]:
+    for path in (config.dmg, config.output_report):
+        if path.exists() or path.is_symlink():
+            raise PreSigningUIError(f"Pre-signing UI output already exists: {path}")
+    if config.dmg.resolve() == config.output_report.resolve():
+        raise PreSigningUIError("Pre-signing DMG and report paths must be different.")
+    if not config.app.is_dir():
+        raise PreSigningUIError(f"Pre-signing packaged app is missing: {config.app}")
+    output_directories = [config.qualification_root, config.evidence_directory]
+    if config.failure_diagnostics_directory is not None:
+        output_directories.append(config.failure_diagnostics_directory)
+    for output_path in (config.dmg, config.output_report):
+        if any(_path_is_within(output_path, directory) for directory in output_directories):
+            raise PreSigningUIError("Pre-signing DMG and report paths must be outside UI output directories.")
+
+    expected_app_tree_sha256 = app_tree_sha256(config.app)
+    installed_ui_config = InstalledUIQualificationConfig(
+        repo=config.repo,
+        dmg=config.dmg,
+        qualification_root=config.qualification_root,
+        evidence_directory=config.evidence_directory,
+        release_notes_url=config.release_notes_url,
+        expected_app_tree_sha256=expected_app_tree_sha256,
+        owner="bd-to-avp-pre-signing-ui",
+        failure_diagnostics_directory=config.failure_diagnostics_directory,
+    )
+    try:
+        validate_installed_ui_output_paths(installed_ui_config)
+    except InstalledUIQualificationError as error:
+        raise PreSigningUIError(str(error)) from error
+    try:
+        create_release_dmg(config.app, config.dmg, verify_signatures=False)
+        evidence = run_installed_ui_qualification(installed_ui_config)
+        report = {
+            "app_tree_sha256": expected_app_tree_sha256,
+            "dmg": {
+                "name": config.dmg.name,
+                "sha256": _file_sha256(config.dmg),
+                "size_bytes": config.dmg.stat().st_size,
+            },
+            "evidence": dict(evidence),
+            "schema_version": 1,
+            "source_sha": config.source_sha,
+            "workflow": {
+                "run_attempt": config.workflow_run_attempt,
+                "run_id": config.workflow_run_id,
+            },
+        }
+        _write_report(config.output_report, report)
+        return report
+    except BaseException as error:
+        for path in (config.output_report, config.evidence_directory, config.dmg):
+            try:
+                _remove_owned_output(path)
+            except BaseException as cleanup_error:
+                error.add_note(
+                    f"Pre-signing output cleanup failed for {path}: {type(cleanup_error).__name__}: {cleanup_error}"
+                )
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run installed UI qualification before production signing.")
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--dmg", type=Path, required=True)
+    parser.add_argument("--qualification-root", type=Path, required=True)
+    parser.add_argument("--evidence-directory", type=Path, required=True)
+    parser.add_argument("--output-report", type=Path, required=True)
+    parser.add_argument("--failure-diagnostics-directory", type=Path)
+    parser.add_argument("--release-notes-url", default=RELEASES_URL)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--workflow-run-id", type=int, required=True)
+    parser.add_argument("--workflow-run-attempt", type=int, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = PreSigningUIConfig(
+        repo=args.repo,
+        app=args.app,
+        dmg=args.dmg,
+        qualification_root=args.qualification_root,
+        evidence_directory=args.evidence_directory,
+        output_report=args.output_report,
+        failure_diagnostics_directory=args.failure_diagnostics_directory,
+        release_notes_url=args.release_notes_url,
+        source_sha=args.source_sha,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_attempt=args.workflow_run_attempt,
+    )
+    try:
+        run(config)
+    except (CleanMachineError, InstalledUIQualificationError, MacOSReleaseError, PreSigningUIError) as error:
+        build_parser().error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/signed_artifact_ui.py
+++ b/scripts/signed_artifact_ui.py
@@ -4,14 +4,17 @@ import argparse
 import hashlib
 import json
 import shutil
-import uuid
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from scripts.artifact_identity import app_tree_sha256
+from scripts.installed_ui_qualification import (
+    InstalledUIQualificationConfig,
+    InstalledUIQualificationError,
+    run as run_installed_ui_qualification,
+)
 from scripts.signed_artifact_receipt import (
     PROFILE_CASE_ID,
     SignedArtifactReceiptError,
@@ -20,13 +23,7 @@ from scripts.signed_artifact_receipt import (
     validate_policy_case,
     write_receipt,
 )
-from scripts.tier3_clean_machine import (
-    APP_NAME,
-    RELEASES_URL,
-    CleanMachineError,
-    MacOSOperations,
-    normalize_installed_ui_candidate_evidence,
-)
+from scripts.tier3_clean_machine import RELEASES_URL, CleanMachineError, MacOSOperations
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -88,30 +85,8 @@ def _artifact(receipt: Mapping[str, Any], kind: str) -> Mapping[str, Any]:
     return artifacts[0]
 
 
-def _preserve_failure_diagnostics(
-    config: SignedArtifactUIConfig,
-    raw_ui_directory: Path,
-    error: BaseException,
-) -> None:
-    destination = config.failure_diagnostics_directory
-    if destination is None:
-        return
-    destination.mkdir(parents=True)
-    (destination / "failure.txt").write_text(f"{type(error).__name__}: {error}\n", encoding="utf-8")
-    result_bundle = config.qualification_root / "InstalledUI-candidate.xcresult"
-    if result_bundle.is_dir():
-        shutil.copytree(result_bundle, destination / result_bundle.name)
-    if raw_ui_directory.is_dir():
-        shutil.copytree(raw_ui_directory, destination / raw_ui_directory.name)
-
-
 def _run(config: SignedArtifactUIConfig, operations: MacOSOperations) -> Mapping[str, Any]:
-    if (
-        config.output_receipt.exists()
-        or config.evidence_directory.exists()
-        or config.qualification_root.exists()
-        or (config.failure_diagnostics_directory is not None and config.failure_diagnostics_directory.exists())
-    ):
+    if config.output_receipt.exists() or config.evidence_directory.exists() or config.qualification_root.exists():
         raise SignedArtifactUIError("Signed artifact UI outputs and workspace must not already exist.")
     if operations.app_running():
         raise SignedArtifactUIError("The production app must not be running before signed artifact UI qualification.")
@@ -139,54 +114,22 @@ def _run(config: SignedArtifactUIConfig, operations: MacOSOperations) -> Mapping
     if dmg.get("asset_id") != expectation.dmg_asset_id:
         raise SignedArtifactUIError("Release receipt DMG asset ID changed before UI qualification.")
 
-    synthetic_home = config.qualification_root / "Home"
-    app_path = config.qualification_root / "Applications" / APP_NAME
-    mount_point = config.qualification_root / "Mount"
-    raw_ui_directory = config.qualification_root / "InstalledUIEvidence"
-    marker_path = config.qualification_root / ".bd-to-avp-signed-artifact-ui.json"
-    marker = {"owner": "bd-to-avp-signed-artifact-ui", "run_id": str(uuid.uuid4())}
-    config.qualification_root.mkdir(parents=True)
-    marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-    try:
-        synthetic_home.mkdir(parents=True)
-        operations.install_app(config.dmg, app_path, mount_point)
-        installed_app_tree_sha256 = app_tree_sha256(app_path)
-        if installed_app_tree_sha256 != expectation.signed_app_tree_sha256:
-            raise SignedArtifactUIError("Installed app tree digest does not match the signed package receipt.")
-        operations.collect_ui_evidence(
-            repo=config.repo.resolve(),
-            phase="candidate",
-            app_path=app_path,
-            synthetic_home=synthetic_home,
-            output_directory=raw_ui_directory,
+    evidence_digests = run_installed_ui_qualification(
+        InstalledUIQualificationConfig(
+            repo=config.repo,
+            dmg=config.dmg,
+            qualification_root=config.qualification_root,
+            evidence_directory=config.evidence_directory,
             release_notes_url=config.release_notes_url,
-        )
-        operations.quit_app()
-        if operations.app_running():
-            raise SignedArtifactUIError("Signed artifact UI test left the production app running.")
-        evidence_digests = normalize_installed_ui_candidate_evidence(
-            raw_ui_directory,
-            config.evidence_directory,
-            release_notes_url=config.release_notes_url,
-        )
-        receipt = build_receipt(expectation=expectation, evidence=evidence_digests)
-        write_receipt(receipt, config.output_receipt)
-        return receipt
-    except BaseException as error:
-        _preserve_failure_diagnostics(config, raw_ui_directory, error)
-        raise
-    finally:
-        try:
-            operations.quit_app()
-        finally:
-            if config.qualification_root.exists():
-                try:
-                    observed_marker = json.loads(marker_path.read_text(encoding="utf-8"))
-                except (OSError, json.JSONDecodeError) as error:
-                    raise SignedArtifactUIError("Signed artifact UI cleanup marker is missing or invalid.") from error
-                if observed_marker != marker:
-                    raise SignedArtifactUIError("Signed artifact UI cleanup marker changed during the run.")
-                shutil.rmtree(config.qualification_root)
+            expected_app_tree_sha256=expectation.signed_app_tree_sha256,
+            owner="bd-to-avp-signed-artifact-ui",
+            failure_diagnostics_directory=config.failure_diagnostics_directory,
+        ),
+        operations,
+    )
+    receipt = build_receipt(expectation=expectation, evidence=evidence_digests)
+    write_receipt(receipt, config.output_receipt)
+    return receipt
 
 
 def run(config: SignedArtifactUIConfig, operations: MacOSOperations | None = None) -> Mapping[str, Any]:
@@ -240,7 +183,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     try:
         run(config)
-    except (CleanMachineError, SignedArtifactReceiptError, SignedArtifactUIError) as error:
+    except (
+        CleanMachineError,
+        InstalledUIQualificationError,
+        SignedArtifactReceiptError,
+        SignedArtifactUIError,
+    ) as error:
         build_parser().error(str(error))
     return 0
 

--- a/tests/test_installed_ui_qualification.py
+++ b/tests/test_installed_ui_qualification.py
@@ -1,0 +1,79 @@
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.installed_ui_qualification import (
+    InstalledUIQualificationConfig,
+    InstalledUIQualificationError,
+    run,
+    validate_installed_ui_output_paths,
+)
+from scripts.tier3_clean_machine import CleanMachineError
+
+
+class FailingOperations:
+    def install_app(self, _dmg_path: Path, _destination: Path, _mount_point: Path) -> None:
+        raise CleanMachineError("primary UI failure")
+
+    def collect_ui_evidence(self, **_kwargs: object) -> None:
+        raise AssertionError("evidence collection must not run after installation fails")
+
+    def quit_app(self) -> None:
+        raise RuntimeError("cleanup quit failure")
+
+    def app_running(self) -> bool:
+        return False
+
+
+class InstalledUIQualificationTests(unittest.TestCase):
+    @staticmethod
+    def config(root: Path) -> InstalledUIQualificationConfig:
+        return InstalledUIQualificationConfig(
+            repo=root,
+            dmg=root / "candidate.dmg",
+            qualification_root=root / "qualification",
+            evidence_directory=root / "evidence",
+            release_notes_url="https://example.com/releases",
+            expected_app_tree_sha256="a" * 64,
+            owner="test-installed-ui",
+            failure_diagnostics_directory=root / "diagnostics",
+        )
+
+    def test_rejects_overlapping_output_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config = self.config(root)
+            overlapping = InstalledUIQualificationConfig(
+                **{
+                    **config.__dict__,
+                    "failure_diagnostics_directory": config.qualification_root / "diagnostics",
+                }
+            )
+
+            with self.assertRaisesRegex(InstalledUIQualificationError, "must not overlap"):
+                validate_installed_ui_output_paths(overlapping)
+
+    def test_primary_failure_survives_diagnostics_and_cleanup_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config = self.config(root)
+
+            with (
+                patch(
+                    "scripts.installed_ui_qualification._preserve_failure_diagnostics",
+                    side_effect=OSError("diagnostics failure"),
+                ),
+                self.assertRaisesRegex(CleanMachineError, "primary UI failure") as raised,
+            ):
+                run(config, FailingOperations())
+
+            notes = getattr(raised.exception, "__notes__", [])
+            self.assertTrue(any("diagnostics failure" in note for note in notes))
+            self.assertTrue(any("cleanup quit failure" in note for note in notes))
+            self.assertFalse(config.qualification_root.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -123,6 +123,43 @@ class MacOSReleaseArtifactTests(unittest.TestCase):
         smoke_tools.assert_called_once_with(app_path)
         smoke_worker.assert_called_once_with(app_path)
 
+    def test_verify_release_app_without_signatures_keeps_layout_validation(self) -> None:
+        app_path = Path("/tmp") / NATIVE_APP_NAME
+        metadata = release_metadata(app_path)
+
+        with (
+            patch("scripts.macos_release.verify_layout") as verify_layout,
+            patch("scripts.macos_release.inspect_app_bundle", return_value=metadata) as inspect_bundle,
+        ):
+            result = verify_release_app(app_path, verify_signatures=False)
+
+        self.assertEqual(result, metadata)
+        verify_layout.assert_called_once_with(app_path)
+        inspect_bundle.assert_called_once_with(app_path, verify_signatures=False)
+
+    def test_create_release_dmg_allows_explicit_unsigned_pre_signing_package(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_path = root / NATIVE_APP_NAME
+            output_path = root / "release.dmg"
+            metadata = release_metadata(app_path)
+
+            def release_tool(command: list[str]) -> subprocess.CompletedProcess[str]:
+                if command[:4] == ["diskutil", "image", "create", "from"]:
+                    Path(command[-1]).write_bytes(b"dmg")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with (
+                patch("scripts.macos_release.verify_layout") as verify_layout,
+                patch("scripts.macos_release.inspect_app_bundle", return_value=metadata) as inspect_bundle,
+                patch("scripts.macos_release.run", side_effect=release_tool),
+            ):
+                result = create_release_dmg(app_path, output_path, verify_signatures=False)
+
+        self.assertEqual(result, output_path)
+        verify_layout.assert_called_once_with(app_path)
+        inspect_bundle.assert_called_once_with(app_path, verify_signatures=False)
+
     def test_native_app_smoke_uses_packaged_native_smoke(self) -> None:
         app_path = Path("/tmp") / NATIVE_APP_NAME
         with patch("scripts.macos_release.smoke_packaged_native_app") as packaged_smoke:

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -119,6 +119,11 @@ def test_app(root: Path, payload: bytes = b"current build") -> Path:
 
 
 class NativeAppPackagingTests(unittest.TestCase):
+    def test_package_defaults_to_ad_hoc_signing(self) -> None:
+        args = parse_args(["package"])
+
+        self.assertEqual(args.sign_identity, "-")
+
     def test_worker_smoke_uses_current_protocol_version(self) -> None:
         self.assertEqual(WORKER_PROTOCOL_VERSION, PROTOCOL_VERSION)
 

--- a/tests/test_pre_signing_ui.py
+++ b/tests/test_pre_signing_ui.py
@@ -1,0 +1,187 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.pre_signing_ui import PreSigningUIConfig, PreSigningUIError, run
+from scripts.tier3_clean_machine import CleanMachineError
+
+
+class PreSigningUITests(unittest.TestCase):
+    @staticmethod
+    def config(root: Path) -> PreSigningUIConfig:
+        app = root / "3D Blu-ray to Vision Pro.app"
+        app.mkdir(parents=True)
+        return PreSigningUIConfig(
+            repo=root,
+            app=app,
+            dmg=root / "candidate.dmg",
+            qualification_root=root / "qualification",
+            evidence_directory=root / "evidence",
+            output_report=root / "report.json",
+            failure_diagnostics_directory=root / "diagnostics",
+            release_notes_url="https://example.com/releases",
+            source_sha="a" * 40,
+            workflow_run_id=123,
+            workflow_run_attempt=2,
+        )
+
+    def test_builds_dmg_runs_shared_fixture_and_writes_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = root / "3D Blu-ray to Vision Pro.app"
+            app.mkdir()
+            dmg = root / "candidate.dmg"
+            report_path = root / "report.json"
+            config = PreSigningUIConfig(
+                repo=root,
+                app=app,
+                dmg=dmg,
+                qualification_root=root / "qualification",
+                evidence_directory=root / "evidence",
+                output_report=report_path,
+                failure_diagnostics_directory=root / "diagnostics",
+                release_notes_url="https://example.com/releases",
+                source_sha="a" * 40,
+                workflow_run_id=123,
+                workflow_run_attempt=2,
+            )
+
+            def create_dmg(_app: Path, output: Path, *, verify_signatures: bool) -> Path:
+                self.assertFalse(verify_signatures)
+                output.write_bytes(b"dmg")
+                return output
+
+            with (
+                patch("scripts.pre_signing_ui.app_tree_sha256", return_value="b" * 64),
+                patch("scripts.pre_signing_ui.create_release_dmg", side_effect=create_dmg) as create_mock,
+                patch(
+                    "scripts.pre_signing_ui.run_installed_ui_qualification",
+                    return_value={"candidate-ui.json": "c" * 64},
+                ) as ui_mock,
+            ):
+                report = run(config)
+
+            saved = json.loads(report_path.read_text(encoding="utf-8"))
+
+        create_mock.assert_called_once()
+        ui_config = ui_mock.call_args.args[0]
+        self.assertEqual(ui_config.dmg, dmg)
+        self.assertEqual(ui_config.expected_app_tree_sha256, "b" * 64)
+        self.assertEqual(ui_config.owner, "bd-to-avp-pre-signing-ui")
+        self.assertEqual(report, saved)
+        self.assertEqual(saved["schema_version"], 1)
+        self.assertEqual(saved["source_sha"], "a" * 40)
+        self.assertEqual(saved["workflow"], {"run_attempt": 2, "run_id": 123})
+        self.assertEqual(saved["dmg"]["size_bytes"], 3)
+        self.assertEqual(saved["evidence"], {"candidate-ui.json": "c" * 64})
+
+    def test_rejects_existing_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = root / "3D Blu-ray to Vision Pro.app"
+            app.mkdir()
+            report_path = root / "report.json"
+            report_path.write_text("{}\n", encoding="utf-8")
+            config = PreSigningUIConfig(
+                repo=root,
+                app=app,
+                dmg=root / "candidate.dmg",
+                qualification_root=root / "qualification",
+                evidence_directory=root / "evidence",
+                output_report=report_path,
+                failure_diagnostics_directory=None,
+                release_notes_url="https://example.com/releases",
+                source_sha="a" * 40,
+                workflow_run_id=123,
+                workflow_run_attempt=1,
+            )
+
+            with self.assertRaisesRegex(PreSigningUIError, "output already exists"):
+                run(config)
+
+    def test_rejects_stale_shared_outputs_before_creating_dmg(self) -> None:
+        for output_name in ("qualification_root", "evidence_directory", "failure_diagnostics_directory"):
+            with self.subTest(output_name=output_name), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                config = self.config(root)
+                output_path = getattr(config, output_name)
+                if not isinstance(output_path, Path):
+                    raise AssertionError("shared output path must be configured")
+                output_path.mkdir(parents=True)
+
+                with (
+                    patch("scripts.pre_signing_ui.app_tree_sha256", return_value="b" * 64),
+                    patch("scripts.pre_signing_ui.create_release_dmg") as create_mock,
+                    self.assertRaisesRegex(PreSigningUIError, "must not already exist"),
+                ):
+                    run(config)
+
+                create_mock.assert_not_called()
+
+    def test_removes_owned_outputs_when_installed_ui_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config = self.config(root)
+
+            def create_dmg(_app: Path, output: Path, *, verify_signatures: bool) -> Path:
+                self.assertFalse(verify_signatures)
+                output.write_bytes(b"dmg")
+                return output
+
+            def fail_installed_ui(_config: object) -> object:
+                config.evidence_directory.mkdir()
+                if config.failure_diagnostics_directory is None:
+                    raise AssertionError("diagnostics path must be configured")
+                config.failure_diagnostics_directory.mkdir()
+                (config.failure_diagnostics_directory / "failure.txt").write_text(
+                    "simulated failure\n",
+                    encoding="utf-8",
+                )
+                raise CleanMachineError("simulated UI failure")
+
+            with (
+                patch("scripts.pre_signing_ui.app_tree_sha256", return_value="b" * 64),
+                patch("scripts.pre_signing_ui.create_release_dmg", side_effect=create_dmg),
+                patch("scripts.pre_signing_ui.run_installed_ui_qualification", side_effect=fail_installed_ui),
+                self.assertRaisesRegex(CleanMachineError, "simulated UI failure"),
+            ):
+                run(config)
+
+            self.assertFalse(config.dmg.exists())
+            self.assertFalse(config.evidence_directory.exists())
+            self.assertFalse(config.output_report.exists())
+            self.assertTrue((config.failure_diagnostics_directory / "failure.txt").is_file())
+
+    def test_removes_owned_outputs_when_report_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config = self.config(root)
+
+            def create_dmg(_app: Path, output: Path, *, verify_signatures: bool) -> Path:
+                self.assertFalse(verify_signatures)
+                output.write_bytes(b"dmg")
+                return output
+
+            def collect_evidence(_config: object) -> dict[str, str]:
+                config.evidence_directory.mkdir()
+                return {"candidate-ui.json": "c" * 64}
+
+            with (
+                patch("scripts.pre_signing_ui.app_tree_sha256", return_value="b" * 64),
+                patch("scripts.pre_signing_ui.create_release_dmg", side_effect=create_dmg),
+                patch("scripts.pre_signing_ui.run_installed_ui_qualification", side_effect=collect_evidence),
+                patch("scripts.pre_signing_ui._write_report", side_effect=OSError("report failure")),
+                self.assertRaisesRegex(OSError, "report failure"),
+            ):
+                run(config)
+
+            self.assertFalse(config.dmg.exists())
+            self.assertFalse(config.evidence_directory.exists())
+            self.assertFalse(config.output_report.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -86,6 +86,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         }
         workflow = load_release_engine()
         prepare = workflow["jobs"]["prepare"]
+        pre_signing = workflow["jobs"]["pre-signing-package"]
         package = workflow["jobs"]["package"]
 
         self.assertEqual({operator["name"] for operator in operators.values()}, set(operators))
@@ -111,6 +112,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertEqual(checkout["with"]["persist-credentials"], "false")
         self.assertIn("refs/heads/main", str(prepare))
         self.assertIn("refs/remotes/origin/main", str(prepare))
+        self.assertIn("refs/remotes/origin/main", str(pre_signing))
+        self.assertIn("Protected main moved before pre-signing qualification", str(pre_signing))
+        self.assertIn("pre-signing-package", package["needs"])
         self.assertIn("refs/remotes/origin/main", str(package))
         self.assertIn("moved after signing approval", str(package))
         self.assertGreaterEqual(str(package).count("refs/remotes/origin/main"), 4)
@@ -230,7 +234,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("release_route", policy["outputs"])
         self.assertIn("operator_workflow_path", policy["outputs"])
         self.assertEqual(workflow["jobs"]["prepare"]["needs"], "policy")
-        self.assertEqual(set(workflow["jobs"]["package"]["needs"]), {"policy", "prepare", "qualify-preparation"})
+        self.assertEqual(
+            set(workflow["jobs"]["package"]["needs"]),
+            {"policy", "prepare", "qualify-preparation", "pre-signing-package"},
+        )
         self.assertIn("--expected-fingerprint", str(workflow["jobs"]["package"]))
         self.assertIn("needs.policy.outputs.engine_workflow_ref", str(workflow["jobs"]["package"]))
 
@@ -330,7 +337,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
         cleanup_script = cleanup_step["run"]
         package_step = next(step for step in package["steps"] if step["name"] == "Package application for GitHub")
 
-        self.assertEqual(set(package["needs"]), {"policy", "prepare", "qualify-preparation"})
+        self.assertEqual(
+            set(package["needs"]),
+            {"policy", "prepare", "qualify-preparation", "pre-signing-package"},
+        )
         self.assertEqual(package["environment"], "macos-signing")
         self.assertEqual(package["permissions"]["contents"], "read")
         self.assertEqual(package["runs-on"], "macos-26")
@@ -795,6 +805,7 @@ printf '%s' "$CODESIGN_METADATA"
         workflow = load_release_engine()
         jobs = workflow["jobs"]
         qualify_prep = jobs["qualify-preparation"]
+        pre_signing = jobs["pre-signing-package"]
         package = jobs["package"]
         verify_draft = jobs["verify-draft"]
         build_receipt = jobs["build-receipt"]
@@ -809,25 +820,38 @@ printf '%s' "$CODESIGN_METADATA"
             )
         )
         self.assertIn("qualify-preparation", set(jobs["package"]["needs"]))
+        self.assertIn("pre-signing-package", set(jobs["package"]["needs"]))
         self.assertIn("qualify-preparation", set(jobs["build-python"]["needs"]))
         self.assertEqual(set(qualify_prep["needs"]), {"prepare"})
+        self.assertEqual(set(pre_signing["needs"]), {"policy", "prepare", "qualify-preparation"})
         self.assertIn("qualify-artifact", set(jobs["publish-release"]["needs"]))
         self.assertIn("signed-artifact-ui", set(jobs["publish-release"]["needs"]))
         self.assertIn("signed-artifact-ui", set(qualify_artifact["needs"]))
         self.assertIn("needs.signed-artifact-ui.result == 'success'", jobs["publish-release"]["if"])
         self.assertIn("needs.qualify-artifact.result == 'success'", jobs["publish-release"]["if"])
         self.assertNotIn("environment", qualify_prep)
+        self.assertNotIn("environment", pre_signing)
         self.assertNotIn("environment", signed_ui)
         self.assertNotIn("environment", qualify_artifact)
         self.assertNotIn("secrets.", str(qualify_prep))
+        self.assertNotIn("secrets.", str(pre_signing))
         self.assertNotIn("secrets.", str(signed_ui))
         self.assertNotIn("secrets.", str(qualify_artifact))
         self.assertEqual(qualify_prep["permissions"], {"contents": "read"})
+        self.assertEqual(pre_signing["permissions"], {"contents": "read"})
         self.assertEqual(signed_ui["permissions"], {"contents": "read"})
         self.assertEqual(qualify_artifact["permissions"], {"contents": "read"})
         self.assertIn("steps.release_package.outputs.artifact-id", package["outputs"]["workflow_artifact_id"])
         self.assertIn("steps.receipt_artifact.outputs.artifact-id", build_receipt["outputs"]["receipt_artifact_id"])
         self.assertIn("qualify_release_scope", str(qualify_prep))
+        self.assertEqual(pre_signing["runs-on"], "macos-26")
+        self.assertIn("scripts/native_app.py package --sign-identity -", str(pre_signing))
+        self.assertIn("scripts/smoke_release_app.py", str(pre_signing))
+        self.assertIn("--skip-spctl", str(pre_signing))
+        self.assertIn("scripts.pre_signing_ui", str(pre_signing))
+        self.assertNotIn("notarytool", str(pre_signing))
+        self.assertNotIn("CERTIFICATE", str(pre_signing))
+        self.assertNotIn("APPLE_ID", str(pre_signing))
         self.assertIn("signed_artifact_ui", str(signed_ui))
         self.assertIn("signed-artifact-ui-receipt.json", str(signed_ui))
         self.assertNotIn("GH_TOKEN", str(signed_ui))

--- a/tests/test_ssif_probe.py
+++ b/tests/test_ssif_probe.py
@@ -50,6 +50,8 @@ class SsifProbeTests(unittest.TestCase):
             raise unittest.SkipTest("pkg-config is unavailable")
         if subprocess.run(["pkg-config", "--exists", "libbluray"], check=False).returncode != 0:
             raise unittest.SkipTest("libbluray is unavailable")
+        if subprocess.run(["pkg-config", "--exists", "libudfread"], check=False).returncode != 0:
+            raise unittest.SkipTest("libudfread is unavailable")
         cls.temporary_directory = tempfile.TemporaryDirectory()
         cls.helper_path = Path(cls.temporary_directory.name) / "ssif_probe"
         build_result = subprocess.run(

--- a/tests/test_ssif_probe_builder.py
+++ b/tests/test_ssif_probe_builder.py
@@ -8,39 +8,45 @@ from scripts import build_ssif_probe_macos
 
 
 class SsifProbeBuilderTests(unittest.TestCase):
-    def test_manifest_pins_development_dependencies(self) -> None:
+    def test_manifest_records_known_good_source_provenance(self) -> None:
         manifest = build_ssif_probe_macos.load_manifest(build_ssif_probe_macos.MANIFEST_PATH)
 
-        self.assertEqual(manifest.schema_version, 1)
+        self.assertEqual(manifest.schema_version, 2)
         self.assertEqual(manifest.platform, "macOS arm64")
         self.assertEqual(manifest.minimum_macos, "14.0")
         self.assertEqual(manifest.linkage, "dynamic-development-only")
-        self.assertEqual(manifest.libbluray.version, "1.4.1")
-        self.assertEqual(manifest.libudfread.version, "1.2.0")
+        self.assertEqual(manifest.libbluray.known_good_source.version, "1.4.1")
+        self.assertEqual(manifest.libudfread.known_good_source.version, "1.2.0")
+        self.assertIn("libbluray-1.4.1", manifest.libbluray.known_good_source.url)
+        self.assertIn("libudfread-1.2.0", manifest.libudfread.known_good_source.url)
         self.assertEqual(manifest.libbluray.license, "LGPL-2.1-or-later")
         self.assertEqual(manifest.libudfread.license, "LGPL-2.1-or-later")
 
     def test_manifest_rejects_unknown_fields(self) -> None:
         manifest = """
-schema_version = 1
+schema_version = 2
 platform = "macOS arm64"
 minimum_macos = "14.0"
 linkage = "dynamic-development-only"
 unexpected = true
 
 [libbluray]
-version = "1.4.1"
 pkg_config = "libbluray"
-source_url = "https://example.com/libbluray.tar.xz"
-source_sha256 = "bluray"
 license = "LGPL-2.1-or-later"
 
+[libbluray.known_good_source]
+version = "1.4.1"
+url = "https://example.com/libbluray.tar.xz"
+sha256 = "bluray"
+
 [libudfread]
-version = "1.2.0"
 pkg_config = "libudfread"
-source_url = "https://example.com/libudfread.tar.xz"
-source_sha256 = "udfread"
 license = "LGPL-2.1-or-later"
+
+[libudfread.known_good_source]
+version = "1.2.0"
+url = "https://example.com/libudfread.tar.xz"
+sha256 = "udfread"
 """
         with tempfile.TemporaryDirectory() as temporary_directory:
             manifest_path = Path(temporary_directory) / "manifest.toml"
@@ -53,23 +59,27 @@ license = "LGPL-2.1-or-later"
     def test_build_command_uses_dynamic_pkg_config_linkage(self, pkg_config_mock) -> None:
         pkg_config_mock.side_effect = ["-I/native/include", "-L/native/lib -lbluray"]
         manifest = build_ssif_probe_macos.SsifProbeManifest(
-            schema_version=1,
+            schema_version=2,
             platform="macOS arm64",
             minimum_macos="14.0",
             linkage="dynamic-development-only",
             libbluray=build_ssif_probe_macos.NativeDependency(
-                version="1.4.1",
                 pkg_config="libbluray",
-                source_url="https://example.com/libbluray.tar.xz",
-                source_sha256="bluray",
                 license="LGPL-2.1-or-later",
+                known_good_source=build_ssif_probe_macos.SourceProvenance(
+                    version="1.4.1",
+                    url="https://example.com/libbluray.tar.xz",
+                    sha256="bluray",
+                ),
             ),
             libudfread=build_ssif_probe_macos.NativeDependency(
-                version="1.2.0",
                 pkg_config="libudfread",
-                source_url="https://example.com/libudfread.tar.xz",
-                source_sha256="udfread",
                 license="LGPL-2.1-or-later",
+                known_good_source=build_ssif_probe_macos.SourceProvenance(
+                    version="1.2.0",
+                    url="https://example.com/libudfread.tar.xz",
+                    sha256="udfread",
+                ),
             ),
         )
 
@@ -98,6 +108,36 @@ license = "LGPL-2.1-or-later"
                 "-lbluray",
             ],
         )
+
+    @patch("scripts.build_ssif_probe_macos.pkg_config", return_value="1.5.0")
+    def test_dependency_verification_accepts_host_version(self, pkg_config_mock) -> None:
+        dependency = build_ssif_probe_macos.NativeDependency(
+            pkg_config="libbluray",
+            license="LGPL-2.1-or-later",
+            known_good_source=build_ssif_probe_macos.SourceProvenance(
+                version="1.4.1",
+                url="https://example.com/libbluray.tar.xz",
+                sha256="bluray",
+            ),
+        )
+
+        self.assertEqual(build_ssif_probe_macos.verify_dependency(dependency), "1.5.0")
+        pkg_config_mock.assert_called_once_with(["--modversion", "libbluray"])
+
+    @patch("scripts.build_ssif_probe_macos.pkg_config", return_value="")
+    def test_dependency_verification_rejects_missing_version(self, _pkg_config_mock) -> None:
+        dependency = build_ssif_probe_macos.NativeDependency(
+            pkg_config="libbluray",
+            license="LGPL-2.1-or-later",
+            known_good_source=build_ssif_probe_macos.SourceProvenance(
+                version="1.4.1",
+                url="https://example.com/libbluray.tar.xz",
+                sha256="bluray",
+            ),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "did not report an installed version"):
+            build_ssif_probe_macos.verify_dependency(dependency)
 
 
 if __name__ == "__main__":

--- a/tests/test_ssif_probe_integration.py
+++ b/tests/test_ssif_probe_integration.py
@@ -57,7 +57,11 @@ class SsifProbeIntegrationTests(unittest.TestCase):
 
         self.assertEqual(result.stderr, "")
         inspection = json.loads(result.stdout)
-        self.assertEqual(inspection["libbluray_version"], "1.4.1")
+        installed_libbluray_version = subprocess.check_output(
+            ["pkg-config", "--modversion", "libbluray"],
+            text=True,
+        ).strip()
+        self.assertEqual(inspection["libbluray_version"], installed_libbluray_version)
         self.assertTrue(inspection["content_3d"])
         self.assertFalse(inspection["aacs_detected"])
         self.assertFalse(inspection["aacs_handled"])

--- a/vendor/ssif-probe-macos-arm64.toml
+++ b/vendor/ssif-probe-macos-arm64.toml
@@ -1,18 +1,22 @@
-schema_version = 1
+schema_version = 2
 platform = "macOS arm64"
 minimum_macos = "14.0"
 linkage = "dynamic-development-only"
 
 [libbluray]
-version = "1.4.1"
 pkg_config = "libbluray"
-source_url = "https://download.videolan.org/videolan/libbluray/1.4.1/libbluray-1.4.1.tar.xz"
-source_sha256 = "76b5dc40097f28dca4ebb009c98ed51321b2927453f75cc72cf74acd09b9f449"
 license = "LGPL-2.1-or-later"
 
+[libbluray.known_good_source]
+version = "1.4.1"
+url = "https://download.videolan.org/videolan/libbluray/1.4.1/libbluray-1.4.1.tar.xz"
+sha256 = "76b5dc40097f28dca4ebb009c98ed51321b2927453f75cc72cf74acd09b9f449"
+
 [libudfread]
-version = "1.2.0"
 pkg_config = "libudfread"
-source_url = "https://download.videolan.org/videolan/libudfread/libudfread-1.2.0.tar.xz"
-source_sha256 = "bb477cbd4cfbfc7787d9d05b71ee5e70430f5cfebf1297497f7e83547958050f"
 license = "LGPL-2.1-or-later"
+
+[libudfread.known_good_source]
+version = "1.2.0"
+url = "https://download.videolan.org/videolan/libudfread/libudfread-1.2.0.tar.xz"
+sha256 = "bb477cbd4cfbfc7787d9d05b71ee5e70430f5cfebf1297497f7e83547958050f"


### PR DESCRIPTION
## Summary
- treat the SSIF Homebrew libraries as behavior-tested development dependencies while retaining checksum-pinned known-good source provenance
- add a secret-free production package, smoke, DMG install, and UI accessibility gate before the `macos-signing` environment can start
- share the installed UI fixture between preventive and exact signed-artifact qualification with fail-safe cleanup and bounded diagnostics

## Release safety
- the pre-signing report is preventive and non-evidentiary
- Developer ID signing, notarization, signed-DMG verification, exact-artifact UI qualification, appcast, and publication gates remain mandatory
- `create_release_dmg()` remains signature-strict by default; the unsigned path is explicit and covered only for the preventive fixture

## Validation
- 1,823 Python tests passed (3 skipped) with the local `ffmpeg-full` keg isolated from a conflicting Homebrew `ffmpeg` dylib
- 484 native tests passed
- 75 focused release/SSIF tests passed (2 real-media skips)
- Ruff, mypy, actionlint, `uv build`, and observability validation passed
- the full ad-hoc package, maintained release smoke, production-shaped DMG, clean install, and installed UI accessibility fixture passed locally
- JetBrains inspection is inconclusive because the configured IntelliJ project lacks a Python language SDK; no actionable findings were returned

Refs #625
Refs #609
Refs #554
Related #209