### PR TITLE
Record cancelled Beta 6 signed attempt

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -139,6 +139,7 @@
       "releaseQualificationResume": "uv run python -m unittest tests.test_release_qualification_resume",
       "releaseQualificationArtifact": "uv run python -m unittest tests.test_release_qualification_artifact",
       "releaseQualificationApply": "uv run python -m unittest tests.test_release_qualification_apply",
+      "cancelledReleaseAttempt": "uv run python -m scripts.release_milestone_context --cancelled-attempt-tag v0.3.2-beta.6",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/.github/release-freezes.json
+++ b/.github/release-freezes.json
@@ -1,5 +1,10 @@
 {
   "schema": "bd_to_avp.release_freezes",
   "schema_version": 1,
-  "frozen_release_tags": {}
+  "frozen_release_tags": {
+    "v0.3.2-beta.6": {
+      "issue": 609,
+      "reason": "Cancelled unpublished signed attempt; build 168 is permanently non-reusable pending explicitly authorized draft cleanup."
+    }
+  }
 }

--- a/docs/0.3.2-beta.5-cut-packet.md
+++ b/docs/0.3.2-beta.5-cut-packet.md
@@ -2,8 +2,9 @@
 
 > **Published and immutable; exact-artifact qualification blocked.**
 > Beta 5 must not be rebuilt, retagged, unpublished, replaced, or modified.
-> Its corrective successor is Beta 6 build `168`, whose dispatch and signing
-> approval remain separate exact-run-bound decisions.
+> Corrective Beta 6 build `168` became a cancelled unpublished signed attempt
+> and is permanently burned. Issue #609 owns a newer successor after separately
+> authorized Beta 6 draft disposition.
 
 Beta `0.3.2b5` is the published recovery successor to failed unpublished Beta
 `0.3.2b4`. Issue #609 owns preparation, qualification, publication, and

--- a/docs/0.3.2-beta.6-cut-packet.md
+++ b/docs/0.3.2-beta.6-cut-packet.md
@@ -1,10 +1,10 @@
 # 0.3.2 Beta 6 Cut Packet
 
-> **Prepared metadata; publication pending.**
-> Release dispatch is not authorized by this preparation. A future guarded
-> Prerelease run must use the exact merged protected-`main` SHA under a temporary
-> merge hold, and `macos-signing` approval requires separate explicit run-bound
-> authorization in the active conversation.
+> **Cancelled, unpublished, signed attempt; build `168` is permanently burned.**
+> Guarded Prerelease run `32502068709` reached signed, notarized draft assets and
+> an immutable release receipt before it was intentionally cancelled to harden
+> release fixtures. Draft release `374538590` remains present and must not be
+> deleted without separate explicit authorization.
 
 Beta `0.3.2b6` is the corrective successor to published, immutable Beta
 `0.3.2b5`. Issue #609 owns preparation, qualification, publication, and
@@ -34,9 +34,42 @@ Build `168` is globally newer than published immutable Beta 5 build `167`,
 Beta 2 build `164`, Beta 1 build `163`, Stable `0.3.1` build `162`, and all
 earlier published production history. Failed signed Beta 3 build `165`, failed
 signed Beta 4 build `166`, and burned builds `147` and `154` remain unavailable;
-abandoned metadata build `157` also remains unavailable. As checked on August
-21, 2026, no `v0.3.2-beta.6` tag, release, draft, PyPI version, Homebrew pull
-request, or appcast item exists.
+abandoned metadata build `157` also remains unavailable. Before dispatch on
+August 21, 2026, no `v0.3.2-beta.6` tag, release, draft, PyPI version, Homebrew
+pull request, or appcast item existed. The cancelled run subsequently created
+unpublished draft `374538590`; no Git tag, public release, Pages appcast item,
+PyPI version, or Homebrew change was created.
+
+## Cancelled Signed Attempt
+
+- Prerelease run `32502068709`, attempt `1`, used protected-`main` source SHA
+  `b4abf8829b6a539b40bb369bfd62dea504d35be1`.
+- The `macos-signing` approval was granted by `cbusillo` with approval
+  fingerprint
+  `b29680899e9bf2f6d33ac552021f437b01f26b81cd85779ce951cf02c4da9c67`.
+- Signing, notarization, package verification, draft creation, appcast
+  construction, draft asset verification, and release receipt construction all
+  completed successfully.
+- The run was intentionally cancelled in job `96839729307`, step
+  `Run installed candidate UI accessibility lane`, before exact-artifact
+  qualification, appcast deployment, or publication.
+- Draft `374538590` retains the exact DMG, checksum, appcast, and release receipt.
+  Their IDs, sizes, and SHA-256 digests are recorded in
+  `docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`.
+- The checked receipt is
+  `docs/release-attempts/v0.3.2-beta.6/release-receipt.json`; it proves the signed
+  package identity but does not prove exact-artifact UI or milestone acceptance.
+- `.github/release-freezes.json` blocks reuse of `v0.3.2-beta.6`. Build `168`
+  must remain absent from all future updater feeds and successor releases.
+  The future successor qualification must list `168` in
+  `immutable_history.burned_builds`; milestone-context validation blocks
+  successor preparation while the retained draft has no authorized deletion
+  disposition.
+
+The draft is diagnostic evidence, not a resumable release candidate after the
+fixture-hardening changes merged. Record and review a separate authorized draft
+deletion before preparing Beta 7/build `169`; do not mutate this cancelled-attempt
+record or the checked receipt.
 
 ## Corrective Scope
 
@@ -91,7 +124,8 @@ the accurate record of failed exact-artifact qualification. Beta 6 must rerun
 the clean-machine, installed UI, and Sparkle update route against the exact
 signed Beta 6 artifact.
 
-This preparation does not create a tag, release, signed artifact, appcast item,
-PyPI version, Homebrew change, or publication. Do not dispatch Prerelease or
-approve `macos-signing` without separate explicit authorization for the exact
-run ID, full protected-`main` SHA, workflow, and watcher fingerprint.
+This attempt did not create a public tag, published release, Pages appcast item,
+PyPI version, Homebrew change, or accepted qualification. Do not dispatch
+Prerelease for Beta 6, reuse build `168`, delete draft `374538590`, or approve a
+successor signing run without the separately reviewed recovery steps owned by
+issue #609.

--- a/docs/0.3.2-beta.6-cut-packet.md
+++ b/docs/0.3.2-beta.6-cut-packet.md
@@ -1,10 +1,10 @@
 # 0.3.2 Beta 6 Cut Packet
 
-> **Cancelled, unpublished, signed attempt; build `168` is permanently burned.**
+> **Cancelled, unpublished, signed attempt; release identity permanently burned.**
 > Guarded Prerelease run `32502068709` reached signed, notarized draft assets and
 > an immutable release receipt before it was intentionally cancelled to harden
-> release fixtures. Draft release `374538590` remains present and must not be
-> deleted without separate explicit authorization.
+> release fixtures. Build `168` is permanently burned. Draft release `374538590`
+> remains present and must not be deleted without separate explicit authorization.
 
 Beta `0.3.2b6` is the corrective successor to published, immutable Beta
 `0.3.2b5`. Issue #609 owns preparation, qualification, publication, and

--- a/docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json
+++ b/docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json
@@ -1,0 +1,64 @@
+{
+  "build_version": "168",
+  "cancellation_reason": "operator_cancelled_for_release_fixture_hardening",
+  "cancelled_job": "Prove signed artifact UI accessibility",
+  "cancelled_job_id": 96839729307,
+  "cancelled_step": "Run installed candidate UI accessibility lane",
+  "delete_requires_authorization": true,
+  "draft_assets": [
+    {
+      "asset_id": 523987569,
+      "kind": "appcast",
+      "name": "appcast.xml",
+      "sha256": "136a9f5f2ebc54d616dba23b3fa1120c5a9eea58cb1115c63b407b9dccbd4451",
+      "size_bytes": 84793
+    },
+    {
+      "asset_id": 523986632,
+      "kind": "checksum",
+      "name": "SHA256SUMS",
+      "sha256": "c051267f8ea09527427a9bc05c70fe851883cf4505c7d894fb9af07bcd5562b8",
+      "size_bytes": 108
+    },
+    {
+      "asset_id": 523986431,
+      "kind": "dmg",
+      "name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.6.dmg",
+      "sha256": "4a761933279a3e891908f059eed37634e5360f6233ef7bed1b3d0935dc1c7fb1",
+      "size_bytes": 166862194
+    },
+    {
+      "asset_id": 523988156,
+      "kind": "receipt",
+      "name": "release-receipt.json",
+      "sha256": "f4641acb7b6dbff6936508171bf2d1d964b4c2c6fbb7d7d63524883654aedb2f",
+      "size_bytes": 2297
+    }
+  ],
+  "draft_checked_at": "2026-08-21T18:31:47Z",
+  "draft_deleted": false,
+  "draft_release_id": 374538590,
+  "draft_state": "present",
+  "must_not_rebuild": true,
+  "package_version": "0.3.2b6",
+  "public_version": "0.3.2-beta.6",
+  "published_at": null,
+  "recorded_at": "2026-08-21T18:31:47Z",
+  "release_receipt_asset_id": 523988156,
+  "release_receipt_asset_size_bytes": 2297,
+  "release_receipt_file_sha256": "f4641acb7b6dbff6936508171bf2d1d964b4c2c6fbb7d7d63524883654aedb2f",
+  "release_receipt_path": "docs/release-attempts/v0.3.2-beta.6/release-receipt.json",
+  "release_receipt_sha256": "14bd8c5c4c2cd5242b34514c63361aad1a3314e9075e514c520de9ae87dc251f",
+  "release_tag": "v0.3.2-beta.6",
+  "schema_version": 1,
+  "signing_approval_environment": "macos-signing",
+  "signing_approval_fingerprint": "b29680899e9bf2f6d33ac552021f437b01f26b81cd85779ce951cf02c4da9c67",
+  "signing_approval_reviewer": "cbusillo",
+  "source_sha": "b4abf8829b6a539b40bb369bfd62dea504d35be1",
+  "status": "cancelled_unpublished_signed_candidate",
+  "tag_exists": false,
+  "workflow_completed_at": "2026-08-21T16:40:01Z",
+  "workflow_conclusion": "cancelled",
+  "workflow_run_attempt": 1,
+  "workflow_run_id": 32502068709
+}

--- a/docs/release-attempts/v0.3.2-beta.6/release-receipt.json
+++ b/docs/release-attempts/v0.3.2-beta.6/release-receipt.json
@@ -1,0 +1,75 @@
+{
+  "appcast": {
+    "live_pages_sha256": "136a9f5f2ebc54d616dba23b3fa1120c5a9eea58cb1115c63b407b9dccbd4451",
+    "live_pages_state": "pending_release_deploy",
+    "live_pages_url": "https://cbusillo.github.io/BD_to_AVP/appcast.xml"
+  },
+  "artifacts": [
+    {
+      "asset_id": 523987569,
+      "kind": "appcast",
+      "name": "appcast.xml",
+      "sha256": "136a9f5f2ebc54d616dba23b3fa1120c5a9eea58cb1115c63b407b9dccbd4451",
+      "size_bytes": 84793
+    },
+    {
+      "asset_id": 523986632,
+      "kind": "checksum",
+      "name": "SHA256SUMS",
+      "sha256": "c051267f8ea09527427a9bc05c70fe851883cf4505c7d894fb9af07bcd5562b8",
+      "size_bytes": 108
+    },
+    {
+      "asset_id": 523986431,
+      "kind": "dmg",
+      "name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.6.dmg",
+      "sha256": "4a761933279a3e891908f059eed37634e5360f6233ef7bed1b3d0935dc1c7fb1",
+      "size_bytes": 166862194
+    }
+  ],
+  "protected_branch": "main",
+  "receipt_sha256": "14bd8c5c4c2cd5242b34514c63361aad1a3314e9075e514c520de9ae87dc251f",
+  "receipt_type": "bd-to-avp-release-engine",
+  "release": {
+    "created_at": "2026-08-21T16:36:17Z",
+    "id": 374538590,
+    "make_latest": false,
+    "name": "v0.3.2-beta.6",
+    "prerelease": true,
+    "tag": "v0.3.2-beta.6",
+    "target_sha": "b4abf8829b6a539b40bb369bfd62dea504d35be1"
+  },
+  "release_route": "prerelease",
+  "repository": "cbusillo/BD_to_AVP",
+  "schema_version": 1,
+  "signed_app_tree_sha256": "8c947d3c9d0d82d05c996dd0d3901e1bf0afbdb9546fda665ebf4089c63f0fd9",
+  "source_sha": "b4abf8829b6a539b40bb369bfd62dea504d35be1",
+  "tier1_case_references": [
+    "release-workflow-identity",
+    "signed-packaged-route-parity"
+  ],
+  "verification": {
+    "app_notarization": "passed",
+    "app_staple": "passed",
+    "appcast": "passed",
+    "asset_redownload": "passed",
+    "attestation": "passed",
+    "dmg_notarization": "passed",
+    "dmg_staple": "passed",
+    "gatekeeper": "passed",
+    "package_smoke": "passed"
+  },
+  "versions": {
+    "build": "168",
+    "package": "0.3.2b6",
+    "public": "0.3.2-beta.6"
+  },
+  "workflow": {
+    "actor": "shiny-code-bot",
+    "engine_path": ".github/workflows/release-engine.yml",
+    "name": "Prerelease",
+    "path": ".github/workflows/prerelease.yml",
+    "run_attempt": 1,
+    "run_id": 32502068709
+  }
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -34,8 +34,12 @@ as recorded in [the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md). Beta
 exact-artifact qualification is blocked because the packaged worker reported
 `0.0.0` instead of `0.3.2b5`; the publication and qualification boundary are
 tracked in [the 0.3.2 Beta 5 cut packet](0.3.2-beta.5-cut-packet.md). The next
-prepared identity is corrective Beta `0.3.2b6` build `168`, tracked in
-[the 0.3.2 Beta 6 cut packet](0.3.2-beta.6-cut-packet.md) and issue #609.
+corrective identity, Beta `0.3.2b6` build `168`, became a cancelled unpublished
+signed attempt after draft creation and is permanently burned, as recorded in
+[the 0.3.2 Beta 6 cut packet](0.3.2-beta.6-cut-packet.md) and
+`docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`. Its draft
+remains present pending separate explicit deletion authorization. Issue #609
+owns that disposition and preparation of a newer successor identity.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease
@@ -567,6 +571,13 @@ diagnostic and retry evidence. If a newer immutable release supersedes a failed
 draft and no exact-commit retry remains useful, verify the published tag and
 assets, then delete only the abandoned draft through the GitHub Releases UI.
 Maintainers may otherwise see that draft pinned above newer published releases.
+An intentionally cancelled signed attempt uses an immutable
+`cancelled-attempt-v1.json` record while its draft remains present. That record
+must bind the checked receipt, all draft asset IDs and digests, the cancellation
+boundary, and the run-bound signing approval. Freeze the release tag immediately.
+A later deletion requires fresh explicit authorization and a separate immutable
+disposition record; never rewrite the cancelled-attempt record to claim that the
+draft was deleted.
 
 To restore an earlier last-good cumulative feed, dispatch `Manage Sparkle Pages`
 from `main` with `restore` and the selected published release tag. The workflow

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -17,8 +17,10 @@ immutable. Stable `0.3.1` build `162`, Beta `0.3.2b1` build `163`, and Beta
 immutable. Beta `0.3.2b3` build `165` and Beta `0.3.2b4` build `166` are failed
 unpublished signed attempts and their identities are burned. Beta 5's
 post-publication exact-artifact qualification is blocked by packaged worker
-version metadata. The next prepared target is corrective Beta `0.3.2b6` build
-`168`; issue #609 owns publication and exact-artifact qualification.
+version metadata. Corrective Beta `0.3.2b6` build `168` is a cancelled,
+unpublished signed attempt with retained draft `374538590`; its tag and build
+are permanently non-reusable. Issue #609 owns draft disposition and preparation
+of a newer successor.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -443,7 +445,7 @@ qualification contract, and the successor advances to Beta 5 build `167`
 rather than reusing either Beta 4 identity. The failed-attempt details are in
 [the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md).
 
-## 0.3.2 Beta 5 Publication And Beta 6 Prepared Target
+## 0.3.2 Beta 5 Publication And Cancelled Beta 6 Attempt
 
 Guarded Prerelease run `32488665999` published immutable
 `v0.3.2-beta.5` build `167` on August 21, 2026 from source SHA
@@ -453,8 +455,7 @@ embedded worker reported `0.0.0` instead of `0.3.2b5`. PR #623 corrects that
 diagnostics identity and strengthens the pre-signing package gate. PR #622
 remains blocked as the accurate Beta 5 evidence record.
 
-The repository is prepared for review of guarded Prerelease dispatch for
-`v0.3.2-beta.6`:
+The reviewed Beta 6 identity was:
 
 - internal version `0.3.2b6` and public version `0.3.2-beta.6`;
 - public tag and title `v0.3.2-beta.6`;
@@ -464,18 +465,20 @@ The repository is prepared for review of guarded Prerelease dispatch for
 - the same production product, bundle, feed, key, signing team, and diagnostics
   endpoint as published Beta `0.3.2b5`.
 
-Publication must place Beta 6 above immutable Beta 5 build `167`, Beta 2 build
-`164`, Beta 1 build `163`, Stable `0.3.1` build `162`, and all earlier
-published history, with failed Beta 3 build `165` and failed Beta 4 build `166`
-absent. Stable and RC clients exclude the Beta item; Beta and Alpha clients can
-select it because build `168` is newer.
+Guarded Prerelease run `32502068709` built, Developer ID signed, notarized, and
+verified build `168` from source SHA
+`b4abf8829b6a539b40bb369bfd62dea504d35be1`. It created unpublished draft
+`374538590`, cumulative appcast assets, and an immutable release receipt, then
+was intentionally cancelled in the installed candidate UI accessibility lane
+before exact-artifact qualification, Pages deployment, or publication.
 
-As checked on August 21, 2026, no `v0.3.2-beta.6` tag, release, draft, PyPI
-version, Homebrew pull request, or appcast item exists. Dispatch requires
-separate explicit release authorization under a fixed-`main` merge hold. The
-reviewed metadata, release-note seed, corrective scope, immutable Beta 5 prior
-receipt, and qualification boundary are in
-[the 0.3.2 Beta 6 cut packet](0.3.2-beta.6-cut-packet.md).
+No Git tag, public release, Pages appcast item, PyPI version, or Homebrew change
+was created. The retained draft is diagnostic evidence only. The exact asset
+identities and checked receipt are recorded under
+`docs/release-attempts/v0.3.2-beta.6/`; `.github/release-freezes.json` prevents
+redispatch of the Beta 6 tag. Build `168` must remain absent from future updater
+feeds. Issue #609 requires fresh explicit authorization before draft deletion
+and a newer successor identity, expected to begin at Beta 7/build `169`.
 
 ## Historical Boundaries
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,6 +79,7 @@ BETA3_RECOVERY_TARGET_BUILD = "148"
 CUT_PACKET_PREPARED = "**Prepared metadata; publication pending.**"
 CUT_PACKET_RECOVERY_PENDING = "**Published and immutable; PyPI recovery pending.**"
 CUT_PACKET_PUBLISHED = "**Published and immutable.**"
+CUT_PACKET_CANCELLED = "**Cancelled, unpublished, signed attempt; release identity permanently burned.**"
 
 
 class ReleaseError(RuntimeError):
@@ -776,9 +777,11 @@ def validate_release_cut_packet(metadata: ReleaseMetadata, *, repo_root: Path = 
         text = path.read_text(encoding="utf-8")
     except OSError as error:
         raise ReleaseError(f"Unable to load release cut packet from {path}: {error}") from error
-    recognized_states = (CUT_PACKET_PREPARED, CUT_PACKET_RECOVERY_PENDING, CUT_PACKET_PUBLISHED)
+    recognized_states = (CUT_PACKET_PREPARED, CUT_PACKET_RECOVERY_PENDING, CUT_PACKET_PUBLISHED, CUT_PACKET_CANCELLED)
     if sum(state in text for state in recognized_states) != 1:
-        raise ReleaseError("Release cut packet must declare exactly one prepared-pending or published immutable state.")
+        raise ReleaseError(
+            "Release cut packet must declare exactly one prepared, published, recovery-pending, or cancelled state."
+        )
     return relative
 
 

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -37,9 +37,13 @@ CHANGE_SCOPED_EVIDENCE_PATH_PATTERN = re.compile(r"^docs/qualification/(v[^/]+)-
 FAILED_ATTEMPT_ROOT = Path("docs/release-attempts")
 FAILED_ATTEMPT_RECORD_NAME = "failed-attempt-v1.json"
 FAILED_ATTEMPT_RECEIPT_NAME = "release-receipt.json"
+CANCELLED_ATTEMPT_RECORD_NAME = "cancelled-attempt-v1.json"
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+CANCELLATION_REASON_PATTERN = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
 IMMUTABLE_CANDIDATE_FIELDS = (
     "source_git_sha",
     "release_run_id",
@@ -73,6 +77,45 @@ FAILED_ATTEMPT_RECORD_KEYS = frozenset(
         "workflow_run_id",
     }
 )
+CANCELLED_ATTEMPT_RECORD_KEYS = frozenset(
+    {
+        "build_version",
+        "cancellation_reason",
+        "cancelled_job",
+        "cancelled_job_id",
+        "cancelled_step",
+        "delete_requires_authorization",
+        "draft_assets",
+        "draft_checked_at",
+        "draft_deleted",
+        "draft_release_id",
+        "draft_state",
+        "must_not_rebuild",
+        "package_version",
+        "public_version",
+        "published_at",
+        "recorded_at",
+        "release_receipt_asset_id",
+        "release_receipt_asset_size_bytes",
+        "release_receipt_file_sha256",
+        "release_receipt_path",
+        "release_receipt_sha256",
+        "release_tag",
+        "schema_version",
+        "signing_approval_environment",
+        "signing_approval_fingerprint",
+        "signing_approval_reviewer",
+        "source_sha",
+        "status",
+        "tag_exists",
+        "workflow_completed_at",
+        "workflow_conclusion",
+        "workflow_run_attempt",
+        "workflow_run_id",
+    }
+)
+CANCELLED_ATTEMPT_ASSET_KEYS = frozenset({"asset_id", "kind", "name", "sha256", "size_bytes"})
+CANCELLED_ATTEMPT_ASSET_KINDS = frozenset({"appcast", "checksum", "dmg", "receipt"})
 
 
 class ReleaseMilestoneContextError(RuntimeError):
@@ -180,6 +223,168 @@ def _sequence(value: object, description: str) -> Sequence[Any]:
     return cast(Sequence[Any], value)
 
 
+def _positive_integer(value: object, description: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ReleaseMilestoneContextError(f"{description} must be a positive integer.")
+    return value
+
+
+def _sha(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA_PATTERN.fullmatch(text) is None:
+        raise ReleaseMilestoneContextError(f"{description} must be a full lowercase Git SHA.")
+    return text
+
+
+def _sha256(value: object, description: str) -> str:
+    text = _string(value, description)
+    if SHA256_PATTERN.fullmatch(text) is None:
+        raise ReleaseMilestoneContextError(f"{description} must be a lowercase SHA-256 digest.")
+    return text
+
+
+def _timestamp(value: object, description: str) -> datetime:
+    text = _string(value, description)
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReleaseMilestoneContextError(f"{description} must be an ISO-8601 timestamp.") from error
+
+
+def validate_cancelled_attempt_record(repo_root: Path, release_tag: str) -> Mapping[str, Any]:
+    attempt_root = FAILED_ATTEMPT_ROOT / release_tag
+    record_relative = attempt_root / CANCELLED_ATTEMPT_RECORD_NAME
+    receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
+    record = _load_json(repo_root / record_relative, "cancelled release-attempt record")
+    if set(record) != CANCELLED_ATTEMPT_RECORD_KEYS:
+        raise ReleaseMilestoneContextError("Cancelled release-attempt record keys do not match the required schema.")
+    if (
+        record.get("schema_version") != 1
+        or record.get("status") != "cancelled_unpublished_signed_candidate"
+        or record.get("workflow_conclusion") != "cancelled"
+        or record.get("published_at") is not None
+        or record.get("draft_deleted") is not False
+        or record.get("draft_state") != "present"
+        or record.get("tag_exists") is not False
+        or record.get("must_not_rebuild") is not True
+        or record.get("delete_requires_authorization") is not True
+    ):
+        raise ReleaseMilestoneContextError(
+            "Cancelled release-attempt record must prove a draft-present, unpublished, "
+            "permanently non-reusable candidate."
+        )
+    cancellation_reason = _string(record.get("cancellation_reason"), "cancelled release reason")
+    if CANCELLATION_REASON_PATTERN.fullmatch(cancellation_reason) is None:
+        raise ReleaseMilestoneContextError("Cancelled release reason must be a lowercase machine-readable identifier.")
+    if record.get("release_tag") != release_tag:
+        raise ReleaseMilestoneContextError("Cancelled release-attempt tag does not match its canonical directory.")
+    if record.get("release_receipt_path") != receipt_relative.as_posix():
+        raise ReleaseMilestoneContextError("Cancelled release-attempt receipt path is not canonical.")
+    github_config = _load_json(repo_root / GITHUB_CONFIG_PATH, "GitHub repository configuration")
+    release_operations = _mapping(github_config.get("releaseOperations"), "release operations configuration")
+    if record.get("signing_approval_environment") != release_operations.get("approvalEnvironment"):
+        raise ReleaseMilestoneContextError("Cancelled release-attempt signing approval environment is invalid.")
+    if record.get("signing_approval_reviewer") != release_operations.get("approvalActor"):
+        raise ReleaseMilestoneContextError("Cancelled release-attempt signing approval reviewer is invalid.")
+    _sha256(record.get("signing_approval_fingerprint"), "cancelled release signing approval fingerprint")
+    _string(record.get("cancelled_job"), "cancelled release job")
+    _positive_integer(record.get("cancelled_job_id"), "cancelled release job ID")
+    _string(record.get("cancelled_step"), "cancelled release step")
+    source_sha = _sha(record.get("source_sha"), "cancelled release source SHA")
+    workflow_completed_at = _timestamp(record.get("workflow_completed_at"), "cancelled release workflow completion")
+    draft_checked_at = _timestamp(record.get("draft_checked_at"), "cancelled release draft check")
+    recorded_at = _timestamp(record.get("recorded_at"), "cancelled release record timestamp")
+    if draft_checked_at < workflow_completed_at or recorded_at < draft_checked_at:
+        raise ReleaseMilestoneContextError("Cancelled release-attempt timestamps are out of order.")
+
+    try:
+        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
+    except ReleaseReceiptError as error:
+        raise ReleaseMilestoneContextError(f"Cancelled release-attempt receipt is invalid: {error}") from error
+    if record.get("release_receipt_file_sha256") != receipt_file_sha256:
+        raise ReleaseMilestoneContextError("Cancelled release-attempt receipt file digest does not match the record.")
+    if record.get("release_receipt_sha256") != receipt.get("receipt_sha256"):
+        raise ReleaseMilestoneContextError("Cancelled release-attempt receipt self-digest does not match the record.")
+
+    release = _mapping(receipt.get("release"), "cancelled release-attempt receipt release")
+    versions = _mapping(receipt.get("versions"), "cancelled release-attempt receipt versions")
+    workflow = _mapping(receipt.get("workflow"), "cancelled release-attempt receipt workflow")
+    identity_pairs = {
+        "package_version": versions.get("package"),
+        "public_version": versions.get("public"),
+        "build_version": versions.get("build"),
+        "release_tag": release.get("tag"),
+        "source_sha": receipt.get("source_sha"),
+        "workflow_run_id": workflow.get("run_id"),
+        "workflow_run_attempt": workflow.get("run_attempt"),
+        "draft_release_id": release.get("id"),
+    }
+    if any(record.get(field) != value for field, value in identity_pairs.items()):
+        raise ReleaseMilestoneContextError("Cancelled release-attempt identity differs from its checked receipt.")
+    if (
+        release.get("target_sha") != source_sha
+        or release.get("prerelease") is not True
+        or workflow.get("name") != "Prerelease"
+        or workflow.get("actor") != "shiny-code-bot"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Cancelled release-attempt receipt does not preserve guarded prerelease identity."
+        )
+
+    draft_assets: dict[str, Mapping[str, Any]] = {}
+    for index, raw_asset in enumerate(_sequence(record.get("draft_assets"), "cancelled release draft assets")):
+        asset = _mapping(raw_asset, f"cancelled release draft asset {index}")
+        if set(asset) != CANCELLED_ATTEMPT_ASSET_KEYS:
+            raise ReleaseMilestoneContextError("Cancelled release draft asset keys do not match the required schema.")
+        kind = _string(asset.get("kind"), f"cancelled release draft asset {index} kind")
+        if kind not in CANCELLED_ATTEMPT_ASSET_KINDS or kind in draft_assets:
+            raise ReleaseMilestoneContextError(
+                "Cancelled release draft assets must contain four unique required kinds."
+            )
+        _positive_integer(asset.get("asset_id"), f"cancelled release draft asset {kind} ID")
+        _positive_integer(asset.get("size_bytes"), f"cancelled release draft asset {kind} size")
+        _string(asset.get("name"), f"cancelled release draft asset {kind} name")
+        _sha256(asset.get("sha256"), f"cancelled release draft asset {kind} digest")
+        draft_assets[kind] = asset
+    if set(draft_assets) != CANCELLED_ATTEMPT_ASSET_KINDS:
+        raise ReleaseMilestoneContextError("Cancelled release draft assets are incomplete.")
+
+    for raw_artifact in _sequence(receipt.get("artifacts"), "cancelled release-attempt receipt artifacts"):
+        artifact = _mapping(raw_artifact, "cancelled release-attempt receipt artifact")
+        kind = _string(artifact.get("kind"), "cancelled release-attempt receipt artifact kind")
+        if draft_assets.get(kind) != artifact:
+            raise ReleaseMilestoneContextError(
+                f"Cancelled release draft asset {kind} differs from the checked release receipt."
+            )
+    receipt_asset = draft_assets["receipt"]
+    if (
+        receipt_asset.get("name") != FAILED_ATTEMPT_RECEIPT_NAME
+        or receipt_asset.get("asset_id") != record.get("release_receipt_asset_id")
+        or receipt_asset.get("size_bytes") != record.get("release_receipt_asset_size_bytes")
+        or receipt_asset.get("sha256") != receipt_file_sha256
+    ):
+        raise ReleaseMilestoneContextError("Cancelled release receipt asset identity does not match the record.")
+    return record
+
+
+def _require_immutable_if_tracked(repo_root: Path, base_sha: str, relative_path: Path) -> None:
+    tracked = subprocess.run(
+        ["git", "cat-file", "-e", f"{base_sha}:{relative_path.as_posix()}"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if tracked.returncode != 0:
+        return
+    changed = subprocess.run(
+        ["git", "diff", "--quiet", base_sha, "--", relative_path.as_posix()],
+        cwd=repo_root,
+        check=False,
+    )
+    if changed.returncode != 0:
+        raise ReleaseMilestoneContextError("Committed cancelled release-attempt evidence must remain immutable.")
+
+
 def _validate_failed_unpublished_candidate(
     repo_root: Path,
     *,
@@ -189,6 +394,37 @@ def _validate_failed_unpublished_candidate(
 ) -> int:
     release_tag = _string(base_candidate.get("release_tag"), "failed candidate release tag")
     attempt_root = FAILED_ATTEMPT_ROOT / release_tag
+    cancelled_record_relative = attempt_root / CANCELLED_ATTEMPT_RECORD_NAME
+    cancelled_record_path = repo_root / cancelled_record_relative
+    if cancelled_record_path.is_file():
+        if (repo_root / attempt_root / FAILED_ATTEMPT_RECORD_NAME).exists():
+            raise ReleaseMilestoneContextError("Release attempt cannot have both failed and cancelled records.")
+        _require_immutable_if_tracked(repo_root, base_sha, cancelled_record_relative)
+        _require_immutable_if_tracked(repo_root, base_sha, attempt_root / FAILED_ATTEMPT_RECEIPT_NAME)
+        record = validate_cancelled_attempt_record(repo_root, release_tag)
+        expected_candidate = {
+            "package_version": record.get("package_version"),
+            "public_version": record.get("public_version"),
+            "build_version": record.get("build_version"),
+            "release_tag": record.get("release_tag"),
+            "dmg_name": next(
+                (
+                    asset.get("name")
+                    for asset in _sequence(record.get("draft_assets"), "cancelled release draft assets")
+                    if _mapping(asset, "cancelled release draft asset").get("kind") == "dmg"
+                ),
+                None,
+            ),
+            "workflow": "Prerelease",
+        }
+        if any(base_candidate.get(field) != value for field, value in expected_candidate.items()):
+            raise ReleaseMilestoneContextError(
+                "Cancelled release-attempt record does not bind the base qualification candidate."
+            )
+        raise ReleaseMilestoneContextError(
+            "Cancelled signed candidate still has a retained draft; an explicitly authorized draft-deletion "
+            "record is required before successor preparation."
+        )
     record_relative = attempt_root / FAILED_ATTEMPT_RECORD_NAME
     receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
     for relative in (record_relative, receipt_relative):
@@ -276,6 +512,14 @@ def _validate_failed_unpublished_candidate(
         raise ReleaseMilestoneContextError(f"Failed release-attempt build identity is invalid: {error}") from error
 
 
+def _requires_unpublished_candidate_recovery(repo_root: Path, base_candidate: Mapping[str, Any]) -> bool:
+    release_tag = _string(base_candidate.get("release_tag"), "base qualification candidate release tag")
+    cancelled_record = repo_root / FAILED_ATTEMPT_ROOT / release_tag / CANCELLED_ATTEMPT_RECORD_NAME
+    return cancelled_record.is_file() or any(
+        field not in base_candidate or base_candidate[field] is None for field in IMMUTABLE_CANDIDATE_FIELDS
+    )
+
+
 def _validate_prepublication_candidate_transition(
     repo_root: Path,
     *,
@@ -343,7 +587,7 @@ def _validate_prepublication_candidate_transition(
                 raise ReleaseMilestoneContextError(
                     f"Published prior receipt does not match base qualification candidate.{field}."
                 )
-    elif any(field not in base_candidate or base_candidate[field] is None for field in IMMUTABLE_CANDIDATE_FIELDS):
+    elif _requires_unpublished_candidate_recovery(repo_root, base_candidate):
         failed_build = _validate_failed_unpublished_candidate(
             repo_root,
             base_sha=base_sha,
@@ -1312,6 +1556,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     source.add_argument("--release-receipt", type=Path)
     source.add_argument("--manifest", type=Path)
     source.add_argument("--base-sha")
+    source.add_argument("--cancelled-attempt-tag")
     parser.add_argument("--head-sha")
     parser.add_argument("--head-branch")
     parser.add_argument("--base-repo")
@@ -1321,6 +1566,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
     try:
+        if args.cancelled_attempt_tag is not None:
+            record = validate_cancelled_attempt_record(args.repo_root.resolve(), args.cancelled_attempt_tag)
+            outputs = {
+                "build_version": _string(record.get("build_version"), "cancelled release build version"),
+                "release_tag": args.cancelled_attempt_tag,
+                "status": "validated_cancelled_attempt",
+            }
+            if args.github_output is not None:
+                _write_github_output(args.github_output, outputs)
+            print(json.dumps(outputs, sort_keys=True))
+            return 0
         receipt_path = args.release_receipt
         manifest_path = args.manifest
         if args.base_sha is not None:

--- a/tests/test_cancelled_release_attempt.py
+++ b/tests/test_cancelled_release_attempt.py
@@ -1,0 +1,106 @@
+import json
+import shutil
+import tempfile
+import unittest
+
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from scripts.release_milestone_context import (
+    ReleaseMilestoneContextError,
+    main,
+    validate_cancelled_attempt_record,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_TAG = "v0.3.2-beta.6"
+
+
+class CancelledReleaseAttemptTests(unittest.TestCase):
+    def test_repository_record_binds_cancelled_signed_attempt(self) -> None:
+        record = validate_cancelled_attempt_record(REPO_ROOT, RELEASE_TAG)
+
+        self.assertEqual(record["build_version"], "168")
+        self.assertEqual(record["draft_release_id"], 374538590)
+        self.assertFalse(record["draft_deleted"])
+        self.assertTrue(record["must_not_rebuild"])
+
+    def assert_mutation_rejected(self, field: str, value: object, message: str) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = REPO_ROOT / "docs" / "release-attempts" / RELEASE_TAG
+            destination = root / "docs" / "release-attempts" / RELEASE_TAG
+            shutil.copytree(source, destination)
+            config_destination = root / ".github" / "github.json"
+            config_destination.parent.mkdir(parents=True)
+            shutil.copy2(REPO_ROOT / ".github" / "github.json", config_destination)
+            record_path = destination / "cancelled-attempt-v1.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record[field] = value
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, message):
+                validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+    def test_rejects_deleted_draft_claim(self) -> None:
+        self.assert_mutation_rejected("draft_deleted", True, "draft-present")
+
+    def test_rejects_non_cancelled_workflow_conclusion(self) -> None:
+        self.assert_mutation_rejected("workflow_conclusion", "failure", "draft-present")
+
+    def test_rejects_receipt_file_digest_mismatch(self) -> None:
+        self.assert_mutation_rejected("release_receipt_file_sha256", "0" * 64, "file digest")
+
+    def test_rejects_receipt_asset_identity_mismatch(self) -> None:
+        self.assert_mutation_rejected("release_receipt_asset_id", 1, "receipt asset identity")
+
+    def test_rejects_invalid_signing_approval_fingerprint(self) -> None:
+        self.assert_mutation_rejected("signing_approval_fingerprint", "invalid", "SHA-256")
+
+    def test_rejects_draft_asset_digest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = REPO_ROOT / "docs" / "release-attempts" / RELEASE_TAG
+            destination = root / "docs" / "release-attempts" / RELEASE_TAG
+            shutil.copytree(source, destination)
+            config_destination = root / ".github" / "github.json"
+            config_destination.parent.mkdir(parents=True)
+            shutil.copy2(REPO_ROOT / ".github" / "github.json", config_destination)
+            record_path = destination / "cancelled-attempt-v1.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["draft_assets"][0]["sha256"] = "0" * 64
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "differs from the checked release receipt"):
+                validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+    def test_cli_writes_validated_github_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output.txt"
+            stdout = StringIO()
+
+            with redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--cancelled-attempt-tag",
+                        RELEASE_TAG,
+                        "--repo-root",
+                        str(REPO_ROOT),
+                        "--github-output",
+                        str(output_path),
+                    ]
+                )
+
+            outputs = dict(line.split("=", 1) for line in output_path.read_text(encoding="utf-8").splitlines())
+
+        self.assertEqual(result, 0)
+        self.assertEqual(outputs["release_tag"], RELEASE_TAG)
+        self.assertEqual(outputs["build_version"], "168")
+        self.assertEqual(outputs["status"], "validated_cancelled_attempt")
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "validated_cancelled_attempt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,7 +199,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(app["bundle_identifier"], "com.shinycomputers.bd-to-avp")
         self.assertNotIn("briefcase", pyproject["tool"])
 
-    def test_repository_is_prepared_for_beta(self) -> None:
+    def test_repository_records_cancelled_beta6_metadata(self) -> None:
         metadata = release.load_release_metadata()
 
         self.assertEqual(metadata.package_version, "0.3.2b6")
@@ -215,7 +215,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
-        self.assertNotIn("v0.3.2-beta.6", freeze_policy["frozen_release_tags"])
+        beta6_freeze = freeze_policy["frozen_release_tags"]["v0.3.2-beta.6"]
+        self.assertEqual(beta6_freeze["issue"], 609)
+        self.assertIn("permanently non-reusable", beta6_freeze["reason"])
 
         cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.6-cut-packet.md").read_text(encoding="utf-8")
         self.assertIn("`0.3.2b6`", cut_packet)
@@ -226,8 +228,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("PR #620", cut_packet)
         self.assertIn("PR #623", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertIn("Prepared metadata; publication pending.", cut_packet)
-        self.assertIn("Release dispatch is not authorized", cut_packet)
+        self.assertIn("Cancelled, unpublished, signed attempt", cut_packet)
+        self.assertIn("Draft release `374538590` remains present", cut_packet)
+        self.assertIn("build `168` is permanently burned", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -228,9 +228,10 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("PR #620", cut_packet)
         self.assertIn("PR #623", cut_packet)
         self.assertIn("Privacy rules version `5`", cut_packet)
-        self.assertIn("Cancelled, unpublished, signed attempt", cut_packet)
-        self.assertIn("Draft release `374538590` remains present", cut_packet)
-        self.assertIn("build `168` is permanently burned", cut_packet)
+        self.assertIn(release.CUT_PACKET_CANCELLED, cut_packet)
+        self.assertIn("Draft release `374538590`", cut_packet)
+        self.assertIn("remains present", cut_packet)
+        self.assertIn("Build `168` is permanently burned", cut_packet)
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)
 
@@ -482,11 +483,17 @@ class ReleaseMetadataTests(unittest.TestCase):
                 Path("docs/1.2.3-beta.2-cut-packet.md"),
             )
 
+            cut_packet.write_text(f"> {release.CUT_PACKET_CANCELLED}\n", encoding="utf-8")
+            self.assertEqual(
+                release.validate_release_cut_packet(metadata, repo_root=root),
+                Path("docs/1.2.3-beta.2-cut-packet.md"),
+            )
+
             cut_packet.write_text(
                 "> **Prepared for guarded Prerelease dispatch; not yet authorized or published.**\n",
                 encoding="utf-8",
             )
-            with self.assertRaisesRegex(release.ReleaseError, "prepared-pending or published"):
+            with self.assertRaisesRegex(release.ReleaseError, "prepared, published"):
                 release.validate_release_cut_packet(metadata, repo_root=root)
 
     def test_rc2_records_immutable_published_identity(self) -> None:

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -13,6 +13,8 @@ from scripts.release_milestone_context import (
     EVIDENCE_INDEX_PATH,
     RELEASE_LEDGER_PATH,
     ReleaseMilestoneContextError,
+    _validate_failed_unpublished_candidate,
+    _requires_unpublished_candidate_recovery,
     discover_milestone_manifest,
     discover_milestone_receipt,
     require_manifest_evidence_baseline,
@@ -1493,6 +1495,42 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     head_repo="cbusillo/BD_to_AVP",
                     base_branch="main",
                 )
+
+    def test_cancelled_attempt_blocks_successor_until_authorized_draft_deletion(self) -> None:
+        base_candidate = {
+            "package_version": "0.3.2b6",
+            "public_version": "0.3.2-beta.6",
+            "build_version": "168",
+            "release_tag": "v0.3.2-beta.6",
+            "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.6.dmg",
+            "workflow": "Prerelease",
+        }
+
+        with self.assertRaisesRegex(ReleaseMilestoneContextError, "authorized draft-deletion"):
+            _validate_failed_unpublished_candidate(
+                REPO_ROOT,
+                base_sha="0" * 40,
+                base_qualification={"status": "preregistered_pending_exact_candidate"},
+                base_candidate=base_candidate,
+            )
+
+    def test_bound_cancelled_attempt_still_requires_recovery(self) -> None:
+        base_candidate = {
+            "release_tag": "v0.3.2-beta.6",
+            **{
+                field: "bound"
+                for field in (
+                    "source_git_sha",
+                    "release_run_id",
+                    "release_id",
+                    "dmg_sha256",
+                    "appcast_sha256",
+                    "signed_app_tree_sha256",
+                )
+            },
+        }
+
+        self.assertTrue(_requires_unpublished_candidate_recovery(REPO_ROOT, base_candidate))
 
     def test_allows_beta_change_scoped_evidence_append_without_checked_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -293,7 +293,7 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
         self.assertIn("| GitHub Latest | No |", summary)
         self.assertIn("| PyPI publication | No |", summary)
 
-    def test_beta4_unfreeze_and_explicit_freeze_fail_closed(self) -> None:
+    def test_committed_and_explicit_release_freezes_fail_closed(self) -> None:
         beta3_environment = valid_metadata_environment(
             PRERELEASE_WORKFLOW_NAME,
             release_tag="v0.3.0-beta.3",
@@ -316,6 +316,17 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
         )
         beta4_metadata = validate_release_metadata(beta4_environment)
         self.assertEqual(beta4_metadata.release_tag, "v0.3.0-beta.4")
+
+        beta6_environment = valid_metadata_environment(
+            PRERELEASE_WORKFLOW_NAME,
+            release_tag="v0.3.2-beta.6",
+            channel="beta",
+            prerelease="true",
+            make_latest="false",
+            publish_pypi="false",
+        )
+        with self.assertRaisesRegex(ReleaseWorkflowPolicyError, r"frozen by issue #609"):
+            validate_release_metadata(beta6_environment)
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             freezes_path = Path(temporary_directory) / "release-freezes.json"

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -279,14 +279,25 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('--release-tag "$BASE_SNAPSHOT_TAG"', str(prepare))
         self.assertIn('--release-tag "$LATEST_SNAPSHOT_TAG"', str(prepare))
 
-    def test_beta4_unfreeze_retains_release_preflight_guards(self) -> None:
+    def test_release_freeze_retains_release_preflight_guards(self) -> None:
         workflow = load_release_engine()
         prepare_steps = workflow["jobs"]["prepare"]["steps"]
         step_names = [step["name"] for step in prepare_steps]
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
 
         self.assertEqual(freeze_policy["schema"], "bd_to_avp.release_freezes")
-        self.assertEqual(freeze_policy["frozen_release_tags"], {})
+        self.assertEqual(
+            freeze_policy["frozen_release_tags"],
+            {
+                "v0.3.2-beta.6": {
+                    "issue": 609,
+                    "reason": (
+                        "Cancelled unpublished signed attempt; build 168 is permanently non-reusable pending "
+                        "explicitly authorized draft cleanup."
+                    ),
+                }
+            },
+        )
         self.assertLess(
             step_names.index("Validate route and summarize publication effects"),
             step_names.index("Reject existing release identity"),


### PR DESCRIPTION
## Summary
- check in the exact Beta 6 release receipt and an immutable cancelled-attempt record bound to run `32502068709`, draft `374538590`, signing approval, and all four draft assets
- freeze `v0.3.2-beta.6` so build `168` cannot be redispatched or reused
- make successor preparation fail until a separately authorized draft-deletion disposition exists
- update release history and cut packets without claiming publication, exact-artifact qualification, or draft deletion

## Safety boundaries
- draft release `374538590` remains present and untouched
- no tag, public release, Pages appcast item, PyPI version, or Homebrew change is created
- Beta 6/build `168` is permanently non-reusable
- this change does not prepare Beta 7/build `169` or authorize any signing/release run

## Validation
- live GitHub draft, asset IDs/sizes/digests, cancelled workflow boundary, and `macos-signing` approval match the checked record
- no remote Beta 6 tag or live appcast item exists
- 1,833 Python tests passed with 3 expected skips
- 172 focused release/recovery tests passed
- Ruff, mypy, `uv build`, observability validation, and `git diff --check` passed
- independent release review findings were addressed; JetBrains inspection remained inconclusive because its IDE lifecycle mutated the worktree and surfaced broad pre-existing formatting noise

Refs #609