### PR TITLE
Record Beta 5 failed qualification disposition

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -144,6 +144,7 @@
       "releaseQualificationArtifact": "uv run python -m unittest tests.test_release_qualification_artifact",
       "releaseQualificationApply": "uv run python -m unittest tests.test_release_qualification_apply",
       "cancelledReleaseAttempt": "uv run python -m scripts.release_milestone_context --cancelled-attempt-tag v0.3.2-beta.6",
+      "failedPostPublicationQualification": "uv run python -m scripts.release_milestone_context --failed-post-publication-tag v0.3.2-beta.5",
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",

--- a/docs/0.3.2-beta.5-cut-packet.md
+++ b/docs/0.3.2-beta.5-cut-packet.md
@@ -3,8 +3,8 @@
 > **Published and immutable; exact-artifact qualification blocked.**
 > Beta 5 must not be rebuilt, retagged, unpublished, replaced, or modified.
 > Corrective Beta 6 build `168` became a cancelled unpublished signed attempt
-> and is permanently burned. Issue #609 owns a newer successor after separately
-> authorized Beta 6 draft disposition.
+> and is permanently burned. Its abandoned draft was deleted under separately
+> recorded authorization. Issue #609 owns any newer successor preparation.
 
 Beta `0.3.2b5` is the published recovery successor to failed unpublished Beta
 `0.3.2b4`. Issue #609 owns preparation, qualification, publication, and
@@ -106,14 +106,21 @@ unpublished Beta 3 and Beta 4 are not release-note bases or appcast items.
   worker reported `0.0.0` instead of `0.3.2b5`. Runtime launch and conversion
   remained functional, but exact-artifact evidence reconciliation correctly
   stopped.
+- The terminal failed-post-publication record is
+  [`failed-post-publication-qualification-v1.json`](release-evidence/v0.3.2-beta.5/failed-post-publication-qualification-v1.json).
+  It binds release `374445536`, all four asset identities, the checked receipt,
+  publication run `32488665999`, failed qualification run `32491156253` and job
+  `96798878506`, the exact `worker_version` mismatch, PR #623, actors, and
+  timestamps without claiming qualification success.
 
 ## Qualification And Authorization
 
 Immutable Beta `v0.3.2-beta.2` was Beta 5's prior published artifact,
 release-note base, and Sparkle update-route input. Beta 5 is now the prior
 published update source for Beta 6. PR #622 remains open and blocked as the
-accurate Beta 5 evidence record; it must not be merged by weakening or bypassing
-the failed milestone gate.
+superseded success-shaped evidence route; after the immutable failure
+disposition merges, close it without merging and retain a durable explanation.
+The failed milestone gate must not be weakened or bypassed.
 
 Beta 5's immutable publication receipt is carried into Beta 6 preparation only
 to bind the real prior artifact. It does not claim Beta 5 milestone completion.

--- a/docs/release-evidence/v0.3.2-beta.5/failed-post-publication-qualification-v1.json
+++ b/docs/release-evidence/v0.3.2-beta.5/failed-post-publication-qualification-v1.json
@@ -1,0 +1,108 @@
+{
+  "assets": [
+    {
+      "asset_id": 523818423,
+      "kind": "appcast",
+      "name": "appcast.xml",
+      "sha256": "aace6fba81fafd168e6b223fb75d6d670024f02d6da27bea306450a4404e8b68",
+      "size_bytes": 83171
+    },
+    {
+      "asset_id": 523816825,
+      "kind": "checksum",
+      "name": "SHA256SUMS",
+      "sha256": "04dbd1edddcb43dbaab1d95daa43a9ea317f72f4a7f128cd30ae150f11438ff1",
+      "size_bytes": 108
+    },
+    {
+      "asset_id": 523816722,
+      "kind": "dmg",
+      "name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.5.dmg",
+      "sha256": "a1959ce18a4b15a5cbf438759ab35d86dfe8e02f301324f8cdff90fd91d7c1c8",
+      "size_bytes": 166966129
+    },
+    {
+      "asset_id": 523819236,
+      "kind": "receipt",
+      "name": "release-receipt.json",
+      "sha256": "81e1568ff93c0fad946dff59c5d4e00c97008162db93218cc4f58dcd2ad8af6c",
+      "size_bytes": 2297
+    }
+  ],
+  "disposition_sha256": "a139a72172c9f40f655e4ccbc3416e400317058f26486881e3e0043963eb87b6",
+  "disposition_type": "failed_post_publication_qualification",
+  "failed_qualification": {
+    "actor": "cbusillo",
+    "build_version": "167",
+    "completed_at": "2026-08-21T14:17:05Z",
+    "conclusion": "failure",
+    "expected": "0.3.2b5",
+    "failed_job": "Collect exact post-publication qualification receipts",
+    "failed_job_completed_at": "2026-08-21T14:17:05Z",
+    "failed_job_id": 96798878506,
+    "failed_job_started_at": "2026-08-21T14:15:32Z",
+    "failed_step": "Run exact clean-machine qualification",
+    "failed_step_completed_at": "2026-08-21T14:16:55Z",
+    "failed_step_number": 10,
+    "failed_step_started_at": "2026-08-21T14:16:20Z",
+    "failure_code": "packaged_worker_version_mismatch",
+    "failure_subject": "worker_version",
+    "manifest_sha256": "ab55cf416035c8809bd48d005289b0fc47e514e471709bfa5b1acaba0afcfe2d",
+    "observed": "0.0.0",
+    "release_tag": "v0.3.2-beta.5",
+    "run_attempt": 1,
+    "run_id": 32491156253,
+    "source_sha": "f6ce414db07030e2ad2c081a9d4287639a113446",
+    "started_at": "2026-08-21T14:15:27Z",
+    "workflow_name": "Milestone v0.3.2-beta.5 ab55cf416035c8809bd48d005289b0fc47e514e471709bfa5b1acaba0afcfe2d",
+    "workflow_path": ".github/workflows/milestone-qualification.yml"
+  },
+  "preservation": {
+    "asset_replacement_prohibited": true,
+    "qualification_passed": false,
+    "rebuild_same_identity_prohibited": true,
+    "release_must_remain_published": true,
+    "release_mutation_prohibited": true,
+    "retag_prohibited": true
+  },
+  "receipt": {
+    "file_sha256": "81e1568ff93c0fad946dff59c5d4e00c97008162db93218cc4f58dcd2ad8af6c",
+    "path": "docs/release-evidence/v0.3.2-beta.5/release-receipt.json",
+    "payload_sha256": "9ab74f3ef369ed64de0f5e25297f025c88aeeeb811bb4c73525e3a25f5db1b89"
+  },
+  "recorded_at": "2026-08-23T02:50:43Z",
+  "recorded_by": "cbusillo",
+  "release": {
+    "build_version": "167",
+    "immutable": true,
+    "package_version": "0.3.2b5",
+    "prerelease": true,
+    "public_version": "0.3.2-beta.5",
+    "published_at": "2026-08-21T14:10:21Z",
+    "release_id": 374445536,
+    "release_tag": "v0.3.2-beta.5",
+    "source_sha": "f6ce414db07030e2ad2c081a9d4287639a113446"
+  },
+  "release_workflow": {
+    "actor": "shiny-code-bot",
+    "completed_at": "2026-08-21T14:11:03Z",
+    "conclusion": "success",
+    "engine_path": ".github/workflows/release-engine.yml",
+    "name": "Prerelease",
+    "path": ".github/workflows/prerelease.yml",
+    "run_attempt": 1,
+    "run_id": 32488665999,
+    "started_at": "2026-08-21T13:47:16Z"
+  },
+  "remediation": {
+    "author": "shiny-code-bot",
+    "merge_commit_sha": "b83f9b7864db11f3f585bf3017e31eeb844932ef",
+    "merged_at": "2026-08-21T14:47:11Z",
+    "merged_by": "cbusillo",
+    "pull_request_number": 623,
+    "released_artifact_unchanged": true,
+    "successor_only": true
+  },
+  "schema_version": 1,
+  "status": "recorded_failed_post_publication_qualification"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,13 +33,15 @@ as recorded in [the 0.3.2 Beta 4 cut packet](0.3.2-beta.4-cut-packet.md). Beta
 `0.3.2b5` build `167` is published and immutable, but its post-publication
 exact-artifact qualification is blocked because the packaged worker reported
 `0.0.0` instead of `0.3.2b5`; the publication and qualification boundary are
-tracked in [the 0.3.2 Beta 5 cut packet](0.3.2-beta.5-cut-packet.md). The next
-corrective identity, Beta `0.3.2b6` build `168`, became a cancelled unpublished
-signed attempt after draft creation and is permanently burned, as recorded in
+tracked in [the 0.3.2 Beta 5 cut packet](0.3.2-beta.5-cut-packet.md) and its
+immutable failed-post-publication disposition. The next corrective identity,
+Beta `0.3.2b6` build `168`, became a cancelled unpublished signed attempt after
+draft creation and is permanently burned, as recorded in
 [the 0.3.2 Beta 6 cut packet](0.3.2-beta.6-cut-packet.md) and
-`docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`. Its draft
-remains present pending separate explicit deletion authorization. Issue #609
-owns that disposition and preparation of a newer successor identity.
+`docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`. Its abandoned
+draft was deleted only after explicit authorization, with the immutable
+disposition at `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json`.
+Issue #609 owns any separately authorized newer successor preparation.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -105,6 +105,28 @@ receipt makes the real prior artifact available to `qualification-base` and the
 next exact-artifact route; it does not convert a failed milestone result into
 accepted evidence.
 
+When exact post-publication qualification fails after a release is already
+immutable, record the terminal result in
+`docs/release-evidence/<tag>/failed-post-publication-qualification-v1.json`.
+The canonical, self-digested record binds the checked receipt and every release
+asset, the successful publication workflow, the exact failed qualification
+run/job/step and observation, successor-only remediation, actors, timestamps,
+and the prohibition on rebuilding, retagging, replacing, unpublishing, or
+claiming qualification success. Validate a tracked record directly with:
+
+```sh
+uv run python -m scripts.release_milestone_context \
+  --failed-post-publication-tag <published-tag>
+```
+
+This disposition preserves failed qualification truth. It is not an accepted
+qualification receipt, does not make the failed evidence PR mergeable, and does
+not authorize successor preparation or release operations.
+Workflow and publication timestamps are revalidated from GitHub before record
+creation, then locked by the exact run/release identifiers, canonical file, and
+disposition self-digest; the release receipt itself does not carry those
+timestamps.
+
 Carry-forward is allowed only when an accepted named receipt exists and the
 diff from that receipt's source SHA contains no path covered by the case's
 direct invalidation patterns or referenced contracts. Stable continues to

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -42,6 +42,9 @@ RELEASE_EVIDENCE_RECEIPT_NAME = "release-receipt.json"
 CANCELLED_ATTEMPT_RECORD_NAME = "cancelled-attempt-v1.json"
 DRAFT_DELETION_RECORD_NAME = "draft-deletion-v1.json"
 FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_NAME = "failed-post-publication-qualification-v1.json"
+FAILED_POST_PUBLICATION_PATH_PATTERN = re.compile(
+    rf"^docs/release-evidence/(v[^/]+)/{re.escape(FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_NAME)}$"
+)
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
@@ -1777,6 +1780,53 @@ def discover_milestone_receipt(
     receipt_matches = [
         (path, match.group(1)) for path in changed_paths if (match := RECEIPT_PATH_PATTERN.fullmatch(path)) is not None
     ]
+    disposition_matches = [
+        (path, match.group(1))
+        for path in changed_paths
+        if (match := FAILED_POST_PUBLICATION_PATH_PATTERN.fullmatch(path)) is not None
+    ]
+    if disposition_matches:
+        if len(disposition_matches) != 1:
+            raise ReleaseMilestoneContextError(
+                "A failed post-publication disposition pull request must add exactly one disposition record."
+            )
+        disposition_relative, disposition_tag = disposition_matches[0]
+        release_evidence_changes = sorted(path for path in changed_paths if path.startswith("docs/release-evidence/"))
+        if release_evidence_changes != [disposition_relative]:
+            raise ReleaseMilestoneContextError(
+                "A failed post-publication disposition pull request may change only its new disposition record "
+                "under docs/release-evidence/."
+            )
+        disposition_in_base = subprocess.run(
+            ["git", "cat-file", "-e", f"{base_sha}:{disposition_relative}"],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+        if disposition_in_base.returncode == 0:
+            raise ReleaseMilestoneContextError(
+                "A failed post-publication qualification disposition must be new and immutable."
+            )
+        receipt_relative = (RELEASE_EVIDENCE_ROOT / disposition_tag / RELEASE_EVIDENCE_RECEIPT_NAME).as_posix()
+        receipt_in_base = subprocess.run(
+            ["git", "cat-file", "-e", f"{base_sha}:{receipt_relative}"],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+        receipt_changed = subprocess.run(
+            ["git", "diff", "--quiet", f"{base_sha}...{head_sha}", "--", receipt_relative],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+        if receipt_in_base.returncode != 0 or receipt_changed.returncode != 0:
+            raise ReleaseMilestoneContextError(
+                "A failed post-publication qualification disposition must bind an unchanged checked receipt "
+                "from protected main."
+            )
+        validate_failed_post_publication_qualification_record(repo_root, disposition_tag)
+        return None
     config = _load_json(repo_root / GITHUB_CONFIG_PATH, "GitHub repository config")
     operations = _mapping(config.get("releaseOperations"), "releaseOperations")
     _policy_path, policy_relative = _repository_path(

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -35,10 +35,13 @@ RECEIPT_PATH_PATTERN = re.compile(r"^docs/release-evidence/(v[^/]+)/release-rece
 MANIFEST_PATH_PATTERN = re.compile(rf"^docs/release-evidence/(v[^/]+)/{re.escape(MANIFEST_NAME)}$")
 CHANGE_SCOPED_EVIDENCE_PATH_PATTERN = re.compile(r"^docs/qualification/(v[^/]+)-change-scoped-evidence-v1\.json$")
 FAILED_ATTEMPT_ROOT = Path("docs/release-attempts")
+RELEASE_EVIDENCE_ROOT = Path("docs/release-evidence")
 FAILED_ATTEMPT_RECORD_NAME = "failed-attempt-v1.json"
 FAILED_ATTEMPT_RECEIPT_NAME = "release-receipt.json"
+RELEASE_EVIDENCE_RECEIPT_NAME = "release-receipt.json"
 CANCELLED_ATTEMPT_RECORD_NAME = "cancelled-attempt-v1.json"
 DRAFT_DELETION_RECORD_NAME = "draft-deletion-v1.json"
+FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_NAME = "failed-post-publication-qualification-v1.json"
 RECOVERY_AUTHORIZATION_PATHS = frozenset({"docs/release-evidence/v0.3.0-pypi-recovery.json"})
 EXPECTED_REPOSITORY = "cbusillo/BD_to_AVP"
 EXPECTED_BASE_BRANCH = "main"
@@ -141,6 +144,101 @@ DRAFT_DELETION_RECORD_KEYS = frozenset(
         "verified_absent_at",
     }
 )
+FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_KEYS = frozenset(
+    {
+        "assets",
+        "disposition_sha256",
+        "disposition_type",
+        "failed_qualification",
+        "preservation",
+        "receipt",
+        "recorded_at",
+        "recorded_by",
+        "release",
+        "release_workflow",
+        "remediation",
+        "schema_version",
+        "status",
+    }
+)
+FAILED_POST_PUBLICATION_RELEASE_KEYS = frozenset(
+    {
+        "build_version",
+        "immutable",
+        "package_version",
+        "prerelease",
+        "public_version",
+        "published_at",
+        "release_id",
+        "release_tag",
+        "source_sha",
+    }
+)
+FAILED_POST_PUBLICATION_RECEIPT_KEYS = frozenset({"file_sha256", "path", "payload_sha256"})
+FAILED_POST_PUBLICATION_ASSET_KEYS = frozenset({"asset_id", "kind", "name", "sha256", "size_bytes"})
+FAILED_POST_PUBLICATION_ASSET_KINDS = frozenset({"appcast", "checksum", "dmg", "receipt"})
+FAILED_POST_PUBLICATION_WORKFLOW_KEYS = frozenset(
+    {
+        "actor",
+        "completed_at",
+        "conclusion",
+        "engine_path",
+        "name",
+        "path",
+        "run_attempt",
+        "run_id",
+        "started_at",
+    }
+)
+FAILED_POST_PUBLICATION_QUALIFICATION_KEYS = frozenset(
+    {
+        "actor",
+        "build_version",
+        "completed_at",
+        "conclusion",
+        "expected",
+        "failure_code",
+        "failure_subject",
+        "failed_job",
+        "failed_job_completed_at",
+        "failed_job_id",
+        "failed_job_started_at",
+        "failed_step",
+        "failed_step_completed_at",
+        "failed_step_number",
+        "failed_step_started_at",
+        "manifest_sha256",
+        "observed",
+        "release_tag",
+        "run_attempt",
+        "run_id",
+        "source_sha",
+        "started_at",
+        "workflow_name",
+        "workflow_path",
+    }
+)
+FAILED_POST_PUBLICATION_REMEDIATION_KEYS = frozenset(
+    {
+        "author",
+        "merge_commit_sha",
+        "merged_at",
+        "merged_by",
+        "pull_request_number",
+        "released_artifact_unchanged",
+        "successor_only",
+    }
+)
+FAILED_POST_PUBLICATION_PRESERVATION_KEYS = frozenset(
+    {
+        "asset_replacement_prohibited",
+        "qualification_passed",
+        "rebuild_same_identity_prohibited",
+        "release_must_remain_published",
+        "release_mutation_prohibited",
+        "retag_prohibited",
+    }
+)
 
 
 class ReleaseMilestoneContextError(RuntimeError):
@@ -231,6 +329,13 @@ def _load_release_attempt_json(path: Path, description: str) -> Mapping[str, Any
     if serialized != canonical:
         raise ReleaseMilestoneContextError(f"{description.capitalize()} must use canonical JSON serialization.")
     return value
+
+
+def failed_post_publication_disposition_sha256(record: Mapping[str, Any]) -> str:
+    payload = dict(record)
+    payload.pop("disposition_sha256", None)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def _load_json_at_revision(
@@ -490,6 +595,277 @@ def validate_draft_deletion_record(
     return deletion
 
 
+def validate_failed_post_publication_qualification_record(
+    repo_root: Path,
+    release_tag: str,
+) -> Mapping[str, Any]:
+    evidence_root = RELEASE_EVIDENCE_ROOT / release_tag
+    record_relative = evidence_root / FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_NAME
+    receipt_relative = evidence_root / RELEASE_EVIDENCE_RECEIPT_NAME
+    record = _load_release_attempt_json(
+        repo_root / record_relative,
+        "failed post-publication qualification disposition",
+    )
+    if set(record) != FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_KEYS:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification disposition keys do not match the required schema."
+        )
+    if (
+        record.get("schema_version") != 1
+        or record.get("disposition_type") != "failed_post_publication_qualification"
+        or record.get("status") != "recorded_failed_post_publication_qualification"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification disposition status does not match the required schema."
+        )
+    if record.get("disposition_sha256") != failed_post_publication_disposition_sha256(record):
+        raise ReleaseMilestoneContextError("Failed post-publication qualification disposition self-digest mismatch.")
+
+    release = _mapping(record.get("release"), "failed post-publication disposition release")
+    receipt_binding = _mapping(record.get("receipt"), "failed post-publication disposition receipt")
+    release_workflow = _mapping(record.get("release_workflow"), "failed post-publication release workflow")
+    qualification = _mapping(record.get("failed_qualification"), "failed post-publication qualification")
+    remediation = _mapping(record.get("remediation"), "failed post-publication remediation")
+    preservation = _mapping(record.get("preservation"), "failed post-publication preservation")
+    if set(release) != FAILED_POST_PUBLICATION_RELEASE_KEYS:
+        raise ReleaseMilestoneContextError("Failed post-publication release keys do not match the required schema.")
+    if set(receipt_binding) != FAILED_POST_PUBLICATION_RECEIPT_KEYS:
+        raise ReleaseMilestoneContextError("Failed post-publication receipt keys do not match the required schema.")
+    if set(release_workflow) != FAILED_POST_PUBLICATION_WORKFLOW_KEYS:
+        raise ReleaseMilestoneContextError("Failed post-publication workflow keys do not match the required schema.")
+    if set(qualification) != FAILED_POST_PUBLICATION_QUALIFICATION_KEYS:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification keys do not match the required schema."
+        )
+    if set(remediation) != FAILED_POST_PUBLICATION_REMEDIATION_KEYS:
+        raise ReleaseMilestoneContextError("Failed post-publication remediation keys do not match the required schema.")
+    if set(preservation) != FAILED_POST_PUBLICATION_PRESERVATION_KEYS:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication preservation keys do not match the required schema."
+        )
+
+    if release.get("release_tag") != release_tag:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification tag does not match its canonical directory."
+        )
+    if receipt_binding.get("path") != receipt_relative.as_posix():
+        raise ReleaseMilestoneContextError("Failed post-publication qualification receipt path is not canonical.")
+    try:
+        receipt, receipt_file_sha256 = load_validated_checked_receipt(repo_root / receipt_relative)
+    except ReleaseReceiptError as error:
+        raise ReleaseMilestoneContextError(
+            f"Failed post-publication qualification receipt is invalid: {error}"
+        ) from error
+    if receipt_binding.get("file_sha256") != receipt_file_sha256:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification receipt file digest does not match the record."
+        )
+    if receipt_binding.get("payload_sha256") != receipt.get("receipt_sha256"):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification receipt self-digest does not match the record."
+        )
+
+    checked_release = _mapping(receipt.get("release"), "failed post-publication checked release")
+    checked_versions = _mapping(receipt.get("versions"), "failed post-publication checked versions")
+    checked_workflow = _mapping(receipt.get("workflow"), "failed post-publication checked workflow")
+    release_identity = {
+        "build_version": checked_versions.get("build"),
+        "package_version": checked_versions.get("package"),
+        "prerelease": checked_release.get("prerelease"),
+        "public_version": checked_versions.get("public"),
+        "release_id": checked_release.get("id"),
+        "release_tag": checked_release.get("tag"),
+        "source_sha": receipt.get("source_sha"),
+    }
+    if any(release.get(field) != value for field, value in release_identity.items()):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification release identity differs from its checked receipt."
+        )
+    if release.get("immutable") is not True:
+        raise ReleaseMilestoneContextError("Failed post-publication qualification release must remain immutable.")
+    source_sha = _sha(release.get("source_sha"), "failed post-publication release source SHA")
+    _positive_integer(release.get("release_id"), "failed post-publication release ID")
+    _string(release.get("package_version"), "failed post-publication package version")
+    _string(release.get("public_version"), "failed post-publication public version")
+    _string(release.get("build_version"), "failed post-publication build version")
+    published_at = _timestamp(release.get("published_at"), "failed post-publication release timestamp")
+
+    checked_assets: dict[str, Mapping[str, Any]] = {}
+    asset_kinds: list[str] = []
+    for index, raw_asset in enumerate(_sequence(record.get("assets"), "failed post-publication assets")):
+        asset = _mapping(raw_asset, f"failed post-publication asset {index}")
+        if set(asset) != FAILED_POST_PUBLICATION_ASSET_KEYS:
+            raise ReleaseMilestoneContextError("Failed post-publication asset keys do not match the required schema.")
+        kind = _string(asset.get("kind"), f"failed post-publication asset {index} kind")
+        if kind not in FAILED_POST_PUBLICATION_ASSET_KINDS or kind in checked_assets:
+            raise ReleaseMilestoneContextError(
+                "Failed post-publication assets must contain four unique required kinds."
+            )
+        _positive_integer(asset.get("asset_id"), f"failed post-publication asset {kind} ID")
+        _positive_integer(asset.get("size_bytes"), f"failed post-publication asset {kind} size")
+        _string(asset.get("name"), f"failed post-publication asset {kind} name")
+        _sha256(asset.get("sha256"), f"failed post-publication asset {kind} digest")
+        checked_assets[kind] = asset
+        asset_kinds.append(kind)
+    if set(checked_assets) != FAILED_POST_PUBLICATION_ASSET_KINDS or asset_kinds != sorted(asset_kinds):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication assets must contain the sorted complete required asset set."
+        )
+    for raw_artifact in _sequence(receipt.get("artifacts"), "failed post-publication receipt artifacts"):
+        artifact = _mapping(raw_artifact, "failed post-publication receipt artifact")
+        kind = _string(artifact.get("kind"), "failed post-publication receipt artifact kind")
+        if checked_assets.get(kind) != artifact:
+            raise ReleaseMilestoneContextError(
+                f"Failed post-publication asset {kind} differs from the checked release receipt."
+            )
+    receipt_asset = checked_assets["receipt"]
+    try:
+        receipt_size = (repo_root / receipt_relative).stat().st_size
+    except OSError as error:
+        raise ReleaseMilestoneContextError(
+            f"Unable to inspect failed post-publication receipt at {repo_root / receipt_relative}: {error}"
+        ) from error
+    if (
+        receipt_asset.get("name") != RELEASE_EVIDENCE_RECEIPT_NAME
+        or receipt_asset.get("sha256") != receipt_file_sha256
+        or receipt_asset.get("size_bytes") != receipt_size
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication receipt asset identity does not match the checked receipt."
+        )
+
+    workflow_identity = {
+        "actor": checked_workflow.get("actor"),
+        "engine_path": checked_workflow.get("engine_path"),
+        "name": checked_workflow.get("name"),
+        "path": checked_workflow.get("path"),
+        "run_attempt": checked_workflow.get("run_attempt"),
+        "run_id": checked_workflow.get("run_id"),
+    }
+    if any(release_workflow.get(field) != value for field, value in workflow_identity.items()):
+        raise ReleaseMilestoneContextError("Failed post-publication release workflow differs from the checked receipt.")
+    if release_workflow.get("conclusion") != "success":
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication release workflow must preserve publication success."
+        )
+    release_started_at = _timestamp(
+        release_workflow.get("started_at"),
+        "failed post-publication release workflow start",
+    )
+    release_completed_at = _timestamp(
+        release_workflow.get("completed_at"),
+        "failed post-publication release workflow completion",
+    )
+
+    if (
+        qualification.get("release_tag") != release_tag
+        or qualification.get("source_sha") != source_sha
+        or qualification.get("build_version") != release.get("build_version")
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification does not bind the exact published release identity."
+        )
+    manifest_sha256 = _sha256(
+        qualification.get("manifest_sha256"),
+        "failed post-publication qualification manifest digest",
+    )
+    expected_workflow_name = f"Milestone {release_tag} {manifest_sha256}"
+    if (
+        qualification.get("conclusion") != "failure"
+        or qualification.get("workflow_name") != expected_workflow_name
+        or qualification.get("workflow_path") != ".github/workflows/milestone-qualification.yml"
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification workflow identity or conclusion is invalid."
+        )
+    _positive_integer(qualification.get("run_id"), "failed post-publication qualification run ID")
+    _positive_integer(qualification.get("run_attempt"), "failed post-publication qualification run attempt")
+    _positive_integer(qualification.get("failed_job_id"), "failed post-publication qualification job ID")
+    _positive_integer(
+        qualification.get("failed_step_number"),
+        "failed post-publication qualification step number",
+    )
+    _string(qualification.get("actor"), "failed post-publication qualification actor")
+    _string(qualification.get("failed_job"), "failed post-publication qualification failed job")
+    _string(qualification.get("failed_step"), "failed post-publication qualification failed step")
+    failure_code = _string(qualification.get("failure_code"), "failed post-publication qualification code")
+    if CANCELLATION_REASON_PATTERN.fullmatch(failure_code) is None:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification code must be a lowercase machine-readable identifier."
+        )
+    _string(qualification.get("failure_subject"), "failed post-publication qualification subject")
+    expected = _string(qualification.get("expected"), "failed post-publication qualification expected value")
+    observed = _string(qualification.get("observed"), "failed post-publication qualification observed value")
+    if expected == observed:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification expected and observed values must differ."
+        )
+    qualification_started_at = _timestamp(
+        qualification.get("started_at"),
+        "failed post-publication qualification start",
+    )
+    qualification_completed_at = _timestamp(
+        qualification.get("completed_at"),
+        "failed post-publication qualification completion",
+    )
+    job_started_at = _timestamp(
+        qualification.get("failed_job_started_at"),
+        "failed post-publication qualification job start",
+    )
+    job_completed_at = _timestamp(
+        qualification.get("failed_job_completed_at"),
+        "failed post-publication qualification job completion",
+    )
+    step_started_at = _timestamp(
+        qualification.get("failed_step_started_at"),
+        "failed post-publication qualification step start",
+    )
+    step_completed_at = _timestamp(
+        qualification.get("failed_step_completed_at"),
+        "failed post-publication qualification step completion",
+    )
+
+    _positive_integer(remediation.get("pull_request_number"), "failed post-publication remediation pull request")
+    _sha(remediation.get("merge_commit_sha"), "failed post-publication remediation merge commit")
+    _string(remediation.get("author"), "failed post-publication remediation author")
+    _string(remediation.get("merged_by"), "failed post-publication remediation merge actor")
+    merged_at = _timestamp(remediation.get("merged_at"), "failed post-publication remediation merge timestamp")
+    if remediation.get("successor_only") is not True or remediation.get("released_artifact_unchanged") is not True:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication remediation must be successor-only and preserve the published artifact."
+        )
+    if preservation != {
+        "asset_replacement_prohibited": True,
+        "qualification_passed": False,
+        "rebuild_same_identity_prohibited": True,
+        "release_must_remain_published": True,
+        "release_mutation_prohibited": True,
+        "retag_prohibited": True,
+    }:
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication preservation requirements must prohibit published release mutation."
+        )
+    _string(record.get("recorded_by"), "failed post-publication disposition actor")
+    recorded_at = _timestamp(record.get("recorded_at"), "failed post-publication disposition timestamp")
+    if not (
+        release_started_at
+        <= published_at
+        <= release_completed_at
+        <= qualification_started_at
+        <= job_started_at
+        <= step_started_at
+        <= step_completed_at
+        <= job_completed_at
+        <= qualification_completed_at
+        <= merged_at
+        <= recorded_at
+    ):
+        raise ReleaseMilestoneContextError(
+            "Failed post-publication qualification disposition timestamps are out of order."
+        )
+    return record
+
+
 def _require_immutable_if_tracked(repo_root: Path, base_sha: str, relative_path: Path) -> None:
     tracked = subprocess.run(
         ["git", "cat-file", "-e", f"{base_sha}:{relative_path.as_posix()}"],
@@ -713,6 +1089,21 @@ def validate_release_recovery_records(repo_root: Path) -> Mapping[str, Mapping[s
             raise ReleaseMilestoneContextError(f"Release-attempt identity is invalid: {error}") from error
         attempts.append((version.order_key, build, release_tag))
         records[release_tag] = entry
+
+    evidence_root = repo_root / RELEASE_EVIDENCE_ROOT
+    for disposition_path in sorted(evidence_root.glob(f"*/{FAILED_POST_PUBLICATION_QUALIFICATION_RECORD_NAME}")):
+        release_tag = disposition_path.parent.name
+        if release_tag in records:
+            raise ReleaseMilestoneContextError(
+                f"Release {release_tag} cannot be both an unpublished attempt and a published qualification "
+                "disposition."
+            )
+        records[release_tag] = {
+            "qualification_disposition": validate_failed_post_publication_qualification_record(
+                repo_root,
+                release_tag,
+            )
+        }
 
     qualifications: list[tuple[tuple[int, ...], Path, Mapping[str, Any]]] = []
     qualification_root = repo_root / "docs" / "qualification"
@@ -1795,6 +2186,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     source.add_argument("--base-sha")
     source.add_argument("--cancelled-attempt-tag")
     source.add_argument("--draft-deletion-tag")
+    source.add_argument("--failed-post-publication-tag")
     parser.add_argument("--head-sha")
     parser.add_argument("--head-branch")
     parser.add_argument("--base-repo")
@@ -1822,6 +2214,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "build_version": _string(attempt_record.get("build_version"), "cancelled release build version"),
                 "release_tag": args.draft_deletion_tag,
                 "status": "validated_draft_deletion",
+            }
+            if args.github_output is not None:
+                _write_github_output(args.github_output, outputs)
+            print(json.dumps(outputs, sort_keys=True))
+            return 0
+        if args.failed_post_publication_tag is not None:
+            record = validate_failed_post_publication_qualification_record(
+                args.repo_root.resolve(),
+                args.failed_post_publication_tag,
+            )
+            release = _mapping(record.get("release"), "failed post-publication release")
+            qualification = _mapping(record.get("failed_qualification"), "failed post-publication qualification")
+            outputs = {
+                "build_version": _string(release.get("build_version"), "failed post-publication build version"),
+                "qualification_run_id": str(
+                    _positive_integer(
+                        qualification.get("run_id"),
+                        "failed post-publication qualification run ID",
+                    )
+                ),
+                "release_tag": args.failed_post_publication_tag,
+                "status": "validated_failed_post_publication_qualification",
             }
             if args.github_output is not None:
                 _write_github_output(args.github_output, outputs)

--- a/tests/test_release_recovery_records.py
+++ b/tests/test_release_recovery_records.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from scripts.release_milestone_context import (
     ReleaseMilestoneContextError,
+    failed_post_publication_disposition_sha256,
+    validate_failed_post_publication_qualification_record,
     validate_failed_attempt_record,
     validate_release_recovery_records,
 )
@@ -24,16 +26,141 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
         config_path.parent.mkdir(parents=True)
         shutil.copy2(REPO_ROOT / ".github" / "github.json", config_path)
 
+    @staticmethod
+    def copy_beta5_disposition(root: Path) -> Path:
+        source = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2-beta.5"
+        destination = root / "docs" / "release-evidence" / "v0.3.2-beta.5"
+        shutil.copytree(source, destination)
+        return destination / "failed-post-publication-qualification-v1.json"
+
+    @staticmethod
+    def write_disposition(path: Path, record: dict[str, object]) -> None:
+        record["disposition_sha256"] = failed_post_publication_disposition_sha256(record)
+        path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
     def test_repository_recovery_records_validate_directly_from_disk(self) -> None:
         records = validate_release_recovery_records(REPO_ROOT)
 
         self.assertEqual(records["v0.3.2-beta.3"]["attempt"]["build_version"], "165")
         self.assertEqual(records["v0.3.2-beta.4"]["attempt"]["build_version"], "166")
         self.assertEqual(records["v0.3.2-beta.6"]["attempt"]["build_version"], "168")
+        for release_tag in ("v0.3.2-beta.3", "v0.3.2-beta.4", "v0.3.2-beta.6"):
+            with self.subTest(release_tag=release_tag):
+                self.assertTrue(records[release_tag]["attempt"]["must_not_rebuild"])
         self.assertEqual(
             records["v0.3.2-beta.6"]["disposition"]["status"],
             "deleted_abandoned_unpublished_draft",
         )
+        beta5 = records["v0.3.2-beta.5"]["qualification_disposition"]
+        self.assertEqual(beta5["failed_qualification"]["observed"], "0.0.0")
+        self.assertFalse(beta5["preservation"]["qualification_passed"])
+
+    def test_beta5_failed_post_publication_disposition_validates_directly_from_disk(self) -> None:
+        record = validate_failed_post_publication_qualification_record(REPO_ROOT, "v0.3.2-beta.5")
+
+        self.assertEqual(record["release"]["build_version"], "167")
+        self.assertEqual(record["release_workflow"]["run_id"], 32488665999)
+        self.assertEqual(record["failed_qualification"]["run_id"], 32491156253)
+        self.assertEqual(record["failed_qualification"]["failed_job_id"], 96798878506)
+        self.assertEqual(record["failed_qualification"]["observed"], "0.0.0")
+        self.assertEqual(record["remediation"]["pull_request_number"], 623)
+        self.assertEqual(
+            record["disposition_sha256"],
+            "a139a72172c9f40f655e4ccbc3416e400317058f26486881e3e0043963eb87b6",
+        )
+
+    def test_rejects_noncanonical_failed_post_publication_serialization(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            record_path = self.copy_beta5_disposition(root)
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "canonical JSON serialization"):
+                validate_failed_post_publication_qualification_record(root, "v0.3.2-beta.5")
+
+    def test_rejects_failed_post_publication_disposition_tampering(self) -> None:
+        cases = (
+            (
+                "schema",
+                lambda record: record.__setitem__("unexpected", True),
+                "keys do not match",
+            ),
+            (
+                "release source",
+                lambda record: record["release"].__setitem__("source_sha", "0" * 40),
+                "release identity",
+            ),
+            ("receipt digest", lambda record: record["receipt"].__setitem__("file_sha256", "0" * 64), "file digest"),
+            ("asset digest", lambda record: record["assets"][0].__setitem__("sha256", "0" * 64), "asset appcast"),
+            (
+                "qualification source",
+                lambda record: record["failed_qualification"].__setitem__("source_sha", "0" * 40),
+                "exact published release identity",
+            ),
+            (
+                "observed value",
+                lambda record: record["failed_qualification"].__setitem__("observed", "0.3.2b5"),
+                "expected and observed",
+            ),
+            (
+                "remediation scope",
+                lambda record: record["remediation"].__setitem__("successor_only", False),
+                "successor-only",
+            ),
+            (
+                "released artifact",
+                lambda record: record["remediation"].__setitem__("released_artifact_unchanged", False),
+                "successor-only",
+            ),
+            (
+                "qualification claim",
+                lambda record: record["preservation"].__setitem__("qualification_passed", True),
+                "preservation requirements",
+            ),
+            (
+                "timestamp order",
+                lambda record: record.__setitem__("recorded_at", "2026-08-21T14:16:00Z"),
+                "timestamps are out of order",
+            ),
+            (
+                "qualification timestamp order",
+                lambda record: record["failed_qualification"].__setitem__("started_at", "2026-08-21T14:10:30Z"),
+                "timestamps are out of order",
+            ),
+        )
+        for description, mutate, expected_error in cases:
+            with self.subTest(description=description), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory)
+                record_path = self.copy_beta5_disposition(root)
+                record = json.loads(record_path.read_text(encoding="utf-8"))
+                mutate(record)
+                self.write_disposition(record_path, record)
+
+                with self.assertRaisesRegex(ReleaseMilestoneContextError, expected_error):
+                    validate_failed_post_publication_qualification_record(root, "v0.3.2-beta.5")
+
+    def test_rejects_failed_post_publication_disposition_self_digest_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            record_path = self.copy_beta5_disposition(root)
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["disposition_sha256"] = "0" * 64
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "self-digest mismatch"):
+                validate_failed_post_publication_qualification_record(root, "v0.3.2-beta.5")
+
+    def test_rejects_failed_post_publication_receipt_file_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.copy_beta5_disposition(root)
+            receipt_path = root / "docs" / "release-evidence" / "v0.3.2-beta.5" / "release-receipt.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt_path.write_text(json.dumps(receipt, indent=4, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "receipt file digest"):
+                validate_failed_post_publication_qualification_record(root, "v0.3.2-beta.5")
 
     def test_failed_attempt_records_validate_directly_from_disk(self) -> None:
         for release_tag, build_version in (("v0.3.2-beta.3", "165"), ("v0.3.2-beta.4", "166")):

--- a/tests/test_release_recovery_records.py
+++ b/tests/test_release_recovery_records.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -7,6 +8,7 @@ from pathlib import Path
 
 from scripts.release_milestone_context import (
     ReleaseMilestoneContextError,
+    discover_milestone_receipt,
     failed_post_publication_disposition_sha256,
     validate_failed_post_publication_qualification_record,
     validate_failed_attempt_record,
@@ -38,6 +40,42 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
         record["disposition_sha256"] = failed_post_publication_disposition_sha256(record)
         path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
+    @staticmethod
+    def build_disposition_repository(root: Path, *, tamper_receipt: bool = False) -> tuple[str, str]:
+        evidence_root = root / "docs" / "release-evidence" / "v0.3.2-beta.5"
+        evidence_root.mkdir(parents=True)
+        source_root = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2-beta.5"
+        shutil.copy2(source_root / "release-receipt.json", evidence_root / "release-receipt.json")
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "base receipt"], cwd=root, check=True)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        shutil.copy2(
+            source_root / "failed-post-publication-qualification-v1.json",
+            evidence_root / "failed-post-publication-qualification-v1.json",
+        )
+        if tamper_receipt:
+            receipt_path = evidence_root / "release-receipt.json"
+            receipt_path.write_text(receipt_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "add disposition"], cwd=root, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return base_sha, head_sha
+
     def test_repository_recovery_records_validate_directly_from_disk(self) -> None:
         records = validate_release_recovery_records(REPO_ROOT)
 
@@ -68,6 +106,39 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
             record["disposition_sha256"],
             "a139a72172c9f40f655e4ccbc3416e400317058f26486881e3e0043963eb87b6",
         )
+
+    def test_discovers_failed_post_publication_disposition_without_requiring_milestone_success(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            base_sha, head_sha = self.build_disposition_repository(root)
+
+            receipt_path = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="code/issue-634-beta5-disposition",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(receipt_path)
+
+    def test_rejects_disposition_pull_request_that_mutates_checked_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            base_sha, head_sha = self.build_disposition_repository(root, tamper_receipt=True)
+
+            with self.assertRaisesRegex(ReleaseMilestoneContextError, "may change only its new disposition record"):
+                discover_milestone_receipt(
+                    root,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    head_branch="code/issue-634-beta5-disposition",
+                    base_repo="cbusillo/BD_to_AVP",
+                    head_repo="cbusillo/BD_to_AVP",
+                    base_branch="main",
+                )
 
     def test_rejects_noncanonical_failed_post_publication_serialization(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

- add a generic canonical, self-digested failed-post-publication qualification disposition schema and validator
- record Beta 5 exactly as published, binding release/tag/source/build, all four asset identities, checked receipt digests, publication workflow, failed qualification run/job/step, `worker_version: 0.0.0`, PR #623, actors, and timestamps
- add direct disk, schema, canonical serialization, receipt, asset, temporal, preservation, remediation, and self-digest tampering regressions
- preserve unpublished burned builds `165`, `166`, and `168` as non-reusable while keeping published build `167` out of the burned-build path
- document that the terminal record preserves failed qualification truth and supersedes PR #622 without claiming Beta 5 passed

## Independently Revalidated Evidence

- immutable prerelease `v0.3.2-beta.5`, release `374445536`, build `167`, source/tag SHA `f6ce414db07030e2ad2c081a9d4287639a113446`
- guarded Prerelease run `32488665999` succeeded; all four release assets redownloaded and matched GitHub digests
- checked receipt file SHA-256 `81e1568ff93c0fad946dff59c5d4e00c97008162db93218cc4f58dcd2ad8af6c` and payload SHA-256 `9ab74f3ef369ed64de0f5e25297f025c88aeeeb811bb4c73525e3a25f5db1b89`
- milestone qualification run `32491156253`, job `96798878506`, step `Run exact clean-machine qualification` failed on the exact source SHA
- the downloaded published DMG independently reproduced `Packaged worker version mismatch: expected 0.3.2b5, found '0.0.0'`
- remediation PR #623 merged as `b83f9b7864db11f3f585bf3017e31eeb844932ef` and applies only to successors
- Production Preflight run `32597420260` and artifact `9482019033` were revalidated on exact protected-main SHA `68f82ab8dc6f6f868b9161a9f9c12613493f2ffd`

## Validation

- focused release recovery/milestone/workflow/policy suites: 203 tests passed
- broad Python: 1,870 passed, 4 expected skips with broken local Homebrew ffmpeg isolated from `PATH`
- native: 484 passed
- production package, packaged-worker cancellation/preview smoke, `uv build`, bundled-tool verification, import/CLI smoke passed
- Ruff format/lint, focused and broad mypy, actionlint, release metadata/policy validation, and observability migration validation passed
- JetBrains inspection was attempted twice; the final run reported zero actionable findings but remained inconclusive because IntelliJ lacks a trustworthy Python SDK. Helper-created IDE metadata was removed.

## Release Safety

- does not edit, delete, replace, retag, unpublish, or rebuild Beta 5
- does not claim Beta 5 passed qualification
- does not prepare Beta 7, reserve build `169`, dispatch a release, approve `macos-signing`, or perform publication operations
- PR #622 must close without merge after this disposition is merged

Refs #634
Refs #631
Related: #609, #622, #623
