### PR TITLE
Add release-independent production preflight

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -70,6 +70,8 @@
     "requiredEvent": "workflow_dispatch",
     "approvalEnvironment": "macos-signing",
     "engineWorkflowPath": ".github/workflows/release-engine.yml",
+    "productionPreflightWorkflowPath": ".github/workflows/production-preflight.yml",
+    "productionPreflightEngineWorkflowPath": ".github/workflows/production-preflight-engine.yml",
     "evidenceWorkflowPath": ".github/workflows/release-evidence.yml",
     "milestoneQualificationWorkflowPath": ".github/workflows/milestone-qualification.yml",
     "qualificationPolicyPath": "docs/qualification/release-qualification-policy-v1.json",
@@ -109,6 +111,8 @@
     "releaseWorkflows": [
       ".github/workflows/briefcase.yml",
       ".github/workflows/prerelease.yml",
+      ".github/workflows/production-preflight.yml",
+      ".github/workflows/production-preflight-engine.yml",
       ".github/workflows/release-engine.yml",
       ".github/workflows/release-evidence.yml",
       ".github/workflows/milestone-qualification.yml",
@@ -176,6 +180,7 @@
   "importantWorkflows": [
     "CI",
     "CodeQL",
+    "Production Preflight",
     "Stable",
     "Prerelease",
     "Release Evidence",

--- a/.github/workflows/production-preflight-engine.yml
+++ b/.github/workflows/production-preflight-engine.yml
@@ -1,0 +1,296 @@
+---
+name: Production preflight engine
+
+"on":
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact full current protected main SHA to qualify
+        required: true
+        type: string
+      support_diagnostics_endpoint:
+        description: Production support diagnostics endpoint embedded in the app
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  XCODEGEN_VERSION: 2.45.4
+  XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
+  XCODE_VERSION: "26.5"
+  XCODE_BUILD_VERSION: 17F42
+
+jobs:
+  preflight:
+    name: Build and qualify the production package
+    runs-on: macos-26
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Require an exact protected main input
+        id: input
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Production preflight requires an exact full lowercase Git SHA." >&2
+            exit 1
+          fi
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Production preflight must be dispatched from protected main." >&2
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$SOURCE_SHA" ]; then
+            echo "Production preflight input must equal the dispatched main SHA." >&2
+            exit 1
+          fi
+
+      - name: Checkout requested main commit
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+
+      - name: Bind source and workflow identity
+        id: source
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          python3 -m scripts.production_preflight validate-source \
+            --source-sha "$SOURCE_SHA" \
+            --output production-preflight-source.json
+
+      - name: Verify pinned production runner
+        id: runner
+        env:
+          BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE: ""
+          SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ inputs.support_diagnostics_endpoint }}
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "arm64"
+          test "$(sw_vers -productVersion | cut -d. -f1)" = "26"
+          test -n "$SUPPORT_DIAGNOSTICS_ENDPOINT"
+          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
+          if [ ! -d "$XCODE_PATH" ]; then
+            echo "Pinned Xcode path is unavailable: $XCODE_PATH" >&2
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_PATH"
+          test "$(xcodebuild -version | sed -n '1p')" = "Xcode $XCODE_VERSION"
+          test "$(xcodebuild -version | sed -n '2p')" = "Build version $XCODE_BUILD_VERSION"
+          if [ -n "${BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE:-}" ]; then
+            echo "Production preflight must not override the macOS 26 deployment target." >&2
+            exit 1
+          fi
+
+      - name: Install pinned XcodeGen
+        id: xcodegen
+        run: |
+          set -euo pipefail
+          ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
+          curl --fail --location --silent --show-error \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/$XCODEGEN_VERSION/xcodegen.zip" \
+            --output "$ARCHIVE"
+          printf '%s  %s\n' "$XCODEGEN_SHA256" "$ARCHIVE" | shasum -a 256 --check
+          ditto -x -k "$ARCHIVE" "$RUNNER_TEMP"
+          test "$("$RUNNER_TEMP/xcodegen/bin/xcodegen" --version)" = "Version: $XCODEGEN_VERSION"
+          echo "$RUNNER_TEMP/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Set up uv
+        id: uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install Python and locked dependencies
+        id: dependencies
+        run: |
+          set -euo pipefail
+          uv python install 3.12
+          uv sync --locked --all-groups --python 3.12
+
+      - name: Build the production-shaped app with ad-hoc signing
+        id: package
+        env:
+          BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE: ""
+          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ inputs.support_diagnostics_endpoint }}
+        run: |
+          set -euo pipefail
+          APP_PATH="macos/build/package/3D Blu-ray to Vision Pro.app"
+          echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
+          uv run python scripts/native_app.py package --sign-identity - \
+            2>&1 | tee "$RUNNER_TEMP/production-preflight-package.log"
+          test -d "$APP_PATH"
+
+      - name: Smoke exact packaged worker identity and protocol
+        id: smoke
+        run: |
+          set -euo pipefail
+          uv run python scripts/smoke_release_app.py \
+            --app-path "$APP_PATH" \
+            --skip-spctl \
+            2>&1 | tee production-preflight-smoke.log
+
+      - name: Create, install, and qualify the preventive DMG
+        id: installed-ui
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          uv run python -m scripts.pre_signing_ui \
+            --app "$APP_PATH" \
+            --dmg "$RUNNER_TEMP/production-preflight.dmg" \
+            --qualification-root "$RUNNER_TEMP/production-preflight-installed-ui" \
+            --evidence-directory production-preflight-installed-ui-evidence \
+            --output-report production-preflight-installed-ui-report.json \
+            --failure-diagnostics-directory production-preflight-installed-ui-diagnostics \
+            --source-sha "$SOURCE_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            2>&1 | tee "$RUNNER_TEMP/production-preflight-installed-ui.log"
+
+      - name: Bind bounded success evidence
+        id: evidence
+        run: |
+          set -euo pipefail
+          uv run python -m scripts.production_preflight finalize \
+            --source-report production-preflight-source.json \
+            --smoke-log production-preflight-smoke.log \
+            --installed-ui-report production-preflight-installed-ui-report.json \
+            --installed-ui-evidence production-preflight-installed-ui-evidence \
+            --output production-preflight-success.json
+
+      - name: Summarize production preflight
+        if: success()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Production preflight passed"
+            echo
+            echo "- Source: \`${{ inputs.source_sha }}\`"
+            echo "- Package version: \`$(jq -r .package_version production-preflight-success.json)\`"
+            echo "- App tree: \`$(jq -r .app_tree_sha256 production-preflight-success.json)\`"
+            echo "- Preventive DMG: \`$(jq -r .preventive_dmg.sha256 production-preflight-success.json)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Collect bounded failure diagnostics
+        if: failure()
+        env:
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
+          EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          INPUT_OUTCOME: ${{ steps.input.outcome }}
+          INSTALLED_UI_OUTCOME: ${{ steps.installed-ui.outcome }}
+          PACKAGE_OUTCOME: ${{ steps.package.outcome }}
+          RUNNER_OUTCOME: ${{ steps.runner.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          SOURCE_OUTCOME: ${{ steps.source.outcome }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          DIAGNOSTICS=production-preflight-diagnostics
+          mkdir "$DIAGNOSTICS"
+          CHECKOUT_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+          MAIN_SHA=$(git rev-parse refs/remotes/origin/main 2>/dev/null || true)
+          jq -n \
+            --arg checkout_outcome "$CHECKOUT_OUTCOME" \
+            --arg checkout_sha "$CHECKOUT_SHA" \
+            --arg dependencies_outcome "$DEPENDENCIES_OUTCOME" \
+            --arg evidence_outcome "$EVIDENCE_OUTCOME" \
+            --arg input_outcome "$INPUT_OUTCOME" \
+            --arg installed_ui_outcome "$INSTALLED_UI_OUTCOME" \
+            --arg main_sha "$MAIN_SHA" \
+            --arg package_outcome "$PACKAGE_OUTCOME" \
+            --arg runner_outcome "$RUNNER_OUTCOME" \
+            --arg smoke_outcome "$SMOKE_OUTCOME" \
+            --arg source_outcome "$SOURCE_OUTCOME" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg workflow_ref "$GITHUB_WORKFLOW_REF" \
+            --arg workflow_sha "$GITHUB_WORKFLOW_SHA" \
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            '{
+              schema_version: 1,
+              source_sha: $source_sha,
+              checkout_sha: $checkout_sha,
+              protected_main_sha: $main_sha,
+              workflow: {
+                ref: $workflow_ref,
+                sha: $workflow_sha,
+                run_id: $run_id,
+                run_attempt: $run_attempt
+              },
+              outcomes: {
+                input: $input_outcome,
+                checkout: $checkout_outcome,
+                source: $source_outcome,
+                runner: $runner_outcome,
+                dependencies: $dependencies_outcome,
+                package: $package_outcome,
+                smoke: $smoke_outcome,
+                installed_ui: $installed_ui_outcome,
+                evidence: $evidence_outcome
+              }
+            }' > "$DIAGNOSTICS/context.json"
+          if [ -f production-preflight-source.json ]; then
+            cp production-preflight-source.json "$DIAGNOSTICS/"
+          fi
+          if [ -f "$RUNNER_TEMP/production-preflight-package.log" ]; then
+            tail -c 262144 "$RUNNER_TEMP/production-preflight-package.log" > "$DIAGNOSTICS/package-tail.log"
+          fi
+          if [ -f production-preflight-smoke.log ]; then
+            tail -c 262144 production-preflight-smoke.log > "$DIAGNOSTICS/smoke-tail.log"
+          fi
+          if [ -f "$RUNNER_TEMP/production-preflight-installed-ui.log" ]; then
+            tail -c 262144 "$RUNNER_TEMP/production-preflight-installed-ui.log" \
+              > "$DIAGNOSTICS/installed-ui-tail.log"
+          fi
+          if [ -d production-preflight-installed-ui-diagnostics ]; then
+            mkdir "$DIAGNOSTICS/installed-ui"
+            TOTAL_FILES=$(find production-preflight-installed-ui-diagnostics -type f | wc -l | tr -d ' ')
+            printf '%s\n' "$TOTAL_FILES" > "$DIAGNOSTICS/installed-ui-file-count.txt"
+            FILE_COUNT=0
+            while IFS= read -r FILE; do
+              FILE_COUNT=$((FILE_COUNT + 1))
+              if [ "$FILE_COUNT" -gt 50 ]; then
+                break
+              fi
+              RELATIVE_PATH=${FILE#production-preflight-installed-ui-diagnostics/}
+              DESTINATION="$DIAGNOSTICS/installed-ui/$RELATIVE_PATH"
+              mkdir -p "$(dirname "$DESTINATION")"
+              tail -c 131072 "$FILE" > "$DESTINATION"
+            done < <(find production-preflight-installed-ui-diagnostics -type f | LC_ALL=C sort)
+          fi
+
+      - name: Retain bounded failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-preflight-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            production-preflight-diagnostics
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Retain bounded success evidence
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-preflight-success-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            production-preflight-success.json
+            production-preflight-source.json
+            production-preflight-smoke.log
+            production-preflight-installed-ui-evidence
+            production-preflight-installed-ui-report.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/production-preflight-engine.yml
+++ b/.github/workflows/production-preflight-engine.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ github.sha }}
 
       - name: Bind source and workflow identity
         id: source

--- a/.github/workflows/production-preflight.yml
+++ b/.github/workflows/production-preflight.yml
@@ -1,0 +1,26 @@
+---
+name: Production Preflight
+
+"on":
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact full current protected main SHA to qualify
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: production-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Run release-independent production preflight
+    uses: ./.github/workflows/production-preflight-engine.yml
+    with:
+      source_sha: ${{ inputs.source_sha }}
+      support_diagnostics_endpoint: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
+    permissions:
+      contents: read

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -606,25 +606,24 @@ jobs:
             exit "$QUALIFICATION_EXIT_CODE"
           fi
 
-  pre-signing-package:
-    name: Qualify production package before signing
+  pre-signing-policy:
+    name: Revalidate guarded release policy before production preflight
     needs:
       - policy
       - prepare
       - qualify-preparation
-    runs-on: macos-26
-    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
-      - name: Checkout validated main commit
+      - name: Checkout guarded release policy
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Verify pre-signing runner and checkout
+      - name: Revalidate the guarded release identity
         env:
           EXPECTED_POLICY_FINGERPRINT: ${{ needs.policy.outputs.policy_fingerprint }}
           RELEASE_REPOSITORY: ${{ github.repository }}
@@ -647,105 +646,20 @@ jobs:
           INPUT_OPERATOR_RUN_ATTEMPT: ${{ inputs.operator_run_attempt }}
           INPUT_OPERATOR_ACTOR: ${{ inputs.operator_actor }}
           INPUT_OPERATOR_TRIGGERING_ACTOR: ${{ inputs.operator_triggering_actor }}
-        run: |
-          set -euo pipefail
-          python3 scripts/release_workflow_policy.py engine \
-            --expected-fingerprint "$EXPECTED_POLICY_FINGERPRINT"
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if [ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]; then
-            echo "Protected main moved before pre-signing qualification." >&2
-            exit 1
-          fi
-          test "$(uname -m)" = "arm64"
-          test "$(sw_vers -productVersion | cut -d. -f1)" = "26"
-          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
-          if [ ! -d "$XCODE_PATH" ]; then
-            echo "Pinned Xcode path is unavailable: $XCODE_PATH" >&2
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE_PATH"
-          test "$(xcodebuild -version | sed -n '1p')" = "Xcode $XCODE_VERSION"
-          test "$(xcodebuild -version | sed -n '2p')" = "Build version $XCODE_BUILD_VERSION"
-          if [ -n "${BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE:-}" ]; then
-            echo "Release builds must not override the macOS 26 deployment target." >&2
-            exit 1
-          fi
+        run: >-
+          python3 scripts/release_workflow_policy.py engine
+          --expected-fingerprint "$EXPECTED_POLICY_FINGERPRINT"
 
-      - name: Install pinned XcodeGen
-        run: |
-          set -euo pipefail
-          ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
-          curl --fail --location --silent --show-error \
-            "https://github.com/yonaskolb/XcodeGen/releases/download/$XCODEGEN_VERSION/xcodegen.zip" \
-            --output "$ARCHIVE"
-          printf '%s  %s\n' "$XCODEGEN_SHA256" "$ARCHIVE" | shasum -a 256 --check
-          ditto -x -k "$ARCHIVE" "$RUNNER_TEMP"
-          test "$("$RUNNER_TEMP/xcodegen/bin/xcodegen" --version)" = "Version: $XCODEGEN_VERSION"
-          echo "$RUNNER_TEMP/xcodegen/bin" >> "$GITHUB_PATH"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: true
-          python-version: "3.12"
-
-      - name: Install Python and locked dependencies
-        run: |
-          uv python install 3.12
-          uv sync --locked --all-groups --python 3.12
-
-      - name: Build and smoke the production-shaped package
-        env:
-          BD_TO_AVP_MACOS_DEPLOYMENT_TARGET_OVERRIDE: ""
-          BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
-        run: |
-          set -euo pipefail
-          APP_PATH="macos/build/package/3D Blu-ray to Vision Pro.app"
-          echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
-          uv run python scripts/native_app.py package --sign-identity -
-          test -d "$APP_PATH"
-          uv run python scripts/smoke_release_app.py \
-            --app-path "$APP_PATH" \
-            --skip-spctl \
-            | tee pre-signing-smoke.log
-
-      - name: Run installed UI qualification before signing
-        run: |
-          set -euo pipefail
-          uv run python -m scripts.pre_signing_ui \
-            --app "$APP_PATH" \
-            --dmg "$RUNNER_TEMP/pre-signing-package.dmg" \
-            --qualification-root "$RUNNER_TEMP/pre-signing-installed-ui" \
-            --evidence-directory pre-signing-installed-ui-evidence \
-            --output-report pre-signing-installed-ui-report.json \
-            --failure-diagnostics-directory pre-signing-installed-ui-diagnostics \
-            --source-sha "$GITHUB_SHA" \
-            --workflow-run-id "$GITHUB_RUN_ID" \
-            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT"
-
-      - name: Retain pre-signing failure diagnostics
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pre-signing-package-diagnostics-${{ github.run_attempt }}
-          path: |
-            pre-signing-smoke.log
-            pre-signing-installed-ui-diagnostics
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Retain pre-signing qualification report
-        if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pre-signing-package-${{ github.run_attempt }}
-          path: |
-            pre-signing-smoke.log
-            pre-signing-installed-ui-evidence
-            pre-signing-installed-ui-report.json
-          if-no-files-found: error
-          retention-days: 7
+  pre-signing-package:
+    name: Qualify production package before signing
+    needs:
+      - pre-signing-policy
+    uses: ./.github/workflows/production-preflight-engine.yml
+    with:
+      source_sha: ${{ inputs.release_sha }}
+      support_diagnostics_endpoint: ${{ vars.SUPPORT_DIAGNOSTICS_ENDPOINT }}
+    permissions:
+      contents: read
 
   package:
     name: Build, sign, notarize, and validate DMG

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,20 +51,38 @@ category is explicitly not applicable rather than failed. Metadata
 preparation and review do not authorize dispatch; run-bound signing approval
 remains a separate verified boundary.
 
+Before a successor version or build identity is prepared, dispatch
+`Production Preflight` from protected `main` with the exact full current
+40-character `main` SHA. The release-independent workflow rejects abbreviated,
+non-`main`, mismatched, or stale SHAs before qualifying the package. It has
+read-only repository permission, uses no signing environment or secret, and
+cannot create a tag, release, draft, appcast deployment, or package publication.
+Its seven-day workflow artifact contains only source-bound validation, package
+smoke, installed-UI evidence, and a bounded success manifest; failure artifacts
+contain bounded source/workflow context and diagnostic tails rather than the app
+or preventive DMG. A passing run is readiness evidence for that exact SHA, not
+release authorization or signed-artifact evidence. If `main` moves, rerun the
+preflight before preparing metadata.
+
 Before the `macos-signing` environment can request approval, the reusable
-release engine runs a secret-free macOS pre-signing package gate. That job
-builds the production package with ad-hoc signing, runs the complete maintained
-release-app smoke, creates a production-shaped DMG, and exercises the same
-installed UI accessibility fixture used by the signed-artifact lane. Failure,
-cancellation, or skipped execution prevents the signing job from starting. The
-later Developer ID, notarization, signed-DMG, exact-artifact UI, appcast, and
-post-publication gates remain mandatory; pre-signing qualification moves fixture
-and packaged-runtime feedback earlier without substituting for release evidence.
+release engine invokes the same `.github/workflows/production-preflight-engine.yml`
+implementation again for its exact protected-`main` SHA. The shared job builds
+the production package with ad-hoc signing, runs the complete maintained
+release-app smoke (including exact embedded worker version and protocol
+readiness), creates and installs a production-shaped preventive DMG, and
+exercises the shared installed UI accessibility fixture. Failure, cancellation,
+or skipped execution prevents the signing job from starting. The later
+Developer ID, notarization, signed-DMG, exact-artifact UI, appcast, and
+post-publication gates remain mandatory; production preflight moves fixture and
+packaged-runtime feedback earlier without substituting for release evidence.
 
 ## Release Preparation
 
 Every release version and Sparkle build number is committed through a normal
-pull request before release orchestration runs. Use the repository command:
+pull request before release orchestration runs. First record a successful
+`Production Preflight` run for the exact protected `main` SHA that will be the
+base of the metadata change; do not consume the successor identity when that
+run is absent, failed, or stale. Then use the repository command:
 
 ```sh
 uv run python -m scripts.release prepare \

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -513,7 +513,17 @@ prerelease flag; prerelease-form tags marked Stable are never accepted.
 
 ## Operator Boundaries
 
-Operators receive two manual entry workflows:
+`Production Preflight` is a separate manual, non-authorizing workflow. It accepts
+only an exact full current protected-`main` SHA and runs the production-shaped
+ad-hoc package, exact packaged-worker smoke, preventive DMG installation, and
+shared installed-UI qualification before a successor identity is prepared. It
+has no signing environment, secrets, write permission, route selection, tag,
+draft, appcast, or publication capability. Its bounded seven-day artifacts are
+source-specific readiness diagnostics, not signed release evidence. The guarded
+release engine invokes the same maintained preflight implementation again before
+the signing job can request `macos-signing` approval.
+
+Release operators receive two manual entry workflows:
 
 - **Stable**, which accepts only committed Stable metadata; and
 - **Prerelease**, which accepts committed Alpha, Beta, or RC metadata.

--- a/scripts/production_preflight.py
+++ b/scripts/production_preflight.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY = "cbusillo/BD_to_AVP"
+MAIN_REF = "refs/heads/main"
+MAIN_REMOTE_REF = "refs/remotes/origin/main"
+REQUIRED_EVENT = "workflow_dispatch"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+WORKFLOW_REF_PATTERN = re.compile(rf"^{re.escape(REPOSITORY)}/\.github/workflows/[^@]+@{re.escape(MAIN_REF)}$")
+PACKAGE_VERSION_PREFIX = "Package version metadata passed: "
+PRODUCTION_PREFLIGHT_WORKFLOW_PATH = ".github/workflows/production-preflight.yml"
+PRODUCTION_PREFLIGHT_ENGINE_WORKFLOW_PATH = ".github/workflows/production-preflight-engine.yml"
+STABLE_WORKFLOW_PATH = ".github/workflows/briefcase.yml"
+PRERELEASE_WORKFLOW_PATH = ".github/workflows/prerelease.yml"
+ALLOWED_CALLER_WORKFLOW_PATHS = {
+    PRODUCTION_PREFLIGHT_WORKFLOW_PATH,
+    STABLE_WORKFLOW_PATH,
+    PRERELEASE_WORKFLOW_PATH,
+}
+MAX_REPORT_BYTES = 1024 * 1024
+MAX_EVIDENCE_FILES = 100
+MAX_EVIDENCE_FILE_BYTES = 1024 * 1024
+MAX_EVIDENCE_TOTAL_BYTES = 16 * 1024 * 1024
+
+
+class ProductionPreflightError(RuntimeError):
+    pass
+
+
+def _required(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name, "")
+    if not value:
+        raise ProductionPreflightError(f"Production preflight is missing {name}.")
+    return value
+
+
+def _full_sha(value: str, description: str) -> str:
+    if SHA_PATTERN.fullmatch(value) is None:
+        raise ProductionPreflightError(f"{description} must be a full lowercase Git SHA.")
+    return value
+
+
+def _positive_int(value: str, description: str) -> int:
+    if not value.isdecimal() or int(value) <= 0:
+        raise ProductionPreflightError(f"{description} must be a positive integer.")
+    return int(value)
+
+
+def _caller_workflow_path(workflow_ref: str) -> str:
+    prefix = f"{REPOSITORY}/"
+    suffix = f"@{MAIN_REF}"
+    if WORKFLOW_REF_PATTERN.fullmatch(workflow_ref) is None:
+        raise ProductionPreflightError("Production preflight workflow must be loaded from protected main.")
+    workflow_path = workflow_ref.removeprefix(prefix).removesuffix(suffix)
+    if workflow_path not in ALLOWED_CALLER_WORKFLOW_PATHS:
+        raise ProductionPreflightError(f"Production preflight caller workflow is not approved: {workflow_path}")
+    return workflow_path
+
+
+def _git_output(repo: Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        command = " ".join(arguments)
+        raise ProductionPreflightError(f"Could not inspect production preflight Git state: {command}") from error
+    return result.stdout.strip()
+
+
+def validate_source(
+    source_sha: str,
+    *,
+    repo: Path = REPO_ROOT,
+    environment: Mapping[str, str] = os.environ,
+) -> Mapping[str, object]:
+    source_sha = _full_sha(source_sha, "Production preflight source SHA")
+    repository = _required(environment, "GITHUB_REPOSITORY")
+    if repository != REPOSITORY:
+        raise ProductionPreflightError(f"Production preflight repository {repository!r} does not match {REPOSITORY!r}.")
+    event_name = _required(environment, "GITHUB_EVENT_NAME")
+    if event_name != REQUIRED_EVENT:
+        raise ProductionPreflightError("Production preflight must originate from workflow_dispatch.")
+    ref = _required(environment, "GITHUB_REF")
+    if ref != MAIN_REF:
+        raise ProductionPreflightError("Production preflight must originate from protected main.")
+    github_sha = _full_sha(_required(environment, "GITHUB_SHA"), "GitHub source SHA")
+    if github_sha != source_sha:
+        raise ProductionPreflightError("Production preflight input SHA does not match the dispatched main commit.")
+    workflow_ref = _required(environment, "GITHUB_WORKFLOW_REF")
+    workflow_path = _caller_workflow_path(workflow_ref)
+    workflow_sha = _full_sha(_required(environment, "GITHUB_WORKFLOW_SHA"), "Workflow definition SHA")
+    if workflow_sha != source_sha:
+        raise ProductionPreflightError(
+            "Production preflight workflow definition does not match the requested source SHA."
+        )
+
+    checkout_sha = _full_sha(_git_output(repo, "rev-parse", "HEAD"), "Checked out source SHA")
+    if checkout_sha != source_sha:
+        raise ProductionPreflightError("Production preflight checkout does not match the requested source SHA.")
+    protected_main_sha = _full_sha(
+        _git_output(repo, "rev-parse", MAIN_REMOTE_REF),
+        "Protected main SHA",
+    )
+    if protected_main_sha != source_sha:
+        raise ProductionPreflightError("The requested production preflight SHA is no longer current protected main.")
+
+    return {
+        "checkout_sha": checkout_sha,
+        "event_name": event_name,
+        "protected_main_ref": MAIN_REF,
+        "protected_main_sha": protected_main_sha,
+        "repository": repository,
+        "schema_version": 1,
+        "source_sha": source_sha,
+        "implementation": {
+            "path": PRODUCTION_PREFLIGHT_ENGINE_WORKFLOW_PATH,
+            "sha": source_sha,
+        },
+        "workflow": {
+            "actor": _required(environment, "GITHUB_ACTOR"),
+            "path": workflow_path,
+            "ref": workflow_ref,
+            "run_attempt": _positive_int(
+                _required(environment, "GITHUB_RUN_ATTEMPT"),
+                "Workflow run attempt",
+            ),
+            "run_id": _positive_int(_required(environment, "GITHUB_RUN_ID"), "Workflow run ID"),
+            "sha": workflow_sha,
+            "triggering_actor": _required(environment, "GITHUB_TRIGGERING_ACTOR"),
+        },
+    }
+
+
+def _file_evidence(path: Path, *, maximum_bytes: int = MAX_REPORT_BYTES) -> Mapping[str, object]:
+    if not path.is_file():
+        raise ProductionPreflightError(f"Production preflight evidence file is missing: {path}")
+    size_bytes = path.stat().st_size
+    if size_bytes > maximum_bytes:
+        raise ProductionPreflightError(f"Production preflight evidence exceeds its {maximum_bytes}-byte bound: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as evidence_file:
+        for chunk in iter(lambda: evidence_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "name": path.name,
+        "sha256": digest.hexdigest(),
+        "size_bytes": size_bytes,
+    }
+
+
+def _directory_evidence(path: Path) -> Mapping[str, object]:
+    if not path.is_dir():
+        raise ProductionPreflightError(f"Production preflight evidence directory is missing: {path}")
+    files = sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
+    if not files:
+        raise ProductionPreflightError(f"Production preflight evidence directory is empty: {path}")
+    if len(files) > MAX_EVIDENCE_FILES:
+        raise ProductionPreflightError(
+            f"Production preflight evidence exceeds its {MAX_EVIDENCE_FILES}-file bound: {path}"
+        )
+    entries: list[Mapping[str, object]] = []
+    total_size_bytes = 0
+    for candidate in files:
+        evidence = dict(_file_evidence(candidate, maximum_bytes=MAX_EVIDENCE_FILE_BYTES))
+        evidence["name"] = candidate.relative_to(path).as_posix()
+        total_size_bytes += cast(int, evidence["size_bytes"])
+        entries.append(evidence)
+    if total_size_bytes > MAX_EVIDENCE_TOTAL_BYTES:
+        raise ProductionPreflightError(
+            f"Production preflight evidence exceeds its {MAX_EVIDENCE_TOTAL_BYTES}-byte total bound: {path}"
+        )
+    return {
+        "file_count": len(entries),
+        "files": entries,
+        "name": path.name,
+        "total_size_bytes": total_size_bytes,
+    }
+
+
+def _json_object(path: Path, description: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ProductionPreflightError(f"{description} is not readable JSON: {path}") from error
+    if not isinstance(value, dict):
+        raise ProductionPreflightError(f"{description} must be a JSON object: {path}")
+    return cast(Mapping[str, Any], value)
+
+
+def _package_version(smoke_log: Path) -> str:
+    try:
+        lines = smoke_log.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ProductionPreflightError(f"Production package smoke log is unreadable: {smoke_log}") from error
+    versions = [line.removeprefix(PACKAGE_VERSION_PREFIX) for line in lines if line.startswith(PACKAGE_VERSION_PREFIX)]
+    if len(versions) != 1 or not versions[0]:
+        raise ProductionPreflightError("Production package smoke must report exactly one package version.")
+    return versions[0]
+
+
+def finalize_success(
+    *,
+    source_report: Path,
+    smoke_log: Path,
+    installed_ui_report: Path,
+    installed_ui_evidence: Path,
+) -> Mapping[str, object]:
+    source = _json_object(source_report, "Production preflight source report")
+    installed_ui = _json_object(installed_ui_report, "Installed UI report")
+    source_sha = source.get("source_sha")
+    if not isinstance(source_sha, str) or SHA_PATTERN.fullmatch(source_sha) is None:
+        raise ProductionPreflightError("Production preflight source report has an invalid source SHA.")
+    if installed_ui.get("source_sha") != source_sha:
+        raise ProductionPreflightError("Installed UI report source SHA does not match production preflight source.")
+    source_workflow = source.get("workflow")
+    implementation = source.get("implementation")
+    installed_workflow = installed_ui.get("workflow")
+    if not isinstance(source_workflow, dict) or not isinstance(installed_workflow, dict):
+        raise ProductionPreflightError("Production preflight reports are missing workflow identity.")
+    if implementation != {"path": PRODUCTION_PREFLIGHT_ENGINE_WORKFLOW_PATH, "sha": source_sha}:
+        raise ProductionPreflightError("Production preflight source report has invalid shared implementation identity.")
+    for field in ("run_id", "run_attempt"):
+        if installed_workflow.get(field) != source_workflow.get(field):
+            raise ProductionPreflightError(f"Installed UI report workflow {field} does not match source validation.")
+
+    package_version = _package_version(smoke_log)
+    app_tree_sha256 = installed_ui.get("app_tree_sha256")
+    dmg = installed_ui.get("dmg")
+    if not isinstance(app_tree_sha256, str) or DIGEST_PATTERN.fullmatch(app_tree_sha256) is None:
+        raise ProductionPreflightError("Installed UI report has an invalid app tree digest.")
+    if not isinstance(dmg, dict):
+        raise ProductionPreflightError("Installed UI report is missing preventive DMG evidence.")
+    dmg_name = dmg.get("name")
+    dmg_sha256 = dmg.get("sha256")
+    dmg_size_bytes = dmg.get("size_bytes")
+    if not isinstance(dmg_name, str) or not dmg_name.endswith(".dmg"):
+        raise ProductionPreflightError("Installed UI report has an invalid preventive DMG name.")
+    if not isinstance(dmg_sha256, str) or DIGEST_PATTERN.fullmatch(dmg_sha256) is None:
+        raise ProductionPreflightError("Installed UI report has an invalid preventive DMG digest.")
+    if not isinstance(dmg_size_bytes, int) or isinstance(dmg_size_bytes, bool) or dmg_size_bytes <= 0:
+        raise ProductionPreflightError("Installed UI report has an invalid preventive DMG size.")
+
+    return {
+        "app_tree_sha256": app_tree_sha256,
+        "package_version": package_version,
+        "preventive_dmg": dmg,
+        "schema_version": 1,
+        "source_sha": source_sha,
+        "source_validation": _file_evidence(source_report),
+        "production_package_smoke": _file_evidence(smoke_log),
+        "installed_ui_qualification": _file_evidence(installed_ui_report),
+        "installed_ui_evidence": _directory_evidence(installed_ui_evidence),
+        "implementation": implementation,
+        "workflow": source_workflow,
+    }
+
+
+def _write_json(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(value, temporary, indent=2, sort_keys=True)
+            temporary.write("\n")
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate and bind release-independent production preflight evidence.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-source")
+    validate_parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    validate_parser.add_argument("--source-sha", required=True)
+    validate_parser.add_argument("--output", type=Path, required=True)
+
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--source-report", type=Path, required=True)
+    finalize_parser.add_argument("--smoke-log", type=Path, required=True)
+    finalize_parser.add_argument("--installed-ui-report", type=Path, required=True)
+    finalize_parser.add_argument("--installed-ui-evidence", type=Path, required=True)
+    finalize_parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, *, environment: Mapping[str, str] = os.environ) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate-source":
+            report = validate_source(args.source_sha, repo=args.repo, environment=environment)
+        else:
+            report = finalize_success(
+                source_report=args.source_report,
+                smoke_log=args.smoke_log,
+                installed_ui_report=args.installed_ui_report,
+                installed_ui_evidence=args.installed_ui_evidence,
+            )
+        _write_json(args.output, report)
+    except ProductionPreflightError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_production_preflight.py
+++ b/tests/test_production_preflight.py
@@ -1,0 +1,204 @@
+import json
+import tempfile
+import unittest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.production_preflight import (
+    MAIN_REMOTE_REF,
+    ProductionPreflightError,
+    finalize_success,
+    validate_source,
+)
+
+
+SOURCE_SHA = "1" * 40
+WORKFLOW_REF = "cbusillo/BD_to_AVP/.github/workflows/production-preflight.yml@refs/heads/main"
+
+
+def valid_environment() -> dict[str, str]:
+    return {
+        "GITHUB_ACTOR": "cbusillo",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REPOSITORY": "cbusillo/BD_to_AVP",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_RUN_ID": "123456789",
+        "GITHUB_SHA": SOURCE_SHA,
+        "GITHUB_TRIGGERING_ACTOR": "cbusillo",
+        "GITHUB_WORKFLOW_REF": WORKFLOW_REF,
+        "GITHUB_WORKFLOW_SHA": SOURCE_SHA,
+    }
+
+
+class ProductionPreflightTests(unittest.TestCase):
+    @patch("scripts.production_preflight._git_output")
+    def test_validate_source_binds_exact_current_protected_main(self, git_output) -> None:
+        git_output.side_effect = lambda _repo, *arguments: (
+            SOURCE_SHA if arguments in (("rev-parse", "HEAD"), ("rev-parse", MAIN_REMOTE_REF)) else ""
+        )
+
+        report = validate_source(SOURCE_SHA, environment=valid_environment())
+
+        self.assertEqual(report["source_sha"], SOURCE_SHA)
+        self.assertEqual(report["checkout_sha"], SOURCE_SHA)
+        self.assertEqual(report["protected_main_sha"], SOURCE_SHA)
+        self.assertEqual(
+            report["implementation"],
+            {"path": ".github/workflows/production-preflight-engine.yml", "sha": SOURCE_SHA},
+        )
+        self.assertEqual(report["workflow"]["ref"], WORKFLOW_REF)
+        self.assertEqual(report["workflow"]["path"], ".github/workflows/production-preflight.yml")
+        self.assertEqual(report["workflow"]["run_id"], 123456789)
+        self.assertEqual(report["workflow"]["run_attempt"], 2)
+
+    @patch("scripts.production_preflight._git_output")
+    def test_validate_source_accepts_guarded_prerelease_caller(self, git_output) -> None:
+        git_output.return_value = SOURCE_SHA
+        environment = valid_environment()
+        environment["GITHUB_WORKFLOW_REF"] = "cbusillo/BD_to_AVP/.github/workflows/prerelease.yml@refs/heads/main"
+
+        report = validate_source(SOURCE_SHA, environment=environment)
+
+        self.assertEqual(report["workflow"]["path"], ".github/workflows/prerelease.yml")
+
+    def test_validate_source_rejects_abbreviated_sha(self) -> None:
+        with self.assertRaisesRegex(ProductionPreflightError, "full lowercase Git SHA"):
+            validate_source(SOURCE_SHA[:12], environment=valid_environment())
+
+    def test_validate_source_rejects_non_main_ref(self) -> None:
+        environment = valid_environment()
+        environment["GITHUB_REF"] = "refs/heads/task"
+
+        with self.assertRaisesRegex(ProductionPreflightError, "protected main"):
+            validate_source(SOURCE_SHA, environment=environment)
+
+    def test_validate_source_rejects_unapproved_main_workflow(self) -> None:
+        environment = valid_environment()
+        environment["GITHUB_WORKFLOW_REF"] = "cbusillo/BD_to_AVP/.github/workflows/unapproved.yml@refs/heads/main"
+
+        with self.assertRaisesRegex(ProductionPreflightError, "caller workflow is not approved"):
+            validate_source(SOURCE_SHA, environment=environment)
+
+    @patch("scripts.production_preflight._git_output")
+    def test_validate_source_rejects_stale_main_sha(self, git_output) -> None:
+        git_output.side_effect = [SOURCE_SHA, "2" * 40]
+
+        with self.assertRaisesRegex(ProductionPreflightError, "no longer current protected main"):
+            validate_source(SOURCE_SHA, environment=valid_environment())
+
+    @patch("scripts.production_preflight._git_output")
+    def test_validate_source_rejects_mismatched_dispatch_sha(self, git_output) -> None:
+        environment = valid_environment()
+        environment["GITHUB_SHA"] = "2" * 40
+
+        with self.assertRaisesRegex(ProductionPreflightError, "input SHA does not match"):
+            validate_source(SOURCE_SHA, environment=environment)
+
+        git_output.assert_not_called()
+
+    @patch("scripts.production_preflight._git_output")
+    def test_validate_source_rejects_workflow_definition_from_another_commit(self, git_output) -> None:
+        environment = valid_environment()
+        environment["GITHUB_WORKFLOW_SHA"] = "2" * 40
+
+        with self.assertRaisesRegex(ProductionPreflightError, "workflow definition does not match"):
+            validate_source(SOURCE_SHA, environment=environment)
+
+        git_output.assert_not_called()
+
+    def test_finalize_success_binds_smoke_and_installed_ui_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_report = root / "source.json"
+            smoke_log = root / "smoke.log"
+            installed_ui_report = root / "installed-ui.json"
+            installed_ui_evidence = root / "evidence"
+            installed_ui_evidence.mkdir()
+            (installed_ui_evidence / "candidate-ui.json").write_text('{"passed": true}\n', encoding="utf-8")
+            source_report.write_text(
+                json.dumps(
+                    {
+                        "source_sha": SOURCE_SHA,
+                        "implementation": {
+                            "path": ".github/workflows/production-preflight-engine.yml",
+                            "sha": SOURCE_SHA,
+                        },
+                        "workflow": {"run_id": 123456789, "run_attempt": 2, "ref": WORKFLOW_REF},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            smoke_log.write_text(
+                "Package version metadata passed: 0.3.2b5\nRelease app smoke passed\n", encoding="utf-8"
+            )
+            installed_ui_report.write_text(
+                json.dumps(
+                    {
+                        "app_tree_sha256": "a" * 64,
+                        "dmg": {"name": "preventive.dmg", "sha256": "b" * 64, "size_bytes": 42},
+                        "source_sha": SOURCE_SHA,
+                        "workflow": {"run_id": 123456789, "run_attempt": 2},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = finalize_success(
+                source_report=source_report,
+                smoke_log=smoke_log,
+                installed_ui_report=installed_ui_report,
+                installed_ui_evidence=installed_ui_evidence,
+            )
+
+        self.assertEqual(report["source_sha"], SOURCE_SHA)
+        self.assertEqual(report["implementation"]["sha"], SOURCE_SHA)
+        self.assertEqual(report["package_version"], "0.3.2b5")
+        self.assertEqual(report["app_tree_sha256"], "a" * 64)
+        self.assertEqual(report["preventive_dmg"]["sha256"], "b" * 64)
+        self.assertEqual(report["production_package_smoke"]["size_bytes"], 66)
+        self.assertEqual(report["installed_ui_evidence"]["file_count"], 1)
+
+    def test_finalize_success_rejects_source_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_report = root / "source.json"
+            smoke_log = root / "smoke.log"
+            installed_ui_report = root / "installed-ui.json"
+            installed_ui_evidence = root / "evidence"
+            installed_ui_evidence.mkdir()
+            (installed_ui_evidence / "candidate-ui.json").write_text("{}\n", encoding="utf-8")
+            source_report.write_text(
+                json.dumps(
+                    {
+                        "source_sha": SOURCE_SHA,
+                        "implementation": {
+                            "path": ".github/workflows/production-preflight-engine.yml",
+                            "sha": SOURCE_SHA,
+                        },
+                        "workflow": {"run_id": 1, "run_attempt": 1},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            smoke_log.write_text("Package version metadata passed: 1.2.3\n", encoding="utf-8")
+            installed_ui_report.write_text(
+                json.dumps(
+                    {
+                        "app_tree_sha256": "a" * 64,
+                        "dmg": {},
+                        "source_sha": "2" * 40,
+                        "workflow": {"run_id": 1, "run_attempt": 1},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ProductionPreflightError, "source SHA does not match"):
+                finalize_success(
+                    source_report=source_report,
+                    smoke_log=smoke_log,
+                    installed_ui_report=installed_ui_report,
+                    installed_ui_evidence=installed_ui_evidence,
+                )

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -167,6 +167,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("contents: write", shared_text + manual_text)
         self.assertNotIn("id-token: write", shared_text + manual_text)
         self.assertNotIn("attestations: write", shared_text + manual_text)
+        checkout = next(step for step in shared_job["steps"] if step.get("id") == "checkout")
+        self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+        self.assertNotEqual(checkout["with"]["ref"], "${{ inputs.source_sha }}")
 
         self.assertEqual(release_job["uses"], manual_job["uses"])
         self.assertEqual(release_job["with"]["source_sha"], "${{ inputs.release_sha }}")

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -58,6 +58,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_sparkle_bundle_uses_importable_module_entrypoint(self) -> None:
         workflow = load_release_engine()
         workflow_text = str(workflow)
+        production_preflight_text = str(load_workflow("production-preflight-engine.yml"))
         ci_text = str(load_workflow("ci.yml"))
         smoke_text = (REPO_ROOT / "docs" / "release-smoke.md").read_text(encoding="utf-8")
 
@@ -66,7 +67,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("python scripts/sparkle_bundle.py", smoke_text)
         self.assertNotIn("python scripts/briefcase_app.py", workflow_text + ci_text)
         self.assertNotIn("python -m scripts.briefcase_app", workflow_text + ci_text)
-        self.assertIn("python scripts/native_app.py package", workflow_text)
+        self.assertIn("python scripts/native_app.py package", production_preflight_text)
         self.assertIn("python scripts/native_app.py package", ci_text)
         self.assertIn("python -m scripts.macos_release", workflow_text)
 
@@ -85,7 +86,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
             "Prerelease": load_workflow("prerelease.yml"),
         }
         workflow = load_release_engine()
+        production_preflight = load_workflow("production-preflight-engine.yml")
         prepare = workflow["jobs"]["prepare"]
+        pre_signing_policy = workflow["jobs"]["pre-signing-policy"]
         pre_signing = workflow["jobs"]["pre-signing-package"]
         package = workflow["jobs"]["package"]
 
@@ -112,8 +115,11 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertEqual(checkout["with"]["persist-credentials"], "false")
         self.assertIn("refs/heads/main", str(prepare))
         self.assertIn("refs/remotes/origin/main", str(prepare))
-        self.assertIn("refs/remotes/origin/main", str(pre_signing))
-        self.assertIn("Protected main moved before pre-signing qualification", str(pre_signing))
+        self.assertIn("--expected-fingerprint", str(pre_signing_policy))
+        self.assertEqual(pre_signing["uses"], "./.github/workflows/production-preflight-engine.yml")
+        self.assertEqual(pre_signing["with"]["source_sha"], "${{ inputs.release_sha }}")
+        self.assertIn("refs/remotes/origin/main", str(production_preflight))
+        self.assertIn("scripts.production_preflight validate-source", str(production_preflight))
         self.assertIn("pre-signing-package", package["needs"])
         self.assertIn("refs/remotes/origin/main", str(package))
         self.assertIn("moved after signing approval", str(package))
@@ -124,6 +130,102 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("refs/tags/$RELEASE_TAG^{}", str(prepare))
         self.assertIn("jq -r .name", str(prepare))
         self.assertNotIn("refs/heads/release", str(workflow))
+
+    def test_release_independent_production_preflight_is_secret_free_and_non_publishing(self) -> None:
+        manual = load_workflow("production-preflight.yml")
+        shared = load_workflow("production-preflight-engine.yml")
+        release_engine = load_release_engine()
+        manual_job = manual["jobs"]["preflight"]
+        shared_call = shared["on"]["workflow_call"]
+        shared_job = shared["jobs"]["preflight"]
+        release_job = release_engine["jobs"]["pre-signing-package"]
+        shared_text = (REPO_ROOT / ".github/workflows/production-preflight-engine.yml").read_text(encoding="utf-8")
+        manual_text = (REPO_ROOT / ".github/workflows/production-preflight.yml").read_text(encoding="utf-8")
+
+        self.assertEqual(manual["name"], "Production Preflight")
+        self.assertEqual(set(manual["on"]), {"workflow_dispatch"})
+        source_input = manual["on"]["workflow_dispatch"]["inputs"]["source_sha"]
+        self.assertEqual(source_input["required"], "true")
+        self.assertEqual(source_input["type"], "string")
+        self.assertEqual(manual["permissions"], {})
+        self.assertEqual(manual_job["uses"], "./.github/workflows/production-preflight-engine.yml")
+        self.assertEqual(manual_job["with"]["source_sha"], "${{ inputs.source_sha }}")
+        self.assertEqual(manual_job["permissions"], {"contents": "read"})
+        self.assertNotIn("environment", manual_job)
+        self.assertNotIn("secrets", manual_job)
+
+        self.assertEqual(set(shared["on"]), {"workflow_call"})
+        self.assertEqual(set(shared_call["inputs"]), {"source_sha", "support_diagnostics_endpoint"})
+        self.assertNotIn("secrets", shared_call)
+        self.assertEqual(shared["permissions"], {"contents": "read"})
+        self.assertEqual(shared_job["permissions"], {"contents": "read"})
+        self.assertEqual(shared_job["runs-on"], "macos-26")
+        self.assertNotIn("environment", shared_job)
+        self.assertNotIn("secrets", shared_job)
+        self.assertNotIn("${{ secrets.", shared_text + manual_text)
+        self.assertNotIn("GH_TOKEN", shared_text)
+        self.assertNotIn("contents: write", shared_text + manual_text)
+        self.assertNotIn("id-token: write", shared_text + manual_text)
+        self.assertNotIn("attestations: write", shared_text + manual_text)
+
+        self.assertEqual(release_job["uses"], manual_job["uses"])
+        self.assertEqual(release_job["with"]["source_sha"], "${{ inputs.release_sha }}")
+        self.assertEqual(release_job["permissions"], {"contents": "read"})
+        self.assertEqual(set(release_job["needs"]), {"pre-signing-policy"})
+        self.assertNotIn("environment", release_job)
+        self.assertNotIn("secrets", release_job)
+
+        forbidden_side_effects = (
+            "gh release",
+            "git tag",
+            "repos/$github_repository/releases",
+            "appcast.xml",
+            "sparkle-pages",
+            "notarytool",
+            "twine upload",
+            "pypi publish",
+        )
+        for forbidden in forbidden_side_effects:
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, shared_text.lower())
+
+        step_names = [step["name"] for step in shared_job["steps"]]
+        required_order = [
+            "Require an exact protected main input",
+            "Checkout requested main commit",
+            "Bind source and workflow identity",
+            "Verify pinned production runner",
+            "Install pinned XcodeGen",
+            "Set up uv",
+            "Install Python and locked dependencies",
+            "Build the production-shaped app with ad-hoc signing",
+            "Smoke exact packaged worker identity and protocol",
+            "Create, install, and qualify the preventive DMG",
+            "Bind bounded success evidence",
+        ]
+        self.assertEqual([name for name in step_names if name in required_order], required_order)
+        self.assertIn("^[0-9a-f]{40}$", shared_text)
+        self.assertIn("refs/heads/main", shared_text)
+        self.assertIn("refs/remotes/origin/main", shared_text)
+        self.assertIn("scripts.production_preflight validate-source", shared_text)
+        self.assertIn("scripts/native_app.py package --sign-identity -", shared_text)
+        self.assertIn("scripts/smoke_release_app.py", shared_text)
+        self.assertIn("--skip-spctl", shared_text)
+        self.assertIn("scripts.pre_signing_ui", shared_text)
+        self.assertIn("scripts.production_preflight finalize", shared_text)
+        self.assertIn("tail -c 262144", shared_text)
+
+        success_upload = next(step for step in shared_job["steps"] if step["name"] == "Retain bounded success evidence")
+        failure_upload = next(
+            step for step in shared_job["steps"] if step["name"] == "Retain bounded failure diagnostics"
+        )
+        self.assertEqual(success_upload["with"]["retention-days"], "7")
+        self.assertEqual(failure_upload["with"]["retention-days"], "7")
+        self.assertNotIn(".dmg", success_upload["with"]["path"])
+        self.assertNotIn(".app", success_upload["with"]["path"])
+        self.assertIn("${{ inputs.source_sha }}", success_upload["with"]["name"])
+        self.assertIn("${{ github.run_id }}", success_upload["with"]["name"])
+        self.assertIn("${{ github.run_id }}", failure_upload["with"]["name"])
 
     def test_reusable_engine_rejects_direct_invocation_and_policy_bypass(self) -> None:
         stable = load_workflow("briefcase.yml")
@@ -814,8 +916,10 @@ printf '%s' "$CODESIGN_METADATA"
 
     def test_qualification_gates_block_signing_and_publication(self) -> None:
         workflow = load_release_engine()
+        production_preflight = load_workflow("production-preflight-engine.yml")
         jobs = workflow["jobs"]
         qualify_prep = jobs["qualify-preparation"]
+        pre_signing_policy = jobs["pre-signing-policy"]
         pre_signing = jobs["pre-signing-package"]
         package = jobs["package"]
         verify_draft = jobs["verify-draft"]
@@ -834,35 +938,41 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("pre-signing-package", set(jobs["package"]["needs"]))
         self.assertIn("qualify-preparation", set(jobs["build-python"]["needs"]))
         self.assertEqual(set(qualify_prep["needs"]), {"prepare"})
-        self.assertEqual(set(pre_signing["needs"]), {"policy", "prepare", "qualify-preparation"})
+        self.assertEqual(set(pre_signing_policy["needs"]), {"policy", "prepare", "qualify-preparation"})
+        self.assertEqual(set(pre_signing["needs"]), {"pre-signing-policy"})
         self.assertIn("qualify-artifact", set(jobs["publish-release"]["needs"]))
         self.assertIn("signed-artifact-ui", set(jobs["publish-release"]["needs"]))
         self.assertIn("signed-artifact-ui", set(qualify_artifact["needs"]))
         self.assertIn("needs.signed-artifact-ui.result == 'success'", jobs["publish-release"]["if"])
         self.assertIn("needs.qualify-artifact.result == 'success'", jobs["publish-release"]["if"])
         self.assertNotIn("environment", qualify_prep)
+        self.assertNotIn("environment", pre_signing_policy)
         self.assertNotIn("environment", pre_signing)
         self.assertNotIn("environment", signed_ui)
         self.assertNotIn("environment", qualify_artifact)
         self.assertNotIn("secrets.", str(qualify_prep))
+        self.assertNotIn("secrets.", str(pre_signing_policy))
         self.assertNotIn("secrets.", str(pre_signing))
         self.assertNotIn("secrets.", str(signed_ui))
         self.assertNotIn("secrets.", str(qualify_artifact))
         self.assertEqual(qualify_prep["permissions"], {"contents": "read"})
+        self.assertEqual(pre_signing_policy["permissions"], {"contents": "read"})
         self.assertEqual(pre_signing["permissions"], {"contents": "read"})
         self.assertEqual(signed_ui["permissions"], {"contents": "read"})
         self.assertEqual(qualify_artifact["permissions"], {"contents": "read"})
         self.assertIn("steps.release_package.outputs.artifact-id", package["outputs"]["workflow_artifact_id"])
         self.assertIn("steps.receipt_artifact.outputs.artifact-id", build_receipt["outputs"]["receipt_artifact_id"])
         self.assertIn("qualify_release_scope", str(qualify_prep))
-        self.assertEqual(pre_signing["runs-on"], "macos-26")
-        self.assertIn("scripts/native_app.py package --sign-identity -", str(pre_signing))
-        self.assertIn("scripts/smoke_release_app.py", str(pre_signing))
-        self.assertIn("--skip-spctl", str(pre_signing))
-        self.assertIn("scripts.pre_signing_ui", str(pre_signing))
-        self.assertNotIn("notarytool", str(pre_signing))
-        self.assertNotIn("CERTIFICATE", str(pre_signing))
-        self.assertNotIn("APPLE_ID", str(pre_signing))
+        self.assertIn("--expected-fingerprint", str(pre_signing_policy))
+        self.assertEqual(pre_signing["uses"], "./.github/workflows/production-preflight-engine.yml")
+        self.assertEqual(production_preflight["jobs"]["preflight"]["runs-on"], "macos-26")
+        self.assertIn("scripts/native_app.py package --sign-identity -", str(production_preflight))
+        self.assertIn("scripts/smoke_release_app.py", str(production_preflight))
+        self.assertIn("--skip-spctl", str(production_preflight))
+        self.assertIn("scripts.pre_signing_ui", str(production_preflight))
+        self.assertNotIn("notarytool", str(production_preflight))
+        self.assertNotIn("CERTIFICATE", str(production_preflight))
+        self.assertNotIn("APPLE_ID", str(production_preflight))
         self.assertIn("signed_artifact_ui", str(signed_ui))
         self.assertIn("signed-artifact-ui-receipt.json", str(signed_ui))
         self.assertNotIn("GH_TOKEN", str(signed_ui))


### PR DESCRIPTION
## Summary
- add a manual, secret-free `Production Preflight` for an exact full current protected `main` SHA
- share one reusable production package, worker smoke, preventive DMG install, and installed-UI implementation with the guarded release engine
- bind bounded success evidence and failure diagnostics to source/workflow identity, with policy tests excluding signing, release, tag, draft, appcast, and publication authority
- document the required pre-identity workflow and register it in repository metadata

## Validation
- focused production-preflight/workflow/package/UI tests: passed
- Python suite: 1,854 passed, 5 skipped with broken local Homebrew ffmpeg excluded; the unisolated run reproduced the known Homebrew dylib mismatch only
- native suite: 484 passed
- real production package → exact worker smoke → preventive DMG → install → installed-UI → bounded final manifest: passed
- `uv build`, release metadata validation, qualification-policy validation, observability migration, import/CLI smoke: passed
- Ruff format/lint, mypy (43 source files), actionlint: passed
- JetBrains inspection: attempted; inconclusive because the helper-owned IntelliJ lifecycle mutated tracked IDE metadata and returned no execution proof. The generated IDE files were excluded from this commit.

No Beta 7 preparation, build 169 reservation, release dispatch, signing approval, tag/release/draft mutation, appcast change, or publication operation occurred.

Refs #633
Refs #631