### PR TITLE
Preserve repeated qualification receipts

### DIFF
--- a/docs/release-qualification-policy.md
+++ b/docs/release-qualification-policy.md
@@ -513,6 +513,11 @@ The plan writes the two Tier 3 receipts, indexes the existing exact signed UI
 receipt for `profile-save-action-accessibility`, and derives the live
 `sparkle-update-route` record from the validated update, profile, release,
 publication, manifest, and artifact bindings.
+Fixed tag-case Tier 3 paths are first-write destinations. If a later exact run
+produces different valid bytes, reconciliation preserves the accepted fixed
+file and index record, then writes and indexes the new receipt at a deterministic
+run-scoped path only when the fixed file has an exact accepted immutable index
+binding.
 `--observe-only` stops at `artifact_available` without downloading.
 `reconciliation_planned` requires an explicit rerun with
 `--apply-plan-sha256 <plan-sha256>`;

--- a/scripts/release_qualification_artifact.py
+++ b/scripts/release_qualification_artifact.py
@@ -518,6 +518,86 @@ def _plan_file_operation(repo_root: Path, path: str, content: bytes) -> dict[str
     }
 
 
+def _load_evidence_index(repo_root: Path) -> tuple[dict[str, Any], list[dict[str, object]]]:
+    index_content = _checked_file(repo_root, EVIDENCE_INDEX_PATH)
+    if index_content is None:
+        raise QualificationArtifactSafetyError("Checked release qualification evidence index is missing.")
+    index = dict(_load_json_bytes(index_content, "release qualification evidence index"))
+    if index.get("schema_version") != 1:
+        raise QualificationArtifactSafetyError("Release qualification evidence index schema version changed.")
+    receipts = [
+        dict(_mapping(item, "release qualification evidence record"))
+        for item in _sequence(index.get("receipts"), "release qualification evidence records")
+    ]
+    receipt_ids: set[str] = set()
+    for record in receipts:
+        receipt_id = _string(record.get("receipt_id"), "release qualification evidence receipt ID")
+        if receipt_id in receipt_ids:
+            raise QualificationArtifactSafetyError(
+                f"Release qualification evidence repeats immutable receipt ID {receipt_id!r}."
+            )
+        receipt_ids.add(receipt_id)
+    return index, receipts
+
+
+def _resolved_rollover_path(
+    repo_root: Path,
+    *,
+    identity: QualificationIdentity,
+    case_id: str,
+    fixed_path: str,
+    rollover_path: str,
+    content: bytes,
+    source: str,
+    existing_records: Sequence[Mapping[str, Any]],
+) -> str:
+    existing = _checked_file(repo_root, fixed_path)
+    if existing is None or existing == content:
+        return fixed_path
+    path_records = [record for record in existing_records if record.get("reference") == fixed_path]
+    existing_digest = hashlib.sha256(existing).hexdigest()
+    receipt_id_pattern = re.compile(rf"^{re.escape(identity.release_tag)}:{re.escape(case_id)}:[1-9][0-9]*$")
+    if len(path_records) != 1:
+        raise QualificationArtifactSafetyError(f"Checked qualification receipt {fixed_path!r} conflicts.")
+    backing = path_records[0]
+    receipt_id = backing.get("receipt_id")
+    if (
+        not isinstance(receipt_id, str)
+        or receipt_id_pattern.fullmatch(receipt_id) is None
+        or backing.get("case_id") != case_id
+        or backing.get("sha256") != existing_digest
+        or backing.get("source") != source
+        or backing.get("source_sha") != identity.candidate_sha
+        or backing.get("status") != "accepted"
+    ):
+        raise QualificationArtifactSafetyError(f"Checked qualification receipt {fixed_path!r} conflicts.")
+    return rollover_path
+
+
+def _receipt_destinations(
+    repo_root: Path,
+    *,
+    identity: QualificationIdentity,
+    run_id: int,
+    receipt_contents: Mapping[str, bytes],
+    existing_records: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    destinations: dict[str, str] = {}
+    for case_id in CASE_IDS:
+        fixed_path = f"docs/qualification/{identity.release_tag}-{case_id}-v1.json"
+        destinations[case_id] = _resolved_rollover_path(
+            repo_root,
+            identity=identity,
+            case_id=case_id,
+            fixed_path=fixed_path,
+            rollover_path=f"docs/qualification/{identity.release_tag}-{case_id}-run-{run_id}-v1.json",
+            content=receipt_contents[case_id],
+            source="tier3_automation_receipt",
+            existing_records=existing_records,
+        )
+    return destinations
+
+
 def _validated_release_receipt(
     repo_root: Path,
     *,
@@ -646,6 +726,7 @@ def _build_live_qualification(
     entries: Mapping[str, bytes],
     release_receipt: Mapping[str, Any],
     qualification_run: Mapping[str, Any],
+    clean_receipt_path: str,
     accepted_at: str,
 ) -> bytes:
     _validate_live_publication_record(
@@ -700,7 +781,6 @@ def _build_live_qualification(
         != profile_snapshot.get("profile_after_semantic_sha256")
     ):
         raise QualificationArtifactSafetyError("Profile snapshot does not prove preservation across the update.")
-    clean_receipt_path = f"docs/qualification/{identity.release_tag}-clean-machine-signed-update-v1.json"
     clean_receipt_content = entries["clean-machine-signed-update.json"]
     artifact_digest = _string(artifact.get("digest"), "Milestone Qualification artifact digest")
     if not artifact_digest.startswith("sha256:"):
@@ -777,11 +857,13 @@ def _append_index_record(
 
 
 def _plan_index_operations(
-    repo_root: Path,
     *,
+    index: Mapping[str, Any],
+    existing_receipts: Sequence[Mapping[str, Any]],
     identity: QualificationIdentity,
     run: Mapping[str, Any],
     receipt_contents: Mapping[str, bytes],
+    receipt_destinations: Mapping[str, str],
     signed_ui_path: str,
     signed_ui_content: bytes,
     signed_ui_receipt: Mapping[str, Any],
@@ -789,20 +871,12 @@ def _plan_index_operations(
     live_content: bytes,
     accepted_at: str,
 ) -> tuple[list[dict[str, object]], bytes]:
-    index_content = _checked_file(repo_root, EVIDENCE_INDEX_PATH)
-    if index_content is None:
-        raise QualificationArtifactSafetyError("Checked release qualification evidence index is missing.")
-    index = dict(_load_json_bytes(index_content, "release qualification evidence index"))
-    if index.get("schema_version") != 1:
-        raise QualificationArtifactSafetyError("Release qualification evidence index schema version changed.")
-    receipts = [
-        dict(_mapping(item, "release qualification evidence record"))
-        for item in _sequence(index.get("receipts"), "release qualification evidence records")
-    ]
+    updated_index = dict(index)
+    receipts = [dict(record) for record in existing_receipts]
     run_id = _integer(run.get("id"), "workflow run ID")
     operations: list[dict[str, object]] = []
     for case_id in CASE_IDS:
-        destination = f"docs/qualification/{identity.release_tag}-{case_id}-v1.json"
+        destination = receipt_destinations[case_id]
         content = receipt_contents[case_id]
         record: dict[str, object] = {
             "accepted_at": accepted_at,
@@ -816,16 +890,24 @@ def _plan_index_operations(
         }
         _append_index_record(receipts, operations, record)
     signed_ui_workflow = _mapping(signed_ui_receipt.get("workflow"), "signed UI receipt workflow")
+    profile_receipt_id = (
+        f"{identity.release_tag}:{PROFILE_CASE_ID}:"
+        f"{_integer(signed_ui_workflow.get('run_id'), 'signed UI workflow run ID')}"
+    )
+    existing_profile_records = [record for record in receipts if record.get("receipt_id") == profile_receipt_id]
+    profile_accepted_at = accepted_at
+    if existing_profile_records:
+        profile_accepted_at = _string(
+            existing_profile_records[0].get("accepted_at"),
+            "existing signed UI evidence accepted_at",
+        )
     _append_index_record(
         receipts,
         operations,
         {
-            "accepted_at": accepted_at,
+            "accepted_at": profile_accepted_at,
             "case_id": PROFILE_CASE_ID,
-            "receipt_id": (
-                f"{identity.release_tag}:{PROFILE_CASE_ID}:"
-                f"{_integer(signed_ui_workflow.get('run_id'), 'signed UI workflow run ID')}"
-            ),
+            "receipt_id": profile_receipt_id,
             "reference": signed_ui_path,
             "sha256": hashlib.sha256(signed_ui_content).hexdigest(),
             "source": "signed_artifact_receipt",
@@ -847,8 +929,8 @@ def _plan_index_operations(
             "status": "accepted",
         },
     )
-    index["receipts"] = receipts
-    return operations, _pretty_json_bytes(index)
+    updated_index["receipts"] = receipts
+    return operations, _pretty_json_bytes(updated_index)
 
 
 def plan_reconciliation_bundle(
@@ -908,7 +990,17 @@ def plan_reconciliation_bundle(
         release_receipt=release_receipt,
         policy_id=_string(receipts[CASE_IDS[0]].get("policy_id"), "qualification policy ID"),
     )
-    live_path = f"docs/qualification/{identity.release_tag}-live-qualification-v1.json"
+    run_id = _integer(run.get("id"), "workflow run ID")
+    receipt_contents = {case_id: entries[f"{case_id}.json"] for case_id in CASE_IDS}
+    index, existing_index_receipts = _load_evidence_index(repo_root)
+    receipt_destinations = _receipt_destinations(
+        repo_root,
+        identity=identity,
+        run_id=run_id,
+        receipt_contents=receipt_contents,
+        existing_records=existing_index_receipts,
+    )
+    fixed_live_path = f"docs/qualification/{identity.release_tag}-live-qualification-v1.json"
     live_content = _build_live_qualification(
         repo_root,
         identity=identity,
@@ -918,15 +1010,25 @@ def plan_reconciliation_bundle(
         entries=entries,
         release_receipt=release_receipt,
         qualification_run=qualification_run,
+        clean_receipt_path=receipt_destinations["clean-machine-signed-update"],
         accepted_at=accepted_at,
     )
+    live_path = _resolved_rollover_path(
+        repo_root,
+        identity=identity,
+        case_id=SPARKLE_CASE_ID,
+        fixed_path=fixed_live_path,
+        rollover_path=f"docs/qualification/{identity.release_tag}-live-qualification-run-{run_id}-v1.json",
+        content=live_content,
+        source="signed_artifact_receipt",
+        existing_records=existing_index_receipts,
+    )
     operations: list[dict[str, object]] = []
-    receipt_contents = {case_id: entries[f"{case_id}.json"] for case_id in CASE_IDS}
     for case_id in CASE_IDS:
         operations.append(
             _plan_file_operation(
                 repo_root,
-                f"docs/qualification/{identity.release_tag}-{case_id}-v1.json",
+                receipt_destinations[case_id],
                 receipt_contents[case_id],
             )
         )
@@ -947,10 +1049,12 @@ def plan_reconciliation_bundle(
         }
     )
     index_operations, index_content = _plan_index_operations(
-        repo_root,
+        index=index,
+        existing_receipts=existing_index_receipts,
         identity=identity,
         run=run,
         receipt_contents=receipt_contents,
+        receipt_destinations=receipt_destinations,
         signed_ui_path=signed_ui_path,
         signed_ui_content=signed_ui_content,
         signed_ui_receipt=signed_ui_receipt,
@@ -971,10 +1075,7 @@ def plan_reconciliation_bundle(
     if not artifact_digest.startswith("sha256:"):
         raise QualificationArtifactError("Milestone Qualification artifact digest is invalid.")
     materialized_files = {
-        **{
-            f"docs/qualification/{identity.release_tag}-{case_id}-v1.json": receipt_contents[case_id]
-            for case_id in CASE_IDS
-        },
+        **{receipt_destinations[case_id]: receipt_contents[case_id] for case_id in CASE_IDS},
         live_path: live_content,
         EVIDENCE_INDEX_PATH: index_content,
     }

--- a/tests/test_release_qualification_artifact.py
+++ b/tests/test_release_qualification_artifact.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 import zipfile
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from scripts.qualify_release_scope import _validate_live_publication_evidence
@@ -259,6 +259,51 @@ class ReleaseQualificationArtifactTests(unittest.TestCase):
                 archive.writestr(name, content)
         return output.getvalue()
 
+    def later_run(
+        self,
+        entries: dict[str, bytes],
+        *,
+        run_id: int,
+    ) -> tuple[dict[str, bytes], dict[str, object], dict[str, object], bytes]:
+        updated = dict(entries)
+        receipt_digests: dict[str, str] = {}
+        for case_id in ("clean-machine-signed-update", "installed-ui-accessibility"):
+            receipt = json.loads(updated[f"{case_id}.json"])
+            for field in ("started_at", "completed_at"):
+                timestamp = datetime.fromisoformat(receipt["timestamps"][field].replace("Z", "+00:00"))
+                receipt["timestamps"][field] = (timestamp + timedelta(days=1)).isoformat().replace("+00:00", "Z")
+            expires_on = datetime.fromisoformat(receipt["cadence"]["expires_on"])
+            receipt["cadence"]["expires_on"] = (expires_on + timedelta(days=1)).date().isoformat()
+            receipt["receipt_sha256"] = receipt_sha256(receipt)
+            updated[f"{case_id}.json"] = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode()
+            receipt_digests[case_id] = receipt["receipt_sha256"]
+        qualification_run = json.loads(updated["qualification-run.json"])
+        for summary in qualification_run["tier3_receipts"]:
+            summary["receipt_sha256"] = receipt_digests[summary["case_id"]]
+        updated["qualification-run.json"] = (json.dumps(qualification_run, indent=2) + "\n").encode()
+        archive = self.archive(updated)
+        run = {"id": run_id, "run_attempt": 1, "updated_at": "2026-08-10T19:05:28Z"}
+        artifact = {
+            "digest": "sha256:" + hashlib.sha256(archive).hexdigest(),
+            "id": ARTIFACT_ID + 1,
+            "name": f"milestone-qualification-{RELEASE_TAG}-1",
+            "run_id": run_id,
+            "state": "available",
+        }
+        return updated, run, artifact, archive
+
+    def commit_initial_reconciliation(
+        self,
+        root: Path,
+        bundle,
+    ) -> None:
+        for file in bundle.files:
+            path = root / file.path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(file.content)
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "initial reconciliation"], cwd=root, check=True)
+
     def test_valid_archive_produces_deterministic_plan(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -434,6 +479,139 @@ class ReleaseQualificationArtifactTests(unittest.TestCase):
             ["present", "present", "present", "present", "identical", "identical", "identical", "identical"],
         )
 
+    def test_later_run_rolls_over_accepted_tier3_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, archive = self.fixture(root)
+            initial = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            self.commit_initial_reconciliation(root, initial)
+            later_entries, later_run, later_artifact, later_archive = self.later_run(
+                entries,
+                run_id=RUN_ID + 1,
+            )
+
+            rollover = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=later_run,
+                artifact=later_artifact,
+                manifest=manifest,
+                archive_bytes=later_archive,
+            )
+
+        files = {file.path: file.content for file in rollover.files}
+        clean_path = f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-run-{RUN_ID + 1}-v1.json"
+        ui_path = f"docs/qualification/{RELEASE_TAG}-installed-ui-accessibility-run-{RUN_ID + 1}-v1.json"
+        self.assertEqual(files[clean_path], later_entries["clean-machine-signed-update.json"])
+        self.assertEqual(files[ui_path], later_entries["installed-ui-accessibility.json"])
+        self.assertNotIn(f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-v1.json", files)
+        live_path = f"docs/qualification/{RELEASE_TAG}-live-qualification-run-{RUN_ID + 1}-v1.json"
+        live = json.loads(files[live_path])
+        observations = live["cases"][0]["observations"]
+        self.assertEqual(observations["qualification_receipt_reference"], clean_path)
+        self.assertEqual(
+            observations["qualification_receipt_sha256"],
+            hashlib.sha256(later_entries["clean-machine-signed-update.json"]).hexdigest(),
+        )
+        index = json.loads(files["docs/qualification/release-evidence-v1.json"])
+        records = {item["receipt_id"]: item for item in index["receipts"]}
+        self.assertIn(f"{RELEASE_TAG}:clean-machine-signed-update:{RUN_ID}", records)
+        self.assertIn(f"{RELEASE_TAG}:sparkle-update-route:{RUN_ID}", records)
+        self.assertEqual(
+            records[f"{RELEASE_TAG}:clean-machine-signed-update:{RUN_ID + 1}"]["reference"],
+            clean_path,
+        )
+        self.assertEqual(records[f"{RELEASE_TAG}:sparkle-update-route:{RUN_ID + 1}"]["reference"], live_path)
+
+    def test_later_run_rollover_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, archive = self.fixture(root)
+            initial = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            self.commit_initial_reconciliation(root, initial)
+            _later_entries, later_run, later_artifact, later_archive = self.later_run(
+                entries,
+                run_id=RUN_ID + 1,
+            )
+            rollover = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=later_run,
+                artifact=later_artifact,
+                manifest=manifest,
+                archive_bytes=later_archive,
+            )
+            for file in rollover.files:
+                path = root / file.path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(file.content)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "rollover receipts"], cwd=root, check=True)
+
+            replay = plan_reconciliation(
+                repo_root=root,
+                identity=identity,
+                run=later_run,
+                artifact=later_artifact,
+                manifest=manifest,
+                archive_bytes=later_archive,
+            )
+
+        self.assertFalse(replay["requires_changes"])
+        self.assertTrue(all(operation["state"] in {"identical", "present"} for operation in replay["operations"]))
+
+    def test_later_run_rollover_rejects_ambiguous_fixed_path_backing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, entries, archive = self.fixture(root)
+            initial = plan_reconciliation_bundle(
+                repo_root=root,
+                identity=identity,
+                run=run,
+                artifact=artifact,
+                manifest=manifest,
+                archive_bytes=archive,
+            )
+            self.commit_initial_reconciliation(root, initial)
+            index_path = root / "docs/qualification/release-evidence-v1.json"
+            index = json.loads(index_path.read_bytes())
+            fixed_path = f"docs/qualification/{RELEASE_TAG}-clean-machine-signed-update-v1.json"
+            backing = next(item for item in index["receipts"] if item["reference"] == fixed_path)
+            duplicate = dict(backing)
+            duplicate["receipt_id"] = f"{RELEASE_TAG}:clean-machine-signed-update:{RUN_ID + 99}"
+            index["receipts"].append(duplicate)
+            index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "ambiguous fixed receipt"], cwd=root, check=True)
+            _later_entries, later_run, later_artifact, later_archive = self.later_run(
+                entries,
+                run_id=RUN_ID + 1,
+            )
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "conflicts"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=later_run,
+                    artifact=later_artifact,
+                    manifest=manifest,
+                    archive_bytes=later_archive,
+                )
+
     def test_signed_ui_identity_mismatch_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -537,6 +715,38 @@ class ReleaseQualificationArtifactTests(unittest.TestCase):
             index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             subprocess.run(["git", "add", "."], cwd=root, check=True)
             subprocess.run(["git", "commit", "-qm", "conflicting profile record"], cwd=root, check=True)
+
+            with self.assertRaisesRegex(QualificationArtifactSafetyError, "immutable record"):
+                plan_reconciliation(
+                    repo_root=root,
+                    identity=identity,
+                    run=run,
+                    artifact=artifact,
+                    manifest=manifest,
+                    archive_bytes=archive,
+                )
+
+    def test_conflicting_sparkle_index_record_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            identity, manifest, run, artifact, _entries, archive = self.fixture(root)
+            index_path = root / "docs/qualification/release-evidence-v1.json"
+            index = json.loads(index_path.read_bytes())
+            index["receipts"].append(
+                {
+                    "accepted_at": "2026-08-09T19:05:28Z",
+                    "case_id": "sparkle-update-route",
+                    "receipt_id": f"{RELEASE_TAG}:sparkle-update-route:{RUN_ID}",
+                    "reference": f"docs/qualification/{RELEASE_TAG}-live-qualification-v1.json",
+                    "sha256": "0" * 64,
+                    "source": "signed_artifact_receipt",
+                    "source_sha": identity.candidate_sha,
+                    "status": "accepted",
+                }
+            )
+            index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "conflicting sparkle record"], cwd=root, check=True)
 
             with self.assertRaisesRegex(QualificationArtifactSafetyError, "immutable record"):
                 plan_reconciliation(


### PR DESCRIPTION
## Summary
- preserve accepted fixed Tier 3 and live Sparkle evidence on later exact qualification runs
- write new receipts to deterministic run-scoped paths only with an exact accepted immutable backing
- reject duplicate/malformed receipt IDs and ambiguous fixed-path records
- keep the signed UI acceptance record immutable across later qualification runs

## Validation
- release artifact suite: 22 passed
- focused release qualification/controller/evidence suite: 171 passed
- actual final Beta 7 artifact `9503234172` yields plan `c483fde2c00d950035fc6b6d5ff4b6483f3f60273b20f7ebf94d864a056b9d1d`
- Ruff check/format clean
- final independent blocker reviews found no blockers
- JetBrains remains inconclusive in this exact worktree because the IDE lacks a configured Python SDK

Refs #609