### PR TITLE
Fix prior-profile milestone qualification

### DIFF
--- a/docs/tier3-clean-machine.md
+++ b/docs/tier3-clean-machine.md
@@ -54,11 +54,12 @@ gh workflow run milestone-qualification.yml \
 
 The successful run uploads the validated signed-artifact UI receipt, both Tier
 3 receipts, normalized evidence, checked manifest digest, evidence branch SHA,
-and a bounded run summary with 30-day retention. A failed Sparkle installation
-uploads a separate `sparkle-install-diagnostics.json` artifact containing only
-fixed classifications, runtime-layout enums, directory-state enums, process
-state, and installed-build state; it excludes raw unified logs, paths,
-usernames, hostnames, process IDs, Accessibility output, and exception text.
+and a bounded run summary with 30-day retention. A failed pre-update validation
+or Sparkle installation uploads a separate `sparkle-install-diagnostics.json`
+artifact containing only fixed classifications, runtime-layout enums,
+directory-state enums, process state, and installed-build state; it excludes
+raw unified logs, paths, usernames, hostnames, process IDs, Accessibility
+output, and exception text.
 Download successful outputs,
 validate them again, and add the accepted receipts to the same evidence branch.
 The hosted collector proves the real Sparkle install/relaunch path, exact
@@ -153,10 +154,13 @@ The runner performs this bounded sequence:
    disappeared.
 6. Verify the final candidate bundle, build, signed app tree, and replacement
    running process, then verify the selected route and unrelated preference are
-   preserved and the seeded profile library matches the exact expected
-   semantic migration from schema version 5 to version 6. The migration must
-   preserve profile identity, encoding options, and safe pipeline defaults while
-   removing legacy per-run defaults that version 6 intentionally no longer stores.
+   preserved. The harness seeds the version 5 profile fixture and accepts the
+   exact version 6 migration either when the prior release first launches or
+   during the candidate relaunch. It records which boundary performed the
+   migration and requires the exact expected version 6 document afterward,
+   preserving profile identity, encoding options, and safe pipeline defaults
+   while removing legacy per-run defaults that version 6 intentionally no
+   longer stores.
 7. Run the candidate installed-app XCUITest lane. It verifies main-window
    readiness, profile-save accessibility and success, updater settings, the
    public releases link, and cropped light/dark app-window screenshots.

--- a/scripts/tier3_clean_machine.py
+++ b/scripts/tier3_clean_machine.py
@@ -2081,18 +2081,33 @@ def _seed_profile(synthetic_home: Path) -> tuple[Path, dict[str, Any]]:
     return profile_path, profile_document
 
 
-def _validate_profile_migration(
+def _validate_profile_before_update(
+    profile_path: Path,
+    seeded_profile: Mapping[str, Any],
+) -> tuple[str, dict[str, Any], str]:
+    expected_migrated = _load_profile_document(PROFILE_FIXTURE_V6_PATH, "Expected migrated profile fixture")
+    profile_before = _load_profile_document(profile_path, "Profile library before Sparkle update")
+    if seeded_profile.get("version") != 5 or expected_migrated.get("version") != 6:
+        raise CleanMachineError("Profile migration fixtures do not describe the expected version 5-to-6 transition.")
+    if profile_before == seeded_profile:
+        migration_timing = "v5-to-v6-during-update"
+    elif profile_before == expected_migrated:
+        migration_timing = "v5-to-v6-before-update"
+    else:
+        raise CleanMachineError("Profile library changed before the Sparkle update began.")
+    return file_sha256(profile_path), profile_before, migration_timing
+
+
+def _validate_profile_after_update(
     profile_path: Path,
     profile_before: Mapping[str, Any],
 ) -> tuple[str, dict[str, Any]]:
     expected_after = _load_profile_document(PROFILE_FIXTURE_V6_PATH, "Expected migrated profile fixture")
     profile_after = _load_profile_document(profile_path, "Profile library after Sparkle relaunch")
-    if profile_before.get("version") != 5 or expected_after.get("version") != 6:
+    if profile_before.get("version") not in {5, 6} or expected_after.get("version") != 6:
         raise CleanMachineError("Profile migration fixtures do not describe the expected version 5-to-6 transition.")
     if profile_after != expected_after:
-        raise CleanMachineError(
-            "Profile library did not match the expected version 5-to-6 migration across Sparkle relaunch."
-        )
+        raise CleanMachineError("Profile library did not match the expected version 6 state after Sparkle relaunch.")
     return file_sha256(profile_path), profile_after
 
 
@@ -2503,21 +2518,34 @@ def _run_qualification(
         if operations.read_preference(synthetic_home, SENTINEL_KEY) != SENTINEL_VALUE:
             raise CleanMachineError("Preference sentinel did not persist before the Sparkle update.")
 
-        operations.collect_ui_evidence(
-            repo=config.repo.resolve(),
-            phase="updater",
-            app_path=app_path,
-            synthetic_home=synthetic_home,
-            output_directory=raw_ui_directory,
-            release_notes_url=feed.release_notes_url,
-        )
-        operations.quit_app()
-        if operations.app_running():
-            raise CleanMachineError("Installed UI updater inspection left the production app running.")
-        profile_before = _load_profile_document(profile_path, "Profile library before Sparkle update")
-        if profile_before != seeded_profile:
-            raise CleanMachineError("Profile library changed before the Sparkle update began.")
-        profile_before_sha256 = file_sha256(profile_path)
+        failure_stage = "prior-installed-ui"
+        try:
+            operations.collect_ui_evidence(
+                repo=config.repo.resolve(),
+                phase="updater",
+                app_path=app_path,
+                synthetic_home=synthetic_home,
+                output_directory=raw_ui_directory,
+                release_notes_url=feed.release_notes_url,
+            )
+            operations.quit_app()
+            if operations.app_running():
+                raise CleanMachineError("Installed UI updater inspection left the production app running.")
+            failure_stage = "prior-profile-baseline"
+            profile_before_sha256, profile_before, profile_migration = _validate_profile_before_update(
+                profile_path, seeded_profile
+            )
+        except (CleanMachineError, OSError, subprocess.TimeoutExpired) as error:
+            diagnostic_summary = _record_sparkle_failure_diagnostics(
+                config=config,
+                operations=operations,
+                runtime_layout=runtime_layout,
+                prior=prior,
+                candidate=candidate,
+                failure_stage=failure_stage,
+                reason_code="pre-update-validation-failed",
+            )
+            raise CleanMachineError(f"{error} {diagnostic_summary}") from error
 
         failure_stage = "updater-state-machine"
         try:
@@ -2573,7 +2601,7 @@ def _run_qualification(
             raise CleanMachineError(f"{error} {diagnostic_summary}") from error
         route_after = operations.read_preference(synthetic_home, UPDATE_ROUTE_KEY)
         sentinel_after = operations.read_preference(synthetic_home, SENTINEL_KEY)
-        profile_after_sha256, profile_after = _validate_profile_migration(profile_path, profile_before)
+        profile_after_sha256, profile_after = _validate_profile_after_update(profile_path, profile_before)
         if route_after != config.route or sentinel_after != SENTINEL_VALUE:
             raise CleanMachineError("Update route or unrelated preference changed across Sparkle relaunch.")
 
@@ -2646,11 +2674,12 @@ def _run_qualification(
                 "profile_before_semantic_sha256": _semantic_json_sha256(profile_before),
                 "profile_encoding_options_preserved": True,
                 "profile_identity_preserved": True,
-                "profile_migration": "v5-to-v6",
+                "profile_migration": profile_migration,
                 "profile_migration_matched": True,
                 "profile_safe_pipeline_defaults_preserved": True,
                 "profile_version_after": profile_after["version"],
                 "profile_version_before": profile_before["version"],
+                "profile_version_seeded": seeded_profile["version"],
                 "route_after": route_after,
                 "route_preserved": True,
                 "sentinel_preserved": sentinel_after == SENTINEL_VALUE,

--- a/tests/test_tier3_clean_machine.py
+++ b/tests/test_tier3_clean_machine.py
@@ -110,6 +110,7 @@ class FakeOperations(QualificationOperations):
         self.post_install_update_observations = 0
         self.checkpoint_root: Path | None = None
         self.profile_after_relaunch = PROFILE_FIXTURE_V6_PATH.read_bytes()
+        self.migrate_profile_during_updater_ui = False
         self.tamper_profile_before_update = False
 
     def inspect_environment(self, qualification_root: Path, environment_class: str) -> EnvironmentFacts:
@@ -318,6 +319,9 @@ class FakeOperations(QualificationOperations):
     ) -> None:
         if phase == "updater" and self.tamper_prior_before_update:
             (app_path / "tampered-before-updater").write_text("changed\n", encoding="utf-8")
+        if phase == "updater" and self.migrate_profile_during_updater_ui:
+            profile_path = synthetic_home / PROFILE_RELATIVE_PATH
+            profile_path.write_bytes(PROFILE_FIXTURE_V6_PATH.read_bytes())
         if phase == "updater" and self.tamper_profile_before_update:
             profile_path = synthetic_home / PROFILE_RELATIVE_PATH
             profile_document = json.loads(profile_path.read_text(encoding="utf-8"))
@@ -1080,7 +1084,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             profile_evidence = json.loads(
                 (config.evidence_directory / "profile-snapshot.json").read_text(encoding="utf-8")
             )
-            self.assertEqual(profile_evidence["profile_migration"], "v5-to-v6")
+            self.assertEqual(profile_evidence["profile_migration"], "v5-to-v6-during-update")
             self.assertTrue(profile_evidence["profile_migration_matched"])
             self.assertTrue(profile_evidence["profile_identity_preserved"])
             self.assertTrue(profile_evidence["profile_encoding_options_preserved"])
@@ -1088,6 +1092,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
             self.assertTrue(profile_evidence["unsafe_legacy_run_defaults_removed"])
             self.assertEqual(profile_evidence["profile_version_before"], 5)
             self.assertEqual(profile_evidence["profile_version_after"], 6)
+            self.assertEqual(profile_evidence["profile_version_seeded"], 5)
             self.assertNotEqual(
                 profile_evidence["profile_before_sha256"],
                 profile_evidence["profile_after_sha256"],
@@ -1107,7 +1112,7 @@ class Tier3CleanMachineTests(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 CleanMachineError,
-                "did not match the expected version 5-to-6 migration",
+                "did not match the expected version 6 state",
             ):
                 run_qualification(config, operations)
 
@@ -1117,6 +1122,8 @@ class Tier3CleanMachineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             config, operations = self.fixture(root)
+            config = replace(config, diagnostics_output=root / "sparkle-install-diagnostics.json")
+            operations.migrate_profile_during_updater_ui = True
             operations.tamper_profile_before_update = True
 
             with self.assertRaisesRegex(
@@ -1127,6 +1134,31 @@ class Tier3CleanMachineTests(unittest.TestCase):
 
             self.assertFalse(operations.pressed_actions)
             self.assertFalse(config.evidence_directory.exists())
+            diagnostics = json.loads(config.diagnostics_output.read_text(encoding="utf-8"))
+            self.assertEqual(diagnostics["failure_stage"], "prior-profile-baseline")
+            self.assertEqual(diagnostics["reason_code"], "pre-update-validation-failed")
+            self.assertEqual(diagnostics["status"], "failed")
+
+    def test_run_accepts_profile_migrated_by_prior_release_before_update(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config, operations = self.fixture(root)
+            operations.migrate_profile_during_updater_ui = True
+
+            run_qualification(config, operations)
+
+            profile_evidence = json.loads(
+                (config.evidence_directory / "profile-snapshot.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(profile_evidence["profile_migration"], "v5-to-v6-before-update")
+            self.assertTrue(profile_evidence["profile_migration_matched"])
+            self.assertEqual(profile_evidence["profile_version_seeded"], 5)
+            self.assertEqual(profile_evidence["profile_version_before"], 6)
+            self.assertEqual(profile_evidence["profile_version_after"], 6)
+            self.assertEqual(
+                profile_evidence["profile_before_sha256"],
+                profile_evidence["profile_after_sha256"],
+            )
 
     def test_run_rejects_invalid_profile_document_after_relaunch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- accept the exact schema-v6 profile produced when immutable Beta 5 migrates the seeded v5 fixture before the Sparkle update
- continue to require the exact expected v6 document after Beta 7 relaunch, preserving fail-closed profile-loss coverage
- retain bounded diagnostics for pre-update UI and profile-baseline failures
- document both valid migration boundaries

## Evidence
- Failed milestone run: `32668904791`
- Exact failure: `Profile library changed before the Sparkle update began.`
- Candidate update action was never reached in that run
- Beta 5 source already declares `ProfileDocument.currentVersion = 6`

## Validation
- `uv run python -m unittest tests.test_tier3_clean_machine` (`43/43` passed)
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- `uv run ruff check --no-fix scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- `uv run ruff format --check scripts/tier3_clean_machine.py tests/test_tier3_clean_machine.py`
- blocker-only independent review: no findings

The whole local Python suite reached `1873` tests; its three errors are unrelated Homebrew `ffmpeg-full` binaries resolving incompatible `ffmpeg` dylibs on this machine.

Refs #609