### PR TITLE
release: prepare v0.3.2 RC 1

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -82,7 +82,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.2-rc.1-cut-packet.md
+++ b/docs/0.3.2-rc.1-cut-packet.md
@@ -1,0 +1,234 @@
+# 0.3.2 RC 1 Cut Packet
+
+> **Prepared metadata; publication pending.**
+> The 0.3.2 RC line entered feature freeze on August 24, 2026. Only
+> release-blocking corrections may enter this line. This preparation does not
+> authorize Prerelease dispatch, `macos-signing` approval, tag or draft
+> creation, appcast deployment, or publication.
+
+RC `0.3.2rc1` is the first release candidate after published and fully
+qualified Beta 7. Issue #613 owns preparation and later publication closeout.
+The candidate carries the qualified Main Feature / All 3D Videos workflow,
+packaged-worker identity correction, release-independent production preflight,
+and strengthened installed-UI and release-evidence contracts without adding new
+product scope.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2rc1` |
+| Public version | `0.3.2-rc.1` |
+| Bundle and Sparkle build | `170` |
+| GitHub tag and release title | `v0.3.2-rc.1` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2-rc.1.dmg` |
+| Sparkle channel | `rc` |
+| GitHub prerelease | `true` |
+| GitHub Latest | `false` |
+| Publish to PyPI or Homebrew | `false` |
+| First candidate of cycle | `true` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `170` is the next global successor after published Beta 7 build `169`.
+The relevant immutable and unavailable history remains:
+
+- Beta 3 `0.3.2b3` / `v0.3.2-beta.3` / build `165` failed after signing and
+  notarization but before publication; the identity is permanently burned.
+- Beta 4 `0.3.2b4` / `v0.3.2-beta.4` / build `166` failed after signing and
+  notarization but before publication; the identity is permanently burned.
+- Beta 5 `0.3.2b5` / `v0.3.2-beta.5` / build `167` is published and immutable,
+  with an immutable failed post-publication qualification disposition for the
+  packaged worker reporting `0.0.0`.
+- Beta 6 `0.3.2b6` / `v0.3.2-beta.6` / build `168` is a cancelled unpublished
+  signed attempt. Its draft was deleted under the separately authorized
+  immutable disposition, and the identity is permanently burned.
+- Beta 7 `0.3.2b7` / `v0.3.2-beta.7` / build `169` is published, immutable,
+  and qualified from source and tag SHA
+  `d994ce11f9d4a669f068c89dc8e51ca269710290`.
+- Earlier burned builds `147` and `154` and abandoned metadata build `157`
+  remain unavailable.
+
+As revalidated on August 24, 2026, no `v0.3.2-rc.1` tag, release, draft,
+appcast item, checked release-evidence directory, PyPI version, or Homebrew
+change exists. No Stable or Prerelease workflow is nonterminal.
+
+## Feature Freeze And Scope
+
+Feature freeze is active for the 0.3.2 RC line. Permitted changes after this
+preparation are limited to corrections required by failed preparation gates,
+review findings that block release safety, or later exact-candidate
+qualification failures. New features, broad refactors, dependency-only churn,
+and non-blocking polish remain excluded.
+
+RC 1 carries forward the Beta 7 product behavior and release-safety work. The
+dependency-only protected-main merges after Beta 7 refreshed Python development
+dependencies, support-diagnostics dependencies, and GitHub Actions pins; they
+did not expand product scope. Production Preflight qualified their combined
+protected-main result before this metadata was prepared.
+
+## Beta 7 Qualification Review
+
+The qualification controller reports Beta 7 as
+`ready_with_optional_actions` / passed:
+
+- `15` completed cases;
+- `0` blocking cases;
+- `0` operator-required cases; and
+- one optional stale `native-sparkle-release-notes` case.
+
+The final exact Milestone Qualification run is `32680024505` attempt `1`.
+Clean-machine Sparkle update, installed-UI accessibility, profile preservation,
+packaged-worker identity, release identity, and all other blocking cases passed.
+The optional native release-notes presentation case is not an RC preparation
+blocker and remains visible for fresh exact-candidate qualification.
+
+## Immediate Published Predecessor
+
+Beta 7 is the immediate published update and release-note predecessor:
+
+- release ID `375333598`;
+- release workflow run `32666346343` attempt `1`;
+- source and tag SHA `d994ce11f9d4a669f068c89dc8e51ca269710290`;
+- DMG SHA-256
+  `76b74c7bf692879a4fe78b38e24a7f2d25bac034673e09861fd4f14c7ef966fc`;
+- signed app-tree SHA-256
+  `9e778470b4bbffc16e5600b6e5d8ee33a06b85c3391e92bb40f23b9bd54d9da6`;
+- cumulative appcast SHA-256
+  `18bcadc222adb37c1215d64520d97ad7876b03e1640c7142605e4188890ed1db`;
+  and
+- release receipt file SHA-256
+  `6afe63b1212ce0b59d7b893f8b501297361c45e8fbf88484ab915e92f0b060b3`.
+
+The checked predecessor remains
+`docs/release-evidence/v0.3.2-beta.7/release-receipt.json`. It is historical
+input only and must not be edited, rebuilt, replaced, or republished.
+
+## Production Preflight
+
+Release-independent Production Preflight run `32791057931` attempt `1` passed
+on exact protected-main SHA
+`f65185dc9762c804ce8c879e6d044cfb8b9213a3` before RC metadata preparation.
+Artifact `9543254128`,
+`production-preflight-success-f65185dc9762c804ce8c879e6d044cfb8b9213a3-32791057931-1`,
+is source-bound to that SHA and records:
+
+- package version `0.3.2b7` and exact packaged-worker protocol readiness;
+- preventive DMG SHA-256
+  `ed56fda9b6d7817dc353202f699f641762ed8d130c8ab381be658f22637c0a30`;
+- installed app-tree SHA-256
+  `5ceaad83060aa6066806ba3fa19b382aeac670002c48c86722dfaf9c1925b8b0`;
+- four installed-UI evidence files totaling `201846` bytes; and
+- no signing environment, release secret, tag, release, draft, appcast
+  deployment, or publication side effect.
+
+The exact protected-main CI run `32789904125` and CodeQL run `32789904114`
+also passed on that SHA. If protected `main` moves before this preparation PR
+merges, rerun Production Preflight on the new exact base before updating or
+merging the metadata.
+
+## Update-Route Matrix
+
+| Installed preference | RC 1 eligibility | Required behavior |
+| --- | --- | --- |
+| Stable | Excluded | Remain on the newest eligible Stable build; never offer RC 1. |
+| RC | Eligible | Offer build `170` when newer than the installed eligible build. |
+| Beta | Eligible | Offer RC 1 as the forward stage after Beta 7. |
+| Alpha | Eligible | Offer RC 1 as a newer eligible production item. |
+
+Fresh post-publication milestone qualification must prove the signed Beta 7
+build `169` to RC 1 build `170` automatic Sparkle update, exact candidate
+identity, profile-library preservation, and installed-UI accessibility. The RC
+item remains a prerelease and must not become GitHub Latest or enter PyPI or
+Homebrew.
+
+## Qualification Record
+
+`docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json` preregisters the
+RC matrix with exact candidate artifact, release, appcast, workflow, and source
+identities left null until a separately authorized guarded release exists. It
+uses `--release-stage rc --first-candidate-of-cycle`, carries Beta 7 as the
+immediate immutable predecessor, and preserves all abandoned and burned builds.
+
+Preparation requires the policy classifier to pass on the exact candidate head.
+Release-workflow identity and signed-package parity require fresh exact-run
+receipts. The Beta 7 to RC 1 Sparkle route, clean-machine signed update, and
+installed-UI accessibility require fresh milestone evidence. Nonblocking
+operator-assisted and native presentation cases remain visible without being
+misrepresented as completed.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2-rc.1` begins the feature-frozen 0.3.2 release-candidate
+> line. It carries the qualified Main Feature / All 3D Videos batch workflow,
+> correct packaged-worker version reporting, production-shaped preflight, and
+> strengthened installed-UI and release-evidence protections from Beta 7, with
+> refreshed development, diagnostics, and workflow dependencies. No new
+> product feature scope is introduced in RC 1.
+
+GitHub-generated notes compare with published immutable Beta 7
+`v0.3.2-beta.7`. Failed unpublished Beta 3 and Beta 4 and cancelled unpublished
+Beta 6 are not release-note bases or appcast items.
+
+## Known Issues
+
+- Native Sparkle release-notes presentation evidence is stale and optional;
+  fresh exact-candidate evidence remains desirable but does not block
+  preparation or milestone closeout under the current policy.
+- The first-RC USB Blu-ray / MakeMKV, protected real-media conversion, and
+  Vision Pro physical-playback cases remain operator-assisted, nonblocking
+  evidence. They must remain visible in qualification status and must not be
+  claimed as passed without exact receipts.
+- The direct-distribution app supports Apple Silicon on macOS 26 or later.
+- The GUI does not install MakeMKV or command-line dependencies on first launch;
+  users must install MakeMKV separately before Blu-ray conversion.
+
+## Rollback Guidance
+
+Do not replace the RC DMG, appcast asset, tag, release, or receipt after any
+future publication. Correct an application defect with a newer global build.
+Sparkle does not downgrade an installed app. If update distribution must stop,
+use the separately authorized `Manage Sparkle Pages` disable operation; restore
+only a verified last-good published tag through the same guarded workflow.
+
+Before manually moving between production builds, quit the app and copy
+`~/Library/Application Support/3D Blu-ray to Vision Pro/profiles.json` to a safe
+location when it exists. The Beta 7 to RC 1 qualification must prove automatic
+update profile preservation before milestone closeout.
+
+## Support Instructions
+
+Support bundles remain governed by `docs/native-support-bundle-v1.md` and the
+privacy rules version `5` contract. The production app packages the approved
+`BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT`; support should prefer the in-app
+diagnostics flow, preserve the exact package/public/build identity, and attach
+the generated bundle rather than requesting unbounded user data. For updater
+issues, record the installed route, installed build, offered build, release tag,
+and whether the profile library remained intact.
+
+## Immutable Prior And Failed Attempt Evidence
+
+- Beta 5's release receipt and failed post-publication qualification remain
+  under `docs/release-evidence/v0.3.2-beta.5/`.
+- Beta 6's signed receipt, cancellation record, and authorized draft-deletion
+  disposition remain under `docs/release-attempts/v0.3.2-beta.6/`.
+- `.github/release-freezes.json` continues to prohibit reuse of
+  `v0.3.2-beta.6`.
+- Beta 7's publication, signed UI, qualification manifest, qualification
+  record, and release receipt remain under
+  `docs/release-evidence/v0.3.2-beta.7/`.
+- Builds `147`, `154`, `165`, `166`, and `168` remain burned, while build `157`
+  remains abandoned metadata. None may appear as a future updater build.
+
+## Authorization Boundary
+
+Preparation and review do not authorize Prerelease dispatch,
+`macos-signing` approval, tag or release creation, draft creation, appcast
+deployment, or publication. A future authorized release must use the exact
+merged protected-main SHA under a temporary merge hold and be monitored only
+with `uv run python -m scripts.github_release_run watch`. If the watcher exits
+`20`, obtain fresh explicit run-bound authorization in the active conversation
+and approve only with `scripts.github_release_run approve` using the emitted
+run ID, workflow name, full `main` SHA, confirmation SHA, and approval
+fingerprint.

--- a/docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json
@@ -1,0 +1,255 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-beta.7-to-v0.3.2-rc.1",
+      "native-sparkle-notes-rc1",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "170",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2-rc.1.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2rc1",
+    "public_version": "0.3.2-rc.1",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2-rc.1",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "rc",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154,
+      165,
+      166,
+      168
+    ],
+    "previous_beta": {
+      "appcast_sha256": "18bcadc222adb37c1215d64520d97ad7876b03e1640c7142605e4188890ed1db",
+      "build_version": "169",
+      "dmg_sha256": "76b74c7bf692879a4fe78b38e24a7f2d25bac034673e09861fd4f14c7ef966fc",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2b7",
+      "published_at": "2026-08-23T21:44:54Z",
+      "release_id": 375333598,
+      "release_run_id": 32666346343,
+      "release_tag": "v0.3.2-beta.7",
+      "signed_app_tree_sha256": "9e778470b4bbffc16e5600b6e5d8ee33a06b85c3391e92bb40f23b9bd54d9da6",
+      "source_git_sha": "d994ce11f9d4a669f068c89dc8e51ca269710290"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#617",
+    "#620",
+    "#623",
+    "#609",
+    "#613"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-beta.7-to-v0.3.2-rc.1",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-rc1",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-beta.3-change-scoped-evidence-v1",
+      "scope": "immutable change-scoped preparation evidence carried from the failed unpublished Beta 3 attempt"
+    }
+  ],
+  "qualification_id": "v0.3.2-rc.1-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage rc --first-candidate-of-cycle --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,10 +41,12 @@ draft creation and is permanently burned, as recorded in
 `docs/release-attempts/v0.3.2-beta.6/cancelled-attempt-v1.json`. Its abandoned
 draft was deleted only after explicit authorization, with the immutable
 disposition at `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json`.
-Issue #609 owns prepared successor Beta `0.3.2b7`, public tag
-`v0.3.2-beta.7`, and build `169`. Its metadata and preregistered qualification
-are preparation-only; Prerelease dispatch, signing approval, and publication
-remain separately authorized boundaries.
+Issue #609 closed published and fully qualified Beta `0.3.2b7`, public tag
+`v0.3.2-beta.7`, and build `169`. Issue #613 owns prepared successor RC
+`0.3.2rc1`, public tag `v0.3.2-rc.1`, and build `170` under feature freeze.
+Its metadata and preregistered qualification are preparation-only; Prerelease
+dispatch, signing approval, and publication remain separately authorized
+boundaries.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -20,10 +20,11 @@ post-publication exact-artifact qualification is blocked by packaged worker
 version metadata. Corrective Beta `0.3.2b6` build `168` is a cancelled,
 unpublished signed attempt whose draft `374538590` was deleted through the
 authorized immutable-disposition path; its tag and build are permanently
-non-reusable. Issue #609 owns prepared successor Beta `0.3.2b7` build `169`;
-dispatch, signing approval, and publication remain separately authorized.
-Run-bound signing approval
-remains a separate authorization boundary.
+non-reusable. Beta `0.3.2b7` build `169` is published, immutable, and fully
+qualified. Issue #613 owns prepared successor RC `0.3.2rc1` build `170` under
+feature freeze; dispatch, signing approval, and publication remain separately
+authorized. Run-bound signing approval remains a separate authorization
+boundary.
 
 ## Production Identity
 
@@ -486,15 +487,23 @@ to begin at Beta 7/build `169`. Milestone-context validation accepts the
 cancelled candidate only after that disposition validates, then still requires
 build `168` in the successor qualification's burned-build list.
 
-Beta 7 is prepared as internal version `0.3.2b7`, public tag and title
-`v0.3.2-beta.7`, and global build `169`. Published immutable Beta 5 remains its
-prior update-route input; failed builds `165` and `166` and cancelled build
-`168` remain burned. Release-independent Production Preflight run `32620933465`
-passed on exact protected-main SHA
-`02bf566e42b62a18e1a274e33caf1943d26827dd` before metadata preparation. No
-Beta 7 tag, release, draft, appcast item, PyPI version, or Homebrew change was
-created. The preparation contract is recorded in
+Beta 7 is published and immutable as internal version `0.3.2b7`, public tag and
+title `v0.3.2-beta.7`, and global build `169`. Guarded Prerelease run
+`32666346343` published release `375333598` from source and tag SHA
+`d994ce11f9d4a669f068c89dc8e51ca269710290`. Final qualification passed with
+zero blocking or operator-required cases; the immutable publication and
+qualification contract is recorded in
 [the 0.3.2 Beta 7 cut packet](0.3.2-beta.7-cut-packet.md).
+
+RC 1 is prepared under feature freeze as internal version `0.3.2rc1`, public
+tag and title `v0.3.2-rc.1`, and global build `170`. Published immutable Beta 7
+is its immediate release-note and update-route predecessor; failed builds `165`
+and `166` and cancelled build `168` remain burned. Release-independent
+Production Preflight run `32791057931` passed on exact protected-main SHA
+`f65185dc9762c804ce8c879e6d044cfb8b9213a3` before metadata preparation. No RC
+1 tag, release, draft, appcast item, PyPI version, or Homebrew change was
+created. The preparation contract is recorded in
+[the 0.3.2 RC 1 cut packet](0.3.2-rc.1-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 169
+        CURRENT_PROJECT_VERSION: 170
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2b7
+        MARKETING_VERSION: 0.3.2rc1
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2b7"
+version = "0.3.2rc1"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "169"
+build_version = "170"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -134,8 +134,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2b7")
-        self.assertEqual(NATIVE_BUILD_VERSION, "169")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2rc1")
+        self.assertEqual(NATIVE_BUILD_VERSION, "170")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,18 +199,18 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(app["bundle_identifier"], "com.shinycomputers.bd-to-avp")
         self.assertNotIn("briefcase", pyproject["tool"])
 
-    def test_repository_records_beta7_release_state_and_beta6_cancellation(self) -> None:
+    def test_repository_records_rc1_preparation_and_prior_release_history(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2b7")
-        self.assertEqual(metadata.public_version, "0.3.2-beta.7")
-        self.assertEqual(metadata.build_version, "169")
-        self.assertEqual(metadata.release_tag, "v0.3.2-beta.7")
-        self.assertEqual(metadata.release_name, "v0.3.2-beta.7")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-beta.7.dmg")
-        self.assertEqual(metadata.channel, "beta")
+        self.assertEqual(metadata.package_version, "0.3.2rc1")
+        self.assertEqual(metadata.public_version, "0.3.2-rc.1")
+        self.assertEqual(metadata.build_version, "170")
+        self.assertEqual(metadata.release_tag, "v0.3.2-rc.1")
+        self.assertEqual(metadata.release_name, "v0.3.2-rc.1")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-rc.1.dmg")
+        self.assertEqual(metadata.channel, "rc")
         self.assertTrue(metadata.prerelease)
-        self.assertFalse(metadata.first_candidate_of_cycle)
+        self.assertTrue(metadata.first_candidate_of_cycle)
         self.assertFalse(metadata.make_latest)
         self.assertFalse(metadata.publish_pypi)
 
@@ -220,6 +220,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("permanently non-reusable", beta6_freeze["reason"])
         self.assertIn("authorized immutable disposition", beta6_freeze["reason"])
         self.assertNotIn("v0.3.2-beta.7", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.2-rc.1", freeze_policy["frozen_release_tags"])
 
         cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.6-cut-packet.md").read_text(encoding="utf-8")
         self.assertIn("`0.3.2b6`", cut_packet)
@@ -243,7 +244,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `169`", beta7_cut_packet)
         self.assertIn("Production Preflight run `32620933465`", beta7_cut_packet)
         self.assertIn("Builds `165`, `166`, and `168` remain", beta7_cut_packet)
-        beta7_release_receipt = REPO_ROOT / "docs" / "release-evidence" / metadata.release_tag / "release-receipt.json"
+        beta7_release_receipt = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2-beta.7" / "release-receipt.json"
         expected_beta7_state = (
             release.CUT_PACKET_PUBLISHED if beta7_release_receipt.is_file() else release.CUT_PACKET_PREPARED
         )
@@ -253,18 +254,27 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn(expected_beta7_state, beta7_cut_packet)
         self.assertNotIn(unexpected_beta7_state, beta7_cut_packet)
 
+        rc1_cut_packet = (REPO_ROOT / "docs" / "0.3.2-rc.1-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2rc1`", rc1_cut_packet)
+        self.assertIn("Build `170`", rc1_cut_packet)
+        self.assertIn("feature freeze", rc1_cut_packet.lower())
+        self.assertIn("Production Preflight run `32791057931`", rc1_cut_packet)
+        self.assertIn("Beta 7", rc1_cut_packet)
+        self.assertIn(release.CUT_PACKET_PREPARED, rc1_cut_packet)
+        self.assertNotIn(release.CUT_PACKET_PUBLISHED, rc1_cut_packet)
+
         github_config = json.loads((REPO_ROOT / ".github" / "github.json").read_text(encoding="utf-8"))
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2b7")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-beta.7")
-        self.assertEqual(qualification["candidate"]["build_version"], "169")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-beta.7")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2rc1")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-rc.1")
+        self.assertEqual(qualification["candidate"]["build_version"], "170")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-rc.1")
         self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
@@ -273,14 +283,15 @@ class ReleaseMetadataTests(unittest.TestCase):
             "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
         )
         self.assertIn("#623", qualification["issues"])
+        self.assertIn("#613", qualification["issues"])
         self.assertEqual(
             set(qualification["immutable_history"]["burned_builds"]),
             {147, 154, 165, 166, 168},
         )
         previous_beta = qualification["immutable_history"]["previous_beta"]
-        self.assertEqual(previous_beta["release_tag"], "v0.3.2-beta.5")
-        self.assertEqual(previous_beta["package_version"], "0.3.2b5")
-        self.assertEqual(previous_beta["build_version"], "167")
+        self.assertEqual(previous_beta["release_tag"], "v0.3.2-beta.7")
+        self.assertEqual(previous_beta["package_version"], "0.3.2b7")
+        self.assertEqual(previous_beta["build_version"], "169")
         previous_beta_receipt_path = (
             REPO_ROOT / "docs" / "release-evidence" / previous_beta["release_tag"] / "release-receipt.json"
         )
@@ -296,8 +307,8 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(previous_beta_artifacts["appcast"]["sha256"], previous_beta["appcast_sha256"])
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-beta.5-to-v0.3.2-beta.7",
-            "native-sparkle-notes-beta7",
+            "updater-route-v0.3.2-beta.7-to-v0.3.2-rc.1",
+            "native-sparkle-notes-rc1",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",
@@ -386,7 +397,8 @@ class ReleaseMetadataTests(unittest.TestCase):
             expected_candidate_identity,
         )
         self.assertEqual(qualification["status"], "preregistered_pending_exact_candidate")
-        self.assertEqual(qualification["execution_policy"]["release_stage"], "beta")
+        self.assertEqual(qualification["execution_policy"]["release_stage"], "rc")
+        self.assertIn("--first-candidate-of-cycle", qualification["qualification_policy"]["scope_command"])
         self.assertEqual(
             set(qualification["acceptance"]["blocking_case_ids"]),
             {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "169")
+        self.assertEqual(info["CFBundleVersion"], "170")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1121,7 +1121,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-beta.7-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2b7"
+version = "0.3.2rc1"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- declare feature freeze for the 0.3.2 RC line and prepare `0.3.2rc1` / `v0.3.2-rc.1` / build `170`
- carry published, immutable, fully qualified Beta 7/build `169` as the immediate update and release-note predecessor
- preserve failed, cancelled, burned-build, draft-deletion, and Beta 5 failed-qualification evidence
- add the RC cut packet, qualification preregistration, update-route matrix, release notes, rollback guidance, known issues, and support instructions

## Exact Base Evidence

- protected-main base: `f65185dc9762c804ce8c879e6d044cfb8b9213a3`
- Production Preflight: run `32791057931` attempt `1`, artifact `9543254128`
- exact-base CI: run `32789904125`
- exact-base CodeQL: run `32789904114`
- Beta 7 qualification: passed, `15` completed / `0` blocking / `0` operator-required / one optional stale native release-notes case

## Validation

- `uv run python -m scripts.release validate`
- exact-head preparation classifier passed with no blocking retests
- focused release/native/Sparkle workflow tests: `184/184`
- release policy/controller/receipt tests: `279/279`
- full Python suite with pinned bundled FFmpeg tools: `1891/1891` (`3` skipped)
- native XCTest suite: `484/484`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`
- `uv build`
- Ruff format/check, mypy, actionlint
- Beta 5 failed-qualification and Beta 6 cancellation/deletion context validation

JetBrains inspection ran against the exact worktree but returned `UNKNOWN` because the IDE lifecycle mutated tracked `.idea` files. Those IDE-only mutations were removed and the worktree is clean; the helper marked the run non-retryable, so no unsupported retry was performed.

## Authorization Boundary

This PR is preparation-only. It does not authorize or perform Prerelease/Stable dispatch, `macos-signing` approval, tag/release/draft creation, appcast mutation, or publication.

Refs #613