### PR TITLE
Add authorized unlock path for cancelled release attempts

### DIFF
--- a/docs/0.3.2-beta.6-cut-packet.md
+++ b/docs/0.3.2-beta.6-cut-packet.md
@@ -68,8 +68,11 @@ PyPI version, or Homebrew change was created.
 
 The draft is diagnostic evidence, not a resumable release candidate after the
 fixture-hardening changes merged. Record and review a separate authorized draft
-deletion before preparing Beta 7/build `169`; do not mutate this cancelled-attempt
-record or the checked receipt.
+deletion in `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json` before
+preparing Beta 7/build `169`; do not mutate this cancelled-attempt record or the
+checked receipt. The deletion record must bind the immutable attempt digest,
+receipt digest, draft ID, source SHA, authorization actor and canonical
+fingerprint, deletion time, and verified absence of both draft and tag.
 
 ## Corrective Scope
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -576,8 +576,11 @@ An intentionally cancelled signed attempt uses an immutable
 must bind the checked receipt, all draft asset IDs and digests, the cancellation
 boundary, and the run-bound signing approval. Freeze the release tag immediately.
 A later deletion requires fresh explicit authorization and a separate immutable
-disposition record; never rewrite the cancelled-attempt record to claim that the
-draft was deleted.
+`draft-deletion-v1.json` disposition record. The disposition must bind the
+cancelled-attempt file digest, checked receipt digest, draft release ID, source
+SHA, authorization actor and canonical fingerprint, deletion actor and time, and
+subsequent absence of both draft and tag. Never rewrite the cancelled-attempt
+record to claim that the draft was deleted.
 
 To restore an earlier last-good cumulative feed, dispatch `Manage Sparkle Pages`
 from `main` with `restore` and the selected published release tag. The workflow

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -478,7 +478,10 @@ identities and checked receipt are recorded under
 `docs/release-attempts/v0.3.2-beta.6/`; `.github/release-freezes.json` prevents
 redispatch of the Beta 6 tag. Build `168` must remain absent from future updater
 feeds. Issue #609 requires fresh explicit authorization before draft deletion
-and a newer successor identity, expected to begin at Beta 7/build `169`.
+and a checked `draft-deletion-v1.json` disposition before a newer successor
+identity, expected to begin at Beta 7/build `169`. Milestone-context validation
+accepts the cancelled candidate only after that disposition validates, then
+still requires build `168` in the successor qualification's burned-build list.
 
 ## Historical Boundaries
 

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -38,6 +38,7 @@ FAILED_ATTEMPT_ROOT = Path("docs/release-attempts")
 FAILED_ATTEMPT_RECORD_NAME = "failed-attempt-v1.json"
 FAILED_ATTEMPT_RECEIPT_NAME = "release-receipt.json"
 CANCELLED_ATTEMPT_RECORD_NAME = "cancelled-attempt-v1.json"
+DRAFT_DELETION_RECORD_NAME = "draft-deletion-v1.json"
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
@@ -116,6 +117,30 @@ CANCELLED_ATTEMPT_RECORD_KEYS = frozenset(
 )
 CANCELLED_ATTEMPT_ASSET_KEYS = frozenset({"asset_id", "kind", "name", "sha256", "size_bytes"})
 CANCELLED_ATTEMPT_ASSET_KINDS = frozenset({"appcast", "checksum", "dmg", "receipt"})
+DRAFT_DELETION_RECORD_KEYS = frozenset(
+    {
+        "action",
+        "attempt_record_file_sha256",
+        "attempt_record_path",
+        "authorization_actor",
+        "authorization_fingerprint",
+        "deleted_at",
+        "deleted_by",
+        "deletion_reason",
+        "draft_deleted",
+        "draft_exists",
+        "draft_release_id",
+        "published_at",
+        "receipt_file_sha256",
+        "recorded_at",
+        "release_tag",
+        "schema_version",
+        "source_sha",
+        "status",
+        "tag_exists",
+        "verified_absent_at",
+    }
+)
 
 
 class ReleaseMilestoneContextError(RuntimeError):
@@ -367,6 +392,92 @@ def validate_cancelled_attempt_record(repo_root: Path, release_tag: str) -> Mapp
     return record
 
 
+def build_draft_deletion_authorization_fingerprint(
+    *,
+    release_tag: str,
+    draft_release_id: int,
+    source_sha: str,
+    authorization_actor: str,
+) -> str:
+    payload = {
+        "action": "delete_abandoned_unpublished_draft",
+        "authorization_actor": authorization_actor,
+        "draft_release_id": draft_release_id,
+        "release_tag": release_tag,
+        "repository": EXPECTED_REPOSITORY,
+        "schema_version": 1,
+        "source_sha": source_sha,
+    }
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_draft_deletion_record(
+    repo_root: Path,
+    release_tag: str,
+    attempt_record: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    attempt_root = FAILED_ATTEMPT_ROOT / release_tag
+    attempt_relative = attempt_root / CANCELLED_ATTEMPT_RECORD_NAME
+    deletion_relative = attempt_root / DRAFT_DELETION_RECORD_NAME
+    receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
+    attempt_record = attempt_record or validate_cancelled_attempt_record(repo_root, release_tag)
+    deletion = _load_json(repo_root / deletion_relative, "draft-deletion disposition record")
+    if set(deletion) != DRAFT_DELETION_RECORD_KEYS:
+        raise ReleaseMilestoneContextError("Draft-deletion disposition keys do not match the required schema.")
+    if (
+        deletion.get("schema_version") != 1
+        or deletion.get("status") != "deleted_abandoned_unpublished_draft"
+        or deletion.get("action") != "delete_abandoned_unpublished_draft"
+        or deletion.get("draft_deleted") is not True
+        or deletion.get("draft_exists") is not False
+        or deletion.get("tag_exists") is not False
+        or deletion.get("published_at") is not None
+    ):
+        raise ReleaseMilestoneContextError(
+            "Draft-deletion disposition must prove deletion of an unpublished draft without creating a tag."
+        )
+    if deletion.get("attempt_record_path") != attempt_relative.as_posix():
+        raise ReleaseMilestoneContextError("Draft-deletion disposition attempt path is not canonical.")
+    attempt_file_sha256 = hashlib.sha256((repo_root / attempt_relative).read_bytes()).hexdigest()
+    if deletion.get("attempt_record_file_sha256") != attempt_file_sha256:
+        raise ReleaseMilestoneContextError("Draft-deletion disposition does not bind the immutable attempt record.")
+    identity_pairs = {
+        "release_tag": attempt_record.get("release_tag"),
+        "draft_release_id": attempt_record.get("draft_release_id"),
+        "source_sha": attempt_record.get("source_sha"),
+        "receipt_file_sha256": attempt_record.get("release_receipt_file_sha256"),
+    }
+    if any(deletion.get(field) != value for field, value in identity_pairs.items()):
+        raise ReleaseMilestoneContextError("Draft-deletion disposition identity differs from the cancelled attempt.")
+    if receipt_relative.as_posix() != attempt_record.get("release_receipt_path"):
+        raise ReleaseMilestoneContextError("Draft-deletion disposition receipt path is not canonical.")
+    github_config = _load_json(repo_root / GITHUB_CONFIG_PATH, "GitHub repository configuration")
+    release_operations = _mapping(github_config.get("releaseOperations"), "release operations configuration")
+    authorization_actor = _string(deletion.get("authorization_actor"), "draft deletion authorization actor")
+    if authorization_actor != release_operations.get("approvalActor"):
+        raise ReleaseMilestoneContextError("Draft deletion authorization actor is invalid.")
+    expected_fingerprint = build_draft_deletion_authorization_fingerprint(
+        release_tag=release_tag,
+        draft_release_id=_positive_integer(deletion.get("draft_release_id"), "draft deletion release ID"),
+        source_sha=_sha(deletion.get("source_sha"), "draft deletion source SHA"),
+        authorization_actor=authorization_actor,
+    )
+    if deletion.get("authorization_fingerprint") != expected_fingerprint:
+        raise ReleaseMilestoneContextError("Draft deletion authorization fingerprint is invalid.")
+    _string(deletion.get("deleted_by"), "draft deletion actor")
+    deletion_reason = _string(deletion.get("deletion_reason"), "draft deletion reason")
+    if CANCELLATION_REASON_PATTERN.fullmatch(deletion_reason) is None:
+        raise ReleaseMilestoneContextError("Draft deletion reason must be a lowercase machine-readable identifier.")
+    attempt_recorded_at = _timestamp(attempt_record.get("recorded_at"), "cancelled release record timestamp")
+    deleted_at = _timestamp(deletion.get("deleted_at"), "draft deletion timestamp")
+    verified_absent_at = _timestamp(deletion.get("verified_absent_at"), "draft deletion absence verification")
+    recorded_at = _timestamp(deletion.get("recorded_at"), "draft deletion record timestamp")
+    if deleted_at < attempt_recorded_at or verified_absent_at < deleted_at or recorded_at < verified_absent_at:
+        raise ReleaseMilestoneContextError("Draft-deletion disposition timestamps are out of order.")
+    return deletion
+
+
 def _require_immutable_if_tracked(repo_root: Path, base_sha: str, relative_path: Path) -> None:
     tracked = subprocess.run(
         ["git", "cat-file", "-e", f"{base_sha}:{relative_path.as_posix()}"],
@@ -421,10 +532,20 @@ def _validate_failed_unpublished_candidate(
             raise ReleaseMilestoneContextError(
                 "Cancelled release-attempt record does not bind the base qualification candidate."
             )
-        raise ReleaseMilestoneContextError(
-            "Cancelled signed candidate still has a retained draft; an explicitly authorized draft-deletion "
-            "record is required before successor preparation."
-        )
+        deletion_relative = attempt_root / DRAFT_DELETION_RECORD_NAME
+        if not (repo_root / deletion_relative).is_file():
+            raise ReleaseMilestoneContextError(
+                "Cancelled signed candidate still has a retained draft; an explicitly authorized draft-deletion "
+                "record is required before successor preparation."
+            )
+        _require_immutable_if_tracked(repo_root, base_sha, deletion_relative)
+        validate_draft_deletion_record(repo_root, release_tag, record)
+        try:
+            return parse_build_version(_string(record.get("build_version"), "cancelled candidate build version"))
+        except ReleaseError as error:
+            raise ReleaseMilestoneContextError(
+                f"Cancelled release-attempt build identity is invalid: {error}"
+            ) from error
     record_relative = attempt_root / FAILED_ATTEMPT_RECORD_NAME
     receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
     for relative in (record_relative, receipt_relative):
@@ -1557,6 +1678,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     source.add_argument("--manifest", type=Path)
     source.add_argument("--base-sha")
     source.add_argument("--cancelled-attempt-tag")
+    source.add_argument("--draft-deletion-tag")
     parser.add_argument("--head-sha")
     parser.add_argument("--head-branch")
     parser.add_argument("--base-repo")
@@ -1572,6 +1694,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "build_version": _string(record.get("build_version"), "cancelled release build version"),
                 "release_tag": args.cancelled_attempt_tag,
                 "status": "validated_cancelled_attempt",
+            }
+            if args.github_output is not None:
+                _write_github_output(args.github_output, outputs)
+            print(json.dumps(outputs, sort_keys=True))
+            return 0
+        if args.draft_deletion_tag is not None:
+            attempt_record = validate_cancelled_attempt_record(args.repo_root.resolve(), args.draft_deletion_tag)
+            validate_draft_deletion_record(args.repo_root.resolve(), args.draft_deletion_tag, attempt_record)
+            outputs = {
+                "build_version": _string(attempt_record.get("build_version"), "cancelled release build version"),
+                "release_tag": args.draft_deletion_tag,
+                "status": "validated_draft_deletion",
             }
             if args.github_output is not None:
                 _write_github_output(args.github_output, outputs)

--- a/tests/test_cancelled_release_attempt.py
+++ b/tests/test_cancelled_release_attempt.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import shutil
 import tempfile
@@ -9,8 +10,11 @@ from pathlib import Path
 
 from scripts.release_milestone_context import (
     ReleaseMilestoneContextError,
+    _validate_failed_unpublished_candidate,
+    build_draft_deletion_authorization_fingerprint,
     main,
     validate_cancelled_attempt_record,
+    validate_draft_deletion_record,
 )
 
 
@@ -19,6 +23,54 @@ RELEASE_TAG = "v0.3.2-beta.6"
 
 
 class CancelledReleaseAttemptTests(unittest.TestCase):
+    @staticmethod
+    def copy_attempt(root: Path) -> Path:
+        source = REPO_ROOT / "docs" / "release-attempts" / RELEASE_TAG
+        destination = root / "docs" / "release-attempts" / RELEASE_TAG
+        shutil.copytree(source, destination)
+        config_destination = root / ".github" / "github.json"
+        config_destination.parent.mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / ".github" / "github.json", config_destination)
+        return destination
+
+    @staticmethod
+    def write_deletion_record(root: Path, *, fingerprint: str | None = None) -> Path:
+        attempt_root = root / "docs" / "release-attempts" / RELEASE_TAG
+        attempt_path = attempt_root / "cancelled-attempt-v1.json"
+        attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
+        authorization_actor = "cbusillo"
+        record = {
+            "action": "delete_abandoned_unpublished_draft",
+            "attempt_record_file_sha256": hashlib.sha256(attempt_path.read_bytes()).hexdigest(),
+            "attempt_record_path": f"docs/release-attempts/{RELEASE_TAG}/cancelled-attempt-v1.json",
+            "authorization_actor": authorization_actor,
+            "authorization_fingerprint": fingerprint
+            or build_draft_deletion_authorization_fingerprint(
+                release_tag=RELEASE_TAG,
+                draft_release_id=attempt["draft_release_id"],
+                source_sha=attempt["source_sha"],
+                authorization_actor=authorization_actor,
+            ),
+            "deleted_at": "2026-08-21T19:34:00Z",
+            "deleted_by": "shiny-code-bot",
+            "deletion_reason": "explicitly_authorized_abandoned_draft_cleanup",
+            "draft_deleted": True,
+            "draft_exists": False,
+            "draft_release_id": attempt["draft_release_id"],
+            "published_at": None,
+            "receipt_file_sha256": attempt["release_receipt_file_sha256"],
+            "recorded_at": "2026-08-21T19:35:00Z",
+            "release_tag": RELEASE_TAG,
+            "schema_version": 1,
+            "source_sha": attempt["source_sha"],
+            "status": "deleted_abandoned_unpublished_draft",
+            "tag_exists": False,
+            "verified_absent_at": "2026-08-21T19:34:30Z",
+        }
+        path = attempt_root / "draft-deletion-v1.json"
+        path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
     def test_repository_record_binds_cancelled_signed_attempt(self) -> None:
         record = validate_cancelled_attempt_record(REPO_ROOT, RELEASE_TAG)
 
@@ -30,12 +82,7 @@ class CancelledReleaseAttemptTests(unittest.TestCase):
     def assert_mutation_rejected(self, field: str, value: object, message: str) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            source = REPO_ROOT / "docs" / "release-attempts" / RELEASE_TAG
-            destination = root / "docs" / "release-attempts" / RELEASE_TAG
-            shutil.copytree(source, destination)
-            config_destination = root / ".github" / "github.json"
-            config_destination.parent.mkdir(parents=True)
-            shutil.copy2(REPO_ROOT / ".github" / "github.json", config_destination)
+            destination = self.copy_attempt(root)
             record_path = destination / "cancelled-attempt-v1.json"
             record = json.loads(record_path.read_text(encoding="utf-8"))
             record[field] = value
@@ -62,12 +109,7 @@ class CancelledReleaseAttemptTests(unittest.TestCase):
     def test_rejects_draft_asset_digest_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            source = REPO_ROOT / "docs" / "release-attempts" / RELEASE_TAG
-            destination = root / "docs" / "release-attempts" / RELEASE_TAG
-            shutil.copytree(source, destination)
-            config_destination = root / ".github" / "github.json"
-            config_destination.parent.mkdir(parents=True)
-            shutil.copy2(REPO_ROOT / ".github" / "github.json", config_destination)
+            destination = self.copy_attempt(root)
             record_path = destination / "cancelled-attempt-v1.json"
             record = json.loads(record_path.read_text(encoding="utf-8"))
             record["draft_assets"][0]["sha256"] = "0" * 64
@@ -75,6 +117,67 @@ class CancelledReleaseAttemptTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ReleaseMilestoneContextError, "differs from the checked release receipt"):
                 validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+    def test_authorized_draft_deletion_unlocks_successor_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_attempt(root)
+            self.write_deletion_record(root)
+            attempt = validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+            disposition = validate_draft_deletion_record(root, RELEASE_TAG, attempt)
+            build = _validate_failed_unpublished_candidate(
+                root,
+                base_sha="0" * 40,
+                base_qualification={"status": "preregistered_pending_exact_candidate"},
+                base_candidate={
+                    "package_version": "0.3.2b6",
+                    "public_version": "0.3.2-beta.6",
+                    "build_version": "168",
+                    "release_tag": RELEASE_TAG,
+                    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.6.dmg",
+                    "workflow": "Prerelease",
+                },
+            )
+
+        self.assertEqual(disposition["status"], "deleted_abandoned_unpublished_draft")
+        self.assertEqual(build, 168)
+
+    def test_rejects_invalid_draft_deletion_authorization_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_attempt(root)
+            self.write_deletion_record(root, fingerprint="0" * 64)
+            attempt = validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "authorization fingerprint"):
+                validate_draft_deletion_record(root, RELEASE_TAG, attempt)
+
+    def test_draft_deletion_cli_writes_validated_github_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_attempt(root)
+            self.write_deletion_record(root)
+            output_path = root / "github-output.txt"
+            stdout = StringIO()
+
+            with redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--draft-deletion-tag",
+                        RELEASE_TAG,
+                        "--repo-root",
+                        str(root),
+                        "--github-output",
+                        str(output_path),
+                    ]
+                )
+
+            outputs = dict(line.split("=", 1) for line in output_path.read_text(encoding="utf-8").splitlines())
+
+        self.assertEqual(result, 0)
+        self.assertEqual(outputs["status"], "validated_draft_deletion")
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "validated_draft_deletion")
 
     def test_cli_writes_validated_github_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- add a separate immutable `draft-deletion-v1.json` disposition schema for cancelled signed attempts
- bind deletion to the cancelled-attempt digest, receipt digest, draft ID, source SHA, configured authorization actor, and canonical fingerprint
- require ordered deletion/absence/record timestamps and explicit absence of both draft and tag
- allow successor preparation only after the disposition validates; the existing burned-build requirement still applies

## Safety boundaries
- this PR does not delete draft `374538590`
- no deletion disposition is added for Beta 6
- Beta 6/build `168` remains frozen and successor preparation remains blocked today
- a future explicitly authorized deletion can now be recorded and mechanically unlock the existing recovery path

## Validation
- 1,836 Python tests passed with 3 expected skips
- focused blocked, unlocked, invalid-fingerprint, and CLI disposition tests passed
- Ruff, mypy, and `git diff --check` passed

Fixes post-merge auto-review finding `aa1a04d8-c9bf-4447-9251-9bc29fff74ff/f1`.
Refs #609