### PR TITLE
Prepare v0.3.3-beta.1 release metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -94,7 +94,7 @@
     "qualificationStatusCommand": "uv run python -m scripts.release_qualification_controller status --release-tag <tag>",
     "qualificationResumeCommand": "uv run python -m scripts.release_qualification_controller resume --release-tag <tag>",
     "qualificationCollectOperatorCommand": "uv run python -m scripts.release_qualification_controller collect-operator --release-tag <tag> --case-id <case-id> --environment-class <class> --output-answers <path>",
-    "qualificationRecordPath": "docs/qualification/v0.3.2-stable-signed-qualification-v1.json",
+    "qualificationRecordPath": "docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json",
     "qualificationReportArtifacts": [
       "release-qualification-preparation-<run-attempt>",
       "release-qualification-final-<run-attempt>",

--- a/docs/0.3.3-beta.1-cut-packet.md
+++ b/docs/0.3.3-beta.1-cut-packet.md
@@ -1,0 +1,89 @@
+# 0.3.3 Beta 1 Cut Packet
+
+**Prepared metadata; publication pending.**
+
+## Candidate Identity
+
+- Owner: issue #659.
+- Package version: `0.3.3b1`.
+- Public version, tag, and release name: `v0.3.3-beta.1`.
+- Build: `172`.
+- Route: `Prerelease` / Sparkle `beta`; GitHub prerelease; not Latest; PyPI and
+  Homebrew publication disabled.
+- Metadata parent: `dd45908ebfe265c2eaf97e79a012629bd5085bf4`.
+
+This is the first candidate of the `0.3.3` cycle. Its exact post-dispatch source
+SHA, signed DMG checksum, signed app-tree checksum, release run, release ID, and
+appcast checksum are deliberately absent from preregistration and must be
+recorded only from the separately authorized release's immutable receipts.
+
+## Immutable Prior
+
+Published Stable `0.3.2` / build `171` remains the prior updater source and
+immutable release evidence base:
+
+- tag and source SHA: `v0.3.2` / `3ab40c9eb745cd038d1129d55a94cdb1cc4c7bec`;
+- release workflow run: `32872545337` attempt `1`;
+- release ID: `376566532`;
+- DMG SHA-256:
+  `ab395c3741d2e25b8bc8e348da355663919a9568bdb9c0dcd74e8a4667d94b60`;
+- signed app-tree SHA-256:
+  `4554b1852ef758481c417048a2d87bd8f8b165ff90110039bd430ec6fa257878`; and
+- appcast SHA-256:
+  `20eaa4b924fd82148961f3453b462366b3bdc1760e868c3e3ad2f673ffec4c3d`.
+
+Burned builds `147`, `154`, `165`, `166`, and `168`, plus abandoned metadata
+build `157`, remain unavailable and cannot be reused.
+
+## Production Preflight
+
+Production Preflight run `33127615387` attempt `1` succeeded on source SHA
+`0941119081acad1b137c5c48227fc400ed8f62b1`. Its retained artifact is
+`9669125599`, named
+`production-preflight-success-0941119081acad1b137c5c48227fc400ed8f62b1-33127615387-1`.
+The actor and triggering actor were both `cbusillo`.
+
+The source-bound, preventive results were:
+
+- `production-preflight.dmg` SHA-256:
+  `bcd115524980370cb8bfec099f954f2896f40ef938f8e3ac0da5b41d40a41231`;
+- DMG size: `166308864` bytes;
+- installed app-tree SHA-256:
+  `9ce5019434f5acd55d8b49aa15fda42133ac86d40c7a5e561a5b2109a7ca9577`;
+- installed UI evidence: `4` files / `201729` bytes; and
+- installed UI report SHA-256:
+  `e887833d8d54dd5a78998ef4f679e304e90c02fbe2834b7d1d56461876682b61`.
+
+Preflight is readiness evidence for `0941119`, not signed candidate or
+publication evidence for `v0.3.3-beta.1`; it neither selects a route nor creates
+a tag, release, draft, appcast item, PyPI distribution, or Homebrew change.
+
+## Evidence And Absence Boundary
+
+Release Evidence v2's forward-proof purpose is to capture independently
+verifiable, post-publication immutable receipt facts after the guarded release,
+without backfilling the candidate's preregistration fields. The Evidence v2
+index and verification checks are anchored to base
+`0941119081acad1b137c5c48227fc400ed8f62b1` before this candidate is dispatched.
+
+Live absence was verified on August 28, 2026 for the candidate tag, GitHub
+release and draft, appcast item, PyPI `0.3.3b1`, and Homebrew-tap pull request:
+all were absent. The absence verification is not publication evidence and must
+be rechecked at dispatch.
+
+## Qualification And Signing Authorization
+
+`docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json` preregisters
+the closed matrix and acceptance schema for issue #659. It uses the current
+route-table digest and worker protocol, marks the candidate as Beta / Prerelease,
+and requires the first-candidate scope command. Stable `0.3.2` is the sole prior
+immutable evidence base.
+
+Preparation and review do not authorize Prerelease dispatch, `macos-signing`
+approval, tag or release creation, draft creation, appcast deployment, PyPI or
+Homebrew publication, or any other publication mutation. A future release needs
+the exact then-current protected-`main` SHA under a merge hold and must be
+monitored with `uv run python -m scripts.github_release_run watch`. If the
+watcher exits `20`, fresh explicit run-bound authorization is required before
+using `scripts.github_release_run approve` with the emitted run ID, workflow
+name, full `main` SHA, confirmation SHA, and approval fingerprint.

--- a/docs/0.3.3-beta.1-cut-packet.md
+++ b/docs/0.3.3-beta.1-cut-packet.md
@@ -11,7 +11,6 @@
 - Build: `172`.
 - Route: `Prerelease` / Sparkle `beta`; GitHub prerelease; not Latest; PyPI and
   Homebrew publication disabled.
-- Metadata parent: `dd45908ebfe265c2eaf97e79a012629bd5085bf4`.
 
 This is the first candidate of the `0.3.3` cycle. Its exact post-dispatch source
 SHA, signed DMG checksum, signed app-tree checksum, release run, release ID, and

--- a/docs/0.3.3-beta.1-cut-packet.md
+++ b/docs/0.3.3-beta.1-cut-packet.md
@@ -6,7 +6,8 @@
 
 - Owner: issue #659.
 - Package version: `0.3.3b1`.
-- Public version, tag, and release name: `v0.3.3-beta.1`.
+- Public version: `0.3.3-beta.1`.
+- Tag and release name: `v0.3.3-beta.1`.
 - Build: `172`.
 - Route: `Prerelease` / Sparkle `beta`; GitHub prerelease; not Latest; PyPI and
   Homebrew publication disabled.

--- a/docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json
+++ b/docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json
@@ -1,0 +1,249 @@
+{
+  "acceptance": {
+    "blocking_case_ids": [
+      "sparkle-update-route",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ],
+    "milestone_complete": false,
+    "nonblocking_case_ids": [
+      "native-sparkle-release-notes",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "passed": false,
+    "preregistered_matrix_case_ids": [
+      "release-workflow-identity",
+      "updater-route-v0.3.2-to-v0.3.3-beta.1",
+      "native-sparkle-notes-beta1",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility",
+      "usb-bluray-makemkv",
+      "protected-real-media-conversion",
+      "vision-pro-physical-playback",
+      "public-diagnostics-and-field-closure"
+    ],
+    "required_case_ids": [
+      "release-workflow-identity",
+      "sparkle-update-route",
+      "profile-save-action-accessibility",
+      "signed-packaged-route-parity",
+      "gui-preview-low-local-ample-destination",
+      "gui-preview-cancel-cleanup",
+      "gui-preview-failure-cleanup",
+      "capacity-known-low",
+      "capacity-unknown-and-conflicting",
+      "network-generated-final-output",
+      "overwrite-and-conversion-cancel",
+      "malformed-pgs-parser-recovery",
+      "subtitle-partial-output-diagnostics",
+      "clean-machine-signed-update",
+      "installed-ui-accessibility"
+    ]
+  },
+  "candidate": {
+    "appcast_sha256": null,
+    "build_version": "172",
+    "dmg_name": "3D-Blu-ray-to-Vision-Pro-0.3.3-beta.1.dmg",
+    "dmg_sha256": null,
+    "mapping_version": 2,
+    "package_version": "0.3.3b1",
+    "public_version": "0.3.3-beta.1",
+    "release_id": null,
+    "release_run_id": null,
+    "release_tag": "v0.3.3-beta.1",
+    "route_table_id": "route-relative-video-quality-v2",
+    "route_table_sha256": "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
+    "signed_app_tree_sha256": null,
+    "source_git_sha": null,
+    "worker_protocol_version": 12,
+    "workflow": "Prerelease"
+  },
+  "execution_policy": {
+    "approval_command": "uv run python -m scripts.github_release_run approve",
+    "approval_required_exit_code": 20,
+    "field_qualification_timing": "post_publication_exact_artifact",
+    "generic_run_waiter_is_sufficient": false,
+    "macos_signing_requires_fresh_explicit_run_bound_authorization": true,
+    "main_must_remain_fixed_while_nonterminal": true,
+    "release_stage": "beta",
+    "watch_command": "uv run python -m scripts.github_release_run watch"
+  },
+  "immutable_history": {
+    "abandoned_builds": [
+      157
+    ],
+    "burned_builds": [
+      147,
+      154,
+      165,
+      166,
+      168
+    ],
+    "previous_stable": {
+      "appcast_sha256": "20eaa4b924fd82148961f3453b462366b3bdc1760e868c3e3ad2f673ffec4c3d",
+      "build_version": "171",
+      "dmg_sha256": "ab395c3741d2e25b8bc8e348da355663919a9568bdb9c0dcd74e8a4667d94b60",
+      "must_not_rebuild": true,
+      "package_version": "0.3.2",
+      "published_at": "2026-08-25T17:02:23Z",
+      "release_id": 376566532,
+      "release_run_id": 32872545337,
+      "release_tag": "v0.3.2",
+      "signed_app_tree_sha256": "4554b1852ef758481c417048a2d87bd8f8b165ff90110039bd430ec6fa257878",
+      "source_git_sha": "3ab40c9eb745cd038d1129d55a94cdb1cc4c7bec"
+    }
+  },
+  "issues": [
+    "#659"
+  ],
+  "matrix": [
+    {
+      "id": "release-workflow-identity",
+      "migration": "release_run_receipt",
+      "phase": "workflow",
+      "policy_case_id": "release-workflow-identity"
+    },
+    {
+      "id": "updater-route-v0.3.2-to-v0.3.3-beta.1",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "sparkle-update-route"
+    },
+    {
+      "id": "native-sparkle-notes-beta1",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "native-sparkle-release-notes"
+    },
+    {
+      "id": "profile-save-action-accessibility",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "profile-save-action-accessibility"
+    },
+    {
+      "id": "signed-packaged-route-parity",
+      "migration": "release_run_receipt",
+      "phase": "signed_artifact",
+      "policy_case_id": "signed-packaged-route-parity"
+    },
+    {
+      "id": "gui-preview-low-local-ample-destination",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-low-local-ample-destination"
+    },
+    {
+      "id": "gui-preview-cancel-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-cancel-cleanup"
+    },
+    {
+      "id": "gui-preview-failure-cleanup",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "gui-preview-failure-cleanup"
+    },
+    {
+      "id": "capacity-known-low",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-known-low"
+    },
+    {
+      "id": "capacity-unknown-and-conflicting",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "capacity-unknown-and-conflicting"
+    },
+    {
+      "id": "network-generated-final-output",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "network-generated-final-output"
+    },
+    {
+      "id": "overwrite-and-conversion-cancel",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "overwrite-and-conversion-cancel"
+    },
+    {
+      "id": "malformed-pgs-parser-recovery",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "malformed-pgs-parser-recovery"
+    },
+    {
+      "id": "subtitle-partial-output-diagnostics",
+      "migration": "scope_evaluated",
+      "phase": "signed_artifact",
+      "policy_case_id": "subtitle-partial-output-diagnostics"
+    },
+    {
+      "id": "clean-machine-signed-update",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "clean-machine-signed-update"
+    },
+    {
+      "id": "installed-ui-accessibility",
+      "migration": "fresh_retest",
+      "phase": "milestone",
+      "policy_case_id": "installed-ui-accessibility"
+    },
+    {
+      "id": "usb-bluray-makemkv",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "usb-bluray-makemkv"
+    },
+    {
+      "id": "protected-real-media-conversion",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "protected-real-media-conversion"
+    },
+    {
+      "id": "vision-pro-physical-playback",
+      "migration": "scope_evaluated",
+      "phase": "milestone",
+      "policy_case_id": "vision-pro-physical-playback"
+    },
+    {
+      "id": "public-diagnostics-and-field-closure",
+      "migration": "external_nonblocking",
+      "phase": "post_publication",
+      "policy_case_id": "public-diagnostics-and-field-closure"
+    }
+  ],
+  "prior_evidence": [
+    {
+      "id": "v0.3.2-release-evidence-v1",
+      "scope": "immutable qualified Stable 0.3.2 identity, signed-artifact inputs, updater evidence, and publication receipts"
+    }
+  ],
+  "qualification_id": "v0.3.3-beta.1-signed-qualification-v1",
+  "qualification_policy": {
+    "id": "release-qualification-policy-v1",
+    "path": "docs/qualification/release-qualification-policy-v1.json",
+    "scope_command": "uv run python -m scripts.qualify_release_scope --qualification docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json --candidate-sha <full-sha> --evidence docs/qualification/release-evidence-v1.json --release-stage beta --first-candidate-of-cycle --workflow-phase preparation --require-evidence"
+  },
+  "schema_version": 1,
+  "status": "preregistered_pending_exact_candidate"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -47,10 +47,11 @@ disposition at `docs/release-attempts/v0.3.2-beta.6/draft-deletion-v1.json`.
 Issue #609 closed published and fully qualified Beta `0.3.2b7`, public tag
 `v0.3.2-beta.7`, and build `169`. Issue #613 closed published and fully
 qualified RC `0.3.2rc1`, public tag `v0.3.2-rc.1`, and build `170` under
-feature freeze. Issue #614 owns prepared successor Stable `0.3.2`, public tag
-`v0.3.2`, and build `171`. Its metadata and preregistered qualification are
-preparation-only; Stable dispatch, signing approval, and publication remain
-separately authorized boundaries.
+feature freeze. Issue #614 closed published Stable `0.3.2`, public tag
+`v0.3.2`, and build `171`. Issue #659 owns prepared successor Beta `0.3.3b1`,
+public tag `v0.3.3-beta.1`, and build `172`. Its metadata and preregistered
+qualification are preparation-only; Prerelease dispatch, signing approval, and
+publication remain separately authorized boundaries.
 
 The four-route updater preference, release metadata, production-history
 filtering, appcast validation, reusable engine, guarded Stable/Prerelease

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -21,8 +21,9 @@ version metadata. Corrective Beta `0.3.2b6` build `168` is a cancelled,
 unpublished signed attempt whose draft `374538590` was deleted through the
 authorized immutable-disposition path; its tag and build are permanently
 non-reusable. Beta `0.3.2b7` build `169` and RC `0.3.2rc1` build `170` are
-published, immutable, and fully qualified. Issue #614 owns prepared successor
-Stable `0.3.2` build `171`; dispatch, signing approval, and publication remain
+published, immutable, and fully qualified. Stable `0.3.2` build `171` is
+published and immutable. Issue #659 owns prepared successor Beta `0.3.3b1`
+build `172`; Prerelease dispatch, signing approval, and publication remain
 separately authorized. Run-bound signing approval remains a separate
 authorization boundary.
 
@@ -503,15 +504,14 @@ zero blocking cases and 15 completed cases. Its immutable publication and
 qualification contract is recorded in
 [the 0.3.2 RC 1 cut packet](0.3.2-rc.1-cut-packet.md).
 
-Stable 0.3.2 is prepared as internal and public version `0.3.2`, tag and title
-`v0.3.2`, and global build `171`. RC 1 is the immediate global predecessor and
-exact RC-route qualification base. Stable `v0.3.1` build `162` remains the
-previous Stable update and release-note base. The unchanneled Stable item is
-eligible on Stable, RC, Beta, and Alpha routes. Failed builds `165` and `166`
-and cancelled build `168` remain burned. No Stable dispatch, signing approval,
+Beta `0.3.3b1` is prepared as public tag and title `v0.3.3-beta.1` with global
+build `172`. Published Stable `0.3.2` build `171` is the immediate global
+predecessor and immutable Stable update and release-note base. The Beta item is
+eligible only on the Prerelease route. Failed builds `165` and `166` and
+cancelled build `168` remain burned. No Prerelease dispatch, signing approval,
 tag, release, draft, appcast, PyPI, or Homebrew mutation is authorized by this
 preparation. The preparation contract is recorded in
-[the 0.3.2 Stable cut packet](0.3.2-cut-packet.md).
+[the 0.3.3 Beta 1 cut packet](0.3.3-beta.1-cut-packet.md).
 
 ## Historical Boundaries
 

--- a/docs/release-routes.md
+++ b/docs/release-routes.md
@@ -507,7 +507,8 @@ qualification contract is recorded in
 Beta `0.3.3b1` is prepared as public tag and title `v0.3.3-beta.1` with global
 build `172`. Published Stable `0.3.2` build `171` is the immediate global
 predecessor and immutable Stable update and release-note base. The Beta item is
-eligible only on the Prerelease route. Failed builds `165` and `166` and
+eligible only on the Beta and Alpha update routes and is published through the
+Prerelease workflow. Failed builds `165` and `166` and
 cancelled build `168` remain burned. No Prerelease dispatch, signing approval,
 tag, release, draft, appcast, PyPI, or Homebrew mutation is authorized by this
 preparation. The preparation contract is recorded in

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -38,13 +38,13 @@ targets:
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 171
+        CURRENT_PROJECT_VERSION: 172
         BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT: ""
         ENABLE_APP_SANDBOX: NO
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: BluRayToVisionPro/Info.plist
-        MARKETING_VERSION: 0.3.2
+        MARKETING_VERSION: 0.3.3b1
         PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp
         PRODUCT_MODULE_NAME: BluRayToVisionPro
         PRODUCT_NAME: 3D Blu-ray to Vision Pro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bd_to_avp"
-version = "0.3.2"
+version = "0.3.3b1"
 description = "Script to convert 3D Blu-ray Discs (and mts) to Apple Vision Pro (MV-HEVC) files"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -86,7 +86,7 @@ icon = "bd_to_avp/resources/app_icon"
 organization = "Shiny Computers"
 organization_domain = "com.shinycomputers"
 formal_name = "3D Blu-ray to Vision Pro"
-build_version = "171"
+build_version = "172"
 distribution_channel = "direct"
 
 [tool.bd_to_avp.sparkle]

--- a/tests/test_native_app.py
+++ b/tests/test_native_app.py
@@ -134,8 +134,8 @@ class NativeAppPackagingTests(unittest.TestCase):
         self.assertEqual(NATIVE_APP_NAME, "3D Blu-ray to Vision Pro.app")
         self.assertEqual(NATIVE_EXECUTABLE_NAME, NATIVE_PRODUCT_NAME)
         self.assertEqual(NATIVE_BUNDLE_IDENTIFIER, "com.shinycomputers.bd-to-avp")
-        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.2")
-        self.assertEqual(NATIVE_BUILD_VERSION, "171")
+        self.assertEqual(NATIVE_SHORT_VERSION, "0.3.3b1")
+        self.assertEqual(NATIVE_BUILD_VERSION, "172")
         self.assertEqual(NATIVE_MINIMUM_SYSTEM_VERSION, "26.0")
         self.assertEqual(MV_HEVC_ENCODER_NAME, "mv-hevc-encoder")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,20 +199,20 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(app["bundle_identifier"], "com.shinycomputers.bd-to-avp")
         self.assertNotIn("briefcase", pyproject["tool"])
 
-    def test_repository_records_stable_release_state_and_prior_release_history(self) -> None:
+    def test_repository_records_beta1_preparation_and_prior_release_history(self) -> None:
         metadata = release.load_release_metadata()
 
-        self.assertEqual(metadata.package_version, "0.3.2")
-        self.assertEqual(metadata.public_version, "0.3.2")
-        self.assertEqual(metadata.build_version, "171")
-        self.assertEqual(metadata.release_tag, "v0.3.2")
-        self.assertEqual(metadata.release_name, "v0.3.2")
-        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.2.dmg")
-        self.assertEqual(metadata.channel, "stable")
-        self.assertFalse(metadata.prerelease)
-        self.assertFalse(metadata.first_candidate_of_cycle)
-        self.assertTrue(metadata.make_latest)
-        self.assertTrue(metadata.publish_pypi)
+        self.assertEqual(metadata.package_version, "0.3.3b1")
+        self.assertEqual(metadata.public_version, "0.3.3-beta.1")
+        self.assertEqual(metadata.build_version, "172")
+        self.assertEqual(metadata.release_tag, "v0.3.3-beta.1")
+        self.assertEqual(metadata.release_name, "v0.3.3-beta.1")
+        self.assertEqual(metadata.dmg_name, "3D-Blu-ray-to-Vision-Pro-0.3.3-beta.1.dmg")
+        self.assertEqual(metadata.channel, "beta")
+        self.assertTrue(metadata.prerelease)
+        self.assertTrue(metadata.first_candidate_of_cycle)
+        self.assertFalse(metadata.make_latest)
+        self.assertFalse(metadata.publish_pypi)
 
         freeze_policy = json.loads((REPO_ROOT / ".github" / "release-freezes.json").read_text(encoding="utf-8"))
         beta6_freeze = freeze_policy["frozen_release_tags"]["v0.3.2-beta.6"]
@@ -222,6 +222,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertNotIn("v0.3.2-beta.7", freeze_policy["frozen_release_tags"])
         self.assertNotIn("v0.3.2-rc.1", freeze_policy["frozen_release_tags"])
         self.assertNotIn("v0.3.2", freeze_policy["frozen_release_tags"])
+        self.assertNotIn("v0.3.3-beta.1", freeze_policy["frozen_release_tags"])
 
         cut_packet = (REPO_ROOT / "docs" / "0.3.2-beta.6-cut-packet.md").read_text(encoding="utf-8")
         self.assertIn("`0.3.2b6`", cut_packet)
@@ -276,7 +277,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("Build `171`", stable_cut_packet)
         self.assertIn("v0.3.2-rc.1", stable_cut_packet)
         self.assertIn("v0.3.1", stable_cut_packet)
-        stable_release_receipt = REPO_ROOT / "docs" / "release-evidence" / metadata.release_tag / "release-receipt.json"
+        stable_release_receipt = REPO_ROOT / "docs" / "release-evidence" / "v0.3.2" / "release-receipt.json"
         expected_stable_state = (
             release.CUT_PACKET_PUBLISHED if stable_release_receipt.is_file() else release.CUT_PACKET_PREPARED
         )
@@ -286,36 +287,42 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn(expected_stable_state, stable_cut_packet)
         self.assertNotIn(unexpected_stable_state, stable_cut_packet)
 
+        beta1_cut_packet = (REPO_ROOT / "docs" / "0.3.3-beta.1-cut-packet.md").read_text(encoding="utf-8")
+        self.assertIn("`0.3.3b1`", beta1_cut_packet)
+        self.assertIn("Build: `172`", beta1_cut_packet)
+        self.assertIn("Production Preflight run `33127615387`", beta1_cut_packet)
+        self.assertIn("9669125599", beta1_cut_packet)
+        self.assertIn("August 28, 2026", beta1_cut_packet)
+        self.assertIn(release.CUT_PACKET_PREPARED, beta1_cut_packet)
+
         github_config = json.loads((REPO_ROOT / ".github" / "github.json").read_text(encoding="utf-8"))
         qualification_relative = Path(github_config["releaseOperations"]["qualificationRecordPath"])
         self.assertEqual(
             qualification_relative,
-            Path("docs/qualification/v0.3.2-stable-signed-qualification-v1.json"),
+            Path("docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json"),
         )
         self.assertEqual(release.validate_configured_qualification_record(metadata), qualification_relative)
         qualification = json.loads((REPO_ROOT / qualification_relative).read_text(encoding="utf-8"))
-        self.assertEqual(qualification["candidate"]["package_version"], "0.3.2")
-        self.assertEqual(qualification["candidate"]["public_version"], "0.3.2")
-        self.assertEqual(qualification["candidate"]["build_version"], "171")
-        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.2")
-        self.assertEqual(qualification["candidate"]["workflow"], "Stable")
+        self.assertEqual(qualification["candidate"]["package_version"], "0.3.3b1")
+        self.assertEqual(qualification["candidate"]["public_version"], "0.3.3-beta.1")
+        self.assertEqual(qualification["candidate"]["build_version"], "172")
+        self.assertEqual(qualification["candidate"]["release_tag"], "v0.3.3-beta.1")
+        self.assertEqual(qualification["candidate"]["workflow"], "Prerelease")
         self.assertEqual(qualification["candidate"]["worker_protocol_version"], 12)
         self.assertEqual(qualification["candidate"]["mapping_version"], 2)
         self.assertEqual(
             qualification["candidate"]["route_table_sha256"],
             "37756b7327cffe22a5c6d80ec6e69c67324e731aba87f2ebe815b065989ce214",
         )
-        self.assertIn("#623", qualification["issues"])
-        self.assertIn("#613", qualification["issues"])
-        self.assertIn("#614", qualification["issues"])
+        self.assertEqual(qualification["issues"], ["#659"])
         self.assertEqual(
             set(qualification["immutable_history"]["burned_builds"]),
             {147, 154, 165, 166, 168},
         )
         previous_stable = qualification["immutable_history"]["previous_stable"]
-        self.assertEqual(previous_stable["release_tag"], "v0.3.1")
-        self.assertEqual(previous_stable["package_version"], "0.3.1")
-        self.assertEqual(previous_stable["build_version"], "162")
+        self.assertEqual(previous_stable["release_tag"], "v0.3.2")
+        self.assertEqual(previous_stable["package_version"], "0.3.2")
+        self.assertEqual(previous_stable["build_version"], "171")
         previous_stable_receipt_path = (
             REPO_ROOT / "docs" / "release-evidence" / previous_stable["release_tag"] / "release-receipt.json"
         )
@@ -330,24 +337,10 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertEqual(previous_stable_artifacts["dmg"]["sha256"], previous_stable["dmg_sha256"])
         self.assertEqual(previous_stable_artifacts["appcast"]["sha256"], previous_stable["appcast_sha256"])
 
-        rc1 = qualification["immutable_history"]["rc1"]
-        self.assertEqual(rc1["release_tag"], "v0.3.2-rc.1")
-        self.assertEqual(rc1["package_version"], "0.3.2rc1")
-        self.assertEqual(rc1["build_version"], "170")
-        rc1_receipt = json.loads(rc1_release_receipt.read_text(encoding="utf-8"))
-        rc1_artifacts = {artifact["kind"]: artifact for artifact in rc1_receipt["artifacts"]}
-        self.assertEqual(rc1_receipt["source_sha"], rc1["source_git_sha"])
-        self.assertEqual(rc1_receipt["workflow"]["run_id"], rc1["release_run_id"])
-        self.assertEqual(rc1_receipt["release"]["id"], rc1["release_id"])
-        self.assertEqual(rc1_receipt["versions"]["package"], rc1["package_version"])
-        self.assertEqual(rc1_receipt["versions"]["build"], rc1["build_version"])
-        self.assertEqual(rc1_receipt["signed_app_tree_sha256"], rc1["signed_app_tree_sha256"])
-        self.assertEqual(rc1_artifacts["dmg"]["sha256"], rc1["dmg_sha256"])
-        self.assertEqual(rc1_artifacts["appcast"]["sha256"], rc1["appcast_sha256"])
         expected_case_ids = {
             "release-workflow-identity",
-            "updater-route-v0.3.2-rc.1-to-v0.3.2",
-            "native-sparkle-notes-stable",
+            "updater-route-v0.3.2-to-v0.3.3-beta.1",
+            "native-sparkle-notes-beta1",
             "profile-save-action-accessibility",
             "signed-packaged-route-parity",
             "gui-preview-low-local-ample-destination",
@@ -436,8 +429,8 @@ class ReleaseMetadataTests(unittest.TestCase):
             expected_candidate_identity,
         )
         self.assertEqual(qualification["status"], "preregistered_pending_exact_candidate")
-        self.assertEqual(qualification["execution_policy"]["release_stage"], "stable")
-        self.assertNotIn("--first-candidate-of-cycle", qualification["qualification_policy"]["scope_command"])
+        self.assertEqual(qualification["execution_policy"]["release_stage"], "beta")
+        self.assertIn("--first-candidate-of-cycle", qualification["qualification_policy"]["scope_command"])
         self.assertEqual(
             set(qualification["acceptance"]["blocking_case_ids"]),
             {"sparkle-update-route", "clean-machine-signed-update", "installed-ui-accessibility"},

--- a/tests/test_sparkle_packaging.py
+++ b/tests/test_sparkle_packaging.py
@@ -382,7 +382,7 @@ class SparkleBundleTests(unittest.TestCase):
     def test_repository_public_key_matches_app_metadata(self) -> None:
         info = sparkle_bundle.load_expected_info()
 
-        self.assertEqual(info["CFBundleVersion"], "171")
+        self.assertEqual(info["CFBundleVersion"], "172")
         self.assertEqual(info["SUPublicEDKey"], sparkle_bundle.PUBLIC_KEY_PATH.read_text().strip())
 
 

--- a/tests/test_sparkle_workflows.py
+++ b/tests/test_sparkle_workflows.py
@@ -1122,7 +1122,7 @@ printf '%s' "$CODESIGN_METADATA"
         )
         self.assertEqual(
             release_operations["qualificationRecordPath"],
-            "docs/qualification/v0.3.2-stable-signed-qualification-v1.json",
+            "docs/qualification/v0.3.3-beta.1-signed-qualification-v1.json",
         )
         self.assertEqual(len(release_operations["qualificationReportArtifacts"]), 3)
         self.assertIn(

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bd-to-avp"
-version = "0.3.2"
+version = "0.3.3b1"
 source = { editable = "." }
 dependencies = [
     { name = "babelfish" },


### PR DESCRIPTION
## Summary

- prepare internal `0.3.3b1`, public `0.3.3-beta.1`, tag `v0.3.3-beta.1`, and global build `172`
- preregister the closed first-candidate qualification matrix with all post-publication identity fields still `null`
- bind prior immutable Stable `v0.3.2`, exact Production Preflight evidence, issue #659, and the Evidence v2 forward-proof purpose
- add the Beta 1 cut packet and update release route/process state and version assertions

## Evidence

- Production Preflight run `33127615387` passed on exact pre-bump `main` SHA `0941119081acad1b137c5c48227fc400ed8f62b1`
- retained artifact `9669125599` records preventive DMG, installed app-tree, and installed-UI evidence digests
- live absence was rechecked on August 28, 2026 for the tag, release/draft, appcast item, PyPI `0.3.3b1`, and Homebrew-tap PR
- prior Stable receipt values are copied exactly from immutable `v0.3.2` evidence

## Validation

- `scripts.release validate` and `scripts.release metadata`
- first-candidate preparation qualification scope and policy validation
- 186 focused release/native/Sparkle tests; exact-head review additionally ran the full suite successfully
- Evidence v2 all-tag and index checks against base `0941119081acad1b137c5c48227fc400ed8f62b1`
- cancelled-attempt and failed-post-publication historical validators
- Ruff, format, MyPy, JSON parsing, lock check, and diff check
- exact-head Opus review approved `d7e4c56f503afd19f527bc27f30fc947b03c5b40`; Antigravity returned an empty result
- JetBrains inspection was inconclusive because its lifecycle mutated tracked IDE files; those mutations were removed

## Authorization Boundary

This PR prepares metadata only. Prerelease dispatch is separately authorized by the current workstream, but `macos-signing` approval still requires fresh explicit run-bound authorization after `scripts.github_release_run watch` exits `20`.

Refs #659
