### PR TITLE
Allow safe qualification checkpoint rebind

### DIFF
--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -534,6 +534,17 @@ commit exists; it never reconstructs receipts. If equivalent receipts are
 already committed and accepted, `status` reports no blockers and `resume`
 returns `complete` regardless of Actions retention.
 
+When a failed observed milestone run exposes a qualification-runner defect, a
+reviewed protected-main fix may refresh the canonical evidence manifest without
+changing the immutable release, receipt, or signed UI artifact. The controller
+does not silently discard the old checkpoint. It requires the exact failed run
+ID and attempt, the old checkpoint self-digest, and the refreshed main and
+manifest digests; it revalidates the historical run under the old identity,
+requires the new main to descend from the old runner, rejects changes to every
+decision-bearing manifest input and immutable release binding, rescans for a
+competing refreshed run at the mutation boundary, and atomically replaces only
+that observed checkpoint before dispatching the new runner identity.
+
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated
 receipts to that same idempotent branch. Optional physical and native-window

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -40,7 +40,7 @@ from scripts.release_qualification_status import (
     build_status,
     resolve_evidence_binding,
 )
-from scripts.release_qualification_manifest import ReleaseQualificationManifestError
+from scripts.release_qualification_manifest import ReleaseQualificationManifestError, manifest_sha256
 
 
 REPOSITORY = "cbusillo/BD_to_AVP"
@@ -366,6 +366,129 @@ def _validate_checkpoint(checkpoint: Mapping[str, Any], identity: ResumeIdentity
     elif run_id is not None or run_attempt is not None:
         raise QualificationResumeSafetyError("Prepared qualification checkpoint cannot contain an observed run.")
     return dispatch
+
+
+def _identity_from_checkpoint(checkpoint: Mapping[str, Any]) -> ResumeIdentity:
+    recorded = _mapping(checkpoint.get("identity"), "checkpoint identity")
+    _exact_keys(recorded, set(ResumeIdentity.__dataclass_fields__), "checkpoint identity")
+    identity = ResumeIdentity(
+        release_tag=_string(recorded.get("release_tag"), "checkpoint release tag"),
+        candidate_sha=_sha(recorded.get("candidate_sha"), "checkpoint candidate SHA"),
+        release_id=_integer(recorded.get("release_id"), "checkpoint release ID"),
+        manifest_sha256=_sha256(recorded.get("manifest_sha256"), "checkpoint manifest digest"),
+        runner_sha=_sha(recorded.get("runner_sha"), "checkpoint runner SHA"),
+        main_sha=_sha(recorded.get("main_sha"), "checkpoint main SHA"),
+        evidence_ref=_string(recorded.get("evidence_ref"), "checkpoint evidence ref"),
+        evidence_sha=_sha(recorded.get("evidence_sha"), "checkpoint evidence SHA"),
+        evidence_base_sha=_sha(recorded.get("evidence_base_sha"), "checkpoint evidence base SHA"),
+        evidence_pr_number=_integer(recorded.get("evidence_pr_number"), "checkpoint evidence PR number"),
+        release_receipt_file_sha256=_sha256(
+            recorded.get("release_receipt_file_sha256"),
+            "checkpoint release receipt digest",
+        ),
+        signed_ui_artifact_id=_integer(
+            recorded.get("signed_ui_artifact_id"),
+            "checkpoint signed UI artifact ID",
+        ),
+        signed_ui_artifact_sha256=_sha256(
+            recorded.get("signed_ui_artifact_sha256"),
+            "checkpoint signed UI artifact digest",
+        ),
+        policy_sha256=_sha256(recorded.get("policy_sha256"), "checkpoint policy digest"),
+        policy_checkpoint_sha256=_sha256(
+            recorded.get("policy_checkpoint_sha256"),
+            "checkpoint policy checkpoint digest",
+        ),
+        route_table_sha256=_sha256(
+            recorded.get("route_table_sha256"),
+            "checkpoint route table digest",
+        ),
+        controller_runner_sha256=_sha256(
+            recorded.get("controller_runner_sha256"),
+            "checkpoint controller runner digest",
+        ),
+    )
+    if checkpoint.get("identity_sha256") != identity.digest:
+        raise QualificationResumeSafetyError("Qualification resume checkpoint identity digest is invalid.")
+    return identity
+
+
+def _validate_checkpoint_rebind(
+    repo_root: Path,
+    previous: ResumeIdentity,
+    current: ResumeIdentity,
+    current_manifest: Mapping[str, Any],
+) -> None:
+    immutable_fields = (
+        "release_tag",
+        "candidate_sha",
+        "release_id",
+        "evidence_ref",
+        "evidence_pr_number",
+        "release_receipt_file_sha256",
+        "signed_ui_artifact_id",
+        "signed_ui_artifact_sha256",
+        "policy_sha256",
+        "policy_checkpoint_sha256",
+        "route_table_sha256",
+    )
+    changed = [field for field in immutable_fields if getattr(previous, field) != getattr(current, field)]
+    if changed:
+        raise QualificationResumeSafetyError(
+            f"Qualification checkpoint rebind changes immutable release fields: {changed!r}."
+        )
+    if previous.runner_sha != previous.main_sha or current.runner_sha != current.main_sha:
+        raise QualificationResumeSafetyError(
+            "Qualification checkpoint rebind requires protected-main runner identities."
+        )
+    ancestor = cast(
+        subprocess.CompletedProcess[str],
+        _git(repo_root, ["merge-base", "--is-ancestor", previous.main_sha, current.main_sha]),
+    )
+    if ancestor.returncode != 0:
+        raise QualificationResumeSafetyError(
+            "Qualification checkpoint rebind requires the refreshed protected main to descend from the prior runner."
+        )
+    previous_manifest = _manifest_at_revision(repo_root, previous)
+    if manifest_sha256(current_manifest) != current.manifest_sha256:
+        raise QualificationResumeSafetyError(
+            "Refreshed qualification manifest digest changed during checkpoint rebind."
+        )
+    if _checkpoint_rebind_manifest_projection(previous_manifest) != _checkpoint_rebind_manifest_projection(
+        current_manifest
+    ):
+        raise QualificationResumeSafetyError(
+            "Qualification checkpoint rebind changes decision-bearing manifest inputs."
+        )
+
+
+def _manifest_at_revision(repo_root: Path, identity: ResumeIdentity) -> Mapping[str, Any]:
+    manifest_path = f"docs/release-evidence/{identity.release_tag}/qualification-manifest.json"
+    result = cast(
+        subprocess.CompletedProcess[str],
+        _git(repo_root, ["show", f"{identity.evidence_sha}:{manifest_path}"]),
+    )
+    if result.returncode != 0:
+        raise QualificationResumeSafetyError("Unable to load the prior qualification manifest for checkpoint rebind.")
+    try:
+        manifest = _mapping(json.loads(result.stdout), "prior qualification manifest")
+    except json.JSONDecodeError as error:
+        raise QualificationResumeSafetyError("Prior qualification manifest is invalid JSON.") from error
+    recorded_digest = _sha256(manifest.get("manifest_sha256"), "prior qualification manifest digest")
+    if recorded_digest != identity.manifest_sha256 or manifest_sha256(manifest) != recorded_digest:
+        raise QualificationResumeSafetyError("Prior qualification manifest digest conflicts with the checkpoint.")
+    return manifest
+
+
+def _checkpoint_rebind_manifest_projection(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    projection = _mapping(json.loads(json.dumps(manifest)), "qualification manifest projection")
+    normalized = dict(projection)
+    normalized.pop("manifest_sha256", None)
+    normalized.pop("runner_sha", None)
+    canonical_evidence = dict(_mapping(normalized.get("canonical_evidence"), "manifest canonical evidence"))
+    canonical_evidence.pop("base_sha", None)
+    normalized["canonical_evidence"] = canonical_evidence
+    return normalized
 
 
 def _ref_endpoint(branch: str) -> str:
@@ -782,6 +905,7 @@ def _dispatch(
     high_water_run_id: int,
     retry_of_run_id: int | None,
     replace_prepared_checkpoint_sha256: str | None,
+    replace_observed_checkpoint_sha256: str | None,
     status_payload: Mapping[str, Any],
     poll_attempts: int,
     poll_seconds: float,
@@ -795,6 +919,7 @@ def _dispatch(
             high_water_run_id=high_water_run_id,
             retry_of_run_id=retry_of_run_id,
             replace_prepared_checkpoint_sha256=replace_prepared_checkpoint_sha256,
+            replace_observed_checkpoint_sha256=replace_observed_checkpoint_sha256,
             status_payload=status_payload,
             poll_attempts=poll_attempts,
             poll_seconds=poll_seconds,
@@ -810,6 +935,7 @@ def _dispatch_locked(
     high_water_run_id: int,
     retry_of_run_id: int | None,
     replace_prepared_checkpoint_sha256: str | None,
+    replace_observed_checkpoint_sha256: str | None,
     status_payload: Mapping[str, Any],
     poll_attempts: int,
     poll_seconds: float,
@@ -817,16 +943,51 @@ def _dispatch_locked(
 ) -> ResumeResult:
     _require_dispatch_actor(client)
     _revalidate_remote_identity(client, identity)
+    if replace_prepared_checkpoint_sha256 is not None and replace_observed_checkpoint_sha256 is not None:
+        raise QualificationResumeSafetyError("Dispatch cannot replace prepared and observed checkpoints together.")
     existing_checkpoint = _load_checkpoint(checkpoint_path)
     if existing_checkpoint is not None:
-        existing_dispatch = _validate_checkpoint(existing_checkpoint, identity)
+        existing_identity = _identity_from_checkpoint(existing_checkpoint)
+        existing_dispatch = _validate_checkpoint(existing_checkpoint, existing_identity)
         existing_state = cast(str, existing_dispatch["state"])
         existing_run_id = cast(int | None, existing_dispatch.get("run_id"))
-        if replace_prepared_checkpoint_sha256 is not None:
-            recorded_digest = _sha256(
-                existing_checkpoint.get("checkpoint_sha256"),
-                "prepared checkpoint self digest",
+        existing_run_attempt = cast(int | None, existing_dispatch.get("run_attempt"))
+        recorded_digest = _sha256(
+            existing_checkpoint.get("checkpoint_sha256"),
+            "serialized checkpoint self digest",
+        )
+        if replace_observed_checkpoint_sha256 is not None:
+            if (
+                existing_state != "observed"
+                or existing_run_id != retry_of_run_id
+                or recorded_digest != replace_observed_checkpoint_sha256
+            ):
+                raise QualificationResumeSafetyError(
+                    "Observed checkpoint rebind does not match the serialized qualification checkpoint."
+                )
+            previous_run = _run_identity(
+                _workflow_run(client, cast(int, existing_run_id), existing_identity),
+                existing_identity,
             )
+            if (
+                previous_run["run_attempt"] != existing_run_attempt
+                or previous_run["status"] != TERMINAL_RUN_STATUS
+                or previous_run["conclusion"] != "failure"
+            ):
+                raise QualificationResumeSafetyError(
+                    "Observed checkpoint rebind run changed before the replacement dispatch."
+                )
+            refreshed_matches, refreshed_high_water = _workflow_runs(client, identity)
+            if refreshed_matches:
+                raise QualificationResumeSafetyError(
+                    "An exact refreshed qualification run appeared before checkpoint rebind dispatch."
+                )
+            high_water_run_id = max(high_water_run_id, refreshed_high_water)
+        elif existing_identity != identity:
+            raise QualificationResumeSafetyError(
+                "Qualification resume checkpoint conflicts with current release identity."
+            )
+        elif replace_prepared_checkpoint_sha256 is not None:
             if existing_state != "prepared" or recorded_digest != replace_prepared_checkpoint_sha256:
                 raise QualificationResumeSafetyError(
                     "Prepared checkpoint retry does not match the serialized qualification checkpoint."
@@ -1056,6 +1217,90 @@ def resume_qualification(
     if len(active) > 1:
         raise QualificationResumeSafetyError("Multiple active exact Milestone Qualification runs exist.")
     if checkpoint is not None:
+        checkpoint_identity = _identity_from_checkpoint(checkpoint)
+        if checkpoint_identity != identity:
+            _validate_checkpoint_rebind(repo_root, checkpoint_identity, identity, binding.manifest)
+            dispatch_checkpoint = _validate_checkpoint(checkpoint, checkpoint_identity)
+            checkpoint_state = cast(str, dispatch_checkpoint["state"])
+            checkpoint_digest = _sha256(
+                checkpoint.get("checkpoint_sha256"),
+                "checkpoint self digest",
+            )
+            observed_run_id = cast(int | None, dispatch_checkpoint.get("run_id"))
+            observed_run_attempt = cast(int | None, dispatch_checkpoint.get("run_attempt"))
+            if checkpoint_state != "observed" or observed_run_id is None or observed_run_attempt is None:
+                raise QualificationResumeSafetyError(
+                    "Qualification checkpoint rebind requires an observed terminal run."
+                )
+            previous_run = _run_identity(
+                _workflow_run(github, observed_run_id, checkpoint_identity),
+                checkpoint_identity,
+            )
+            if previous_run["run_attempt"] != observed_run_attempt:
+                raise QualificationResumeSafetyError(
+                    "Qualification checkpoint rebind run attempt differs from the observed failed run."
+                )
+            if previous_run["status"] != TERMINAL_RUN_STATUS or previous_run["conclusion"] != "failure":
+                raise QualificationResumeSafetyError(
+                    "Qualification checkpoint rebind requires an exact terminal failed run."
+                )
+            mutation = {
+                "operation": "checkpoint_rebind_dispatch",
+                "endpoint": _workflow_dispatch_endpoint(),
+                "ref": MAIN_BRANCH,
+                "candidate_tag": identity.release_tag,
+                "manifest_sha256": identity.manifest_sha256,
+                "retry_of_run_id": observed_run_id,
+                "replaced_checkpoint_sha256": checkpoint_digest,
+            }
+            if retry_run_id is None or retry_checkpoint_sha256 is None:
+                return _result(
+                    "checkpoint_rebind_required",
+                    EXIT_OPERATOR_REQUIRED,
+                    status_payload,
+                    identity=identity,
+                    checkpoint_path=resolved_checkpoint_path,
+                    run=previous_run,
+                    mutation=mutation,
+                    next_action=(
+                        f"Rerun resume with --retry-run-id {observed_run_id}, "
+                        f"--retry-checkpoint-sha256 {checkpoint_digest}, and the exact expected "
+                        "main and manifest digests."
+                    ),
+                )
+            if retry_run_id != observed_run_id:
+                raise QualificationResumeSafetyError(
+                    "Checkpoint rebind retry run ID does not match the observed failed run."
+                )
+            if retry_checkpoint_sha256 != checkpoint_digest:
+                raise QualificationResumeSafetyError(
+                    "Checkpoint rebind digest does not match the serialized qualification checkpoint."
+                )
+            if not _validate_expected_mutation(
+                identity,
+                expected_main_sha=expected_main_sha,
+                expected_manifest_sha256=expected_manifest_sha256,
+            ):
+                raise QualificationResumeSafetyError(
+                    "Checkpoint rebind requires exact expected main and manifest authorization."
+                )
+            if active:
+                raise QualificationResumeSafetyError(
+                    "An exact refreshed qualification run is already active during checkpoint rebind."
+                )
+            return _dispatch(
+                github,
+                identity,
+                resolved_checkpoint_path,
+                high_water_run_id=high_water_run_id,
+                retry_of_run_id=observed_run_id,
+                replace_prepared_checkpoint_sha256=None,
+                replace_observed_checkpoint_sha256=checkpoint_digest,
+                status_payload=status_payload,
+                poll_attempts=poll_attempts,
+                poll_seconds=poll_seconds,
+                sleep=sleep,
+            )
         dispatch_checkpoint = _validate_checkpoint(checkpoint, identity)
         checkpoint_state = cast(str, dispatch_checkpoint["state"])
         checkpoint_high_water = cast(int, dispatch_checkpoint["high_water_run_id"])
@@ -1108,6 +1353,7 @@ def resume_qualification(
                         high_water_run_id=high_water_run_id,
                         retry_of_run_id=None,
                         replace_prepared_checkpoint_sha256=checkpoint_digest,
+                        replace_observed_checkpoint_sha256=None,
                         status_payload=status_payload,
                         poll_attempts=poll_attempts,
                         poll_seconds=poll_seconds,
@@ -1193,6 +1439,7 @@ def resume_qualification(
             high_water_run_id=high_water_run_id,
             retry_of_run_id=None,
             replace_prepared_checkpoint_sha256=None,
+            replace_observed_checkpoint_sha256=None,
             status_payload=status_payload,
             poll_attempts=poll_attempts,
             poll_seconds=poll_seconds,
@@ -1337,6 +1584,7 @@ def resume_qualification(
         high_water_run_id=high_water_run_id,
         retry_of_run_id=run_id,
         replace_prepared_checkpoint_sha256=None,
+        replace_observed_checkpoint_sha256=None,
         status_payload=status_payload,
         poll_attempts=poll_attempts,
         poll_seconds=poll_seconds,

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -4,8 +4,9 @@ import tempfile
 import unittest
 
 from collections import defaultdict, deque
+from dataclasses import replace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from scripts.release_milestone_context import ReleaseMilestoneContext
 from scripts.release_qualification_apply import ApplyOutcome
@@ -23,6 +24,7 @@ from scripts.release_qualification_resume import (
     _require_no_active_exact_runs,
     _revalidate_remote_identity,
     _run_matches,
+    _validate_checkpoint_rebind,
     _write_checkpoint,
     resume_qualification,
     safety_error_payload,
@@ -197,16 +199,18 @@ def workflow_run(
     status: str,
     conclusion: str | None,
     run_attempt: int = 1,
+    main_sha: str = MAIN_SHA,
+    manifest_sha: str = MANIFEST_SHA,
 ) -> dict[str, object]:
     return {
         "id": run_id,
         "run_attempt": run_attempt,
         "name": "Milestone Qualification",
         "path": ".github/workflows/milestone-qualification.yml",
-        "display_title": f"Milestone {RELEASE_TAG} {MANIFEST_SHA}",
+        "display_title": f"Milestone {RELEASE_TAG} {manifest_sha}",
         "event": "workflow_dispatch",
         "head_branch": "main",
-        "head_sha": MAIN_SHA,
+        "head_sha": main_sha,
         "actor": {"login": "cbusillo"},
         "triggering_actor": {"login": "cbusillo"},
         "status": status,
@@ -458,6 +462,7 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
                 high_water_run_id=100,
                 retry_of_run_id=None,
                 replace_prepared_checkpoint_sha256=None,
+                replace_observed_checkpoint_sha256=None,
                 status_payload=status_payload(),
                 poll_attempts=1,
                 poll_seconds=0,
@@ -636,6 +641,295 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         self.assertEqual(result.payload["state"], "running")
         self.assertEqual(result.payload["run"]["id"], 102)
         self.assertEqual(len(client.posts), 1)
+
+    def test_refreshed_runner_requires_exact_checkpoint_rebind(self) -> None:
+        old_main_sha = "f" * 40
+        old_manifest_sha = "8" * 64
+        old_identity = replace(
+            identity(),
+            manifest_sha256=old_manifest_sha,
+            runner_sha=old_main_sha,
+            main_sha=old_main_sha,
+            evidence_sha="9" * 40,
+            evidence_base_sha=old_main_sha,
+            controller_runner_sha256="a" * 64,
+        )
+        failed = workflow_run(
+            101,
+            status="completed",
+            conclusion="failure",
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [failed]})
+        client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", failed)
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = old_manifest_sha
+        old_manifest["runner_sha"] = old_main_sha
+        old_manifest["canonical_evidence"] = {"ref": EVIDENCE_REF, "base_sha": old_main_sha}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            serialized = _checkpoint_payload(
+                old_identity,
+                state="observed",
+                high_water_run_id=100,
+                retry_of_run_id=None,
+                run_id=101,
+                run_attempt=1,
+            )
+            _write_checkpoint(checkpoint, serialized)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+            ):
+                result = self.run_blocked(client, checkpoint)
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "checkpoint_rebind_required")
+        self.assertIn("--retry-run-id 101", result.payload["next_action"])
+        self.assertIn(serialized["checkpoint_sha256"], result.payload["next_action"])
+        self.assertEqual(client.posts, [])
+
+    def test_refreshed_runner_rebind_dispatches_exact_retry(self) -> None:
+        old_main_sha = "f" * 40
+        old_manifest_sha = "8" * 64
+        old_identity = replace(
+            identity(),
+            manifest_sha256=old_manifest_sha,
+            runner_sha=old_main_sha,
+            main_sha=old_main_sha,
+            evidence_sha="9" * 40,
+            evidence_base_sha=old_main_sha,
+            controller_runner_sha256="a" * 64,
+        )
+        failed = workflow_run(
+            101,
+            status="completed",
+            conclusion="failure",
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        running = workflow_run(102, status="queued", conclusion=None)
+        client = self.configured_client()
+        client.set_sequence(
+            RUNS_ENDPOINT,
+            [
+                {"workflow_runs": [failed]},
+                {"workflow_runs": [failed]},
+                {"workflow_runs": [running, failed]},
+            ],
+        )
+        client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", failed)
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = old_manifest_sha
+        old_manifest["runner_sha"] = old_main_sha
+        old_manifest["canonical_evidence"] = {"ref": EVIDENCE_REF, "base_sha": old_main_sha}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            serialized = _checkpoint_payload(
+                old_identity,
+                state="observed",
+                high_water_run_id=100,
+                retry_of_run_id=None,
+                run_id=101,
+                run_attempt=1,
+            )
+            _write_checkpoint(checkpoint, serialized)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+            ):
+                result = self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            updated = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.payload["state"], "running")
+        self.assertEqual(result.payload["run"]["id"], 102)
+        self.assertEqual(updated["identity"]["manifest_sha256"], MANIFEST_SHA)
+        self.assertEqual(updated["dispatch"]["retry_of_run_id"], 101)
+        self.assertEqual(len(client.posts), 1)
+
+    def test_refreshed_runner_rebind_rejects_new_run_race(self) -> None:
+        old_main_sha = "f" * 40
+        old_manifest_sha = "8" * 64
+        old_identity = replace(
+            identity(),
+            manifest_sha256=old_manifest_sha,
+            runner_sha=old_main_sha,
+            main_sha=old_main_sha,
+            evidence_sha="9" * 40,
+            evidence_base_sha=old_main_sha,
+            controller_runner_sha256="a" * 64,
+        )
+        failed = workflow_run(
+            101,
+            status="completed",
+            conclusion="failure",
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        competing = workflow_run(102, status="queued", conclusion=None)
+        client = self.configured_client()
+        client.set_sequence(
+            RUNS_ENDPOINT,
+            [
+                {"workflow_runs": [failed]},
+                {"workflow_runs": [competing, failed]},
+            ],
+        )
+        client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", failed)
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = old_manifest_sha
+        old_manifest["runner_sha"] = old_main_sha
+        old_manifest["canonical_evidence"] = {"ref": EVIDENCE_REF, "base_sha": old_main_sha}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            serialized = _checkpoint_payload(
+                old_identity,
+                state="observed",
+                high_water_run_id=100,
+                retry_of_run_id=None,
+                run_id=101,
+                run_attempt=1,
+            )
+            _write_checkpoint(checkpoint, serialized)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+                self.assertRaisesRegex(QualificationResumeSafetyError, "refreshed qualification run appeared"),
+            ):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            unchanged = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(unchanged["checkpoint_sha256"], serialized["checkpoint_sha256"])
+        self.assertEqual(client.posts, [])
+
+    def test_refreshed_runner_rebind_rejects_changed_release_identity(self) -> None:
+        previous = identity()
+        current = replace(identity(), release_id=999)
+
+        with self.assertRaisesRegex(QualificationResumeSafetyError, "immutable release fields"):
+            _validate_checkpoint_rebind(REPO_ROOT, previous, current, manifest())
+
+    def test_refreshed_runner_rebind_rejects_decision_input_drift(self) -> None:
+        previous = replace(
+            identity(),
+            manifest_sha256="8" * 64,
+            runner_sha="f" * 40,
+            main_sha="f" * 40,
+            evidence_sha="9" * 40,
+        )
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = previous.manifest_sha256
+        old_manifest["runner_sha"] = previous.runner_sha
+        old_manifest["prior"] = {"release_tag": "v0.9.0"}
+
+        with (
+            patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+            patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+            patch(
+                "scripts.release_qualification_resume.manifest_sha256",
+                side_effect=lambda document: document["manifest_sha256"],
+            ),
+            self.assertRaisesRegex(QualificationResumeSafetyError, "decision-bearing manifest inputs"),
+        ):
+            _validate_checkpoint_rebind(REPO_ROOT, previous, identity(), manifest())
+
+    def test_refreshed_runner_rebind_rechecks_run_attempt_at_mutation_boundary(self) -> None:
+        old_main_sha = "f" * 40
+        old_manifest_sha = "8" * 64
+        old_identity = replace(
+            identity(),
+            manifest_sha256=old_manifest_sha,
+            runner_sha=old_main_sha,
+            main_sha=old_main_sha,
+            evidence_sha="9" * 40,
+            evidence_base_sha=old_main_sha,
+            controller_runner_sha256="a" * 64,
+        )
+        failed = workflow_run(
+            101,
+            status="completed",
+            conclusion="failure",
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        rerun = workflow_run(
+            101,
+            status="completed",
+            conclusion="failure",
+            run_attempt=2,
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        client = self.configured_client()
+        client.set(RUNS_ENDPOINT, {"workflow_runs": [failed]})
+        client.set_sequence("repos/cbusillo/BD_to_AVP/actions/runs/101", [failed, rerun])
+        client.set("user", {"login": "cbusillo"}, active_auth=True)
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = old_manifest_sha
+        old_manifest["runner_sha"] = old_main_sha
+        old_manifest["canonical_evidence"] = {"ref": EVIDENCE_REF, "base_sha": old_main_sha}
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            serialized = _checkpoint_payload(
+                old_identity,
+                state="observed",
+                high_water_run_id=100,
+                retry_of_run_id=None,
+                run_id=101,
+                run_attempt=1,
+            )
+            _write_checkpoint(checkpoint, serialized)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+                self.assertRaisesRegex(QualificationResumeSafetyError, "run changed before"),
+            ):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            unchanged = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(unchanged["checkpoint_sha256"], serialized["checkpoint_sha256"])
+        self.assertEqual(client.posts, [])
 
     def test_successful_run_reports_available_artifact_without_download(self) -> None:
         client = self.configured_client()


### PR DESCRIPTION
## Summary
- allow a failed observed Milestone Qualification checkpoint to follow a reviewed Release Evidence runner refresh
- require the exact old checkpoint digest, failed run ID and attempt, refreshed main SHA, and refreshed manifest digest
- preserve every immutable release/artifact binding and the complete decision-bearing manifest projection
- revalidate the old failed run and rescan for a competing refreshed run at the locked mutation boundary
- atomically replace only the exact serialized observed checkpoint

## Beta 7 recovery case
- Failed run: `32668904791`, attempt `1`
- Old runner/main: `d994ce11f9d4a669f068c89dc8e51ca269710290`
- Refreshed runner/main after PR #640: `77b66f6a0efb4a72820b5a14ee68da3e3967a059`
- Old manifest: `844dd49986a8a3c65d20276c414439085a3a599e81b36994d72cad8dee80d41a`
- Refreshed manifest: `7cb45c5e22e3dbff854a595a9eadc36e9d389d1f90d3a83463b5bec2ce9dd96b`
- Immutable release remains `375333598` / build `169` / source `d994ce11f9d4a669f068c89dc8e51ca269710290`

## Validation
- `uv run python -m unittest tests.test_release_qualification_resume tests.test_release_qualification_controller` (`57` passed)
- focused release evidence/receipt/manifest/controller/apply/artifact/Tier 3 suite (`116` passed)
- `uv run python -m scripts.qualify_release_scope --validate-policy`
- Ruff lint and format checks
- actual Beta 7 old/new manifest projections compare equal after excluding only runner SHA, manifest self-digest, and canonical evidence base SHA
- blocker reviews drove exact run-attempt and mutation-boundary race coverage

Refs #609