### PR TITLE
release: prepare v0.3.2 Stable

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -82,7 +82,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.2-stable-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.2-cut-packet.md
+++ b/docs/0.3.2-cut-packet.md
@@ -1,0 +1,179 @@
+# 0.3.2 Stable Cut Packet
+
+> **Prepared metadata; publication pending.**
+> Stable metadata preparation was explicitly authorized on August 25, 2026.
+> This preparation does not authorize the `Stable` workflow, `macos-signing`
+> approval, tag or release creation, appcast mutation, PyPI publication,
+> Homebrew update, or any other publication operation.
+
+Stable `0.3.2` promotes the published and fully qualified RC 1 product behavior
+without adding product scope. Issue #614 owns preparation, the later explicit
+promotion decision, signed-artifact qualification, publication, immutable
+evidence, and closeout.
+
+## Exact Metadata
+
+| Field | Reviewed value |
+| --- | --- |
+| Package and bundle short version | `0.3.2` |
+| Public version | `0.3.2` |
+| Bundle and Sparkle build | `171` |
+| GitHub tag and release title | `v0.3.2` |
+| DMG name | `3D-Blu-ray-to-Vision-Pro-0.3.2.dmg` |
+| Sparkle channel | absent (Stable default) |
+| GitHub prerelease | `false` |
+| GitHub Latest | `true` |
+| Publish to PyPI | `true` |
+| Downstream Homebrew update | `true` |
+| First candidate of cycle | `false` |
+| Product name | `3D Blu-ray to Vision Pro` |
+| Bundle identifier | `com.shinycomputers.bd-to-avp` |
+| Privacy contract | Privacy rules version `5` |
+
+Build `171` is the next global successor after immutable RC 1 build `170`.
+The unavailable history remains unchanged: builds `147`, `154`, `165`, `166`,
+and `168` are burned, while build `157` is abandoned metadata. None may be
+reused or appear as a future updater build.
+
+## Stable Exit Review
+
+The Stable exit review used exact protected-main SHA
+`bc91fd95ae0ec82d06aa715f29031b0734a8493d`, which matched remote `main` at
+`2026-08-25T14:01:09Z`. RC 1 remained immutable as package `0.3.2rc1`, public
+version `0.3.2-rc.1`, tag `v0.3.2-rc.1`, build `170`, release ID `376092200`,
+and source/tag SHA `1d691a6db7c18d09f55a425ec77a01ab6d917d80`.
+
+The checked qualification manifest validated at self-digest
+`f339b9b1b9600f54724de9a5898b4d68b988142cfbc92c806b71d7ab662b790b`.
+The remote release receipt was byte-identical to the checked receipt at
+SHA-256 `dec0546e8e4c7178fba99492911f12896277260c767f96e0c492d7cbfc3c1d54`.
+The release appcast asset and live Pages appcast were byte-identical at SHA-256
+`a78ff9944cb6f9801913c7195c31907803e71aa7ebafbb7474bb3e4e4ec2f38a`.
+
+The maintained qualification controller reported `passed: true`, `0` blocking
+cases, and `15` completed cases. Exact post-merge CI run `32809070940` passed
+`validate`; CodeQL run `32809070993` passed `Analyze (actions)` and
+`Analyze (python)`, all on the reviewed protected-main SHA. Open code-scanning,
+Dependabot, secret-scanning, and draft security-advisory counts were all zero.
+
+At final review there was no `v0.3.2` tag, release, draft, appcast item, checked
+evidence directory, cut packet, configured Stable qualification candidate,
+Stable metadata identity, or Stable workflow run at the reviewed SHA or after
+RC publication.
+
+## Predecessors And Update Routes
+
+Published RC 1 is the immediate global predecessor and exact qualification
+base:
+
+- release ID `376092200`;
+- release workflow run `32796196439` attempt `1`;
+- source and tag SHA `1d691a6db7c18d09f55a425ec77a01ab6d917d80`;
+- DMG SHA-256
+  `62cb9c0b3fe4ee6ddb309504306520ba6a91292742140479081ff910a4b20dff`;
+- signed app-tree SHA-256
+  `00d5132b7b982f02bf1ffe23909df331bab1c733430756c3f8cbe002fa7f0004`;
+- appcast SHA-256
+  `a78ff9944cb6f9801913c7195c31907803e71aa7ebafbb7474bb3e4e4ec2f38a`;
+  and
+- release receipt file SHA-256
+  `dec0546e8e4c7178fba99492911f12896277260c767f96e0c492d7cbfc3c1d54`.
+
+Stable `v0.3.1` build `162` is the previous Stable release and generated-notes
+base. The maintained release resolver selects `v0.3.1` for Stable release notes
+and `v0.3.2-rc.1` on route `rc` for exact updater qualification.
+
+| Installed preference | Stable 0.3.2 eligibility | Required behavior |
+| --- | --- | --- |
+| Stable | Eligible | Offer build `171` over Stable `v0.3.1` build `162`. |
+| RC | Eligible | Offer build `171` over RC 1 build `170`. |
+| Beta | Eligible | Offer unchanneled Stable build `171` as the newest eligible production item. |
+| Alpha | Eligible | Offer unchanneled Stable build `171` as the newest eligible production item. |
+
+Sparkle must never downgrade an installed app. Signed qualification and
+milestone closeout must prove RC 1 to Stable updating, profile preservation,
+clean-machine installation, installed UI accessibility, and the supported
+Stable route from `v0.3.1` to build `171`.
+
+## Qualification Record
+
+`docs/qualification/v0.3.2-stable-signed-qualification-v1.json` preregisters the
+Stable matrix. Exact candidate source, release, artifact, and appcast values
+remain null until a separately authorized guarded release exists. The record
+preserves immutable Stable `v0.3.1`, RC 1, abandoned metadata, and burned-build
+history.
+
+Release workflow identity and signed-package parity require fresh exact-run
+receipts. Sparkle update, clean-machine signed update, and installed UI
+accessibility require fresh milestone evidence. The stale native Sparkle notes
+case and USB Blu-ray/MakeMKV operator case remain visible and nonblocking under
+the current policy; neither may be represented as passed without an exact
+accepted receipt.
+
+## Production Preflight
+
+No Production Preflight workflow was dispatched during this preparation
+because authorization covered metadata preparation only. Before this
+preparation may merge, a separately authorized Production Preflight must pass
+on exact protected-main SHA `bc91fd95ae0ec82d06aa715f29031b0734a8493d`,
+or the preparation must be refreshed against a newer protected-main SHA and the
+gate rerun there. The workflow is non-authorizing and must not use the signing
+environment or create any release state.
+
+## Reviewed Release-Note Seed
+
+> BD_to_AVP `v0.3.2` promotes the qualified 0.3.2 release-candidate line to
+> Stable. It adds the clearer repetition-first Conversion Setup experience,
+> Main Feature versus All 3D Videos batch selection, safer profile and storage
+> handling, correct packaged-worker identity, and strengthened updater,
+> installed-UI, diagnostics, and release-evidence protections. Stable 0.3.2
+> preserves the production identity and update routes and introduces no product
+> changes beyond the qualified RC 1 behavior.
+
+GitHub-generated Stable notes compare with immutable Stable `v0.3.1`, not RC 1,
+so the final notes summarize the complete Stable-to-Stable change set.
+
+## Known Issues
+
+- Native Sparkle release-notes presentation evidence is stale and optional;
+  fresh exact-candidate evidence remains desirable but does not block
+  preparation or closeout under the current policy.
+- USB Blu-ray / MakeMKV, protected real-media conversion, and Vision Pro
+  physical-playback cases remain operator-assisted, nonblocking evidence.
+- The direct-distribution app supports Apple Silicon on macOS 26 or later.
+- The GUI does not install MakeMKV or command-line dependencies on first launch;
+  users must install MakeMKV separately before Blu-ray conversion.
+
+## Rollback Guidance
+
+Do not replace a published Stable DMG, appcast asset, tag, release, Python
+distribution, Homebrew update, or receipt. Correct a defect with a newer global
+build. If update distribution must stop, use the separately authorized
+`Manage Sparkle Pages` disable operation and restore only a verified last-good
+published tag through the guarded workflow.
+
+Before manually moving between production builds, quit the app and copy
+`~/Library/Application Support/3D Blu-ray to Vision Pro/profiles.json` to a safe
+location when it exists. Sparkle does not downgrade an installed app.
+
+## Support Instructions
+
+Support bundles remain governed by `docs/native-support-bundle-v1.md` and the
+privacy rules version `5` contract. The production app must package the
+approved `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT`. Support should prefer the
+in-app diagnostics flow, preserve exact package/public/build identity, and
+attach the generated bundle rather than requesting unbounded user data. For
+updater issues, record the installed route, installed build, offered build,
+release tag, and whether the profile library remained intact.
+
+## Authorization Boundary
+
+Preparation and review do not authorize Stable dispatch, `macos-signing`
+approval, tag or release creation, draft creation, appcast deployment, PyPI or
+Homebrew publication, or any publication mutation. A future authorized release
+must use the exact merged protected-main SHA under a temporary merge hold and be
+monitored only with `uv run python -m scripts.github_release_run watch`. If the
+watcher exits `20`, obtain fresh explicit run-bound authorization in the active
+conversation and approve only with `scripts.github_release_run approve` using
+the emitted run ID, workflow name, full `main` SHA, confirmation SHA, and
+approval fingerprint.

--- a/docs/qualification/v0.3.2-stable-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.2-stable-signed-qualification-v1.json
@@ -1,0 +1,273 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-rc.1-to-v0.3.2",
+      "native-sparkle-notes-stable",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "171",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.2.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.2",
+    "public_version": "0.3.2",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.2",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Stable"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "stable",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154,
+      165,
+      166,
+      168
+    ],
+    "previous_stable": {
+      "appcast_sha256": "0d824afeba2e8d4f12493818fe77e9280b463e5c6e0de8acd408ee9045ad4812",
+      "build_version": "162",
+      "dmg_sha256": "04fad8c2323f749a4057c6486d0193b278ad3428880be287838a2b5e80eca8c5",
+      "must_not_rebuild": true,
+      "package_version": "0.3.1",
+      "published_at": "2026-08-09T17:44:19Z",
+      "release_id": 367541840,
+      "release_run_id": 31325968679,
+      "release_tag": "v0.3.1",
+      "signed_app_tree_sha256": "e7f721a1d3b3797a879f0293ce6f3c43565956c288fc14e41cd297200fade5df",
+      "source_git_sha": "22982d5037e3b2bd03bbc9fa25332be2c8b04c97"
+    },
+    "rc1": {
+      "appcast_sha256": "a78ff9944cb6f9801913c7195c31907803e71aa7ebafbb7474bb3e4e4ec2f38a",
+      "build_version": "170",
+      "dmg_sha256": "62cb9c0b3fe4ee6ddb309504306520ba6a91292742140479081ff910a4b20dff",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2rc1",
+      "published_at": "2026-08-25T01:38:46Z",
+      "release_id": 376092200,
+      "release_run_id": 32796196439,
+      "release_tag": "v0.3.2-rc.1",
+      "signed_app_tree_sha256": "00d5132b7b982f02bf1ffe23909df331bab1c733430756c3f8cbe002fa7f0004",
+      "source_git_sha": "1d691a6db7c18d09f55a425ec77a01ab6d917d80"
+    }
+  },
+  "issues": [
+    "#542",
+    "#610",
+    "#617",
+    "#620",
+    "#623",
+    "#609",
+    "#613",
+    "#614"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-rc.1-to-v0.3.2",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-stable",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-rc.1-release-evidence-v1",
+      "scope": "immutable qualified RC 1 identity, signed-artifact inputs, updater evidence, and publication receipts"
+    },
+    {
+      "id": "v0.3.1-appcast",
+      "scope": "previous Stable update route and release-note base"
+    }
+  ],
+  "qualification_id": "v0.3.2-stable-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.2-stable-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage stable --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -42,11 +42,12 @@ draft creation and is permanently burned, as recorded in
 draft was deleted only after explicit authorization, with the immutable
 disposition at `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json`.
 Issue #609 closed published and fully qualified Beta `0.3.2b7`, public tag
-`v0.3.2-beta.7`, and build `169`. Issue #613 owns prepared successor RC
-`0.3.2rc1`, public tag `v0.3.2-rc.1`, and build `170` under feature freeze.
-Its metadata and preregistered qualification are preparation-only; Prerelease
-dispatch, signing approval, and publication remain separately authorized
-boundaries.
+`v0.3.2-beta.7`, and build `169`. Issue #613 closed published and fully
+qualified RC `0.3.2rc1`, public tag `v0.3.2-rc.1`, and build `170` under
+feature freeze. Issue #614 owns prepared successor Stable `0.3.2`, public tag
+`v0.3.2`, and build `171`. Its metadata and preregistered qualification are
+preparation-only; Stable dispatch, signing approval, and publication remain
+separately authorized boundaries.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -20,11 +20,11 @@ post-publication exact-artifact qualification is blocked by packaged worker
 version metadata. Corrective Beta `0.3.2b6` build `168` is a cancelled,
 unpublished signed attempt whose draft `374538590` was deleted through the
 authorized immutable-disposition path; its tag and build are permanently
-non-reusable. Beta `0.3.2b7` build `169` is published, immutable, and fully
-qualified. Issue #613 owns prepared successor RC `0.3.2rc1` build `170` under
-feature freeze; dispatch, signing approval, and publication remain separately
-authorized. Run-bound signing approval remains a separate authorization
-boundary.
+non-reusable. Beta `0.3.2b7` build `169` and RC `0.3.2rc1` build `170` are
+published, immutable, and fully qualified. Issue #614 owns prepared successor
+Stable `0.3.2` build `171`; dispatch, signing approval, and publication remain
+separately authorized. Run-bound signing approval remains a separate
+authorization boundary.
 
 ## Production Identity
 
@@ -495,15 +495,23 @@ zero blocking or operator-required cases; the immutable publication and
 qualification contract is recorded in
 [the 0.3.2 Beta 7 cut packet](0.3.2-beta.7-cut-packet.md).
 
-RC 1 is prepared under feature freeze as internal version `0.3.2rc1`, public
-tag and title `v0.3.2-rc.1`, and global build `170`. Published immutable Beta 7
-is its immediate release-note and update-route predecessor; failed builds `165`
-and `166` and cancelled build `168` remain burned. Release-independent
-Production Preflight run `32791057931` passed on exact protected-main SHA
-`f65185dc9762c804ce8c879e6d044cfb8b9213a3` before metadata preparation. No RC
-1 tag, release, draft, appcast item, PyPI version, or Homebrew change was
-created. The preparation contract is recorded in
+RC 1 is published and immutable as internal version `0.3.2rc1`, public tag and
+title `v0.3.2-rc.1`, and global build `170`. Guarded Prerelease run
+`32796196439` published release `376092200` from source and tag SHA
+`1d691a6db7c18d09f55a425ec77a01ab6d917d80`. Final qualification passed with
+zero blocking cases and 15 completed cases. Its immutable publication and
+qualification contract is recorded in
 [the 0.3.2 RC 1 cut packet](0.3.2-rc.1-cut-packet.md).
+
+Stable 0.3.2 is prepared as internal and public version `0.3.2`, tag and title
+`v0.3.2`, and global build `171`. RC 1 is the immediate global predecessor and
+exact RC-route qualification base. Stable `v0.3.1` build `162` remains the
+previous Stable update and release-note base. The unchanneled Stable item is
+eligible on Stable, RC, Beta, and Alpha routes. Failed builds `165` and `166`
+and cancelled build `168` remain burned. No Stable dispatch, signing approval,
+tag, release, draft, appcast, PyPI, or Homebrew mutation is authorized by this
+preparation. The preparation contract is recorded in
+[the 0.3.2 Stable cut packet](0.3.2-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 170
+        CURRENT_PROJECT_VERSION: 171
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2rc1
+        MARKETING_VERSION: 0.3.2
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2rc1"
+version = "0.3.2"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "170"
+build_version = "171"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -134,8 +134,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2rc1")
-        self.assertEqual(NATIVE_BUILD_VERSION, "170")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2")
+        self.assertEqual(NATIVE_BUILD_VERSION, "171")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,20 +199,20 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(app["bundle_identifier"], "com.shinycomputers.bd-to-avp")
         self.assertNotIn("briefcase", pyproject["tool"])
 
-    def test_repository_records_rc1_release_state_and_prior_release_history(self) -> None:
+    def test_repository_records_stable_release_state_and_prior_release_history(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2rc1")
-        self.assertEqual(metadata.public_version, "0.3.2-rc.1")
-        self.assertEqual(metadata.build_version, "170")
-        self.assertEqual(metadata.release_tag, "v0.3.2-rc.1")
-        self.assertEqual(metadata.release_name, "v0.3.2-rc.1")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2-rc.1.dmg")
-        self.assertEqual(metadata.channel, "rc")
-        self.assertTrue(metadata.prerelease)
-        self.assertTrue(metadata.first_candidate_of_cycle)
-        self.assertFalse(metadata.make_latest)
-        self.assertFalse(metadata.publish_pypi)
+        self.assertEqual(metadata.package_version, "0.3.2")
+        self.assertEqual(metadata.public_version, "0.3.2")
+        self.assertEqual(metadata.build_version, "171")
+        self.assertEqual(metadata.release_tag, "v0.3.2")
+        self.assertEqual(metadata.release_name, "v0.3.2")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2.dmg")
+        self.assertEqual(metadata.channel, "stable")
+        self.assertFalse(metadata.prerelease)
+        self.assertFalse(metadata.first_candidate_of_cycle)
+        self.assertTrue(metadata.make_latest)
+        self.assertTrue(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
         beta6_freeze = freeze_policy["frozen_release_tags"]["v0.3.2-beta.6"]
@@ -221,6 +221,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("authorized immutable disposition", beta6_freeze["reason"])
         self.assertNotIn("v0.3.2-beta.7", freeze_policy["frozen_release_tags"])
         self.assertNotIn("v0.3.2-rc.1", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.2", freeze_policy["frozen_release_tags"])
 
         cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.6-cut-packet.md").read_text(encoding="utf-8")
         self.assertIn("`0.3.2b6`", cut_packet)
@@ -260,7 +261,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("feature freeze", rc1_cut_packet.lower())
         self.assertIn("Production Preflight run `32791057931`", rc1_cut_packet)
         self.assertIn("Beta 7", rc1_cut_packet)
-        rc1_release_receipt = REPO_ROOT / "docs" / "release-evidence" / metadata.release_tag / "release-receipt.json"
+        rc1_release_receipt = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2-rc.1" / "release-receipt.json"
         expected_rc1_state = (
             release.CUT_PACKET_PUBLISHED if rc1_release_receipt.is_file() else release.CUT_PACKET_PREPARED
         )
@@ -270,19 +271,34 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn(expected_rc1_state, rc1_cut_packet)
         self.assertNotIn(unexpected_rc1_state, rc1_cut_packet)
 
+        stable_cut_packet = (REPO_ROOT / "docs" / "0.3.2-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.2`", stable_cut_packet)
+        self.assertIn("Build `171`", stable_cut_packet)
+        self.assertIn("v0.3.2-rc.1", stable_cut_packet)
+        self.assertIn("v0.3.1", stable_cut_packet)
+        stable_release_receipt = REPO_ROOT / "docs" / "release-evidence" / metadata.release_tag / "release-receipt.json"
+        expected_stable_state = (
+            release.CUT_PACKET_PUBLISHED if stable_release_receipt.is_file() else release.CUT_PACKET_PREPARED
+        )
+        unexpected_stable_state = (
+            release.CUT_PACKET_PREPARED if stable_release_receipt.is_file() else release.CUT_PACKET_PUBLISHED
+        )
+        self.assertIn(expected_stable_state, stable_cut_packet)
+        self.assertNotIn(unexpected_stable_state, stable_cut_packet)
+
         github_config = json.loads((REPO_ROOT / ".github" / "github.json").read_text(encoding="utf-8"))
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.2-stable-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2rc1")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2-rc.1")
-        self.assertEqual(qualification["candidate"]["build_version"], "170")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2-rc.1")
-        self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2")
+        self.assertEqual(qualification["candidate"]["build_version"], "171")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2")
+        self.assertEqual(qualification["candidate"]["workflow"], "Stable")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
         self.assertEqual(
@@ -291,31 +307,47 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertIn("#623", qualification["issues"])
         self.assertIn("#613", qualification["issues"])
+        self.assertIn("#614", qualification["issues"])
         self.assertEqual(
             set(qualification["immutable_history"]["burned_builds"]),
             {147, 154, 165, 166, 168},
         )
-        previous_beta = qualification["immutable_history"]["previous_beta"]
-        self.assertEqual(previous_beta["release_tag"], "v0.3.2-beta.7")
-        self.assertEqual(previous_beta["package_version"], "0.3.2b7")
-        self.assertEqual(previous_beta["build_version"], "169")
-        previous_beta_receipt_path = (
-            REPO_ROOT / "docs" / "release-evidence" / previous_beta["release_tag"] / "release-receipt.json"
+        previous_stable = qualification["immutable_history"]["previous_stable"]
+        self.assertEqual(previous_stable["release_tag"], "v0.3.1")
+        self.assertEqual(previous_stable["package_version"], "0.3.1")
+        self.assertEqual(previous_stable["build_version"], "162")
+        previous_stable_receipt_path = (
+            REPO_ROOT / "docs" / "release-evidence" / previous_stable["release_tag"] / "release-receipt.json"
         )
-        previous_beta_receipt = json.loads(previous_beta_receipt_path.read_text(encoding="utf-8"))
-        previous_beta_artifacts = {artifact["kind"]: artifact for artifact in previous_beta_receipt["artifacts"]}
-        self.assertEqual(previous_beta_receipt["source_sha"], previous_beta["source_git_sha"])
-        self.assertEqual(previous_beta_receipt["workflow"]["run_id"], previous_beta["release_run_id"])
-        self.assertEqual(previous_beta_receipt["release"]["id"], previous_beta["release_id"])
-        self.assertEqual(previous_beta_receipt["versions"]["package"], previous_beta["package_version"])
-        self.assertEqual(previous_beta_receipt["versions"]["build"], previous_beta["build_version"])
-        self.assertEqual(previous_beta_receipt["signed_app_tree_sha256"], previous_beta["signed_app_tree_sha256"])
-        self.assertEqual(previous_beta_artifacts["dmg"]["sha256"], previous_beta["dmg_sha256"])
-        self.assertEqual(previous_beta_artifacts["appcast"]["sha256"], previous_beta["appcast_sha256"])
+        previous_stable_receipt = json.loads(previous_stable_receipt_path.read_text(encoding="utf-8"))
+        previous_stable_artifacts = {artifact["kind"]: artifact for artifact in previous_stable_receipt["artifacts"]}
+        self.assertEqual(previous_stable_receipt["source_sha"], previous_stable["source_git_sha"])
+        self.assertEqual(previous_stable_receipt["workflow"]["run_id"], previous_stable["release_run_id"])
+        self.assertEqual(previous_stable_receipt["release"]["id"], previous_stable["release_id"])
+        self.assertEqual(previous_stable_receipt["versions"]["package"], previous_stable["package_version"])
+        self.assertEqual(previous_stable_receipt["versions"]["build"], previous_stable["build_version"])
+        self.assertEqual(previous_stable_receipt["signed_app_tree_sha256"], previous_stable["signed_app_tree_sha256"])
+        self.assertEqual(previous_stable_artifacts["dmg"]["sha256"], previous_stable["dmg_sha256"])
+        self.assertEqual(previous_stable_artifacts["appcast"]["sha256"], previous_stable["appcast_sha256"])
+
+        rc1 = qualification["immutable_history"]["rc1"]
+        self.assertEqual(rc1["release_tag"], "v0.3.2-rc.1")
+        self.assertEqual(rc1["package_version"], "0.3.2rc1")
+        self.assertEqual(rc1["build_version"], "170")
+        rc1_receipt = json.loads(rc1_release_receipt.read_text(encoding="utf-8"))
+        rc1_artifacts = {artifact["kind"]: artifact for artifact in rc1_receipt["artifacts"]}
+        self.assertEqual(rc1_receipt["source_sha"], rc1["source_git_sha"])
+        self.assertEqual(rc1_receipt["workflow"]["run_id"], rc1["release_run_id"])
+        self.assertEqual(rc1_receipt["release"]["id"], rc1["release_id"])
+        self.assertEqual(rc1_receipt["versions"]["package"], rc1["package_version"])
+        self.assertEqual(rc1_receipt["versions"]["build"], rc1["build_version"])
+        self.assertEqual(rc1_receipt["signed_app_tree_sha256"], rc1["signed_app_tree_sha256"])
+        self.assertEqual(rc1_artifacts["dmg"]["sha256"], rc1["dmg_sha256"])
+        self.assertEqual(rc1_artifacts["appcast"]["sha256"], rc1["appcast_sha256"])
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-beta.7-to-v0.3.2-rc.1",
-            "native-sparkle-notes-rc1",
+            "updater-route-v0.3.2-rc.1-to-v0.3.2",
+            "native-sparkle-notes-stable",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",
@@ -404,8 +436,8 @@ class ReleaseMetadataTests(unittest.TestCase):
             expected_candidate_identity,
         )
         self.assertEqual(qualification["status"], "preregistered_pending_exact_candidate")
-        self.assertEqual(qualification["execution_policy"]["release_stage"], "rc")
-        self.assertIn("--first-candidate-of-cycle", qualification["qualification_policy"]["scope_command"])
+        self.assertEqual(qualification["execution_policy"]["release_stage"], "stable")
+        self.assertNotIn("--first-candidate-of-cycle", qualification["qualification_policy"]["scope_command"])
         self.assertEqual(
             set(qualification["acceptance"]["blocking_case_ids"]),
             {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "170")
+        self.assertEqual(info["CFBundleVersion"], "171")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1121,7 +1121,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-rc.1-signed-qualification-v1.json",
+            "docs/qualification/v0.3.2-stable-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2rc1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- prepare Stable `0.3.2` / `v0.3.2` / global build `171` from exact protected-main base `bc91fd95ae0ec82d06aa715f29031b0734a8493d`
- preserve immutable Stable `v0.3.1`, RC 1, failed-attempt, burned-build, publication, and qualification history
- add the Stable cut packet and distinct `v0.3.2` Stable qualification preregistration without repurposing the historical `v0.3.1` record
- document release-note and update predecessors, supported updater routes, known issues, rollback, support readiness, and strict authorization boundaries

## Exact Identity

- package/public version: `0.3.2`
- tag/title: `v0.3.2`
- global build: `171`
- DMG: `3D-Blu-ray-to-Vision-Pro-0.3.2.dmg`
- Sparkle channel: absent (Stable default)
- GitHub prerelease: `false`
- GitHub Latest: `true`
- PyPI/Homebrew: eligible only after separately authorized publication

## Predecessors And Routes

- release-note base: immutable Stable `v0.3.1` build `162`
- exact qualification base: immutable RC `v0.3.2-rc.1` build `170` on route `rc`
- required milestone routes: RC 1 → Stable and Stable `v0.3.1` → Stable, with profile preservation
- the unchanneled Stable item is eligible on Stable, RC, Beta, and Alpha routes

## Validation

- `uv run python -m scripts.release validate`
- exact-head preparation classifier passed with `blocking_retests: []`
- release/native/Sparkle metadata tests: `184/184`
- release qualification/controller/receipt tests: `166/166`
- full Python suite with explicit known-good FFmpeg/FFprobe paths: `1894/1894` (`3` skipped)
- native XCTest suite: `484/484`
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package`
- `uv build`
- changed-file Ruff lint and format checks
- `uv run mypy bd_to_avp`
- import and CLI smoke
- independent release-preparation review: no findings
- Production Preflight run `32864834839` attempt `1` passed on exact protected-main SHA `bc91fd95ae0ec82d06aa715f29031b0734a8493d`
- bounded success artifact `9569973622`, `production-preflight-success-bc91fd95ae0ec82d06aa715f29031b0734a8493d-32864834839-1`, digest `sha256:a7b3d9f6f3a890779da87ff49e192896aaf8c535ab12e6adb5e0035bb99c441c`

The first full-suite attempt exposed the local Homebrew `ffmpeg-full` dylib collision. The rerun pinned `/opt/homebrew/opt/ffmpeg/bin/ffmpeg` and `ffprobe` and passed all tests; this is a local toolchain issue, not a candidate failure.

JetBrains inspection returned `UNKNOWN: worktree_mutation_detected` after IntelliJ rewrote tracked `.idea` metadata. The IDE-only changes were removed byte-for-byte and the worktree is clean; the helper marked the run non-retryable, so this is not represented as GREEN.

## Production Preflight

The separately authorized release-independent Production Preflight passed on exact protected-main SHA `bc91fd95ae0ec82d06aa715f29031b0734a8493d`. Run `32864834839` was dispatched and triggered by `shiny-code-bot` from `.github/workflows/production-preflight.yml@refs/heads/main`; the shared implementation was `.github/workflows/production-preflight-engine.yml` at the same SHA. The bounded success manifest was independently rebuilt from the downloaded source, package-smoke, installed-UI report, and four installed-UI evidence files and matched byte-for-byte.

## Authorization Boundary

This PR is preparation-only. It does not authorize or perform Stable workflow dispatch, `macos-signing` approval, tag/release/draft creation, appcast mutation, PyPI publication, Homebrew update, or any publication operation.

Refs #614
