### PR TITLE
Allow completed qualification checkpoint refresh

### DIFF
--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -548,6 +548,12 @@ requires the new main to descend from the old runner, rejects changes to every
 decision-bearing manifest input and immutable release binding, rescans for a
 competing refreshed run at the mutation boundary, and atomically replaces only
 that observed checkpoint before dispatching the new runner identity.
+The same fail-closed replacement is available after an exact successful run
+when a later protected-main reconciliation enhancement requires one fresh run
+bound to the refreshed runner. It uses the same exact run ID, checkpoint digest,
+main digest, manifest digest, ancestry, immutable-binding, projection, and
+duplicate-run checks; it never reuses the earlier artifact under the new
+manifest identity.
 
 The initial evidence PR is expected to remain unmergeable while blocking
 live-artifact or automated Tier 3 receipts are absent. Collectors add validated

--- a/scripts/release_qualification_resume.py
+++ b/scripts/release_qualification_resume.py
@@ -906,6 +906,7 @@ def _dispatch(
     retry_of_run_id: int | None,
     replace_prepared_checkpoint_sha256: str | None,
     replace_observed_checkpoint_sha256: str | None,
+    replace_observed_run_conclusion: str | None,
     status_payload: Mapping[str, Any],
     poll_attempts: int,
     poll_seconds: float,
@@ -920,6 +921,7 @@ def _dispatch(
             retry_of_run_id=retry_of_run_id,
             replace_prepared_checkpoint_sha256=replace_prepared_checkpoint_sha256,
             replace_observed_checkpoint_sha256=replace_observed_checkpoint_sha256,
+            replace_observed_run_conclusion=replace_observed_run_conclusion,
             status_payload=status_payload,
             poll_attempts=poll_attempts,
             poll_seconds=poll_seconds,
@@ -936,6 +938,7 @@ def _dispatch_locked(
     retry_of_run_id: int | None,
     replace_prepared_checkpoint_sha256: str | None,
     replace_observed_checkpoint_sha256: str | None,
+    replace_observed_run_conclusion: str | None,
     status_payload: Mapping[str, Any],
     poll_attempts: int,
     poll_seconds: float,
@@ -945,6 +948,12 @@ def _dispatch_locked(
     _revalidate_remote_identity(client, identity)
     if replace_prepared_checkpoint_sha256 is not None and replace_observed_checkpoint_sha256 is not None:
         raise QualificationResumeSafetyError("Dispatch cannot replace prepared and observed checkpoints together.")
+    if (replace_observed_checkpoint_sha256 is None) != (replace_observed_run_conclusion is None):
+        raise QualificationResumeSafetyError(
+            "Observed checkpoint replacement requires its exact terminal run conclusion."
+        )
+    if replace_observed_run_conclusion not in {None, "failure", "success"}:
+        raise QualificationResumeSafetyError("Observed checkpoint replacement conclusion is unsupported.")
     existing_checkpoint = _load_checkpoint(checkpoint_path)
     if existing_checkpoint is not None:
         existing_identity = _identity_from_checkpoint(existing_checkpoint)
@@ -972,7 +981,7 @@ def _dispatch_locked(
             if (
                 previous_run["run_attempt"] != existing_run_attempt
                 or previous_run["status"] != TERMINAL_RUN_STATUS
-                or previous_run["conclusion"] != "failure"
+                or previous_run["conclusion"] != replace_observed_run_conclusion
             ):
                 raise QualificationResumeSafetyError(
                     "Observed checkpoint rebind run changed before the replacement dispatch."
@@ -1238,14 +1247,18 @@ def resume_qualification(
             )
             if previous_run["run_attempt"] != observed_run_attempt:
                 raise QualificationResumeSafetyError(
-                    "Qualification checkpoint rebind run attempt differs from the observed failed run."
+                    "Qualification checkpoint rebind run attempt differs from the observed terminal run."
                 )
-            if previous_run["status"] != TERMINAL_RUN_STATUS or previous_run["conclusion"] != "failure":
+            previous_conclusion = previous_run["conclusion"]
+            if previous_run["status"] != TERMINAL_RUN_STATUS or previous_conclusion not in {"failure", "success"}:
                 raise QualificationResumeSafetyError(
-                    "Qualification checkpoint rebind requires an exact terminal failed run."
+                    "Qualification checkpoint rebind requires an exact terminal failed or successful run."
                 )
+            refreshing_success = previous_conclusion == "success"
             mutation = {
-                "operation": "checkpoint_rebind_dispatch",
+                "operation": (
+                    "completed_checkpoint_refresh_dispatch" if refreshing_success else "checkpoint_rebind_dispatch"
+                ),
                 "endpoint": _workflow_dispatch_endpoint(),
                 "ref": MAIN_BRANCH,
                 "candidate_tag": identity.release_tag,
@@ -1255,7 +1268,7 @@ def resume_qualification(
             }
             if retry_run_id is None or retry_checkpoint_sha256 is None:
                 return _result(
-                    "checkpoint_rebind_required",
+                    "completed_checkpoint_refresh_required" if refreshing_success else "checkpoint_rebind_required",
                     EXIT_OPERATOR_REQUIRED,
                     status_payload,
                     identity=identity,
@@ -1270,7 +1283,7 @@ def resume_qualification(
                 )
             if retry_run_id != observed_run_id:
                 raise QualificationResumeSafetyError(
-                    "Checkpoint rebind retry run ID does not match the observed failed run."
+                    "Checkpoint rebind retry run ID does not match the observed terminal run."
                 )
             if retry_checkpoint_sha256 != checkpoint_digest:
                 raise QualificationResumeSafetyError(
@@ -1284,6 +1297,10 @@ def resume_qualification(
                 raise QualificationResumeSafetyError(
                     "Checkpoint rebind requires exact expected main and manifest authorization."
                 )
+            if refreshing_success and matches:
+                raise QualificationResumeSafetyError(
+                    "An exact refreshed qualification run already exists during completed checkpoint refresh."
+                )
             if active:
                 raise QualificationResumeSafetyError(
                     "An exact refreshed qualification run is already active during checkpoint rebind."
@@ -1296,6 +1313,7 @@ def resume_qualification(
                 retry_of_run_id=observed_run_id,
                 replace_prepared_checkpoint_sha256=None,
                 replace_observed_checkpoint_sha256=checkpoint_digest,
+                replace_observed_run_conclusion=cast(str, previous_conclusion),
                 status_payload=status_payload,
                 poll_attempts=poll_attempts,
                 poll_seconds=poll_seconds,
@@ -1354,6 +1372,7 @@ def resume_qualification(
                         retry_of_run_id=None,
                         replace_prepared_checkpoint_sha256=checkpoint_digest,
                         replace_observed_checkpoint_sha256=None,
+                        replace_observed_run_conclusion=None,
                         status_payload=status_payload,
                         poll_attempts=poll_attempts,
                         poll_seconds=poll_seconds,
@@ -1440,6 +1459,7 @@ def resume_qualification(
             retry_of_run_id=None,
             replace_prepared_checkpoint_sha256=None,
             replace_observed_checkpoint_sha256=None,
+            replace_observed_run_conclusion=None,
             status_payload=status_payload,
             poll_attempts=poll_attempts,
             poll_seconds=poll_seconds,
@@ -1585,6 +1605,7 @@ def resume_qualification(
         retry_of_run_id=run_id,
         replace_prepared_checkpoint_sha256=None,
         replace_observed_checkpoint_sha256=None,
+        replace_observed_run_conclusion=None,
         status_payload=status_payload,
         poll_attempts=poll_attempts,
         poll_seconds=poll_seconds,

--- a/tests/test_release_qualification_resume.py
+++ b/tests/test_release_qualification_resume.py
@@ -268,6 +268,45 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         client.set(PR_ENDPOINT, [pull_request()])
         return client
 
+    def refreshed_runner_checkpoint(
+        self,
+        checkpoint: Path,
+        *,
+        conclusion: str,
+    ) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+        old_main_sha = "f" * 40
+        old_manifest_sha = "8" * 64
+        old_identity = replace(
+            identity(),
+            manifest_sha256=old_manifest_sha,
+            runner_sha=old_main_sha,
+            main_sha=old_main_sha,
+            evidence_sha="9" * 40,
+            evidence_base_sha=old_main_sha,
+            controller_runner_sha256="a" * 64,
+        )
+        previous_run = workflow_run(
+            101,
+            status="completed",
+            conclusion=conclusion,
+            main_sha=old_main_sha,
+            manifest_sha=old_manifest_sha,
+        )
+        old_manifest = manifest()
+        old_manifest["manifest_sha256"] = old_manifest_sha
+        old_manifest["runner_sha"] = old_main_sha
+        old_manifest["canonical_evidence"] = {"ref": EVIDENCE_REF, "base_sha": old_main_sha}
+        serialized = _checkpoint_payload(
+            old_identity,
+            state="observed",
+            high_water_run_id=100,
+            retry_of_run_id=None,
+            run_id=101,
+            run_attempt=1,
+        )
+        _write_checkpoint(checkpoint, serialized)
+        return previous_run, old_manifest, serialized
+
     def run_blocked(
         self,
         client: FakeGitHubAPI,
@@ -463,6 +502,7 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
                 retry_of_run_id=None,
                 replace_prepared_checkpoint_sha256=None,
                 replace_observed_checkpoint_sha256=None,
+                replace_observed_run_conclusion=None,
                 status_payload=status_payload(),
                 poll_attempts=1,
                 poll_seconds=0,
@@ -764,6 +804,154 @@ class ReleaseQualificationResumeTests(unittest.TestCase):
         self.assertEqual(updated["identity"]["manifest_sha256"], MANIFEST_SHA)
         self.assertEqual(updated["dispatch"]["retry_of_run_id"], 101)
         self.assertEqual(len(client.posts), 1)
+
+    def test_completed_checkpoint_refresh_requires_exact_authorization(self) -> None:
+        client = self.configured_client()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            successful, old_manifest, serialized = self.refreshed_runner_checkpoint(
+                checkpoint,
+                conclusion="success",
+            )
+            client.set(RUNS_ENDPOINT, {"workflow_runs": [successful]})
+            client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", successful)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+            ):
+                result = self.run_blocked(client, checkpoint)
+
+        self.assertEqual(result.exit_code, EXIT_OPERATOR_REQUIRED)
+        self.assertEqual(result.payload["state"], "completed_checkpoint_refresh_required")
+        self.assertEqual(
+            result.payload["planned_mutation"]["operation"],
+            "completed_checkpoint_refresh_dispatch",
+        )
+        self.assertIn("--retry-run-id 101", result.payload["next_action"])
+        self.assertIn(serialized["checkpoint_sha256"], result.payload["next_action"])
+        self.assertEqual(client.posts, [])
+
+    def test_completed_checkpoint_refresh_dispatches_one_exact_run(self) -> None:
+        client = self.configured_client()
+        running = workflow_run(102, status="queued", conclusion=None)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            successful, old_manifest, serialized = self.refreshed_runner_checkpoint(
+                checkpoint,
+                conclusion="success",
+            )
+            client.set_sequence(
+                RUNS_ENDPOINT,
+                [
+                    {"workflow_runs": [successful]},
+                    {"workflow_runs": [successful]},
+                    {"workflow_runs": [running, successful]},
+                ],
+            )
+            client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", successful)
+            client.set("user", {"login": "cbusillo"}, active_auth=True)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+            ):
+                result = self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            updated = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.payload["state"], "running")
+        self.assertEqual(result.payload["run"]["id"], 102)
+        self.assertEqual(updated["identity"]["manifest_sha256"], MANIFEST_SHA)
+        self.assertEqual(updated["dispatch"]["retry_of_run_id"], 101)
+        self.assertEqual(len(client.posts), 1)
+
+    def test_completed_checkpoint_refresh_rejects_new_run_race(self) -> None:
+        client = self.configured_client()
+        competing = workflow_run(102, status="queued", conclusion=None)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            successful, old_manifest, serialized = self.refreshed_runner_checkpoint(
+                checkpoint,
+                conclusion="success",
+            )
+            client.set_sequence(
+                RUNS_ENDPOINT,
+                [
+                    {"workflow_runs": [successful]},
+                    {"workflow_runs": [competing, successful]},
+                ],
+            )
+            client.set("repos/cbusillo/BD_to_AVP/actions/runs/101", successful)
+            client.set("user", {"login": "cbusillo"}, active_auth=True)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+                self.assertRaisesRegex(QualificationResumeSafetyError, "refreshed qualification run appeared"),
+            ):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            unchanged = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(unchanged["checkpoint_sha256"], serialized["checkpoint_sha256"])
+        self.assertEqual(client.posts, [])
+
+    def test_completed_checkpoint_refresh_rechecks_success_at_mutation_boundary(self) -> None:
+        client = self.configured_client()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            checkpoint = Path(temporary_directory) / "checkpoint.json"
+            successful, old_manifest, serialized = self.refreshed_runner_checkpoint(
+                checkpoint,
+                conclusion="success",
+            )
+            changed = dict(successful)
+            changed["conclusion"] = "failure"
+            client.set_sequence(RUNS_ENDPOINT, [{"workflow_runs": [successful]}, {"workflow_runs": [successful]}])
+            client.set_sequence("repos/cbusillo/BD_to_AVP/actions/runs/101", [successful, changed])
+            client.set("user", {"login": "cbusillo"}, active_auth=True)
+            with (
+                patch("scripts.release_qualification_resume._git", return_value=Mock(returncode=0)),
+                patch("scripts.release_qualification_resume._manifest_at_revision", return_value=old_manifest),
+                patch(
+                    "scripts.release_qualification_resume.manifest_sha256",
+                    side_effect=lambda document: document["manifest_sha256"],
+                ),
+                self.assertRaisesRegex(QualificationResumeSafetyError, "run changed"),
+            ):
+                self.run_blocked(
+                    client,
+                    checkpoint,
+                    expected_main_sha=MAIN_SHA,
+                    expected_manifest_sha256=MANIFEST_SHA,
+                    retry_run_id=101,
+                    retry_checkpoint_sha256=serialized["checkpoint_sha256"],
+                )
+            unchanged = json.loads(checkpoint.read_text(encoding="utf-8"))
+
+        self.assertEqual(unchanged["checkpoint_sha256"], serialized["checkpoint_sha256"])
+        self.assertEqual(client.posts, [])
 
     def test_refreshed_runner_rebind_rejects_new_run_race(self) -> None:
         old_main_sha = "f" * 40


### PR DESCRIPTION
## Summary
- allow an exact terminal successful checkpoint to be refreshed after protected-main runner advancement
- require the existing exact run ID, checkpoint digest, main SHA, and manifest digest
- revalidate the prior conclusion/run attempt and reject refreshed-run races under the checkpoint lock
- preserve the existing failed-run rebind path unchanged

## Validation
- focused release controller/evidence suite: 167 passed
- `tests.test_release_qualification_resume`: 41 passed
- Ruff check/format clean
- two independent blocker reviews found no blockers
- JetBrains remains inconclusive in this exact worktree because the IDE lacks a configured Python SDK

Refs #609