### PR TITLE
Harden installed UI and recovery fixture contracts

### DIFF
--- a/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
+++ b/macos/BluRayToVisionProUITests/InstalledUIAcceptanceTests.swift
@@ -24,6 +24,26 @@ final class InstalledUIAcceptanceTests: XCTestCase {
         XCTAssertNil(try readProfileSummaryIfPresent(syntheticHome: syntheticHome))
     }
 
+    func testSeededProfileDocumentReportsExistingLibrary() throws {
+        let syntheticHome = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: syntheticHome) }
+        let profileDirectory = syntheticHome
+            .appendingPathComponent("Library/Application Support/3D Blu-ray to Vision Pro", isDirectory: true)
+        try FileManager.default.createDirectory(at: profileDirectory, withIntermediateDirectories: true)
+        let profileDocument: [String: Any] = [
+            "profiles": [["name": "Seeded Profile"]],
+            "version": 6,
+        ]
+        try JSONSerialization.data(withJSONObject: profileDocument, options: [.sortedKeys])
+            .write(to: profileDirectory.appendingPathComponent("profiles.json"))
+
+        let summary = try XCTUnwrap(readProfileSummaryIfPresent(syntheticHome: syntheticHome))
+
+        XCTAssertEqual(summary.count, 1)
+        XCTAssertEqual(summary.names, ["Seeded Profile"])
+        XCTAssertEqual(summary.version, 6)
+    }
+
     func testPriorUpdaterControlsAndReleaseLinks() throws {
         let context = try QualificationContext.load(expectedPhase: "updater")
         let app = try launchInstalledApp(context: context, appearance: .light)

--- a/scripts/installed_ui_qualification.py
+++ b/scripts/installed_ui_qualification.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+import inspect
 import shutil
 import uuid
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, cast, runtime_checkable
 
 from scripts.artifact_identity import app_tree_sha256
 from scripts.tier3_clean_machine import (
@@ -21,6 +22,30 @@ class InstalledUIQualificationError(RuntimeError):
     pass
 
 
+@runtime_checkable
+class InstalledUIOperations(Protocol):
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        raise NotImplementedError
+
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        raise NotImplementedError
+
+    def app_running(self, app_path: Path | None = None) -> bool:
+        raise NotImplementedError
+
+    def quit_app(self) -> None:
+        raise NotImplementedError
+
+
 @dataclass(frozen=True)
 class InstalledUIQualificationConfig:
     repo: Path
@@ -31,6 +56,38 @@ class InstalledUIQualificationConfig:
     expected_app_tree_sha256: str
     owner: str
     failure_diagnostics_directory: Path | None = None
+
+
+def _operation_signature_shape(
+    operation: Callable[..., object],
+    *,
+    skip_self: bool,
+) -> tuple[tuple[str, inspect._ParameterKind, object], ...]:
+    parameters = tuple(inspect.signature(operation).parameters.values())
+    if skip_self:
+        parameters = parameters[1:]
+    return tuple((parameter.name, parameter.kind, parameter.default) for parameter in parameters)
+
+
+def validate_installed_ui_operations_contract(operations: object) -> InstalledUIOperations:
+    if not isinstance(operations, InstalledUIOperations):
+        raise InstalledUIQualificationError(
+            "Installed UI operations do not implement the maintained production operations contract."
+        )
+    for method_name in ("install_app", "collect_ui_evidence", "app_running", "quit_app"):
+        expected = _operation_signature_shape(
+            cast(Callable[..., object], getattr(InstalledUIOperations, method_name)),
+            skip_self=True,
+        )
+        observed = _operation_signature_shape(
+            cast(Callable[..., object], getattr(operations, method_name)),
+            skip_self=False,
+        )
+        if observed != expected:
+            raise InstalledUIQualificationError(
+                f"Installed UI operations method {method_name} does not match the maintained production contract."
+            )
+    return operations
 
 
 def _paths_overlap(left: Path, right: Path) -> bool:
@@ -77,7 +134,7 @@ def _preserve_failure_diagnostics(
 
 def _cleanup_qualification_workspace(
     config: InstalledUIQualificationConfig,
-    operations: MacOSOperations,
+    operations: InstalledUIOperations,
     marker_path: Path,
     marker: Mapping[str, str],
 ) -> list[Exception]:
@@ -108,9 +165,10 @@ def _cleanup_qualification_workspace(
 
 def _run(
     config: InstalledUIQualificationConfig,
-    operations: MacOSOperations,
+    operations: InstalledUIOperations,
 ) -> Mapping[str, Any]:
     validate_installed_ui_output_paths(config)
+    operations = validate_installed_ui_operations_contract(operations)
     if operations.app_running():
         raise InstalledUIQualificationError("The production app must not be running before installed UI qualification.")
 
@@ -122,7 +180,7 @@ def _run(
     marker = {"owner": config.owner, "run_id": str(uuid.uuid4())}
     config.qualification_root.mkdir(parents=True)
     marker_path.write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-    primary_error: Exception | None = None
+    primary_error: BaseException | None = None
     try:
         synthetic_home.mkdir(parents=True)
         operations.install_app(config.dmg, app_path, mount_point)
@@ -155,6 +213,9 @@ def _run(
                 f"{type(diagnostics_error).__name__}: {diagnostics_error}"
             )
         raise
+    except BaseException as error:
+        primary_error = error
+        raise
     finally:
         cleanup_errors = _cleanup_qualification_workspace(config, operations, marker_path, marker)
         if cleanup_errors:
@@ -167,12 +228,26 @@ def _run(
 
 def run(
     config: InstalledUIQualificationConfig,
-    operations: MacOSOperations | None = None,
+    operations: InstalledUIOperations | None = None,
 ) -> Mapping[str, Any]:
     operations = operations or MacOSOperations()
     try:
         return _run(config, operations)
-    except Exception:
+    except Exception as error:
         if config.evidence_directory.exists():
-            shutil.rmtree(config.evidence_directory)
+            try:
+                shutil.rmtree(config.evidence_directory)
+            except Exception as cleanup_error:
+                error.add_note(
+                    f"Installed UI evidence cleanup also failed: {type(cleanup_error).__name__}: {cleanup_error}"
+                )
+        raise
+    except BaseException as error:
+        if config.evidence_directory.exists():
+            try:
+                shutil.rmtree(config.evidence_directory)
+            except Exception as cleanup_error:
+                error.add_note(
+                    f"Installed UI evidence cleanup also failed: {type(cleanup_error).__name__}: {cleanup_error}"
+                )
         raise

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -221,6 +221,18 @@ def _load_json(path: Path, description: str) -> Mapping[str, Any]:
         raise ReleaseMilestoneContextError(f"Invalid JSON in {description} at {path}: {error}") from error
 
 
+def _load_release_attempt_json(path: Path, description: str) -> Mapping[str, Any]:
+    value = _load_json(path, description)
+    canonical = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    try:
+        serialized = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ReleaseMilestoneContextError(f"Unable to read {description} at {path}: {error}") from error
+    if serialized != canonical:
+        raise ReleaseMilestoneContextError(f"{description.capitalize()} must use canonical JSON serialization.")
+    return value
+
+
 def _load_json_at_revision(
     repo_root: Path,
     revision: str,
@@ -280,7 +292,7 @@ def validate_cancelled_attempt_record(repo_root: Path, release_tag: str) -> Mapp
     attempt_root = FAILED_ATTEMPT_ROOT / release_tag
     record_relative = attempt_root / CANCELLED_ATTEMPT_RECORD_NAME
     receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
-    record = _load_json(repo_root / record_relative, "cancelled release-attempt record")
+    record = _load_release_attempt_json(repo_root / record_relative, "cancelled release-attempt record")
     if set(record) != CANCELLED_ATTEMPT_RECORD_KEYS:
         raise ReleaseMilestoneContextError("Cancelled release-attempt record keys do not match the required schema.")
     if (
@@ -422,7 +434,7 @@ def validate_draft_deletion_record(
     deletion_relative = attempt_root / DRAFT_DELETION_RECORD_NAME
     receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
     attempt_record = attempt_record or validate_cancelled_attempt_record(repo_root, release_tag)
-    deletion = _load_json(repo_root / deletion_relative, "draft-deletion disposition record")
+    deletion = _load_release_attempt_json(repo_root / deletion_relative, "draft-deletion disposition record")
     if set(deletion) != DRAFT_DELETION_RECORD_KEYS:
         raise ReleaseMilestoneContextError("Draft-deletion disposition keys do not match the required schema.")
     if (
@@ -496,6 +508,81 @@ def _require_immutable_if_tracked(repo_root: Path, base_sha: str, relative_path:
         raise ReleaseMilestoneContextError("Committed cancelled release-attempt evidence must remain immutable.")
 
 
+def _load_validated_failed_attempt(
+    repo_root: Path,
+    release_tag: str,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    attempt_root = FAILED_ATTEMPT_ROOT / release_tag
+    record_relative = attempt_root / FAILED_ATTEMPT_RECORD_NAME
+    receipt_relative = attempt_root / FAILED_ATTEMPT_RECEIPT_NAME
+    record = _load_release_attempt_json(repo_root / record_relative, "failed release-attempt record")
+    if set(record) != FAILED_ATTEMPT_RECORD_KEYS:
+        raise ReleaseMilestoneContextError("Failed release-attempt record keys do not match the required schema.")
+    if (
+        record.get("schema_version") != 1
+        or record.get("status") != "failed_unpublished_signed_candidate"
+        or record.get("workflow_conclusion") != "failure"
+        or record.get("published_at") is not None
+        or record.get("draft_deleted") is not True
+        or record.get("must_not_rebuild") is not True
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed release-attempt record must prove an unpublished, deleted-draft, permanently burned candidate."
+        )
+    if record.get("release_tag") != release_tag:
+        raise ReleaseMilestoneContextError("Failed release-attempt tag does not match its canonical directory.")
+    if record.get("release_receipt_path") != receipt_relative.as_posix():
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt path is not canonical.")
+    _string(record.get("failed_job"), "failed release job")
+    _positive_integer(record.get("failed_job_id"), "failed release job ID")
+    _string(record.get("failed_step"), "failed release step")
+    source_sha = _sha(record.get("source_sha"), "failed release source SHA")
+    _positive_integer(record.get("workflow_run_id"), "failed release workflow run ID")
+    _positive_integer(record.get("workflow_run_attempt"), "failed release workflow run attempt")
+    _positive_integer(record.get("draft_release_id"), "failed release draft ID")
+    _timestamp(record.get("recorded_at"), "failed release record timestamp")
+
+    try:
+        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
+    except ReleaseReceiptError as error:
+        raise ReleaseMilestoneContextError(f"Failed release-attempt receipt is invalid: {error}") from error
+    if record.get("release_receipt_file_sha256") != receipt_file_sha256:
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt file digest does not match the record.")
+    if record.get("release_receipt_sha256") != receipt.get("receipt_sha256"):
+        raise ReleaseMilestoneContextError("Failed release-attempt receipt self-digest does not match the record.")
+
+    release = _mapping(receipt.get("release"), "failed release-attempt receipt release")
+    versions = _mapping(receipt.get("versions"), "failed release-attempt receipt versions")
+    workflow = _mapping(receipt.get("workflow"), "failed release-attempt receipt workflow")
+    identity_pairs = {
+        "package_version": versions.get("package"),
+        "public_version": versions.get("public"),
+        "build_version": versions.get("build"),
+        "release_tag": release.get("tag"),
+        "source_sha": receipt.get("source_sha"),
+        "workflow_run_id": workflow.get("run_id"),
+        "workflow_run_attempt": workflow.get("run_attempt"),
+        "draft_release_id": release.get("id"),
+    }
+    if any(record.get(field) != value for field, value in identity_pairs.items()):
+        raise ReleaseMilestoneContextError("Failed release-attempt record identity differs from its checked receipt.")
+    if (
+        release.get("target_sha") != source_sha
+        or release.get("prerelease") is not True
+        or workflow.get("name") != "Prerelease"
+        or workflow.get("actor") != "shiny-code-bot"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed release-attempt receipt does not preserve guarded prerelease identity."
+        )
+    return record, receipt
+
+
+def validate_failed_attempt_record(repo_root: Path, release_tag: str) -> Mapping[str, Any]:
+    record, _receipt = _load_validated_failed_attempt(repo_root, release_tag)
+    return record
+
+
 def _validate_failed_unpublished_candidate(
     repo_root: Path,
     *,
@@ -558,48 +645,14 @@ def _validate_failed_unpublished_candidate(
         if tracked_in_base.returncode == 0:
             raise ReleaseMilestoneContextError("Failed release-attempt recovery records must be new and immutable.")
 
-    record = _load_json(repo_root / record_relative, "failed release-attempt record")
-    if set(record) != FAILED_ATTEMPT_RECORD_KEYS:
-        raise ReleaseMilestoneContextError("Failed release-attempt record keys do not match the required schema.")
-    if (
-        record.get("schema_version") != 1
-        or record.get("status") != "failed_unpublished_signed_candidate"
-        or record.get("workflow_conclusion") != "failure"
-        or record.get("published_at") is not None
-        or record.get("draft_deleted") is not True
-        or record.get("must_not_rebuild") is not True
-        or base_qualification.get("status") != "preregistered_pending_exact_candidate"
-    ):
+    record, receipt = _load_validated_failed_attempt(repo_root, release_tag)
+    if base_qualification.get("status") != "preregistered_pending_exact_candidate":
         raise ReleaseMilestoneContextError(
             "Failed release-attempt record must prove an unpublished, deleted-draft, permanently burned candidate."
         )
-    if record.get("release_receipt_path") != receipt_relative.as_posix():
-        raise ReleaseMilestoneContextError("Failed release-attempt receipt path is not canonical.")
-
-    try:
-        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
-    except ReleaseReceiptError as error:
-        raise ReleaseMilestoneContextError(f"Failed release-attempt receipt is invalid: {error}") from error
-    if record.get("release_receipt_file_sha256") != receipt_file_sha256:
-        raise ReleaseMilestoneContextError("Failed release-attempt receipt file digest does not match the record.")
-    if record.get("release_receipt_sha256") != receipt.get("receipt_sha256"):
-        raise ReleaseMilestoneContextError("Failed release-attempt receipt self-digest does not match the record.")
-
     release = _mapping(receipt.get("release"), "failed release-attempt receipt release")
     versions = _mapping(receipt.get("versions"), "failed release-attempt receipt versions")
     workflow = _mapping(receipt.get("workflow"), "failed release-attempt receipt workflow")
-    identity_pairs = {
-        "package_version": versions.get("package"),
-        "public_version": versions.get("public"),
-        "build_version": versions.get("build"),
-        "release_tag": release.get("tag"),
-        "source_sha": receipt.get("source_sha"),
-        "workflow_run_id": workflow.get("run_id"),
-        "workflow_run_attempt": workflow.get("run_attempt"),
-        "draft_release_id": release.get("id"),
-    }
-    if any(record.get(field) != value for field, value in identity_pairs.items()):
-        raise ReleaseMilestoneContextError("Failed release-attempt record identity differs from its checked receipt.")
     expected_candidate = {
         "package_version": versions.get("package"),
         "public_version": versions.get("public"),
@@ -619,18 +672,81 @@ def _validate_failed_unpublished_candidate(
         raise ReleaseMilestoneContextError(
             "Failed release-attempt receipt does not bind the base qualification candidate."
         )
-    if (
-        release.get("target_sha") != record.get("source_sha")
-        or release.get("prerelease") is not True
-        or workflow.get("actor") != "shiny-code-bot"
-    ):
-        raise ReleaseMilestoneContextError(
-            "Failed release-attempt receipt does not preserve guarded prerelease identity."
-        )
     try:
         return parse_build_version(_string(record.get("build_version"), "failed candidate build version"))
     except ReleaseError as error:
         raise ReleaseMilestoneContextError(f"Failed release-attempt build identity is invalid: {error}") from error
+
+
+def validate_release_recovery_records(repo_root: Path) -> Mapping[str, Mapping[str, Any]]:
+    records: dict[str, Mapping[str, Any]] = {}
+    attempts: list[tuple[tuple[int, ...], int, str]] = []
+    attempts_root = repo_root / FAILED_ATTEMPT_ROOT
+    try:
+        attempt_directories = sorted(path for path in attempts_root.iterdir() if path.is_dir())
+    except OSError as error:
+        raise ReleaseMilestoneContextError(f"Unable to inspect release-attempt records: {error}") from error
+    for attempt_directory in attempt_directories:
+        release_tag = attempt_directory.name
+        failed_path = attempt_directory / FAILED_ATTEMPT_RECORD_NAME
+        cancelled_path = attempt_directory / CANCELLED_ATTEMPT_RECORD_NAME
+        if failed_path.is_file() == cancelled_path.is_file():
+            raise ReleaseMilestoneContextError(
+                f"Release attempt {release_tag} must contain exactly one failed or cancelled attempt record."
+            )
+        if failed_path.is_file():
+            record = validate_failed_attempt_record(repo_root, release_tag)
+            entry: dict[str, Any] = {"attempt": record}
+        else:
+            record = validate_cancelled_attempt_record(repo_root, release_tag)
+            entry = {"attempt": record}
+            deletion_path = attempt_directory / DRAFT_DELETION_RECORD_NAME
+            if not deletion_path.is_file():
+                raise ReleaseMilestoneContextError(
+                    f"Cancelled release attempt {release_tag} requires an authorized draft-deletion disposition."
+                )
+            entry["disposition"] = validate_draft_deletion_record(repo_root, release_tag, record)
+        try:
+            version = parse_release_version(_string(record.get("package_version"), "release-attempt package version"))
+            build = parse_build_version(_string(record.get("build_version"), "release-attempt build version"))
+        except ReleaseError as error:
+            raise ReleaseMilestoneContextError(f"Release-attempt identity is invalid: {error}") from error
+        attempts.append((version.order_key, build, release_tag))
+        records[release_tag] = entry
+
+    qualifications: list[tuple[tuple[int, ...], Path, Mapping[str, Any]]] = []
+    qualification_root = repo_root / "docs" / "qualification"
+    for qualification_path in sorted(qualification_root.glob("*-signed-qualification-v1.json")):
+        qualification = _load_json(qualification_path, "signed qualification record")
+        candidate = _mapping(qualification.get("candidate"), "signed qualification candidate")
+        package_version = candidate.get("package_version")
+        if not isinstance(package_version, str):
+            continue
+        try:
+            version = parse_release_version(package_version)
+        except ReleaseError as error:
+            raise ReleaseMilestoneContextError(
+                f"Signed qualification candidate identity is invalid at {qualification_path}: {error}"
+            ) from error
+        qualifications.append((version.order_key, qualification_path, qualification))
+
+    for attempt_order, build, release_tag in attempts:
+        for qualification_order, qualification_path, qualification in qualifications:
+            if qualification_order <= attempt_order:
+                continue
+            immutable_history = _mapping(
+                qualification.get("immutable_history"),
+                f"signed qualification immutable history at {qualification_path}",
+            )
+            burned_builds = _sequence(
+                immutable_history.get("burned_builds"),
+                f"signed qualification burned builds at {qualification_path}",
+            )
+            if build not in burned_builds:
+                raise ReleaseMilestoneContextError(
+                    f"Signed qualification {qualification_path} must permanently burn build {build} from {release_tag}."
+                )
+    return records
 
 
 def _requires_unpublished_candidate_recovery(repo_root: Path, base_candidate: Mapping[str, Any]) -> bool:

--- a/tests/test_cancelled_release_attempt.py
+++ b/tests/test_cancelled_release_attempt.py
@@ -165,6 +165,33 @@ class CancelledReleaseAttemptTests(unittest.TestCase):
             with self.assertRaisesRegex(ReleaseMilestoneContextError, "authorization fingerprint"):
                 validate_draft_deletion_record(root, RELEASE_TAG, attempt)
 
+    def test_rejects_draft_deletion_authorization_and_evidence_binding_tampering(self) -> None:
+        mutations = (
+            ("attempt_record_path", "docs/release-attempts/other/cancelled-attempt-v1.json", "path is not canonical"),
+            ("attempt_record_file_sha256", "0" * 64, "immutable attempt record"),
+            ("release_tag", "v0.3.2-beta.99", "identity differs"),
+            ("draft_release_id", 1, "identity differs"),
+            ("source_sha", "0" * 40, "identity differs"),
+            ("receipt_file_sha256", "0" * 64, "identity differs"),
+            ("authorization_actor", "other-actor", "authorization actor"),
+            ("authorization_fingerprint", "0" * 64, "authorization fingerprint"),
+        )
+        for field, value, message in mutations:
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                self.copy_attempt(root)
+                disposition_path = self.write_deletion_record(root)
+                disposition = json.loads(disposition_path.read_text(encoding="utf-8"))
+                disposition[field] = value
+                disposition_path.write_text(
+                    json.dumps(disposition, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                attempt = validate_cancelled_attempt_record(root, RELEASE_TAG)
+
+                with self.assertRaisesRegex(ReleaseMilestoneContextError, message):
+                    validate_draft_deletion_record(root, RELEASE_TAG, attempt)
+
     def test_rejects_mutation_of_committed_draft_deletion_disposition(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_installed_ui_qualification.py
+++ b/tests/test_installed_ui_qualification.py
@@ -1,59 +1,344 @@
+import hashlib
+import json
+import shutil
 import tempfile
 import unittest
 
+from dataclasses import replace
+from itertools import combinations
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
+from scripts.artifact_identity import app_tree_sha256
 from scripts.installed_ui_qualification import (
+    InstalledUIOperations,
     InstalledUIQualificationConfig,
     InstalledUIQualificationError,
     run,
+    validate_installed_ui_operations_contract,
     validate_installed_ui_output_paths,
 )
-from scripts.tier3_clean_machine import CleanMachineError
+from scripts.tier3_clean_machine import APP_NAME, RELEASES_URL, CleanMachineError, MacOSOperations
+
+
+def write_candidate_evidence(output_directory: Path, *, profiles_before: int) -> None:
+    output_directory.mkdir(parents=True)
+    (output_directory / "candidate-ui.json").write_text(
+        json.dumps(
+            {
+                "main_window_ready": True,
+                "profile_document_version": 6,
+                "profile_save_accessible": True,
+                "profile_save_succeeded": True,
+                "profiles_after": profiles_before + 1,
+                "profiles_before": profiles_before,
+                "release_page_url": RELEASES_URL,
+                "release_page_url_observed": True,
+                "schema_version": 1,
+                "status": "passed",
+                "updater_controls_accessible": True,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_directory / "accessibility-tree.json").write_text(
+        json.dumps(
+            {
+                "elements": [
+                    {
+                        "actions": ["AXPress"],
+                        "enabled": True,
+                        "help": "Opens a form to name and save these settings as a reusable profile",
+                        "identifier": "save-profile-action",
+                        "label": "Save current settings as new profile",
+                        "role": "AXButton",
+                    },
+                    {
+                        "actions": ["AXPress"],
+                        "enabled": True,
+                        "help": "Checks for updates",
+                        "identifier": "update-action",
+                        "label": "Check for Updates",
+                        "role": "AXButton",
+                    },
+                    {
+                        "actions": ["AXPress"],
+                        "enabled": True,
+                        "help": "Update route",
+                        "identifier": "update-route-picker",
+                        "label": "",
+                        "role": "AXPopUpButton",
+                    },
+                    {
+                        "actions": ["AXPress"],
+                        "enabled": True,
+                        "help": "Opens all releases",
+                        "identifier": "all-releases-link",
+                        "label": "All Releases",
+                        "role": "AXLink",
+                        "url": RELEASES_URL,
+                    },
+                ],
+                "schema_version": 1,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_directory / "screenshot-light.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"light" * 12)
+    (output_directory / "screenshot-dark.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"dark" * 14)
+
+
+class RecordingOperations:
+    def __init__(
+        self,
+        app_source: Path,
+        *,
+        profiles_before: int = 0,
+        install_error: Exception | None = None,
+        collect_error: BaseException | None = None,
+        failing_quit_call: int | None = None,
+    ) -> None:
+        self.app_source = app_source
+        self.profiles_before = profiles_before
+        self.install_error = install_error
+        self.collect_error = collect_error
+        self.failing_quit_call = failing_quit_call
+        self.install_arguments: tuple[Path, Path, Path] | None = None
+        self.collect_arguments: dict[str, Any] | None = None
+        self.quit_calls = 0
+        self.running = False
+
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        self.install_arguments = (dmg_path, destination, mount_point)
+        if self.install_error is not None:
+            raise self.install_error
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(self.app_source, destination, symlinks=True)
+
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        self.collect_arguments = {
+            "app_path": app_path,
+            "output_directory": output_directory,
+            "phase": phase,
+            "release_notes_url": release_notes_url,
+            "repo": repo,
+            "synthetic_home": synthetic_home,
+        }
+        self.running = True
+        write_candidate_evidence(output_directory, profiles_before=self.profiles_before)
+        if self.collect_error is not None:
+            raise self.collect_error
+
+    def app_running(self, app_path: Path | None = None) -> bool:
+        del app_path
+        return self.running
+
+    def quit_app(self) -> None:
+        self.quit_calls += 1
+        if self.quit_calls == self.failing_quit_call:
+            raise RuntimeError("cleanup quit failure")
+        self.running = False
 
 
 class FailingOperations:
-    def install_app(self, _dmg_path: Path, _destination: Path, _mount_point: Path) -> None:
+    def __init__(self) -> None:
+        self.install_attempted = False
+        self.collect_attempted = False
+        self.running = False
+
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        del dmg_path, destination, mount_point
+        self.install_attempted = True
         raise CleanMachineError("primary UI failure")
 
-    def collect_ui_evidence(self, **_kwargs: object) -> None:
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        del repo, phase, app_path, synthetic_home, output_directory, release_notes_url
+        self.collect_attempted = True
         raise AssertionError("evidence collection must not run after installation fails")
 
     def quit_app(self) -> None:
+        self.running = False
         raise RuntimeError("cleanup quit failure")
 
-    def app_running(self) -> bool:
-        return False
+    def app_running(self, app_path: Path | None = None) -> bool:
+        del app_path
+        return self.running
+
+
+class StaleInstallOperations(RecordingOperations):
+    def install_app(self, dmg_path: Path, destination: Path) -> None:  # type: ignore[override]
+        del dmg_path, destination
 
 
 class InstalledUIQualificationTests(unittest.TestCase):
     @staticmethod
-    def config(root: Path) -> InstalledUIQualificationConfig:
+    def config(root: Path, *, expected_app_tree_sha256: str = "a" * 64) -> InstalledUIQualificationConfig:
         return InstalledUIQualificationConfig(
             repo=root,
             dmg=root / "candidate.dmg",
             qualification_root=root / "qualification",
             evidence_directory=root / "evidence",
-            release_notes_url="https://example.com/releases",
-            expected_app_tree_sha256="a" * 64,
+            release_notes_url=RELEASES_URL,
+            expected_app_tree_sha256=expected_app_tree_sha256,
             owner="test-installed-ui",
             failure_diagnostics_directory=root / "diagnostics",
         )
 
-    def test_rejects_overlapping_output_directories(self) -> None:
+    @staticmethod
+    def make_app(root: Path) -> Path:
+        app = root / APP_NAME
+        executable = app / "Contents" / "MacOS" / "BD_to_AVP"
+        executable.parent.mkdir(parents=True)
+        executable.write_text("candidate\n", encoding="utf-8")
+        resources = app / "Contents" / "Resources"
+        resources.mkdir()
+        (resources / "worker").symlink_to("../MacOS/BD_to_AVP")
+        return app
+
+    def test_production_operations_satisfy_checked_contract(self) -> None:
+        operations = validate_installed_ui_operations_contract(MacOSOperations())
+
+        self.assertIsInstance(operations, InstalledUIOperations)
+
+    def test_rejects_stale_operations_signature(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            operations = StaleInstallOperations(self.make_app(Path(temporary_directory)))
+
+            with self.assertRaisesRegex(InstalledUIQualificationError, "install_app.*production contract"):
+                validate_installed_ui_operations_contract(operations)
+
+    def test_success_installs_exact_app_normalizes_evidence_terminates_and_cleans_workspace(self) -> None:
+        for profiles_before in (0, 2):
+            with self.subTest(profiles_before=profiles_before), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                app_source = self.make_app(root / "source")
+                config = self.config(root, expected_app_tree_sha256=app_tree_sha256(app_source))
+                config.dmg.write_bytes(b"candidate-dmg")
+                operations = RecordingOperations(app_source, profiles_before=profiles_before)
+
+                evidence = run(config, operations)
+
+                expected_app = config.qualification_root / "Applications" / APP_NAME
+                self.assertEqual(
+                    operations.install_arguments,
+                    (config.dmg, expected_app, config.qualification_root / "Mount"),
+                )
+                self.assertEqual(
+                    operations.collect_arguments,
+                    {
+                        "app_path": expected_app,
+                        "output_directory": config.qualification_root / "InstalledUIEvidence",
+                        "phase": "candidate",
+                        "release_notes_url": RELEASES_URL,
+                        "repo": root.resolve(),
+                        "synthetic_home": config.qualification_root / "Home",
+                    },
+                )
+                self.assertEqual(
+                    evidence,
+                    {
+                        "accessibility-tree": hashlib.sha256(
+                            (config.evidence_directory / "accessibility-tree.json").read_bytes()
+                        ).hexdigest(),
+                        "screenshot-dark": hashlib.sha256(
+                            (config.evidence_directory / "screenshot-dark.png").read_bytes()
+                        ).hexdigest(),
+                        "screenshot-light": hashlib.sha256(
+                            (config.evidence_directory / "screenshot-light.png").read_bytes()
+                        ).hexdigest(),
+                        "ui-result": hashlib.sha256(
+                            (config.evidence_directory / "ui-result.json").read_bytes()
+                        ).hexdigest(),
+                    },
+                )
+                ui_result = json.loads((config.evidence_directory / "ui-result.json").read_text(encoding="utf-8"))
+                self.assertEqual(ui_result["profiles_before"], profiles_before)
+                self.assertEqual(ui_result["profiles_after"], profiles_before + 1)
+                self.assertEqual(operations.quit_calls, 2)
+                self.assertFalse(operations.running)
+                self.assertFalse(config.qualification_root.exists())
+                self.assertFalse(config.failure_diagnostics_directory.exists())
+
+    def test_rejects_installed_app_tree_mismatch_before_collecting_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            config = self.config(root)
-            overlapping = InstalledUIQualificationConfig(
-                **{
-                    **config.__dict__,
-                    "failure_diagnostics_directory": config.qualification_root / "diagnostics",
-                }
-            )
+            operations = RecordingOperations(self.make_app(root / "source"))
+            config = self.config(root, expected_app_tree_sha256="0" * 64)
 
-            with self.assertRaisesRegex(InstalledUIQualificationError, "must not overlap"):
-                validate_installed_ui_output_paths(overlapping)
+            with self.assertRaisesRegex(InstalledUIQualificationError, "tree digest"):
+                run(config, operations)
+
+            self.assertIsNone(operations.collect_arguments)
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_rejects_every_output_path_overlap(self) -> None:
+        path_fields = ("qualification_root", "evidence_directory", "failure_diagnostics_directory")
+        for left_field, right_field in combinations(path_fields, 2):
+            for relationship in ("equal", "left-parent", "right-parent"):
+                with (
+                    self.subTest(left=left_field, right=right_field, relationship=relationship),
+                    tempfile.TemporaryDirectory() as temporary_directory,
+                ):
+                    root = Path(temporary_directory)
+                    config = self.config(root)
+                    shared = root / "shared"
+                    if relationship == "equal":
+                        left_path = right_path = shared
+                    elif relationship == "left-parent":
+                        left_path, right_path = shared, shared / "nested"
+                    else:
+                        left_path, right_path = shared / "nested", shared
+                    overlapping = replace(config, **{left_field: left_path, right_field: right_path})
+
+                    with self.assertRaisesRegex(InstalledUIQualificationError, "must not overlap"):
+                        validate_installed_ui_output_paths(overlapping)
+
+    def test_rejects_stale_output_files_directories_and_symlinks(self) -> None:
+        for field in ("qualification_root", "evidence_directory", "failure_diagnostics_directory"):
+            for path_kind in ("file", "directory", "symlink"):
+                with (
+                    self.subTest(field=field, path_kind=path_kind),
+                    tempfile.TemporaryDirectory() as temporary_directory,
+                ):
+                    root = Path(temporary_directory)
+                    config = self.config(root)
+                    path = getattr(config, field)
+                    if path is None:
+                        raise AssertionError("test output path must be configured")
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    if path_kind == "file":
+                        path.write_text("stale\n", encoding="utf-8")
+                    elif path_kind == "directory":
+                        path.mkdir()
+                    else:
+                        path.symlink_to(root / "missing-output", target_is_directory=True)
+
+                    with self.assertRaisesRegex(InstalledUIQualificationError, "must not already exist"):
+                        validate_installed_ui_output_paths(config)
 
     def test_primary_failure_survives_diagnostics_and_cleanup_failures(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -73,6 +358,107 @@ class InstalledUIQualificationTests(unittest.TestCase):
             self.assertTrue(any("diagnostics failure" in note for note in notes))
             self.assertTrue(any("cleanup quit failure" in note for note in notes))
             self.assertFalse(config.qualification_root.exists())
+
+    def test_preserves_bounded_diagnostics_for_evidence_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_source = self.make_app(root / "source")
+            config = self.config(root, expected_app_tree_sha256=app_tree_sha256(app_source))
+            operations = RecordingOperations(app_source, collect_error=CleanMachineError("evidence failure"))
+
+            with self.assertRaisesRegex(CleanMachineError, "evidence failure"):
+                run(config, operations)
+
+            failure_text = (config.failure_diagnostics_directory / "failure.txt").read_text()
+            candidate_evidence = config.failure_diagnostics_directory / "InstalledUIEvidence" / "candidate-ui.json"
+            self.assertIn("CleanMachineError: evidence failure", failure_text)
+            self.assertTrue(candidate_evidence.is_file())
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_cleanup_failure_removes_normalized_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_source = self.make_app(root / "source")
+            config = self.config(root, expected_app_tree_sha256=app_tree_sha256(app_source))
+            operations = RecordingOperations(app_source, failing_quit_call=2)
+
+            with self.assertRaisesRegex(InstalledUIQualificationError, "cleanup failed.*cleanup quit failure"):
+                run(config, operations)
+
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_interrupt_remains_primary_when_cleanup_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_source = self.make_app(root / "source")
+            config = self.config(root, expected_app_tree_sha256=app_tree_sha256(app_source))
+            operations = RecordingOperations(
+                app_source,
+                collect_error=KeyboardInterrupt("operator interrupt"),
+                failing_quit_call=1,
+            )
+
+            with self.assertRaisesRegex(KeyboardInterrupt, "operator interrupt") as raised:
+                run(config, operations)
+
+            notes = getattr(raised.exception, "__notes__", [])
+            self.assertTrue(any("cleanup quit failure" in note for note in notes))
+            self.assertFalse(config.qualification_root.exists())
+
+    def test_interrupt_during_normalization_removes_partial_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app_source = self.make_app(root / "source")
+            config = self.config(root, expected_app_tree_sha256=app_tree_sha256(app_source))
+            operations = RecordingOperations(app_source)
+
+            def interrupt_normalization(
+                _raw_directory: Path,
+                evidence_directory: Path,
+                *,
+                release_notes_url: str,
+            ) -> None:
+                del release_notes_url
+                evidence_directory.mkdir()
+                (evidence_directory / "partial.json").write_text("{}\n", encoding="utf-8")
+                raise KeyboardInterrupt("normalization interrupt")
+
+            with (
+                patch(
+                    "scripts.installed_ui_qualification.normalize_installed_ui_candidate_evidence",
+                    side_effect=interrupt_normalization,
+                ),
+                self.assertRaisesRegex(KeyboardInterrupt, "normalization interrupt"),
+            ):
+                run(config, operations)
+
+            self.assertFalse(config.qualification_root.exists())
+            self.assertFalse(config.evidence_directory.exists())
+
+    def test_primary_failure_survives_evidence_cleanup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config = self.config(root)
+            primary_error = CleanMachineError("primary UI failure")
+
+            def fail_run(_config: InstalledUIQualificationConfig, _operations: InstalledUIOperations) -> None:
+                config.evidence_directory.mkdir()
+                raise primary_error
+
+            with (
+                patch("scripts.installed_ui_qualification._run", side_effect=fail_run),
+                patch(
+                    "scripts.installed_ui_qualification.shutil.rmtree",
+                    side_effect=OSError("evidence cleanup failure"),
+                ),
+                self.assertRaisesRegex(CleanMachineError, "primary UI failure") as raised,
+            ):
+                run(config, FailingOperations())
+
+            notes = getattr(raised.exception, "__notes__", [])
+            self.assertTrue(any("evidence cleanup failure" in note for note in notes))
 
 
 if __name__ == "__main__":

--- a/tests/test_installed_ui_qualification.py
+++ b/tests/test_installed_ui_qualification.py
@@ -188,9 +188,40 @@ class FailingOperations:
         return self.running
 
 
-class StaleInstallOperations(RecordingOperations):
-    def install_app(self, dmg_path: Path, destination: Path) -> None:  # type: ignore[override]
-        del dmg_path, destination
+class StaleInstallOperations:
+    def __init__(self, app_source: Path) -> None:
+        self.app_source = app_source
+        self.running = False
+        self.install_arguments: tuple[Path, Path] | None = None
+
+    def install_app(self, dmg_path: Path, destination: Path) -> None:
+        self.install_arguments = (dmg_path, destination)
+
+    def collect_ui_evidence(
+        self,
+        *,
+        repo: Path,
+        phase: str,
+        app_path: Path,
+        synthetic_home: Path,
+        output_directory: Path,
+        release_notes_url: str,
+    ) -> None:
+        self.collect_arguments = (
+            repo,
+            phase,
+            app_path,
+            synthetic_home,
+            output_directory,
+            release_notes_url,
+        )
+
+    def app_running(self, app_path: Path | None = None) -> bool:
+        self.running_app_path = app_path
+        return self.running
+
+    def quit_app(self) -> None:
+        self.running = False
 
 
 class InstalledUIQualificationTests(unittest.TestCase):

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -371,7 +371,10 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             "workflow_run_attempt": 1,
             "workflow_run_id": 22222,
         }
-        (attempt_root / "failed-attempt-v1.json").write_text(json.dumps(record) + "\n", encoding="utf-8")
+        (attempt_root / "failed-attempt-v1.json").write_text(
+            json.dumps(record, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
         next_qualification = json.loads(json.dumps(base_qualification))
         next_qualification["candidate"].update(

--- a/tests/test_release_recovery_records.py
+++ b/tests/test_release_recovery_records.py
@@ -1,0 +1,93 @@
+import json
+import shutil
+import tempfile
+import unittest
+
+from pathlib import Path
+
+from scripts.release_milestone_context import (
+    ReleaseMilestoneContextError,
+    validate_failed_attempt_record,
+    validate_release_recovery_records,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseRecoveryRecordTests(unittest.TestCase):
+    @staticmethod
+    def copy_recovery_fixtures(root: Path) -> None:
+        shutil.copytree(REPO_ROOT / "docs" / "release-attempts", root / "docs" / "release-attempts")
+        shutil.copytree(REPO_ROOT / "docs" / "qualification", root / "docs" / "qualification")
+        config_path = root / ".github" / "github.json"
+        config_path.parent.mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / ".github" / "github.json", config_path)
+
+    def test_repository_recovery_records_validate_directly_from_disk(self) -> None:
+        records = validate_release_recovery_records(REPO_ROOT)
+
+        self.assertEqual(records["v0.3.2-beta.3"]["attempt"]["build_version"], "165")
+        self.assertEqual(records["v0.3.2-beta.4"]["attempt"]["build_version"], "166")
+        self.assertEqual(records["v0.3.2-beta.6"]["attempt"]["build_version"], "168")
+        self.assertEqual(
+            records["v0.3.2-beta.6"]["disposition"]["status"],
+            "deleted_abandoned_unpublished_draft",
+        )
+
+    def test_failed_attempt_records_validate_directly_from_disk(self) -> None:
+        for release_tag, build_version in (("v0.3.2-beta.3", "165"), ("v0.3.2-beta.4", "166")):
+            with self.subTest(release_tag=release_tag):
+                record = validate_failed_attempt_record(REPO_ROOT, release_tag)
+
+                self.assertEqual(record["build_version"], build_version)
+                self.assertTrue(record["draft_deleted"])
+                self.assertTrue(record["must_not_rebuild"])
+
+    def test_rejects_noncanonical_attempt_serialization(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_recovery_fixtures(root)
+            record_path = root / "docs" / "release-attempts" / "v0.3.2-beta.3" / "failed-attempt-v1.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "canonical JSON serialization"):
+                validate_failed_attempt_record(root, "v0.3.2-beta.3")
+
+    def test_rejects_missing_historical_burns_for_each_failed_attempt(self) -> None:
+        cases = (
+            ("v0.3.2-beta.3", 165, "v0.3.2-beta.4-signed-qualification-v1.json"),
+            ("v0.3.2-beta.4", 166, "v0.3.2-beta.5-signed-qualification-v1.json"),
+        )
+        for release_tag, build, qualification_name in cases:
+            with self.subTest(release_tag=release_tag), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                self.copy_recovery_fixtures(root)
+                qualification_path = root / "docs" / "qualification" / qualification_name
+                qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
+                qualification["immutable_history"]["burned_builds"].remove(build)
+                qualification_path.write_text(
+                    json.dumps(qualification, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(
+                    ReleaseMilestoneContextError,
+                    rf"permanently burn build {build} from {release_tag}",
+                ):
+                    validate_release_recovery_records(root)
+
+    def test_rejects_cancelled_attempt_without_deletion_disposition(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_recovery_fixtures(root)
+            disposition_path = root / "docs" / "release-attempts" / "v0.3.2-beta.6" / "draft-deletion-v1.json"
+            disposition_path.unlink()
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "requires an authorized draft-deletion"):
+                validate_release_recovery_records(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_signed_artifact_ui.py
+++ b/tests/test_signed_artifact_ui.py
@@ -24,7 +24,8 @@ class FakeOperations:
         self.running = False
         self.install_mount_point: Path | None = None
 
-    def install_app(self, _dmg_path: Path, destination: Path, mount_point: Path) -> None:
+    def install_app(self, dmg_path: Path, destination: Path, mount_point: Path) -> None:
+        del dmg_path
         self.install_mount_point = mount_point
         destination.parent.mkdir(parents=True, exist_ok=True)
         if destination.exists():
@@ -116,7 +117,8 @@ class FakeOperations:
     def quit_app(self) -> None:
         self.running = False
 
-    def app_running(self) -> bool:
+    def app_running(self, app_path: Path | None = None) -> bool:
+        del app_path
         return self.running
 
 
@@ -205,10 +207,17 @@ class SignedArtifactUITests(unittest.TestCase):
 
     def test_runner_preserves_bounded_failure_diagnostics(self) -> None:
         class FailingOperations(FakeOperations):
-            def collect_ui_evidence(self, **kwargs: object) -> None:
-                output_directory = kwargs["output_directory"]
-                if not isinstance(output_directory, Path):
-                    raise AssertionError("output_directory must be a path")
+            def collect_ui_evidence(
+                self,
+                *,
+                repo: Path,
+                phase: str,
+                app_path: Path,
+                synthetic_home: Path,
+                output_directory: Path,
+                release_notes_url: str,
+            ) -> None:
+                del repo, phase, app_path, synthetic_home, release_notes_url
                 output_directory.mkdir(parents=True)
                 (output_directory / "partial.json").write_text("{}\n", encoding="utf-8")
                 result_bundle = output_directory.parent / "InstalledUI-candidate.xcresult"


### PR DESCRIPTION
## Summary

- define and runtime-check the installed-UI production operations protocol against `MacOSOperations` and all test doubles
- exercise the shared package/DMG/install/app-tree/evidence/termination/owned-cleanup success path plus failure, interrupt, stale-output, and overlap behavior
- directly cover fresh-empty and seeded profile libraries in the installed-UI XCTest target
- validate Beta 3, Beta 4, and Beta 6 recovery records from disk with canonical serialization, burned-build propagation, and deletion-disposition tampering regressions

## Validation

- `uv run python -m unittest tests.test_installed_ui_qualification tests.test_release_recovery_records tests.test_cancelled_release_attempt tests.test_signed_artifact_ui tests.test_release_milestone_context` — 84 passed
- `DYLD_LIBRARY_PATH=/opt/homebrew/opt/ffmpeg-full/lib uv run python -m unittest discover -s tests -t .` — 1,854 passed, 3 skipped
- `uv run python scripts/native_app.py test` — 484 passed
- focused `BluRayToVisionProInstalledUI` XCUITests — 2 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy bd_to_avp scripts/installed_ui_qualification.py scripts/release_milestone_context.py scripts/pre_signing_ui.py scripts/signed_artifact_ui.py`
- `actionlint`
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- release/workflow policy suites — 184 passed
- `uv build`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`
- secret-free production package → DMG → install → installed-UI qualification passed end to end

JetBrains inspection was attempted twice. The configured IntelliJ project could not prove semantic Python coverage because its language SDK is missing; the final attempt returned zero actionable findings, and helper-generated IDE metadata was removed.

Closes #632
Refs #631
