### PR TITLE
Prepare v0.3.2 Beta 7

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -82,7 +82,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.6-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/.github/release-freezes.json
+++ b/.github/release-freezes.json
@@ -4,7 +4,7 @@
   "frozen_release_tags": {
     "v0.3.2-beta.6": {
       "issue": 609,
-      "reason": "Cancelled unpublished signed attempt; build 168 is permanently non-reusable pending explicitly authorized draft cleanup."
+      "reason": "Cancelled unpublished signed attempt; its draft was deleted under the authorized immutable disposition and build 168 is permanently non-reusable."
     }
   }
 }

--- a/docs/0.3.2-beta.5-cut-packet.md
+++ b/docs/0.3.2-beta.5-cut-packet.md
@@ -4,7 +4,9 @@
 > Beta 5 must not be rebuilt, retagged, unpublished, replaced, or modified.
 > Corrective Beta 6 build `168` became a cancelled unpublished signed attempt
 > and is permanently burned. Its abandoned draft was deleted under separately
-> recorded authorization. Issue #609 owns any newer successor preparation.
+> recorded authorization. Issue #609 has prepared corrective Beta 7 build
+> `169`; dispatch, signing approval, and publication remain separately
+> authorized boundaries.
 
 Beta `0.3.2b5` is the published recovery successor to failed unpublished Beta
 `0.3.2b4`. Issue #609 owns preparation, qualification, publication, and
@@ -116,11 +118,10 @@ unpublished Beta 3 and Beta 4 are not release-note bases or appcast items.
 ## Qualification And Authorization
 
 Immutable Beta `v0.3.2-beta.2` was Beta 5's prior published artifact,
-release-note base, and Sparkle update-route input. Beta 5 is now the prior
-published update source for Beta 6. PR #622 remains open and blocked as the
-superseded success-shaped evidence route; after the immutable failure
-disposition merges, close it without merging and retain a durable explanation.
-The failed milestone gate must not be weakened or bypassed.
+release-note base, and Sparkle update-route input. Beta 5 remains the prior
+published update source for its successors. Superseded success-shaped evidence
+PR #622 was closed without merge on August 23, 2026 after the immutable failure
+disposition merged. The failed milestone gate must not be weakened or bypassed.
 
 Beta 5's immutable publication receipt is carried into Beta 6 preparation only
 to bind the real prior artifact. It does not claim Beta 5 milestone completion.

--- a/docs/0.3.2-beta.6-cut-packet.md
+++ b/docs/0.3.2-beta.6-cut-packet.md
@@ -125,14 +125,16 @@ rebuilt, retagged, unpublished, or replaced.
 ## Qualification And Authorization
 
 Published immutable Beta `v0.3.2-beta.5` is the prior update-route input for
-Beta 6. Beta 5's app launches and converts, but its embedded worker reports
-`0.0.0` instead of `0.3.2b5`; therefore PR #622 remains blocked and unmerged as
-the accurate record of failed exact-artifact qualification. Beta 6 must rerun
-the clean-machine, installed UI, and Sparkle update route against the exact
-signed Beta 6 artifact.
+its successors. Beta 5's app launches and converts, but its embedded worker
+reports `0.0.0` instead of `0.3.2b5`; superseded success-shaped evidence PR
+#622 was closed without merge after the accurate failed-post-publication
+disposition merged. Any successor must rerun the clean-machine, installed UI,
+and Sparkle update route against its exact signed artifact.
 
 This attempt did not create a public tag, published release, Pages appcast item,
 PyPI version, Homebrew change, or accepted qualification. Do not dispatch
-Prerelease for Beta 6, reuse build `168`, or approve a successor signing run
-without the separately reviewed recovery steps owned by issue #609. Draft
-`374538590` has been deleted and must not be recreated.
+Prerelease for Beta 6 or reuse build `168`. Separately authorized successor Beta
+`0.3.2b7` build `169` is prepared from Production Preflight run `32620933465`;
+its Prerelease dispatch and `macos-signing` approval remain separate explicit
+authorization boundaries. Draft `374538590` has been deleted and must not be
+recreated.

--- a/docs/0.3.2-beta.7-cut-packet.md
+++ b/docs/0.3.2-beta.7-cut-packet.md
@@ -1,0 +1,136 @@
+# 0.3.2 Beta 7 Cut Packet
+
+> **Prepared metadata; publication pending.**
+> Release dispatch is not authorized by this preparation. A future guarded
+> Prerelease run must use the exact merged protected-`main` SHA under a temporary
+> merge hold, and `macos-signing` approval requires separate explicit run-bound
+> authorization in the active conversation.
+
+Beta `0.3.2b7` is the successor to published, immutable Beta `0.3.2b5` and the
+cancelled, unpublished Beta 6 signed attempt. Issue #609 owns preparation,
+qualification, publication, and closeout. Product scope remains the batch-disc
+title workflow delivered by PRs #611 and #612, with the release fixes from PRs
+#617, #620, and #623. PRs #635, #636, and #637 harden qualification fixtures,
+add the release-independent Production Preflight, and preserve Beta 5's failed
+post-publication disposition without changing the published release.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2b7` |
+| Public version | `0.3.2-beta.7` |
+| Bundle and Sparkle build | `169` |
+| GitHub tag and release title | `v0.3.2-beta.7` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2-beta.7.dmg` |
+| Sparkle channel | `beta` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `169` is the next global successor after published Beta 5 build `167` and
+cancelled Beta 6 build `168`. The complete relevant attempt history remains:
+
+- Beta 3 `0.3.2b3` / `v0.3.2-beta.3` / build `165` failed after signing and
+  notarization but before publication in run `32446869702`; the identity is
+  permanently burned.
+- Beta 4 `0.3.2b4` / `v0.3.2-beta.4` / build `166` failed after signing and
+  notarization but before publication in run `32453767766`; the identity is
+  permanently burned.
+- Beta 5 `0.3.2b5` / `v0.3.2-beta.5` / build `167` is published and immutable
+  as release `374445536` from source and tag SHA
+  `f6ce414db07030e2ad2c081a9d4287639a113446`.
+- Beta 6 `0.3.2b6` / `v0.3.2-beta.6` / build `168` was a cancelled unpublished
+  signed attempt in run `32502068709`; the identity is permanently burned and
+  draft `374538590` was deleted under its immutable authorized disposition.
+
+Earlier burned builds `147` and `154` and abandoned metadata build `157` also
+remain unavailable. Build `169` is globally newer than published Beta 2 build
+`164`, Beta 1 build `163`, Stable `0.3.1` build `162`, and all earlier
+production history.
+
+As revalidated on August 23, 2026, no Beta 3, Beta 4, Beta 6, or Beta 7 tag
+exists, and deleted draft IDs `374173827`, `374372418`, and `374538590` remain
+absent. No Beta 7 release, draft, appcast item, PyPI version, or Homebrew change
+exists.
+
+## Corrective Scope
+
+- PR #611 replaces scheduler timing assumptions in process-runner heartbeat,
+  broken-pipe cleanup, cancellation, and resource-sampler tests with observable
+  coordination.
+- PR #612 adds Main Feature / All 3D Videos selection for source folders
+  containing Blu-ray ISO images, with durable sequential per-title fan-out,
+  stable retry identity, collision checks, and final-title source removal.
+- PR #617 and PR #620 preserve the signed-artifact UI qualification fixes that
+  allowed Beta 5 to reach publication.
+- PR #623 makes the embedded worker report the enclosing signed app's version
+  and requires package smoke to reject worker/bundle version drift before
+  signing.
+- PRs #635-#637 strengthen production-operation contracts, add an independent
+  production-shaped preflight, and record Beta 5's terminal failed
+  post-publication qualification without weakening the milestone gate.
+
+Beta 2 feedback fixes, broad test audit #554, persistent queue roadmap #501,
+MakeMKV-free SSIF streaming #209, live processed-frame monitor #356, and Vision
+Pro companion/productization work #436-#439 remain excluded.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2-beta.7` preserves the Main Feature / All 3D Videos workflow
+> published in Beta 5 and corrects packaged worker version reporting used by
+> diagnostics and exact-artifact qualification. Its release path also adds a
+> production-shaped preflight and stronger installed-UI evidence contracts.
+
+GitHub-generated notes compare with published immutable Beta
+`v0.3.2-beta.5`. Failed unpublished Beta 3 and Beta 4, and cancelled unpublished
+Beta 6, are not release-note bases or appcast items.
+
+## Immutable Prior And Failed Attempt Evidence
+
+- Beta 5's release receipt remains
+  `docs/release-evidence/v0.3.2-beta.5/release-receipt.json`.
+- Beta 5's terminal failed exact-artifact qualification remains
+  `docs/release-evidence/v0.3.2-beta.5/failed-post-publication-qualification-v1.json`.
+  It records the observed packaged `worker_version: 0.0.0` instead of
+  `0.3.2b5`, and does not claim qualification success.
+- Superseded success-shaped evidence PR #622 was closed without merge on
+  August 23, 2026. PR #623 remains successor-only remediation.
+- Beta 6's immutable cancellation, signed receipt, and authorized draft
+  deletion remain under `docs/release-attempts/v0.3.2-beta.6/`.
+- `.github/release-freezes.json` prevents reuse of `v0.3.2-beta.6`, and the Beta
+  7 qualification record carries build `168` in
+  `immutable_history.burned_builds` alongside builds `165` and `166`.
+
+## Production Preflight
+
+Release-independent Production Preflight run `32620933465` passed on exact
+protected-main SHA `02bf566e42b62a18e1a274e33caf1943d26827dd` before successor
+metadata was prepared. Artifact `9488399557`,
+`production-preflight-success-02bf566e42b62a18e1a274e33caf1943d26827dd-32620933465-1`,
+is source-bound to that SHA and records:
+
+- package version `0.3.2b6` and exact packaged worker protocol readiness;
+- preventive DMG SHA-256
+  `f228c03a5372b1f2bea1f0342a8f6df53ace90ed733ecb8b3a09fbc37983c080`;
+- installed app-tree SHA-256
+  `7203c15f4958f4cddb21ed6b29860c215bf21a24cc87d93d2e96c7a0b072d882`;
+- four installed-UI evidence files totaling `201923` bytes; and
+- no signing environment, release secret, tag, release, draft, appcast
+  deployment, or publication side effect.
+
+## Qualification And Authorization
+
+`docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json` preregisters the
+Beta 7 matrix with candidate artifact, release, and source identities left null
+until a separately authorized guarded release exists. Published immutable Beta
+5 remains the prior Sparkle update source. Builds `165`, `166`, and `168` remain
+burned and must not appear in future updater feeds.
+
+Preparation and review do not authorize Prerelease dispatch, `macos-signing`
+approval, tag or release creation, draft creation, appcast deployment, or any
+publication operation. Those boundaries require separate explicit
+authorization in the active conversation.

--- a/docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json
@@ -1,0 +1,254 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-beta.5-to-v0.3.2-beta.7",
+      "native-sparkle-notes-beta7",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "169",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.7.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2b7",
+    "public_version": "0.3.2-beta.7",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2-beta.7",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "beta",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154,
+      165,
+      166,
+      168
+    ],
+    "previous_beta": {
+      "appcast_sha256": "aace6fba81fafd168e6b223fb75d6d670024f02d6da27bea306450a4404e8b68",
+      "build_version": "167",
+      "dmg_sha256": "a1959ce18a4b15a5cbf438759ab35d86dfe8e02f301324f8cdff90fd91d7c1c8",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2b5",
+      "published_at": "2026-08-21T14:10:21Z",
+      "release_id": 374445536,
+      "release_run_id": 32488665999,
+      "release_tag": "v0.3.2-beta.5",
+      "signed_app_tree_sha256": "5bfd40455266c7006df1281f5b14c1c7547076f6d5a6bab0898f2104d44171a6",
+      "source_git_sha": "f6ce414db07030e2ad2c081a9d4287639a113446"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#617",
+    "#620",
+    "#623",
+    "#609"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-beta.5-to-v0.3.2-beta.7",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-beta7",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-beta.3-change-scoped-evidence-v1",
+      "scope": "immutable change-scoped preparation evidence carried from the failed unpublished Beta 3 attempt"
+    }
+  ],
+  "qualification_id": "v0.3.2-beta.7-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage beta --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,7 +41,10 @@ draft creation and is permanently burned, as recorded in
 `docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`. Its abandoned
 draft was deleted only after explicit authorization, with the immutable
 disposition at `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json`.
-Issue #609 owns any separately authorized newer successor preparation.
+Issue #609 owns prepared successor Beta `0.3.2b7`, public tag
+`v0.3.2-beta.7`, and build `169`. Its metadata and preregistered qualification
+are preparation-only; Prerelease dispatch, signing approval, and publication
+remain separately authorized boundaries.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -20,7 +20,8 @@ post-publication exact-artifact qualification is blocked by packaged worker
 version metadata. Corrective Beta `0.3.2b6` build `168` is a cancelled,
 unpublished signed attempt whose draft `374538590` was deleted through the
 authorized immutable-disposition path; its tag and build are permanently
-non-reusable. Issue #609 owns preparation of a newer successor.
+non-reusable. Issue #609 owns prepared successor Beta `0.3.2b7` build `169`;
+dispatch, signing approval, and publication remain separately authorized.
 Run-bound signing approval
 remains a separate authorization boundary.
 
@@ -452,8 +453,9 @@ Guarded Prerelease run `32488665999` published immutable
 `f6ce414db07030e2ad2c081a9d4287639a113446`. Its exact DMG and appcast remain
 valid public artifacts, but post-publication qualification found that the
 embedded worker reported `0.0.0` instead of `0.3.2b5`. PR #623 corrects that
-diagnostics identity and strengthens the pre-signing package gate. PR #622
-remains blocked as the accurate Beta 5 evidence record.
+diagnostics identity and strengthens the pre-signing package gate. Superseded
+success-shaped evidence PR #622 was closed without merge after the accurate
+failed-post-publication disposition merged.
 
 The reviewed Beta 6 identity was:
 
@@ -483,6 +485,16 @@ verified absence of both draft and tag. A newer successor identity is expected
 to begin at Beta 7/build `169`. Milestone-context validation accepts the
 cancelled candidate only after that disposition validates, then still requires
 build `168` in the successor qualification's burned-build list.
+
+Beta 7 is prepared as internal version `0.3.2b7`, public tag and title
+`v0.3.2-beta.7`, and global build `169`. Published immutable Beta 5 remains its
+prior update-route input; failed builds `165` and `166` and cancelled build
+`168` remain burned. Release-independent Production Preflight run `32620933465`
+passed on exact protected-main SHA
+`02bf566e42b62a18e1a274e33caf1943d26827dd` before metadata preparation. No
+Beta 7 tag, release, draft, appcast item, PyPI version, or Homebrew change was
+created. The preparation contract is recorded in
+[the 0.3.2 Beta 7 cut packet](0.3.2-beta.7-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 168
+        CURRENT_PROJECT_VERSION: 169
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2b6
+        MARKETING_VERSION: 0.3.2b7
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2b6"
+version = "0.3.2b7"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "168"
+build_version = "169"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -134,8 +134,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b6")
-        self.assertEqual(NATIVE_BUILD_VERSION, "168")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b7")
+        self.assertEqual(NATIVE_BUILD_VERSION, "169")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,15 +199,15 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(app["bundle_identifier"], "com.shinycomputers.bd-to-avp")
         self.assertNotIn("briefcase", pyproject["tool"])
 
-    def test_repository_records_cancelled_beta6_metadata(self) -> None:
+    def test_repository_records_beta7_preparation_and_beta6_cancellation(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2b6")
-        self.assertEqual(metadata.public_version, "0.3.2-beta.6")
-        self.assertEqual(metadata.build_version, "168")
-        self.assertEqual(metadata.release_tag, "v0.3.2-beta.6")
-        self.assertEqual(metadata.release_name, "v0.3.2-beta.6")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.6.dmg")
+        self.assertEqual(metadata.package_version, "0.3.2b7")
+        self.assertEqual(metadata.public_version, "0.3.2-beta.7")
+        self.assertEqual(metadata.build_version, "169")
+        self.assertEqual(metadata.release_tag, "v0.3.2-beta.7")
+        self.assertEqual(metadata.release_name, "v0.3.2-beta.7")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.7.dmg")
         self.assertEqual(metadata.channel, "beta")
         self.assertTrue(metadata.prerelease)
         self.assertFalse(metadata.first_candidate_of_cycle)
@@ -218,6 +218,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         beta6_freeze = freeze_policy["frozen_release_tags"]["v0.3.2-beta.6"]
         self.assertEqual(beta6_freeze["issue"], 609)
         self.assertIn("permanently non-reusable", beta6_freeze["reason"])
+        self.assertIn("authorized immutable disposition", beta6_freeze["reason"])
+        self.assertNotIn("v0.3.2-beta.7", freeze_policy["frozen_release_tags"])
 
         cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.6-cut-packet.md").read_text(encoding="utf-8")
         self.assertIn("`0.3.2b6`", cut_packet)
@@ -236,18 +238,25 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("PyPI", cut_packet)
         self.assertIn("Homebrew", cut_packet)
 
+        beta7_cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.7-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2b7`", beta7_cut_packet)
+        self.assertIn("Build `169`", beta7_cut_packet)
+        self.assertIn("Production Preflight run `32620933465`", beta7_cut_packet)
+        self.assertIn("Builds `165`, `166`, and `168` remain", beta7_cut_packet)
+        self.assertIn(release.CUT_PACKET_PREPARED, beta7_cut_packet)
+
         github_config = json.loads((REPO_ROOT / ".github" / "github.json").read_text(encoding="utf-8"))
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-beta.6-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b6")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.6")
-        self.assertEqual(qualification["candidate"]["build_version"], "168")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.6")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b7")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.7")
+        self.assertEqual(qualification["candidate"]["build_version"], "169")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.7")
         self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
@@ -256,6 +265,10 @@ class ReleaseMetadataTests(unittest.TestCase):
             "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
         )
         self.assertIn("#623", qualification["issues"])
+        self.assertEqual(
+            set(qualification["immutable_history"]["burned_builds"]),
+            {147, 154, 165, 166, 168},
+        )
         previous_beta = qualification["immutable_history"]["previous_beta"]
         self.assertEqual(previous_beta["release_tag"], "v0.3.2-beta.5")
         self.assertEqual(previous_beta["package_version"], "0.3.2b5")
@@ -275,8 +288,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(previous_beta_artifacts["appcast"]["sha256"], previous_beta["appcast_sha256"])
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-beta.5-to-v0.3.2-beta.6",
-            "native-sparkle-notes-beta6",
+            "updater-route-v0.3.2-beta.5-to-v0.3.2-beta.7",
+            "native-sparkle-notes-beta7",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "168")
+        self.assertEqual(info["CFBundleVersion"], "169")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -397,8 +397,8 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 "v0.3.2-beta.6": {
                     "issue": 609,
                     "reason": (
-                        "Cancelled unpublished signed attempt; build 168 is permanently non-reusable pending "
-                        "explicitly authorized draft cleanup."
+                        "Cancelled unpublished signed attempt; its draft was deleted under the authorized immutable "
+                        "disposition and build 168 is permanently non-reusable."
                     ),
                 }
             },
@@ -1121,7 +1121,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-beta.6-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2b6"
+version = "0.3.2b7"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- prepare `0.3.2b7` / `v0.3.2-beta.7` / build `169`
- preregister the bounded Beta 7 qualification matrix while retaining Beta 5 as the immutable published update base
- carry burned builds `165`, `166`, and `168`, preserve the Beta 5 failed-post-publication disposition, and preserve the Beta 6 cancellation/deletion disposition
- record release-independent Production Preflight run `32620933465` on exact protected-main SHA `02bf566e42b62a18e1a274e33caf1943d26827dd`

## Validation

- release-independent Production Preflight `32620933465` passed; artifact `9488399557`
- 500 focused release/native/workflow tests passed
- 1,872 broad Python tests passed with 4 expected skips under sanitized PATH
- 484 native tests passed
- `scripts.native_app.py package` passed for `0.3.2b7` / build `169`
- `uv build`, Ruff format/lint, mypy, actionlint, observability migration, import/CLI smoke, release metadata, qualification policy, cancellation/deletion, and failed-post-publication validators passed
- exact-candidate preparation qualification passed for commit `b569554b35387a8161f5a4f813c0dadeb3f2b835`
- JetBrains inspection was attempted twice; cleanup is clean and zero findings were captured, but the verdict remains inconclusive because IntelliJ reports `language_sdk_missing`
- independent staged-diff review found no blocking or materially actionable issue

## Authorization Boundary

This PR is preparation-only. It does not authorize or perform Prerelease workflow dispatch, `macos-signing` approval, tag/release/draft/appcast creation or mutation, or any publication operation.

Refs #609
