### PR TITLE
Generate Release Evidence v2 shadow capture and index

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -149,6 +149,8 @@
       "releaseReceipt": "uv run python -m unittest tests.test_release_receipt",
       "releaseEvidenceV2": "uv run python -m unittest tests.test_release_evidence_v2",
       "releaseEvidenceV2AllTags": "uv run python -m scripts.release_evidence_v2 --all-tags --worktree --base-revision $(git rev-parse HEAD^)",
+      "releaseEvidenceV2IndexCheck": "uv run python -m scripts.release_evidence_v2 index --check --worktree",
+      "releaseEvidenceV2IndexReplay": "uv run python -m scripts.release_evidence_v2 index --check --revision $(git rev-parse HEAD)",
       "signedArtifactReceipt": "uv run python -m unittest tests.test_signed_artifact_receipt",
       "signedArtifactUi": "uv run python -m unittest tests.test_signed_artifact_ui",
       "preSigningUi": "uv run python -m unittest tests.test_installed_ui_qualification tests.test_pre_signing_ui tests.test_signed_artifact_ui",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
             --worktree \
             --base-revision "$BASE_SHA"
 
+      - name: Verify release evidence index
+        run: uv run python -m scripts.release_evidence_v2 index --check --worktree
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -83,6 +83,7 @@ jobs:
           fi
 
       - name: Resolve the immutable release and receipt
+        id: publication
         env:
           EXPECTED_RUN_ID: ${{ steps.source.outputs.release_run_id }}
           EXPECTED_SOURCE_SHA: ${{ steps.source.outputs.release_source_sha }}
@@ -127,6 +128,7 @@ jobs:
             --connect-timeout 10 --max-time 60 \
             "https://cbusillo.github.io/BD_to_AVP/appcast.xml" \
             --output live-appcast.xml
+          echo "live_appcast_verified_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Sanitize release evidence tag and ref
         id: sanitize
@@ -370,7 +372,7 @@ jobs:
       - name: Generate or validate shadow capture-v2
         id: capture-v2
         env:
-          CAPTURE_TIMESTAMP: ${{ github.event.workflow_run.updated_at }}
+          CAPTURE_TIMESTAMP: ${{ steps.publication.outputs.live_appcast_verified_at }}
           CAPTURE_WORKFLOW_ACTOR: ${{ github.event.workflow_run.actor.login }}
           CAPTURE_WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
           CAPTURE_WORKFLOW_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -27,13 +27,13 @@ jobs:
       evidence_ref: ${{ steps.sanitize.outputs.evidence_ref }}
       existing_branch_sha: ${{ steps.reuse.outputs.existing_branch_sha }}
       has_changes: ${{ steps.stage.outputs.has_changes }}
-      manifest_sha256: ${{ steps.reconcile.outputs.manifest_sha256 }}
-      receipt_file_sha256: ${{ steps.reconcile.outputs.receipt_file_sha256 }}
-      release_run_id: ${{ steps.reconcile.outputs.release_run_id }}
+      manifest_sha256: ${{ steps.final-outputs.outputs.manifest_sha256 }}
+      receipt_file_sha256: ${{ steps.final-outputs.outputs.receipt_file_sha256 }}
+      release_run_id: ${{ steps.final-outputs.outputs.release_run_id }}
       release_tag: ${{ steps.sanitize.outputs.release_tag }}
-      signed_ui_receipt_sha256: ${{ steps.reconcile.outputs.signed_ui_receipt_sha256 }}
-      signed_ui_artifact_sha256: ${{ steps.reconcile.outputs.signed_ui_artifact_sha256 }}
-      source_sha: ${{ steps.reconcile.outputs.source_sha }}
+      signed_ui_receipt_sha256: ${{ steps.final-outputs.outputs.signed_ui_receipt_sha256 }}
+      signed_ui_artifact_sha256: ${{ steps.final-outputs.outputs.signed_ui_artifact_sha256 }}
+      source_sha: ${{ steps.final-outputs.outputs.source_sha }}
     steps:
       - name: Checkout current protected main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -373,7 +373,7 @@ jobs:
         id: capture-v2
         env:
           CAPTURE_TIMESTAMP: ${{ steps.publication.outputs.live_appcast_verified_at }}
-          CAPTURE_WORKFLOW_ACTOR: ${{ github.event.workflow_run.actor.login }}
+          CAPTURE_WORKFLOW_ACTOR: ${{ github.actor }}
           CAPTURE_WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
           CAPTURE_WORKFLOW_RUN_ID: ${{ github.run_id }}
           EVIDENCE_REF: ${{ steps.sanitize.outputs.evidence_ref }}
@@ -404,6 +404,22 @@ jobs:
           set -euo pipefail
           python -m scripts.release_evidence_v2 index --write --repo-root "$GITHUB_WORKSPACE"
           python -m scripts.release_evidence_v2 index --check --worktree --repo-root "$GITHUB_WORKSPACE"
+
+      - name: Publish complete evidence outputs
+        id: final-outputs
+        env:
+          RELEASE_TAG: ${{ steps.sanitize.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          BUNDLE="docs/release-evidence/$RELEASE_TAG"
+          {
+            echo "manifest_sha256=$(jq -er .manifest_sha256 "$BUNDLE/qualification-manifest.json")"
+            echo "receipt_file_sha256=$(sha256sum "$BUNDLE/release-receipt.json" | awk '{print $1}')"
+            echo "release_run_id=$(jq -er .workflow.run_id "$BUNDLE/release-receipt.json")"
+            echo "signed_ui_receipt_sha256=$(jq -er .receipt_sha256 "$BUNDLE/signed-artifact-ui-receipt.json")"
+            echo "signed_ui_artifact_sha256=$(sha256sum "$BUNDLE/signed-artifact-ui.zip" | awk '{print $1}')"
+            echo "source_sha=$(jq -er .source_sha "$BUNDLE/release-receipt.json")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Stage only generated evidence files
         id: stage
@@ -532,3 +548,5 @@ jobs:
             The release workflow, immutable asset identities, signed artifact UI receipt, live Pages appcast, qualification manifest, qualification record, release ledger, and cut packet were revalidated before this branch was prepared. Signing and deployment secrets are not available to this workflow.
 
             Publication is immutable, but this PR remains intentionally unmergeable until its post-publication milestone qualification check has accepted every blocking live-artifact and automated Tier 3 receipt. Optional physical-hardware and native-window presentation outcomes remain visible without blocking reconciliation. Add validated receipts to this idempotent branch; do not rebuild, retag, or replace the published release.
+
+            After adding or changing terminal evidence under `docs/release-evidence/<tag>/`, regenerate the advisory index with `uv run python -m scripts.release_evidence_v2 index --write --repo-root .` before pushing.

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -24,12 +24,13 @@ jobs:
       contents: read
     outputs:
       base_main_sha: ${{ steps.base.outputs.sha }}
+      evidence_ref: ${{ steps.sanitize.outputs.evidence_ref }}
       existing_branch_sha: ${{ steps.reuse.outputs.existing_branch_sha }}
       has_changes: ${{ steps.stage.outputs.has_changes }}
       manifest_sha256: ${{ steps.reconcile.outputs.manifest_sha256 }}
       receipt_file_sha256: ${{ steps.reconcile.outputs.receipt_file_sha256 }}
       release_run_id: ${{ steps.reconcile.outputs.release_run_id }}
-      release_tag: ${{ steps.reconcile.outputs.release_tag }}
+      release_tag: ${{ steps.sanitize.outputs.release_tag }}
       signed_ui_receipt_sha256: ${{ steps.reconcile.outputs.signed_ui_receipt_sha256 }}
       signed_ui_artifact_sha256: ${{ steps.reconcile.outputs.signed_ui_artifact_sha256 }}
       source_sha: ${{ steps.reconcile.outputs.source_sha }}
@@ -127,13 +128,23 @@ jobs:
             "https://cbusillo.github.io/BD_to_AVP/appcast.xml" \
             --output live-appcast.xml
 
+      - name: Sanitize release evidence tag and ref
+        id: sanitize
+        run: |
+          set -euo pipefail
+          python -m scripts.release_evidence_v2 sanitize \
+            --release-receipt release-receipt.json \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Preserve an existing idempotent evidence branch
         id: reuse
+        env:
+          EVIDENCE_REF: ${{ steps.sanitize.outputs.evidence_ref }}
+          RELEASE_TAG: ${{ steps.sanitize.outputs.release_tag }}
         run: |
           set -euo pipefail
           RECEIPT_FILE_SHA256=$(sha256sum release-receipt.json | awk '{print $1}')
-          RELEASE_TAG=$(jq -r .release.tag release-receipt.json)
-          BRANCH_NAME="automation/release-evidence-$RELEASE_TAG"
+          BRANCH_NAME="$EVIDENCE_REF"
           MANIFEST_PATH="docs/release-evidence/$RELEASE_TAG/qualification-manifest.json"
           QUALIFICATION_RECORD_PATH="docs/release-evidence/$RELEASE_TAG/qualification-record.json"
           SIGNED_UI_ARCHIVE_PATH="docs/release-evidence/$RELEASE_TAG/signed-artifact-ui.zip"
@@ -348,13 +359,49 @@ jobs:
             --signed-ui-artifact-archive "${{ steps.signed-ui.outputs.archive_path }}" \
             --signed-ui-receipt "${{ steps.signed-ui.outputs.receipt_path }}" \
             --signed-ui-receipt-file-sha256 "${{ steps.signed-ui.outputs.receipt_file_sha256 }}" \
-            --evidence-ref "automation/release-evidence-$(jq -er .release.tag release-receipt.json)" \
+            --evidence-ref "${{ steps.sanitize.outputs.evidence_ref }}" \
             --evidence-base-sha "${{ steps.base.outputs.sha }}" \
             --runner-sha "${{ steps.base.outputs.sha }}" \
             --sparkle-route "${{ steps.signed-ui.outputs.sparkle_route }}" \
             --repo-root "$GITHUB_WORKSPACE" \
             "${RECOVERY_ARGS[@]}" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Generate or validate shadow capture-v2
+        id: capture-v2
+        env:
+          CAPTURE_TIMESTAMP: ${{ github.event.workflow_run.updated_at }}
+          CAPTURE_WORKFLOW_ACTOR: ${{ github.event.workflow_run.actor.login }}
+          CAPTURE_WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
+          CAPTURE_WORKFLOW_RUN_ID: ${{ github.run_id }}
+          EVIDENCE_REF: ${{ steps.sanitize.outputs.evidence_ref }}
+          RELEASE_TAG: ${{ steps.sanitize.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          BUNDLE="docs/release-evidence/$RELEASE_TAG"
+          python -m scripts.release_evidence_v2 capture \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --release-receipt "$BUNDLE/release-receipt.json" \
+            --release release.json \
+            --qualification-record "$BUNDLE/qualification-record.json" \
+            --qualification-manifest "$BUNDLE/qualification-manifest.json" \
+            --signed-ui-archive "$BUNDLE/signed-artifact-ui.zip" \
+            --signed-ui-receipt "$BUNDLE/signed-artifact-ui-receipt.json" \
+            --live-appcast live-appcast.xml \
+            --captured-at "$CAPTURE_TIMESTAMP" \
+            --live-appcast-verified-at "$CAPTURE_TIMESTAMP" \
+            --capture-workflow-actor "$CAPTURE_WORKFLOW_ACTOR" \
+            --capture-workflow-path .github/workflows/release-evidence.yml \
+            --capture-workflow-run-id "$CAPTURE_WORKFLOW_RUN_ID" \
+            --capture-workflow-run-attempt "$CAPTURE_WORKFLOW_RUN_ATTEMPT" \
+            --evidence-ref "$EVIDENCE_REF" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Generate and check shadow index-v2
+        run: |
+          set -euo pipefail
+          python -m scripts.release_evidence_v2 index --write --repo-root "$GITHUB_WORKSPACE"
+          python -m scripts.release_evidence_v2 index --check --worktree --repo-root "$GITHUB_WORKSPACE"
 
       - name: Stage only generated evidence files
         id: stage
@@ -412,7 +459,7 @@ jobs:
 
       - name: Reject conflicting evidence on the idempotent branch
         env:
-          BRANCH_NAME: automation/release-evidence-${{ needs.validate-and-prepare.outputs.release_tag }}
+          EVIDENCE_REF: ${{ needs.validate-and-prepare.outputs.evidence_ref }}
           EXPECTED_EXISTING_BRANCH_SHA: ${{ needs.validate-and-prepare.outputs.existing_branch_sha }}
           EXPECTED_RECEIPT_FILE_SHA256: ${{ needs.validate-and-prepare.outputs.receipt_file_sha256 }}
           EXPECTED_SIGNED_UI_RECEIPT_SHA256: ${{ needs.validate-and-prepare.outputs.signed_ui_receipt_sha256 }}
@@ -420,6 +467,7 @@ jobs:
           RELEASE_TAG: ${{ needs.validate-and-prepare.outputs.release_tag }}
         run: |
           set -euo pipefail
+          BRANCH_NAME="$EVIDENCE_REF"
           REMOTE_BRANCH_SHA=$(git ls-remote --heads origin "refs/heads/$BRANCH_NAME" | awk '{print $1}')
           if [ "$REMOTE_BRANCH_SHA" != "$EXPECTED_EXISTING_BRANCH_SHA" ]; then
             echo "Evidence branch moved after evidence preparation; rerun against its current head." >&2
@@ -467,7 +515,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           add-paths: docs
-          branch: automation/release-evidence-${{ needs.validate-and-prepare.outputs.release_tag }}
+          branch: ${{ needs.validate-and-prepare.outputs.evidence_ref }}
           commit-message: Record immutable evidence for ${{ needs.validate-and-prepare.outputs.release_tag }}
           delete-branch: true
           title: Record immutable evidence for ${{ needs.validate-and-prepare.outputs.release_tag }}

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -371,6 +371,7 @@ jobs:
 
       - name: Generate or validate shadow capture-v2
         id: capture-v2
+        if: steps.reuse.outputs.checkpoint_source != 'main'
         env:
           CAPTURE_TIMESTAMP: ${{ steps.publication.outputs.live_appcast_verified_at }}
           CAPTURE_WORKFLOW_ACTOR: ${{ github.actor }}

--- a/docs/release-evidence-v2.md
+++ b/docs/release-evidence-v2.md
@@ -1,12 +1,14 @@
 # Release Evidence v2
 
 Release Evidence v2 is an additive, offline-verifiable, write-once format for
-release evidence under `docs/release-evidence/<tag>/`. It runs unconditionally
-in shadow mode beside the maintained v1 reconciliation and automatic PR path;
-it does not remove or gate v1 behavior. Evidence files are passive data: the
-verifier uses only local files and local Git operations. For legacy revision
-replay it creates and removes a temporary detached worktree. It does not invoke
-`gh`, `curl`, a network client, or credentials.
+release evidence under `docs/release-evidence/<tag>/`. It runs in shadow mode
+beside the maintained v1 reconciliation and automatic PR path for new or
+in-progress evidence checkpoints; reruns whose complete checkpoint is already
+on protected `main` remain a no-op. It does not remove or gate v1 behavior.
+Evidence files are passive data: the verifier uses only local files and local
+Git operations. For legacy revision replay it creates and removes a temporary
+detached worktree. It does not invoke `gh`, `curl`, a network client, or
+credentials.
 
 ## Verification
 

--- a/docs/release-evidence-v2.md
+++ b/docs/release-evidence-v2.md
@@ -47,6 +47,9 @@ or Git ref use.
 existing verifier class and every sorted repo-relative file/digest in that tag
 directory. The index contains no timestamps or current-time fields and excludes
 itself from release inventories.
+Protected-main CI regenerates this view in memory and rejects committed index
+drift; the release-evidence workflow writes and immediately rechecks the same
+bytes before staging its advisory shadow output.
 
 ## Capture Record
 

--- a/docs/release-evidence-v2.md
+++ b/docs/release-evidence-v2.md
@@ -50,6 +50,9 @@ itself from release inventories.
 Protected-main CI regenerates this view in memory and rejects committed index
 drift; the release-evidence workflow writes and immediately rechecks the same
 bytes before staging its advisory shadow output.
+Any later commit that adds terminal receipts or other checked files beneath a
+release bundle must regenerate `index-v2.json` with the documented `index
+--write` command before CI will accept the branch.
 
 ## Capture Record
 

--- a/docs/release-evidence-v2.md
+++ b/docs/release-evidence-v2.md
@@ -1,11 +1,12 @@
 # Release Evidence v2
 
 Release Evidence v2 is an additive, offline-verifiable, write-once format for
-release evidence under `docs/release-evidence/<tag>/`. It does not alter
-release, qualification, or workflow/controller behavior. Evidence files are
-passive data: the verifier uses only local files and local Git operations. For
-legacy revision replay it creates and removes a temporary detached worktree. It
-does not invoke `gh`, `curl`, a network client, or credentials.
+release evidence under `docs/release-evidence/<tag>/`. It runs unconditionally
+in shadow mode beside the maintained v1 reconciliation and automatic PR path;
+it does not remove or gate v1 behavior. Evidence files are passive data: the
+verifier uses only local files and local Git operations. For legacy revision
+replay it creates and removes a temporary detached worktree. It does not invoke
+`gh`, `curl`, a network client, or credentials.
 
 ## Verification
 
@@ -23,11 +24,29 @@ uv run python -m scripts.release_evidence_v2 --all-tags \
   --revision <full-git-sha> \
   --base-revision <full-git-sha>
 uv run python -m scripts.release_evidence_v2 --tag v0.3.2 --worktree
+uv run python -m scripts.release_evidence_v2 index --write --repo-root .
+uv run python -m scripts.release_evidence_v2 index --check --worktree \
+  --repo-root .
 ```
 
 `--base-revision` enforces write-once history: every v2 record in the base tree
 must exist byte-identically in the verified tree. Changed or deleted records are
 refused.
+
+The capture producer consumes only already-validated v1 files plus explicit
+workflow provenance and timestamps. Its inputs include `--captured-at`,
+`--live-appcast-verified-at`, `--capture-workflow-run-id`, and
+`--capture-workflow-run-attempt`; supplying the same inputs produces identical
+bytes. A capture already present in the bundle is validated and reused, never
+regenerated or overwritten. The `sanitize` command emits the exact canonical
+release tag and `automation/release-evidence-<tag>` ref before workflow shell
+or Git ref use.
+
+`index-v2.json` contains only `schema_version`, a path/digest binding for
+`index-v1.json`, and sorted release entries. Each release entry records the
+existing verifier class and every sorted repo-relative file/digest in that tag
+directory. The index contains no timestamps or current-time fields and excludes
+itself from release inventories.
 
 ## Capture Record
 

--- a/docs/release-evidence/index-v2.json
+++ b/docs/release-evidence/index-v2.json
@@ -1,0 +1,193 @@
+{
+  "legacy_index": {
+    "path": "docs/release-evidence/index-v1.json",
+    "sha256": "c0fd7301bd05e928be4866b36efd589e95209e09a4c0700805fdfa1def97ba7a"
+  },
+  "releases": [
+    {
+      "evidence_class": "legacy-publication-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.0/publication-record.json",
+          "sha256": "9f07d1a349e71ff109627d9f2493d0e2a1c65326a141b45a5c0ee569e2bf7833"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.0/release-receipt.json",
+          "sha256": "f1da7083036120104fe702326cb88224e0233e26a2044a8e0ca0bd57520f9f79"
+        }
+      ],
+      "release_tag": "v0.3.0"
+    },
+    {
+      "evidence_class": "legacy-publication-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.0-rc.3/appcast.xml.base64",
+          "sha256": "434c05a7c3a5fba29ddcb756fe78f978776b9a1a8eb2eca2a590cc2b6a04bdf9"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.0-rc.3/publication-record.json",
+          "sha256": "73a45ad745f117a0c590c1966eeefab1f6f86263cd3948f800de3163078ec01d"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.0-rc.3/release-notes.md",
+          "sha256": "140e457ae718f1391bae01c4f767e09c732c5c33bfe73b222bf7ab4ab0f1fe16"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.0-rc.3/release-receipt.json",
+          "sha256": "e2cd5c52b5e177048783a8ca2d8f6d8ba7580be8f933702a42072928839f2c3d"
+        }
+      ],
+      "release_tag": "v0.3.0-rc.3"
+    },
+    {
+      "evidence_class": "legacy-publication-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.1/publication-record.json",
+          "sha256": "b080989bf03c54ac9f8e37c9c52afd6c97467ced3a582a17f4d7ba8b1044cca6"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.1/release-receipt.json",
+          "sha256": "47ae149d8c6a04085821c9f13dbbd112990902602876895a561530ca83ae2c88"
+        }
+      ],
+      "release_tag": "v0.3.1"
+    },
+    {
+      "evidence_class": "legacy-qualification-manifest-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.2/publication-record.json",
+          "sha256": "47bda0215fd81dcf02a276a8f60e2bf869571865f1c3b1c1c99a9796dba0a370"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2/qualification-manifest.json",
+          "sha256": "6b02525a9cefd8da5992c8923dc8f84ddeb829be6433cb77c1178f899f56a091"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2/qualification-record.json",
+          "sha256": "5ec93f64a7c23acd10bf179b2288600ee0b54a1440a85eee2588126523f2701b"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2/release-receipt.json",
+          "sha256": "21e8d6fa0c4f8e014fd57565f993652cc76a4bb3a968e5752e2a4bcb2a1237b0"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2/signed-artifact-ui-receipt.json",
+          "sha256": "db546c6b94b4676ea65b6f829be5331fbcfc288476d5ec29d7bea6479ffbe248"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2/signed-artifact-ui.zip",
+          "sha256": "4a8d04461220a3b66f865d2a08f201ab1948ff784181b12a93273b90f940d9dd"
+        }
+      ],
+      "release_tag": "v0.3.2"
+    },
+    {
+      "evidence_class": "legacy-qualification-manifest-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/publication-record.json",
+          "sha256": "055866321b18d216abdacfaa73784dc69192702af6e429e7754d2c0fa4a4f6d4"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/qualification-manifest.json",
+          "sha256": "67b8e5caf02801707efc0546b1794258d145510819c8cb22dd91e2ddd45bf62d"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/qualification-record.json",
+          "sha256": "ee82c63ffb6accdc7de5712f1e581efe32b7e6cd51d43a78c48c8791d599ea57"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/release-receipt.json",
+          "sha256": "f88259e5f82f5885f087adf1a284f47bda97741e99ad982ccbcd758efe829f19"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/signed-artifact-ui-receipt.json",
+          "sha256": "3dfe3230c0fec7f1e0e6066e4dacde02d355b51e1074507cfb276c9ef278fec0"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.2/signed-artifact-ui.zip",
+          "sha256": "115611f11c44ac4bee3ca8053d25e1b8823a5a4340ee32e1771f2161d6f208a3"
+        }
+      ],
+      "release_tag": "v0.3.2-beta.2"
+    },
+    {
+      "evidence_class": "legacy-failed-post-publication-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.5/failed-post-publication-qualification-v1.json",
+          "sha256": "84f3bfce0e6c242b3b8d60f0b82e85894b62e1958f3806499d8797cfd2cb1274"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.5/release-receipt.json",
+          "sha256": "81e1568ff93c0fad946dff59c5d4e00c97008162db93218cc4f58dcd2ad8af6c"
+        }
+      ],
+      "release_tag": "v0.3.2-beta.5"
+    },
+    {
+      "evidence_class": "legacy-qualification-manifest-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/publication-record.json",
+          "sha256": "413537b8135cba8d37fe7af689d036e0ab364df2859f5319c84016443197fed0"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/qualification-manifest.json",
+          "sha256": "97afc00742be32f057258eb04b38ebd05b617687134f23da7d40c0a7a75aebd8"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/qualification-record.json",
+          "sha256": "4fb7b10ed15b3c3f341b3386ba9502f3a0d126040916a912e8e8950b188786e0"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/release-receipt.json",
+          "sha256": "6afe63b1212ce0b59d7b893f8b501297361c45e8fbf88484ab915e92f0b060b3"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/signed-artifact-ui-receipt.json",
+          "sha256": "452e5098b1de521b09ab67b96afa5a7cf88e1161383f3f0fe8d2a9705ad8da7f"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-beta.7/signed-artifact-ui.zip",
+          "sha256": "e6fb978a0f90ae5e448210c0c7a4c7356b9bae2bfcd2f2befb7827b3279cd9f0"
+        }
+      ],
+      "release_tag": "v0.3.2-beta.7"
+    },
+    {
+      "evidence_class": "legacy-qualification-manifest-v1",
+      "files": [
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/publication-record.json",
+          "sha256": "d9d26e7357acedec3e968a99cf667a8a2a3c76ce9f50e5778781514c2f1d4d20"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/qualification-manifest.json",
+          "sha256": "ab7173f4379f97209c9e49f48e67d02539a17c61eb63a60b03318ee5e7ee64b5"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/qualification-record.json",
+          "sha256": "7e78c7bf244a8ca8e497c7dccb1b90b346b9a7925f70219927f53a108d64171e"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/release-receipt.json",
+          "sha256": "dec0546e8e4c7178fba99492911f12896277260c767f96e0c492d7cbfc3c1d54"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/signed-artifact-ui-receipt.json",
+          "sha256": "9f3a0cf76896b8a7fa70e4ce5fc715e482e8fbbd4e30bffaac8bf0562b7e7fa1"
+        },
+        {
+          "path": "docs/release-evidence/v0.3.2-rc.1/signed-artifact-ui.zip",
+          "sha256": "c8383f78c7ae3ba58b39f8abda2b8ab5c8aa31100434fc1cec01ee54259031b4"
+        }
+      ],
+      "release_tag": "v0.3.2-rc.1"
+    }
+  ],
+  "schema_version": 2
+}

--- a/scripts/release_evidence_v2.py
+++ b/scripts/release_evidence_v2.py
@@ -50,6 +50,8 @@ from scripts.tier3_receipt import Tier3ReceiptError, load_validated_receipt_byte
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EVIDENCE_ROOT = PurePosixPath("docs/release-evidence")
 CAPTURE_NAME = "capture-v2.json"
+INDEX_NAME = "index-v2.json"
+LEGACY_INDEX_PATH = "docs/release-evidence/index-v1.json"
 QUALIFICATION_NAME = "qualification-v2.json"
 DISPOSITION_NAME = "disposition-v2.json"
 RECEIPT_NAME = "release-receipt.json"
@@ -77,7 +79,7 @@ REQUIRED_CASE_IDS = frozenset(
 )
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
-TAG_PATTERN = re.compile(r"^v[0-9A-Za-z][0-9A-Za-z.-]*$")
+TAG_PATTERN = re.compile(r"^v[0-9A-Za-z](?:[0-9A-Za-z]|[.-][0-9A-Za-z])*$")
 TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$")
 IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 CAPTURE_KEYS = frozenset(
@@ -137,6 +139,22 @@ DISPOSITION_KEYS = frozenset(
 
 class ReleaseEvidenceV2Error(RuntimeError):
     pass
+
+
+def sanitize_release_tag(value: object) -> str:
+    return _tag(value, "release tag")
+
+
+def evidence_ref_for_tag(release_tag: object) -> str:
+    tag = sanitize_release_tag(release_tag)
+    return f"automation/release-evidence-{tag}"
+
+
+def sanitize_evidence_ref(value: object, release_tag: object) -> str:
+    expected = evidence_ref_for_tag(release_tag)
+    if value != expected:
+        raise ReleaseEvidenceV2Error("Evidence ref must exactly match the sanitized release tag.")
+    return expected
 
 
 @dataclass(frozen=True)
@@ -443,6 +461,342 @@ def write_record(path: Path, record: Mapping[str, Any]) -> None:
             ) from None
     except OSError as error:
         raise ReleaseEvidenceV2Error(f"Unable to create write-once record at {path}: {error}") from error
+
+
+def _load_json_path(path: Path, description: str) -> Mapping[str, Any]:
+    try:
+        return _load_json_bytes(path.read_bytes(), description)
+    except OSError as error:
+        raise ReleaseEvidenceV2Error(f"Unable to read {description} at {path}: {error}") from error
+
+
+def _relative_repo_path(repo_root: Path, path: Path, description: str) -> str:
+    try:
+        relative = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as error:
+        raise ReleaseEvidenceV2Error(f"{description} must be inside the repository.") from error
+    return _path(relative, description)
+
+
+def _release_receipt_asset_id(release: Mapping[str, Any], receipt_file_sha256: str) -> int:
+    assets = release.get("assets")
+    if not isinstance(assets, Sequence) or isinstance(assets, (str, bytes, bytearray)):
+        raise ReleaseEvidenceV2Error("Published release assets must be a JSON array.")
+    matches = [
+        asset
+        for asset in assets
+        if isinstance(asset, Mapping)
+        and asset.get("name") == RECEIPT_NAME
+        and asset.get("digest") == f"sha256:{receipt_file_sha256}"
+    ]
+    if len(matches) != 1:
+        raise ReleaseEvidenceV2Error("Published release must contain exactly one matching release receipt asset.")
+    asset_id = matches[0].get("id")
+    return _positive_integer(asset_id, "published release receipt asset ID")
+
+
+def _manifest_signed_ui_artifact_id(path: Path) -> int:
+    manifest = _load_json_path(path, "qualification manifest")
+    signed_ui = _mapping(manifest.get("signed_ui_artifact"), "qualification manifest signed UI artifact")
+    return _positive_integer(signed_ui.get("artifact_id"), "qualification manifest signed UI artifact ID")
+
+
+def _capture_source_inputs(
+    repo_root: Path, source_sha: str, release_tag: str, release_route: str
+) -> dict[str, dict[str, str]]:
+    expected_paths = {
+        **SOURCE_INPUT_PATHS,
+        "qualification_template": qualification_template_path(release_tag, release_route),
+    }
+    inputs: dict[str, dict[str, str]] = {}
+    for name, relative_path in expected_paths.items():
+        data = _git_run(repo_root, ["show", f"{source_sha}:{relative_path}"], f"read source input {name}")
+        inputs[name] = {"path": relative_path, "sha256": _digest_bytes(data)}
+    return inputs
+
+
+def build_capture_v2(
+    repo_root: Path,
+    *,
+    release_receipt_path: Path,
+    release_path: Path,
+    qualification_record_path: Path,
+    signed_ui_archive_path: Path,
+    signed_ui_receipt_path: Path,
+    qualification_manifest_path: Path,
+    live_appcast_path: Path,
+    captured_at: str,
+    live_appcast_verified_at: str,
+    capture_workflow_actor: str,
+    capture_workflow_run_id: int,
+    capture_workflow_run_attempt: int,
+    capture_workflow_path: str = EVIDENCE_WORKFLOW_PATH,
+    release_receipt_asset_id: int | None = None,
+    signed_ui_artifact_id: int | None = None,
+    evidence_ref: str | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    receipt_relative = _relative_repo_path(repo_root, release_receipt_path, "release receipt path")
+    qualification_relative = _relative_repo_path(repo_root, qualification_record_path, "qualification record path")
+    signed_ui_archive_relative = _relative_repo_path(repo_root, signed_ui_archive_path, "signed UI archive path")
+    signed_ui_receipt_relative = _relative_repo_path(repo_root, signed_ui_receipt_path, "signed UI receipt path")
+    release_receipt_bytes = release_receipt_path.read_bytes()
+    release_receipt, receipt_file_sha256 = load_validated_checked_receipt(release_receipt_path)
+    release = _mapping(release_receipt.get("release"), "release receipt release")
+    release_tag = sanitize_release_tag(release.get("tag"))
+    if evidence_ref is not None:
+        sanitize_evidence_ref(evidence_ref, release_tag)
+    source_sha = _sha(release_receipt.get("source_sha"), "release receipt source SHA")
+    release_route = _string(release_receipt.get("release_route"), "release receipt release route")
+    _resolve_revision(repo_root, source_sha)
+    _verify_source_ancestry(_verification_reader(repo_root, verification_revision=None, worktree=True), source_sha)
+    receipt_path_expected = f"docs/release-evidence/{release_tag}/{RECEIPT_NAME}"
+    qualification_path_expected = f"docs/release-evidence/{release_tag}/{QUALIFICATION_RECORD_NAME}"
+    signed_ui_archive_path_expected = f"docs/release-evidence/{release_tag}/{SIGNED_UI_ARCHIVE_NAME}"
+    signed_ui_receipt_path_expected = f"docs/release-evidence/{release_tag}/{SIGNED_UI_RECEIPT_NAME}"
+    if receipt_relative != receipt_path_expected:
+        raise ReleaseEvidenceV2Error("Release receipt path does not match the sanitized release tag.")
+    if qualification_relative != qualification_path_expected:
+        raise ReleaseEvidenceV2Error("Qualification record path does not match the sanitized release tag.")
+    if signed_ui_archive_relative != signed_ui_archive_path_expected:
+        raise ReleaseEvidenceV2Error("Signed UI archive path does not match the sanitized release tag.")
+    if signed_ui_receipt_relative != signed_ui_receipt_path_expected:
+        raise ReleaseEvidenceV2Error("Signed UI receipt path does not match the sanitized release tag.")
+    if release_receipt_asset_id is None:
+        release_receipt_asset_id = _release_receipt_asset_id(
+            _load_json_path(release_path, "published release"), receipt_file_sha256
+        )
+    else:
+        release_receipt_asset_id = _positive_integer(release_receipt_asset_id, "release receipt asset ID")
+    if signed_ui_artifact_id is None:
+        signed_ui_artifact_id = _manifest_signed_ui_artifact_id(qualification_manifest_path)
+    else:
+        signed_ui_artifact_id = _positive_integer(signed_ui_artifact_id, "signed UI artifact ID")
+    qualification_bytes = qualification_record_path.read_bytes()
+    signed_ui_archive_bytes = signed_ui_archive_path.read_bytes()
+    signed_ui_receipt_bytes = signed_ui_receipt_path.read_bytes()
+    live_appcast_bytes = live_appcast_path.read_bytes()
+    signed_ui_receipt_sha256 = _sha256(
+        _mapping(_load_json_bytes(signed_ui_receipt_bytes, "signed UI receipt"), "signed UI receipt").get(
+            "receipt_sha256"
+        ),
+        "signed UI receipt self SHA-256",
+    )
+    signed_ui_receipt_file_sha256 = _digest_bytes(signed_ui_receipt_bytes)
+    live_appcast_sha256 = _digest_bytes(live_appcast_bytes)
+    receipt_appcast_sha256 = _receipt_artifact_digest(release_receipt, "appcast")
+    if live_appcast_sha256 != receipt_appcast_sha256:
+        raise ReleaseEvidenceV2Error("Live appcast bytes do not match the validated release receipt.")
+    _timestamp(captured_at, "capture-v2 captured_at")
+    _timestamp(live_appcast_verified_at, "capture-v2 live appcast verified_at")
+    workflow = _mapping(release_receipt.get("workflow"), "release receipt workflow")
+    release_workflow = {
+        "actor": _string(workflow.get("actor"), "release workflow actor"),
+        "path": _path(workflow.get("path"), "release workflow path"),
+        "run_attempt": _positive_integer(workflow.get("run_attempt"), "release workflow run attempt"),
+        "run_id": _positive_integer(workflow.get("run_id"), "release workflow run ID"),
+    }
+    capture_workflow = {
+        "actor": _string(capture_workflow_actor, "capture workflow actor"),
+        "path": _path(capture_workflow_path, "capture workflow path"),
+        "run_attempt": _positive_integer(capture_workflow_run_attempt, "capture workflow run attempt"),
+        "run_id": _positive_integer(capture_workflow_run_id, "capture workflow run ID"),
+    }
+    record = with_self_digest(
+        {
+            "capture_workflow": capture_workflow,
+            "captured_at": captured_at,
+            "live_appcast": {"sha256": live_appcast_sha256, "verified_at": live_appcast_verified_at},
+            "qualification_record": {
+                "path": qualification_relative,
+                "sha256": _digest_bytes(qualification_bytes),
+            },
+            "receipt": {
+                "asset_id": release_receipt_asset_id,
+                "file_sha256": receipt_file_sha256,
+                "path": receipt_relative,
+                "receipt_sha256": _sha256(release_receipt.get("receipt_sha256"), "release receipt self SHA-256"),
+            },
+            "record_type": "capture",
+            "release_tag": release_tag,
+            "release_workflow": release_workflow,
+            "repository": EXPECTED_REPOSITORY,
+            "schema_version": SCHEMA_VERSION,
+            "signed_ui": {
+                "archive": {"path": signed_ui_archive_relative, "sha256": _digest_bytes(signed_ui_archive_bytes)},
+                "artifact_id": signed_ui_artifact_id,
+                "receipt": {
+                    "file_sha256": signed_ui_receipt_file_sha256,
+                    "path": signed_ui_receipt_relative,
+                    "receipt_sha256": signed_ui_receipt_sha256,
+                },
+            },
+            "source_inputs": _capture_source_inputs(repo_root, source_sha, release_tag, release_route),
+            "source_sha": source_sha,
+            "state": "CAPTURED",
+        }
+    )
+    if _digest_bytes(release_receipt_bytes) != receipt_file_sha256:
+        raise ReleaseEvidenceV2Error("Release receipt digest changed while building capture-v2.")
+    return record
+
+
+def write_or_validate_capture_v2(
+    repo_root: Path,
+    release_tag: str,
+    record: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    tag = sanitize_release_tag(release_tag)
+    capture_path = repo_root / EVIDENCE_ROOT / tag / CAPTURE_NAME
+    if capture_path.exists():
+        existing = _load_record(
+            _verification_reader(repo_root, verification_revision=None, worktree=True),
+            f"{EVIDENCE_ROOT}/{tag}/{CAPTURE_NAME}",
+            "existing capture-v2 record",
+        )
+        validate_v2_bundle(repo_root, tag, worktree=True)
+        return existing
+    write_record(capture_path, record)
+    validate_v2_bundle(repo_root, tag, worktree=True)
+    return record
+
+
+def capture_v2(
+    repo_root: Path,
+    *,
+    release_receipt_path: Path,
+    release_path: Path,
+    qualification_record_path: Path,
+    signed_ui_archive_path: Path,
+    signed_ui_receipt_path: Path,
+    qualification_manifest_path: Path,
+    live_appcast_path: Path,
+    captured_at: str,
+    live_appcast_verified_at: str,
+    capture_workflow_actor: str,
+    capture_workflow_run_id: int,
+    capture_workflow_run_attempt: int,
+    capture_workflow_path: str = EVIDENCE_WORKFLOW_PATH,
+    release_receipt_asset_id: int | None = None,
+    signed_ui_artifact_id: int | None = None,
+    evidence_ref: str | None = None,
+) -> Mapping[str, Any]:
+    receipt, _ = load_validated_checked_receipt(release_receipt_path)
+    release = _mapping(receipt.get("release"), "release receipt release")
+    release_tag = sanitize_release_tag(release.get("tag"))
+    if evidence_ref is not None:
+        sanitize_evidence_ref(evidence_ref, release_tag)
+    capture_path = repo_root.resolve() / EVIDENCE_ROOT / release_tag / CAPTURE_NAME
+    if capture_path.exists():
+        return write_or_validate_capture_v2(repo_root, release_tag, {})
+    record = build_capture_v2(
+        repo_root,
+        release_receipt_path=release_receipt_path,
+        release_path=release_path,
+        qualification_record_path=qualification_record_path,
+        signed_ui_archive_path=signed_ui_archive_path,
+        signed_ui_receipt_path=signed_ui_receipt_path,
+        qualification_manifest_path=qualification_manifest_path,
+        live_appcast_path=live_appcast_path,
+        captured_at=captured_at,
+        live_appcast_verified_at=live_appcast_verified_at,
+        capture_workflow_actor=capture_workflow_actor,
+        capture_workflow_run_id=capture_workflow_run_id,
+        capture_workflow_run_attempt=capture_workflow_run_attempt,
+        capture_workflow_path=capture_workflow_path,
+        release_receipt_asset_id=release_receipt_asset_id,
+        signed_ui_artifact_id=signed_ui_artifact_id,
+        evidence_ref=evidence_ref,
+    )
+    return write_or_validate_capture_v2(repo_root, release_tag, record)
+
+
+def _tree_paths(reader: _BundleReader, prefix: str) -> list[str]:
+    if reader.worktree:
+        root, normalized = _repo_path(reader.repo_root, prefix, "evidence directory")
+        if not root.is_dir():
+            raise ReleaseEvidenceV2Error(f"Evidence directory does not exist: {normalized}.")
+        return sorted(path.relative_to(reader.repo_root).as_posix() for path in root.rglob("*") if path.is_file())
+    if reader.revision is None:
+        raise ReleaseEvidenceV2Error("Verification revision is missing.")
+    return sorted(
+        path
+        for path in _git_run(
+            reader.repo_root,
+            ["ls-tree", "-r", "--name-only", reader.revision, "--", prefix],
+            "list release evidence files",
+        )
+        .decode()
+        .splitlines()
+        if path.startswith(f"{prefix}/")
+    )
+
+
+def canonical_index_bytes(index: Mapping[str, Any]) -> bytes:
+    return (json.dumps(index, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode()
+
+
+def build_index_v2(
+    repo_root: Path,
+    *,
+    revision: str | None = None,
+    worktree: bool = False,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    reader = _verification_reader(repo_root, verification_revision=revision, worktree=worktree)
+    legacy_index_bytes = reader.read(LEGACY_INDEX_PATH, "legacy release evidence index")
+    releases: list[dict[str, Any]] = []
+    for release_tag in _tags_at_revision(reader):
+        verified = verify_tag(
+            repo_root,
+            release_tag,
+            verification_revision=reader.revision if not worktree else None,
+            worktree=worktree,
+        )
+        prefix = f"{EVIDENCE_ROOT.as_posix()}/{release_tag}"
+        files = [
+            {"path": path, "sha256": _digest_bytes(reader.read(path, "release evidence file"))}
+            for path in _tree_paths(reader, prefix)
+            if path != f"{EVIDENCE_ROOT.as_posix()}/{INDEX_NAME}"
+        ]
+        releases.append({"evidence_class": verified["class"], "files": files, "release_tag": release_tag})
+    return {
+        "legacy_index": {"path": LEGACY_INDEX_PATH, "sha256": _digest_bytes(legacy_index_bytes)},
+        "releases": releases,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def write_index_v2(repo_root: Path, index: Mapping[str, Any], *, output_path: Path | None = None) -> Path:
+    repo_root = repo_root.resolve()
+    target = output_path or repo_root / EVIDENCE_ROOT / INDEX_NAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(canonical_index_bytes(index))
+    return target
+
+
+def check_index_v2(
+    repo_root: Path,
+    *,
+    revision: str | None = None,
+    worktree: bool = False,
+    output_path: Path | None = None,
+) -> None:
+    repo_root = repo_root.resolve()
+    expected = canonical_index_bytes(build_index_v2(repo_root, revision=revision, worktree=worktree))
+    if worktree:
+        target = output_path or repo_root / EVIDENCE_ROOT / INDEX_NAME
+        try:
+            actual = target.read_bytes()
+        except OSError as error:
+            raise ReleaseEvidenceV2Error(f"Unable to read index-v2 at {target}: {error}") from error
+    else:
+        reader = _verification_reader(repo_root, verification_revision=revision, worktree=False)
+        target = output_path or repo_root / EVIDENCE_ROOT / INDEX_NAME
+        relative = _relative_repo_path(repo_root, target, "index-v2 path")
+        actual = reader.read(relative, "index-v2")
+    if actual != expected:
+        raise ReleaseEvidenceV2Error(f"index-v2 bytes are not deterministic for the selected evidence tree: {target}.")
 
 
 def _load_record(reader: _BundleReader, relative_path: str, description: str) -> Mapping[str, Any]:
@@ -1550,6 +1904,12 @@ def verify_all_tags(
     return results
 
 
+def _write_github_output(path: Path, outputs: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
 def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Verify passive release-evidence v2 and explicit historical v1 classes offline."
@@ -1565,7 +1925,154 @@ def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _parse_sanitize_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sanitize the canonical release evidence tag and branch ref.")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--release-receipt", type=Path)
+    parser.add_argument("--release-tag")
+    parser.add_argument("--evidence-ref")
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def _parse_capture_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build and write-once validate deterministic capture-v2 evidence.")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--release-receipt", type=Path, required=True)
+    parser.add_argument("--release", type=Path, required=True)
+    parser.add_argument("--qualification-record", type=Path, required=True)
+    parser.add_argument("--qualification-manifest", type=Path, required=True)
+    parser.add_argument("--signed-ui-archive", type=Path, required=True)
+    parser.add_argument("--signed-ui-receipt", type=Path, required=True)
+    parser.add_argument("--live-appcast", type=Path, required=True)
+    parser.add_argument("--captured-at", required=True)
+    parser.add_argument("--live-appcast-verified-at", required=True)
+    parser.add_argument("--capture-workflow-actor", required=True)
+    parser.add_argument("--capture-workflow-path", default=EVIDENCE_WORKFLOW_PATH)
+    parser.add_argument("--capture-workflow-run-id", type=int, required=True)
+    parser.add_argument("--capture-workflow-run-attempt", type=int, required=True)
+    parser.add_argument("--release-receipt-asset-id", type=int)
+    parser.add_argument("--signed-ui-artifact-id", type=int)
+    parser.add_argument("--evidence-ref")
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def _parse_index_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate or check deterministic release evidence index-v2.")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--check", action="store_true")
+    action.add_argument("--write", action="store_true")
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--revision")
+    source.add_argument("--worktree", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def _path_from_cli(value: Path) -> Path:
+    return value if value.is_absolute() else Path.cwd() / value
+
+
+def _run_sanitize(argv: Sequence[str]) -> int:
+    args = _parse_sanitize_arguments(argv)
+    try:
+        tag: str
+        if args.release_receipt is not None:
+            receipt, _ = load_validated_checked_receipt(_path_from_cli(args.release_receipt))
+            release = _mapping(receipt.get("release"), "release receipt release")
+            tag = sanitize_release_tag(release.get("tag"))
+            if args.release_tag is not None and sanitize_release_tag(args.release_tag) != tag:
+                raise ReleaseEvidenceV2Error("Release tag does not match the validated release receipt.")
+        elif args.release_tag is not None:
+            tag = sanitize_release_tag(args.release_tag)
+        else:
+            raise ReleaseEvidenceV2Error("One of --release-receipt or --release-tag is required.")
+        evidence_ref = sanitize_evidence_ref(args.evidence_ref, tag) if args.evidence_ref else evidence_ref_for_tag(tag)
+        outputs = {"evidence_ref": evidence_ref, "release_tag": tag}
+        if args.github_output is not None:
+            _write_github_output(_path_from_cli(args.github_output), outputs)
+        else:
+            print(json.dumps(outputs, sort_keys=True, separators=(",", ":")))
+    except (ReleaseEvidenceError, ReleaseReceiptError, ReleaseEvidenceV2Error) as error:
+        print(f"release-evidence-v2: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _run_capture(argv: Sequence[str]) -> int:
+    args = _parse_capture_arguments(argv)
+    repo_root = args.repo_root.resolve()
+    try:
+        record = capture_v2(
+            repo_root,
+            release_receipt_path=_path_from_cli(args.release_receipt),
+            release_path=_path_from_cli(args.release),
+            qualification_record_path=_path_from_cli(args.qualification_record),
+            signed_ui_archive_path=_path_from_cli(args.signed_ui_archive),
+            signed_ui_receipt_path=_path_from_cli(args.signed_ui_receipt),
+            qualification_manifest_path=_path_from_cli(args.qualification_manifest),
+            live_appcast_path=_path_from_cli(args.live_appcast),
+            captured_at=args.captured_at,
+            live_appcast_verified_at=args.live_appcast_verified_at,
+            capture_workflow_actor=args.capture_workflow_actor,
+            capture_workflow_run_id=args.capture_workflow_run_id,
+            capture_workflow_run_attempt=args.capture_workflow_run_attempt,
+            capture_workflow_path=args.capture_workflow_path,
+            release_receipt_asset_id=args.release_receipt_asset_id,
+            signed_ui_artifact_id=args.signed_ui_artifact_id,
+            evidence_ref=args.evidence_ref,
+        )
+        release_tag = sanitize_release_tag(record.get("release_tag"))
+    except (OSError, ReleaseEvidenceError, ReleaseReceiptError, ReleaseEvidenceV2Error) as error:
+        print(f"release-evidence-v2: {error}", file=sys.stderr)
+        return 1
+    outputs = {
+        "capture_path": f"{EVIDENCE_ROOT.as_posix()}/{release_tag}/{CAPTURE_NAME}",
+        "capture_sha256": record["capture_sha256"],
+        "release_tag": release_tag,
+    }
+    if args.github_output is not None:
+        _write_github_output(_path_from_cli(args.github_output), outputs)
+    else:
+        print(json.dumps(outputs, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def _run_index(argv: Sequence[str]) -> int:
+    args = _parse_index_arguments(argv)
+    repo_root = args.repo_root.resolve()
+    output_path = _path_from_cli(args.output) if args.output is not None else None
+    try:
+        if args.write:
+            if args.revision is not None:
+                raise ReleaseEvidenceV2Error("index-v2 --write cannot target a historical revision.")
+            index = build_index_v2(repo_root, worktree=True)
+            target = write_index_v2(repo_root, index, output_path=output_path)
+            print(json.dumps({"index_path": target.relative_to(repo_root).as_posix()}, separators=(",", ":")))
+        else:
+            check_index_v2(
+                repo_root,
+                revision=args.revision,
+                worktree=args.worktree,
+                output_path=output_path,
+            )
+            print(json.dumps({"index_checked": True}, separators=(",", ":")))
+    except (OSError, ReleaseEvidenceV2Error) as error:
+        print(f"release-evidence-v2: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(argv) if argv is not None else sys.argv[1:]
+    if arguments and arguments[0] == "sanitize":
+        return _run_sanitize(arguments[1:])
+    if arguments and arguments[0] in {"capture", "capture-v2"}:
+        return _run_capture(arguments[1:])
+    if arguments and arguments[0] in {"index", "index-v2"}:
+        return _run_index(arguments[1:])
     args = _parse_arguments(argv)
     try:
         if args.tag:

--- a/scripts/release_evidence_v2.py
+++ b/scripts/release_evidence_v2.py
@@ -647,18 +647,49 @@ def write_or_validate_capture_v2(
     record: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     tag = sanitize_release_tag(release_tag)
+    reader = _verification_reader(repo_root, verification_revision=None, worktree=True)
+    candidate = _validate_capture(reader, record)
+    if candidate.release_tag != tag:
+        raise ReleaseEvidenceV2Error("Generated capture-v2 release tag conflicts with its bundle directory.")
     capture_path = repo_root / EVIDENCE_ROOT / tag / CAPTURE_NAME
     if capture_path.exists():
         existing = _load_record(
-            _verification_reader(repo_root, verification_revision=None, worktree=True),
+            reader,
             f"{EVIDENCE_ROOT}/{tag}/{CAPTURE_NAME}",
             "existing capture-v2 record",
         )
-        validate_v2_bundle(repo_root, tag, worktree=True)
+        _validate_capture(reader, existing)
+        existing_identity = _capture_immutable_identity(existing, "existing capture")
+        candidate_identity = _capture_immutable_identity(record, "generated capture")
+        if existing_identity != candidate_identity:
+            raise ReleaseEvidenceV2Error(
+                "Existing capture-v2 conflicts with the newly supplied immutable release evidence."
+            )
         return existing
     write_record(capture_path, record)
-    validate_v2_bundle(repo_root, tag, worktree=True)
     return record
+
+
+def _capture_immutable_identity(record: Mapping[str, Any], description: str) -> dict[str, Any]:
+    return {
+        "live_appcast_sha256": _mapping(record.get("live_appcast"), f"{description} live appcast").get("sha256"),
+        **{
+            key: record.get(key)
+            for key in (
+                "qualification_record",
+                "receipt",
+                "record_type",
+                "release_tag",
+                "release_workflow",
+                "repository",
+                "schema_version",
+                "signed_ui",
+                "source_inputs",
+                "source_sha",
+                "state",
+            )
+        },
+    }
 
 
 def capture_v2(
@@ -771,7 +802,10 @@ def write_index_v2(repo_root: Path, index: Mapping[str, Any], *, output_path: Pa
     repo_root = repo_root.resolve()
     target = output_path or repo_root / EVIDENCE_ROOT / INDEX_NAME
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(canonical_index_bytes(index))
+    with tempfile.NamedTemporaryFile("wb", dir=target.parent, delete=False) as temporary:
+        temporary.write(canonical_index_bytes(index))
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(target)
     return target
 
 

--- a/scripts/release_evidence_v2.py
+++ b/scripts/release_evidence_v2.py
@@ -717,9 +717,6 @@ def capture_v2(
     release_tag = sanitize_release_tag(release.get("tag"))
     if evidence_ref is not None:
         sanitize_evidence_ref(evidence_ref, release_tag)
-    capture_path = repo_root.resolve() / EVIDENCE_ROOT / release_tag / CAPTURE_NAME
-    if capture_path.exists():
-        return write_or_validate_capture_v2(repo_root, release_tag, {})
     record = build_capture_v2(
         repo_root,
         release_receipt_path=release_receipt_path,
@@ -747,7 +744,17 @@ def _tree_paths(reader: _BundleReader, prefix: str) -> list[str]:
         root, normalized = _repo_path(reader.repo_root, prefix, "evidence directory")
         if not root.is_dir():
             raise ReleaseEvidenceV2Error(f"Evidence directory does not exist: {normalized}.")
-        return sorted(path.relative_to(reader.repo_root).as_posix() for path in root.rglob("*") if path.is_file())
+        return sorted(
+            path
+            for path in _git_run(
+                reader.repo_root,
+                ["ls-files", "--cached", "--others", "--exclude-standard", "--", prefix],
+                "list worktree release evidence files",
+            )
+            .decode()
+            .splitlines()
+            if path.startswith(f"{prefix}/") and (reader.repo_root / path).is_file()
+        )
     if reader.revision is None:
         raise ReleaseEvidenceV2Error("Verification revision is missing.")
     return sorted(
@@ -788,7 +795,6 @@ def build_index_v2(
         files = [
             {"path": path, "sha256": _digest_bytes(reader.read(path, "release evidence file"))}
             for path in _tree_paths(reader, prefix)
-            if path != f"{EVIDENCE_ROOT.as_posix()}/{INDEX_NAME}"
         ]
         releases.append({"evidence_class": verified["class"], "files": files, "release_tag": release_tag})
     return {
@@ -801,11 +807,13 @@ def build_index_v2(
 def write_index_v2(repo_root: Path, index: Mapping[str, Any], *, output_path: Path | None = None) -> Path:
     repo_root = repo_root.resolve()
     target = output_path or repo_root / EVIDENCE_ROOT / INDEX_NAME
+    _relative_repo_path(repo_root, target, "index-v2 output path")
     target.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("wb", dir=target.parent, delete=False) as temporary:
         temporary.write(canonical_index_bytes(index))
         temporary_path = Path(temporary.name)
     temporary_path.replace(target)
+    target.chmod(0o644)
     return target
 
 
@@ -830,7 +838,10 @@ def check_index_v2(
         relative = _relative_repo_path(repo_root, target, "index-v2 path")
         actual = reader.read(relative, "index-v2")
     if actual != expected:
-        raise ReleaseEvidenceV2Error(f"index-v2 bytes are not deterministic for the selected evidence tree: {target}.")
+        raise ReleaseEvidenceV2Error(
+            f"index-v2 is stale for the selected evidence tree: {target}. "
+            "Regenerate it with `uv run python -m scripts.release_evidence_v2 index --write --repo-root .`."
+        )
 
 
 def _load_record(reader: _BundleReader, relative_path: str, description: str) -> Mapping[str, Any]:
@@ -1961,7 +1972,6 @@ def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
 
 def _parse_sanitize_arguments(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Sanitize the canonical release evidence tag and branch ref.")
-    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--release-receipt", type=Path)
     parser.add_argument("--release-tag")
     parser.add_argument("--evidence-ref")
@@ -2029,7 +2039,7 @@ def _run_sanitize(argv: Sequence[str]) -> int:
             _write_github_output(_path_from_cli(args.github_output), outputs)
         else:
             print(json.dumps(outputs, sort_keys=True, separators=(",", ":")))
-    except (ReleaseEvidenceError, ReleaseReceiptError, ReleaseEvidenceV2Error) as error:
+    except (OSError, ReleaseEvidenceError, ReleaseReceiptError, ReleaseEvidenceV2Error) as error:
         print(f"release-evidence-v2: {error}", file=sys.stderr)
         return 1
     return 0

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -1830,7 +1830,11 @@ def discover_milestone_receipt(
                 "A failed post-publication disposition pull request must add exactly one disposition record."
             )
         disposition_relative, disposition_tag = disposition_matches[0]
-        release_evidence_changes = sorted(path for path in changed_paths if path.startswith("docs/release-evidence/"))
+        release_evidence_changes = sorted(
+            path
+            for path in changed_paths
+            if path.startswith("docs/release-evidence/") and path != RELEASE_V2_INDEX_PATH
+        )
         if release_evidence_changes != [disposition_relative]:
             raise ReleaseMilestoneContextError(
                 "A failed post-publication disposition pull request may change only its new disposition record "

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -1652,6 +1652,7 @@ def _validate_release_evidence_tag_scope(changed_paths: Sequence[str], release_t
         if path.startswith("docs/release-evidence/")
         and not path.startswith(expected_prefix)
         and path != RELEASE_LEDGER_PATH
+        and path != RELEASE_V2_INDEX_PATH
         and not _is_recovery_authorization_path(path)
     )
     if unrelated_paths:
@@ -1918,6 +1919,7 @@ def discover_milestone_receipt(
                 if path.startswith("docs/release-evidence/")
                 and not _is_recovery_authorization_path(path)
                 and path != receipt_relative
+                and path != RELEASE_V2_INDEX_PATH
             ]
             if other_checked_release_changes or evidence_index_mutation or RELEASE_LEDGER_PATH in changed_paths:
                 raise ReleaseMilestoneContextError(

--- a/scripts/release_milestone_context.py
+++ b/scripts/release_milestone_context.py
@@ -27,6 +27,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 GITHUB_CONFIG_PATH = Path(".github/github.json")
 EVIDENCE_INDEX_PATH = "docs/qualification/release-evidence-v1.json"
 RELEASE_LEDGER_PATH = "docs/release-evidence/index-v1.json"
+RELEASE_V2_INDEX_PATH = "docs/release-evidence/index-v2.json"
 RUNNER_BOUND_QUALIFICATION_PATHS = {
     "docs/qualification/release-qualification-policy-v1.json",
     "docs/qualification/video-quality-route-table-v2.json",
@@ -1877,7 +1878,9 @@ def discover_milestone_receipt(
         "qualificationRecordPath",
     )
     checked_release_mutation = any(
-        path.startswith("docs/release-evidence/") and not _is_recovery_authorization_path(path)
+        path.startswith("docs/release-evidence/")
+        and path != RELEASE_V2_INDEX_PATH
+        and not _is_recovery_authorization_path(path)
         for path in changed_paths
     )
     evidence_index_mutation = EVIDENCE_INDEX_PATH in changed_paths

--- a/tests/test_release_evidence_v2.py
+++ b/tests/test_release_evidence_v2.py
@@ -19,6 +19,7 @@ from scripts.release_evidence_v2 import (
     build_index_v2,
     canonical_index_bytes,
     canonical_record_bytes,
+    capture_v2,
     check_index_v2,
     evidence_ref_for_tag,
     sanitize_evidence_ref,
@@ -46,6 +47,8 @@ from scripts.tier3_receipt import build_receipt as build_tier3_receipt, receipt_
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TAG = "v0.3.0-rc.3"
+LIVE_APPCAST_BYTES = b"<appcast>test</appcast>\n"
+LIVE_APPCAST_SHA256 = hashlib.sha256(LIVE_APPCAST_BYTES).hexdigest()
 
 
 def digest(path: Path) -> str:
@@ -105,7 +108,13 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
                         "asset_id": 1,
                     },
                     {"kind": "checksum", "name": "SHA256SUMS", "sha256": "b" * 64, "size_bytes": 100, "asset_id": 2},
-                    {"kind": "appcast", "name": "appcast.xml", "sha256": "c" * 64, "size_bytes": 500, "asset_id": 3},
+                    {
+                        "kind": "appcast",
+                        "name": "appcast.xml",
+                        "sha256": LIVE_APPCAST_SHA256,
+                        "size_bytes": len(LIVE_APPCAST_BYTES),
+                        "asset_id": 3,
+                    },
                 ],
             },
             policy_path=root / source_paths["policy"],
@@ -143,7 +152,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
         candidate = qualification["candidate"]
         candidate.update(
             {
-                "appcast_sha256": "c" * 64,
+                "appcast_sha256": LIVE_APPCAST_SHA256,
                 "build_version": "160",
                 "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.0-rc.3.dmg",
                 "dmg_sha256": "a" * 64,
@@ -160,6 +169,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
         (bundle_root / "qualification-record.json").write_text(
             json.dumps(qualification, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
+        (bundle_root / "live-appcast.xml").write_bytes(LIVE_APPCAST_BYTES)
         cases = {case["id"]: case for case in policy["cases"]}
         for case_id, sample_name in (
             ("clean-machine-signed-update", "v0.3.2-clean-machine-signed-update-v1.json"),
@@ -220,7 +230,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
                     "run_id": 22222,
                 },
                 "captured_at": "2026-08-05T12:01:00Z",
-                "live_appcast": {"sha256": "c" * 64, "verified_at": "2026-08-05T12:00:30Z"},
+                "live_appcast": {"sha256": LIVE_APPCAST_SHA256, "verified_at": "2026-08-05T12:00:30Z"},
                 "qualification_record": {
                     "path": f"docs/release-evidence/{TAG}/qualification-record.json",
                     "sha256": digest(bundle / "qualification-record.json"),
@@ -274,7 +284,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
         manifest = json.loads(qualification_manifest_path.read_text(encoding="utf-8"))
         live_qualification = {
             "candidate": {
-                "appcast_sha256": "c" * 64,
+                "appcast_sha256": LIVE_APPCAST_SHA256,
                 "build": versions["build"],
                 "dmg_sha256": "a" * 64,
                 "package_version": versions["package"],
@@ -1071,6 +1081,33 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
             with self.assertRaisesRegex(ReleaseEvidenceV2Error, "different bytes"):
                 write_record(capture_path, changed)
 
+    def test_capture_v2_public_rerun_reuses_existing_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_sha, bundle = self.build_repository(root)
+            capture = self.write_capture(root, source_sha)
+            original = (bundle / CAPTURE_NAME).read_bytes()
+            reused = capture_v2(
+                root,
+                release_receipt_path=bundle / "release-receipt.json",
+                release_path=bundle / "qualification-manifest.json",
+                qualification_record_path=bundle / "qualification-record.json",
+                signed_ui_archive_path=bundle / "signed-artifact-ui.zip",
+                signed_ui_receipt_path=bundle / "signed-artifact-ui-receipt.json",
+                qualification_manifest_path=bundle / "qualification-manifest.json",
+                live_appcast_path=bundle / "live-appcast.xml",
+                captured_at="2026-08-05T12:02:00Z",
+                live_appcast_verified_at="2026-08-05T12:01:30Z",
+                capture_workflow_actor="shiny-code-bot",
+                capture_workflow_run_id=22223,
+                capture_workflow_run_attempt=2,
+                release_receipt_asset_id=99,
+                signed_ui_artifact_id=777,
+                evidence_ref=evidence_ref_for_tag(TAG),
+            )
+            self.assertEqual(reused["capture_sha256"], capture["capture_sha256"])
+            self.assertEqual((bundle / CAPTURE_NAME).read_bytes(), original)
+
     def test_workflow_contract_uses_unconditional_shadow_capture_and_index(self) -> None:
         workflow = (REPO_ROOT / ".github" / "workflows" / "release-evidence.yml").read_text(encoding="utf-8")
         ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
@@ -1079,6 +1116,8 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
         self.assertIn("name: Generate and check shadow index-v2", workflow)
         self.assertIn("--captured-at", workflow)
         self.assertIn("--capture-workflow-run-id", workflow)
+        self.assertIn("name: Publish complete evidence outputs", workflow)
+        self.assertIn("CAPTURE_WORKFLOW_ACTOR: ${{ github.actor }}", workflow)
         self.assertIn("branch: ${{ needs.validate-and-prepare.outputs.evidence_ref }}", workflow)
         self.assertNotIn("if: vars.RELEASE_EVIDENCE_V2", workflow)
         self.assertIn("python -m scripts.release_evidence_v2 index --check --worktree", ci_workflow)
@@ -1090,7 +1129,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
             index_path.write_bytes(canonical_index_bytes(index))
             check_index_v2(REPO_ROOT, worktree=True, output_path=index_path)
             index_path.write_bytes(index_path.read_bytes().replace(b"schema_version", b"schema-version", 1))
-            with self.assertRaisesRegex(ReleaseEvidenceV2Error, "not deterministic"):
+            with self.assertRaisesRegex(ReleaseEvidenceV2Error, "index-v2 is stale"):
                 check_index_v2(REPO_ROOT, worktree=True, output_path=index_path)
 
 

--- a/tests/test_release_evidence_v2.py
+++ b/tests/test_release_evidence_v2.py
@@ -13,13 +13,21 @@ from typing import Any
 from scripts.release_evidence_v2 import (
     CAPTURE_NAME,
     DISPOSITION_NAME,
+    INDEX_NAME,
     QUALIFICATION_NAME,
     ReleaseEvidenceV2Error,
+    build_index_v2,
+    canonical_index_bytes,
     canonical_record_bytes,
+    check_index_v2,
+    evidence_ref_for_tag,
+    sanitize_evidence_ref,
+    sanitize_release_tag,
     validate_v2_bundle,
     verify_all_tags,
     verify_tag,
     verify_write_once_history,
+    write_or_validate_capture_v2,
     qualification_template_path,
     with_self_digest,
     write_record,
@@ -998,6 +1006,82 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
             publication_path.write_text(json.dumps(publication, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             with self.assertRaisesRegex(ReleaseEvidenceV2Error, "nearest recovery variant"):
                 verify_tag(publication_root, "v0.3.0", worktree=True)
+
+    def test_index_v2_is_deterministic_sorted_and_preserves_legacy_index_bytes(self) -> None:
+        revision = git(REPO_ROOT, "rev-parse", "HEAD")
+        legacy_before = (REPO_ROOT / "docs" / "release-evidence" / "index-v1.json").read_bytes()
+        first = build_index_v2(REPO_ROOT, revision=revision)
+        second = build_index_v2(REPO_ROOT, revision=revision)
+        self.assertEqual(canonical_index_bytes(first), canonical_index_bytes(second))
+        self.assertEqual(first["schema_version"], 2)
+        self.assertEqual(first["legacy_index"]["path"], "docs/release-evidence/index-v1.json")
+        self.assertEqual(first["legacy_index"]["sha256"], digest(REPO_ROOT / first["legacy_index"]["path"]))
+        self.assertEqual(
+            [release["release_tag"] for release in first["releases"]],
+            sorted(release["release_tag"] for release in first["releases"]),
+        )
+        for release in first["releases"]:
+            self.assertEqual(release["files"], sorted(release["files"], key=lambda item: item["path"]))
+            self.assertNotIn(f"docs/release-evidence/{INDEX_NAME}", {item["path"] for item in release["files"]})
+        self.assertEqual(legacy_before, (REPO_ROOT / "docs" / "release-evidence" / "index-v1.json").read_bytes())
+
+    def test_index_v2_historical_replay_contains_every_legacy_class(self) -> None:
+        index = build_index_v2(REPO_ROOT, revision="119b27f4bf0e72b1b979d5397993d1ae526db187")
+        classes = {release["evidence_class"] for release in index["releases"]}
+        self.assertIn("legacy-publication-v1", classes)
+        self.assertIn("legacy-qualification-manifest-v1", classes)
+        self.assertIn("legacy-failed-post-publication-v1", classes)
+
+    def test_tag_and_evidence_ref_sanitization_is_exact(self) -> None:
+        self.assertEqual(sanitize_release_tag("v0.3.2-beta.7"), "v0.3.2-beta.7")
+        self.assertEqual(evidence_ref_for_tag("v0.3.2-beta.7"), "automation/release-evidence-v0.3.2-beta.7")
+        self.assertEqual(
+            sanitize_evidence_ref("automation/release-evidence-v0.3.2-beta.7", "v0.3.2-beta.7"),
+            "automation/release-evidence-v0.3.2-beta.7",
+        )
+        for malicious in ("v0.3.2/evil", "v0.3.2..evil", "v0.3.2-", "v0.3.2\n"):
+            with self.assertRaises(ReleaseEvidenceV2Error):
+                sanitize_release_tag(malicious)
+        with self.assertRaises(ReleaseEvidenceV2Error):
+            sanitize_evidence_ref("automation/release-evidence-v0.3.2/evil", "v0.3.2")
+
+    def test_existing_capture_bytes_are_reused_and_conflicting_record_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_sha, bundle = self.build_repository(root)
+            capture = self.write_capture(root, source_sha)
+            capture_path = bundle / CAPTURE_NAME
+            original = capture_path.read_bytes()
+            changed = dict(capture)
+            changed["captured_at"] = "2026-08-05T12:02:00Z"
+            changed = with_self_digest(changed)
+            reused = write_or_validate_capture_v2(root, TAG, changed)
+            self.assertEqual(reused["capture_sha256"], capture["capture_sha256"])
+            self.assertEqual(capture_path.read_bytes(), original)
+            capture_path.unlink()
+            write_record(capture_path, capture)
+            with self.assertRaisesRegex(ReleaseEvidenceV2Error, "different bytes"):
+                write_record(capture_path, changed)
+
+    def test_workflow_contract_uses_unconditional_shadow_capture_and_index(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "release-evidence.yml").read_text(encoding="utf-8")
+        self.assertIn("name: Sanitize release evidence tag and ref", workflow)
+        self.assertIn("name: Generate or validate shadow capture-v2", workflow)
+        self.assertIn("name: Generate and check shadow index-v2", workflow)
+        self.assertIn("--captured-at", workflow)
+        self.assertIn("--capture-workflow-run-id", workflow)
+        self.assertIn("branch: ${{ needs.validate-and-prepare.outputs.evidence_ref }}", workflow)
+        self.assertNotIn("if: vars.RELEASE_EVIDENCE_V2", workflow)
+
+    def test_index_check_rejects_drift_without_changing_legacy_index(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            index = build_index_v2(REPO_ROOT, worktree=True)
+            index_path = Path(temporary_directory) / INDEX_NAME
+            index_path.write_bytes(canonical_index_bytes(index))
+            check_index_v2(REPO_ROOT, worktree=True, output_path=index_path)
+            index_path.write_bytes(index_path.read_bytes().replace(b"schema_version", b"schema-version", 1))
+            with self.assertRaisesRegex(ReleaseEvidenceV2Error, "not deterministic"):
+                check_index_v2(REPO_ROOT, worktree=True, output_path=index_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_evidence_v2.py
+++ b/tests/test_release_evidence_v2.py
@@ -1058,6 +1058,14 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
             reused = write_or_validate_capture_v2(root, TAG, changed)
             self.assertEqual(reused["capture_sha256"], capture["capture_sha256"])
             self.assertEqual(capture_path.read_bytes(), original)
+            conflicting = dict(capture)
+            conflicting["signed_ui"] = {
+                **capture["signed_ui"],
+                "artifact_id": capture["signed_ui"]["artifact_id"] + 1,
+            }
+            conflicting = with_self_digest(conflicting)
+            with self.assertRaisesRegex(ReleaseEvidenceV2Error, "immutable release evidence"):
+                write_or_validate_capture_v2(root, TAG, conflicting)
             capture_path.unlink()
             write_record(capture_path, capture)
             with self.assertRaisesRegex(ReleaseEvidenceV2Error, "different bytes"):
@@ -1065,6 +1073,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
 
     def test_workflow_contract_uses_unconditional_shadow_capture_and_index(self) -> None:
         workflow = (REPO_ROOT / ".github" / "workflows" / "release-evidence.yml").read_text(encoding="utf-8")
+        ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
         self.assertIn("name: Sanitize release evidence tag and ref", workflow)
         self.assertIn("name: Generate or validate shadow capture-v2", workflow)
         self.assertIn("name: Generate and check shadow index-v2", workflow)
@@ -1072,6 +1081,7 @@ class ReleaseEvidenceV2Tests(unittest.TestCase):
         self.assertIn("--capture-workflow-run-id", workflow)
         self.assertIn("branch: ${{ needs.validate-and-prepare.outputs.evidence_ref }}", workflow)
         self.assertNotIn("if: vars.RELEASE_EVIDENCE_V2", workflow)
+        self.assertIn("python -m scripts.release_evidence_v2 index --check --worktree", ci_workflow)
 
     def test_index_check_rejects_drift_without_changing_legacy_index(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -16,6 +16,7 @@ from scripts.release_milestone_context import (
     ReleaseMilestoneContext,
     ReleaseMilestoneContextError,
     _validate_failed_unpublished_candidate,
+    _validate_release_evidence_tag_scope,
     _requires_unpublished_candidate_recovery,
     discover_milestone_manifest,
     discover_milestone_receipt,
@@ -417,6 +418,7 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
         bind_base_candidate: bool = False,
         previous_beta_override: tuple[str, object] | None = None,
         include_extra_evidence_file: bool = False,
+        include_generated_v2_index: bool = False,
         tamper_config: bool = False,
     ) -> tuple[str, str]:
         base_qualification_path = root / "docs/qualification/stable-signed-qualification-v1.json"
@@ -548,6 +550,10 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             publication_path = receipt_path.with_name("publication-record.json")
             publication_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
             paths.append(publication_path)
+        if include_generated_v2_index:
+            index_path = root / "docs/release-evidence/index-v2.json"
+            index_path.write_text('{"legacy_index":{},"releases":[],"schema_version":2}\n', encoding="utf-8")
+            paths.append(index_path)
         subprocess.run(["git", "add", *paths], cwd=root, check=True)
         subprocess.run(["git", "commit", "-qm", "prepare successor after published beta"], cwd=root, check=True)
         head_sha = subprocess.run(
@@ -1554,6 +1560,28 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
 
         self.assertIsNone(discovered)
 
+    def test_allows_generated_v2_index_with_published_prior_receipt_carry_forward(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha, head_sha = self.prepare_published_prior_receipt_transition(
+                root,
+                include_generated_v2_index=True,
+            )
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="prepare/v0.3.1-beta.2",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+                published_receipt_verifier=lambda _path, _receipt, _digest: None,
+            )
+
+        self.assertIsNone(discovered)
+
     def test_rejects_published_prior_receipt_identity_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -2483,6 +2511,16 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
             )
 
         self.assertIsNone(discovered)
+
+    def test_generated_release_evidence_v2_index_is_allowed_with_single_tag_evidence(self) -> None:
+        _validate_release_evidence_tag_scope(
+            (
+                "docs/release-evidence/v0.3.0/release-receipt.json",
+                "docs/release-evidence/v0.3.0/capture-v2.json",
+                "docs/release-evidence/index-v2.json",
+            ),
+            "v0.3.0",
+        )
 
     def test_rejects_non_docs_changes_on_evidence_branch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_release_milestone_context.py
+++ b/tests/test_release_milestone_context.py
@@ -2449,6 +2449,41 @@ class ReleaseMilestoneContextTests(unittest.TestCase):
                     base_branch="main",
                 )
 
+    def test_generated_release_evidence_v2_index_does_not_require_checked_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.build_repository(root)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            index_path = root / "docs/release-evidence/index-v2.json"
+            index_path.write_text('{"legacy_index":{},"releases":[],"schema_version":2}\n', encoding="utf-8")
+            subprocess.run(["git", "add", index_path.relative_to(root)], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "add generated release evidence v2 index"], cwd=root, check=True)
+            head_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            discovered = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="code/issue-662-shadow-capture",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(discovered)
+
     def test_rejects_non_docs_changes_on_evidence_branch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_release_recovery_records.py
+++ b/tests/test_release_recovery_records.py
@@ -41,7 +41,12 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
         path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     @staticmethod
-    def build_disposition_repository(root: Path, *, tamper_receipt: bool = False) -> tuple[str, str]:
+    def build_disposition_repository(
+        root: Path,
+        *,
+        tamper_receipt: bool = False,
+        include_generated_v2_index: bool = False,
+    ) -> tuple[str, str]:
         evidence_root = root / "docs" / "release-evidence" / "v0.3.2-beta.5"
         evidence_root.mkdir(parents=True)
         source_root = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2-beta.5"
@@ -65,6 +70,11 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
         if tamper_receipt:
             receipt_path = evidence_root / "release-receipt.json"
             receipt_path.write_text(receipt_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        if include_generated_v2_index:
+            (root / "docs" / "release-evidence" / "index-v2.json").write_text(
+                '{"legacy_index":{},"releases":[],"schema_version":2}\n',
+                encoding="utf-8",
+            )
         subprocess.run(["git", "add", "."], cwd=root, check=True)
         subprocess.run(["git", "commit", "-qm", "add disposition"], cwd=root, check=True)
         head_sha = subprocess.run(
@@ -111,6 +121,23 @@ class ReleaseRecoveryRecordTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             base_sha, head_sha = self.build_disposition_repository(root)
+
+            receipt_path = discover_milestone_receipt(
+                root,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                head_branch="code/issue-634-beta5-disposition",
+                base_repo="cbusillo/BD_to_AVP",
+                head_repo="cbusillo/BD_to_AVP",
+                base_branch="main",
+            )
+
+        self.assertIsNone(receipt_path)
+
+    def test_allows_generated_v2_index_with_failed_post_publication_disposition(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            base_sha, head_sha = self.build_disposition_repository(root, include_generated_v2_index=True)
 
             receipt_path = discover_milestone_receipt(
                 root,

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1184,6 +1184,10 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("checkpoint_source=main", str(prepare))
         self.assertIn("existing_branch_sha", str(prepare))
         self.assertIn("steps.reuse.outputs.checkpoint_source != 'main'", str(prepare))
+        shadow_capture_step = next(
+            step for step in prepare["steps"] if step["name"] == "Generate or validate shadow capture-v2"
+        )
+        self.assertEqual(shadow_capture_step["if"], "steps.reuse.outputs.checkpoint_source != 'main'")
         self.assertIn("partial qualification checkpoint state", str(prepare))
         self.assertIn("expired before Release Evidence captured it", str(prepare))
         self.assertIn("scripts.release_qualification_manifest validate", str(prepare))

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1198,7 +1198,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("--signed-ui-artifact-archive", str(prepare))
         self.assertIn("signed-artifact-ui.zip", str(prepare))
         self.assertIn("qualification-record.json", str(prepare))
-        self.assertIn("steps.reconcile.outputs.manifest_sha256", str(prepare))
+        self.assertIn("steps.final-outputs.outputs.manifest_sha256", str(prepare))
         self.assertIn(".immutable == true", str(prepare))
         self.assertIn("Preserve an existing idempotent evidence branch", str(prepare))
         self.assertIn("ROLLING_QUALIFICATION_PATH", str(prepare))
@@ -1207,7 +1207,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertIn("EXPECTED_EXISTING_BRANCH_SHA", str(create_pr))
         self.assertIn("Evidence branch moved after evidence preparation", str(create_pr))
         self.assertNotIn("conflicting qualification manifest", str(create_pr))
-        self.assertIn("automation/release-evidence-", str(create_pr))
+        self.assertIn("needs.validate-and-prepare.outputs.evidence_ref", str(create_pr))
         create_pr_steps = [
             step for step in create_pr["steps"] if step.get("uses", "").startswith("peter-evans/create-pull-request@")
         ]
@@ -1217,7 +1217,7 @@ printf '%s' "$CODESIGN_METADATA"
         self.assertEqual(create_pr_inputs["add-paths"], "docs")
         self.assertEqual(
             create_pr_inputs["branch"],
-            "automation/release-evidence-${{ needs.validate-and-prepare.outputs.release_tag }}",
+            "${{ needs.validate-and-prepare.outputs.evidence_ref }}",
         )
         self.assertEqual(
             create_pr_inputs["commit-message"],
@@ -1238,6 +1238,7 @@ printf '%s' "$CODESIGN_METADATA"
             "remains intentionally unmergeable",
             "blocking live-artifact and automated Tier 3 receipt",
             "Optional physical-hardware and native-window presentation",
+            "release_evidence_v2 index --write",
         ):
             with self.subTest(body_fragment=body_fragment):
                 self.assertIn(body_fragment, create_pr_inputs["body"])


### PR DESCRIPTION
## Summary

- generate deterministic `capture-v2.json` and `index-v2.json` in unconditional shadow mode alongside the unchanged v1 release-evidence path
- sanitize the exact release tag/evidence ref before shell or Git ref use
- preserve valid existing capture bytes on rerun while refusing immutable release-evidence conflicts
- verify index drift in protected-main CI and preserve existing optimistic branch/main concurrency checks
- freeze the current legacy inventory through generated path/digest bindings without modifying `index-v1.json`

## Validation

- `uv run python -m unittest tests.test_release_evidence_v2` — 25 passed
- release evidence regression suite — 104 passed
- Ruff check and format check — passed
- mypy — passed
- worktree and committed-revision index checks — passed
- all-tag replay with write-once base verification — passed
- JSON/YAML parsing and `git diff --check` — passed
- Opus final review — APPROVE
- AGY review — skipped per user direction

JetBrains inspection remained inconclusive because its IDE lifecycle generated `.idea` mutations; those files are excluded from every commit in this PR.

Closes #662
Refs #658
Refs #655
