### PR TITLE
Build the persistent queue workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ the queue preserves those decisions for each source and will not start while
 any item still needs attention. Remembered choices are scoped to the matching
 source and Profile and can be forgotten from the resolution prompt.
 
+The macOS app opens to a persistent queue workspace even before a source is
+selected. Files, folders, disc images, and inserted discs can be appended with
+the native picker or drag and drop. Waiting videos can be selected, edited,
+reordered, moved next, removed, and restored with Undo while active and
+completed settings remain locked. Work restored after an app restart never
+starts automatically; interrupted or stopped videos require an explicit
+**Resume Queue**, **Restart Safely**, or recovery choice.
+
 ## Terminal Usage
 
 Navigate to the tool's directory in your terminal and execute the command with the required and optional parameters:

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -84,7 +84,7 @@ struct BluRayToVisionProApp: App {
                 resolutionMemoryStore: resolutionMemoryStore,
                 capabilities: capabilities
             )
-                .frame(minWidth: 820, minHeight: 680)
+                .frame(minWidth: 920, minHeight: 680)
                 .background(
                     WindowAccessor { window in
                         appDelegate.attach(window: window, workCoordinator: workCoordinator)

--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -56,6 +56,29 @@ final class ConversionQueueStore: ObservableObject {
         document.items
     }
 
+    func appendWaitingItems(_ newItems: [DurableConversionQueueItem]) async throws {
+        guard !newItems.isEmpty else {
+            return
+        }
+        try await mutateItems { items in
+            let existingIDs = Set(items.map(\.id))
+            guard newItems.allSatisfy({ $0.state == .waiting }),
+                  Set(newItems.map(\.id)).count == newItems.count,
+                  newItems.allSatisfy({ !existingIDs.contains($0.id) })
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let affectedGroupIDs = Set(newItems.compactMap(\.groupID))
+            let requestedRemoval = Self.multiTitleSourceRemovalRequests(
+                in: items + newItems,
+                groupIDs: affectedGroupIDs
+            )
+            items.append(contentsOf: newItems)
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(in: &items, requests: requestedRemoval)
+        }
+    }
+
     func moveWaitingItem(_ itemID: UUID, before targetID: UUID) async throws {
         guard itemID != targetID else {
             return
@@ -103,6 +126,33 @@ final class ConversionQueueStore: ObservableObject {
         }
     }
 
+    func moveWaitingItem(_ itemID: UUID, after targetID: UUID) async throws {
+        guard itemID != targetID else {
+            return
+        }
+        try await mutateItems { items in
+            guard let sourceIndex = items.firstIndex(where: { $0.id == itemID }),
+                  let targetIndex = items.firstIndex(where: { $0.id == targetID }),
+                  items[sourceIndex].state == .waiting,
+                  items[targetIndex].state == .waiting
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let affectedGroupIDs = Set([items[sourceIndex].groupID, items[targetIndex].groupID].compactMap { $0 })
+            let sourceRemovalRequests = Self.multiTitleSourceRemovalRequests(
+                in: items,
+                groupIDs: affectedGroupIDs
+            )
+            let item = items.remove(at: sourceIndex)
+            guard let adjustedTargetIndex = items.firstIndex(where: { $0.id == targetID }) else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            items.insert(item, at: adjustedTargetIndex + 1)
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(in: &items, requests: sourceRemovalRequests)
+        }
+    }
+
     func removeWaitingItems(_ itemIDs: Set<UUID>) async throws -> PersistentQueueRemovalToken {
         var removedItems: [DurableConversionQueueItem] = []
         let revision = try await mutateItems { items in
@@ -124,6 +174,35 @@ final class ConversionQueueStore: ObservableObject {
                 in: &items,
                 requests: sourceRemovalRequests
             )
+        }
+        return PersistentQueueRemovalToken(items: removedItems, revision: revision)
+    }
+
+    func removeRemovableItems(_ itemIDs: Set<UUID>) async throws -> PersistentQueueRemovalToken {
+        var removedItems: [DurableConversionQueueItem] = []
+        let revision = try await mutateItems { items in
+            let matchingItems = items.filter { itemIDs.contains($0.id) }
+            guard matchingItems.count == itemIDs.count,
+                  matchingItems.allSatisfy({ item in
+                      switch item.state {
+                      case .waiting, .interrupted, .attention, .failed, .stopped, .notStarted:
+                          true
+                      case .inspecting, .processing, .stopping, .completed:
+                          false
+                      }
+                  })
+            else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let affectedGroupIDs = Set(matchingItems.compactMap(\.groupID))
+            let sourceRemovalRequests = Self.multiTitleSourceRemovalRequests(
+                in: items,
+                groupIDs: affectedGroupIDs
+            )
+            removedItems = matchingItems
+            items.removeAll { itemIDs.contains($0.id) }
+            Self.normalizeOrdinals(&items)
+            Self.normalizeMultiTitleSourceRemoval(in: &items, requests: sourceRemovalRequests)
         }
         return PersistentQueueRemovalToken(items: removedItems, revision: revision)
     }

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -208,12 +208,16 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         try await durableQueueStore.moveWaitingItem(itemID, before: targetID)
     }
 
+    func movePersistentQueueItem(_ itemID: UUID, after targetID: UUID) async throws {
+        try await durableQueueStore.moveWaitingItem(itemID, after: targetID)
+    }
+
     func movePersistentQueueItemNext(_ itemID: UUID) async throws {
         try await durableQueueStore.moveWaitingItemNext(itemID)
     }
 
     func removePersistentQueueItems(_ itemIDs: Set<UUID>) async throws -> PersistentQueueRemovalToken {
-        let token = try await durableQueueStore.removeWaitingItems(itemIDs)
+        let token = try await durableQueueStore.removeRemovableItems(itemIDs)
         for itemID in itemIDs {
             releaseAdoption(itemID)
         }
@@ -233,6 +237,100 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     func clearCompletedPersistentQueueItems() async throws -> PersistentQueueRemovalToken {
         try await durableQueueStore.clearCompletedItems()
+    }
+
+    func appendPersistentQueueDrafts(_ drafts: [ConversionDraft]) async throws -> SetupQueueAddResult {
+        let existingIdentities = Set(persistentQueueItems.map {
+            ConversionQueueItem.stablePreviewID(for: $0.draft)
+        })
+        var admittedIdentities = existingIdentities
+        var admittedDrafts: [ConversionDraft] = []
+        var duplicateDisplayNames: [String] = []
+        for draft in drafts {
+            let identity = ConversionQueueItem.stablePreviewID(for: draft)
+            guard admittedIdentities.insert(identity).inserted else {
+                duplicateDisplayNames.append(draft.selectedTitle?.name ?? draft.source.displayName)
+                continue
+            }
+            admittedDrafts.append(draft)
+        }
+        guard !admittedDrafts.isEmpty else {
+            return SetupQueueAddResult(addedCount: 0, duplicateDisplayNames: duplicateDisplayNames)
+        }
+
+        var groupIDsBySource: [QueueSourceIdentity: UUID] = [:]
+        let sourcesRequestingRemoval = Set(admittedDrafts.compactMap { draft in
+            draft.options.job.removeOriginalAfterSuccess
+                ? QueueSourceIdentity(source: draft.source)
+                : nil
+        })
+        var finalRemovalIndexBySource: [QueueSourceIdentity: Int] = [:]
+        for (offset, draft) in admittedDrafts.enumerated() {
+            let sourceIdentity = QueueSourceIdentity(source: draft.source)
+            if sourcesRequestingRemoval.contains(sourceIdentity) {
+                finalRemovalIndexBySource[sourceIdentity] = offset
+            }
+        }
+        let newItems = admittedDrafts.enumerated().map { offset, originalDraft in
+            var options = originalDraft.options
+            let sourceIdentity = QueueSourceIdentity(source: originalDraft.source)
+            options.job.removeOriginalAfterSuccess = finalRemovalIndexBySource[sourceIdentity] == offset
+            let draft = ConversionDraft(
+                source: originalDraft.source,
+                sourceDetails: originalDraft.sourceDetails,
+                profile: originalDraft.profile,
+                destinationURL: originalDraft.destinationURL,
+                options: options,
+                selectedTitle: originalDraft.selectedTitle
+            )
+            let origin: DurableQueueItemOrigin = draft.source.kind == .sourceFolder
+                ? .sourceFolder
+                : (draft.selectedTitle == nil ? .singleSource : .multiTitle)
+            let itemGroupID: UUID?
+            if origin == .singleSource {
+                itemGroupID = nil
+            } else {
+                itemGroupID = groupIDsBySource[sourceIdentity] ?? {
+                    let groupID = UUID()
+                    groupIDsBySource[sourceIdentity] = groupID
+                    return groupID
+                }()
+            }
+            return DurableConversionQueueItem(
+                ordinal: offset,
+                groupID: itemGroupID,
+                origin: origin,
+                intent: DurableQueueItemIntent(draft: draft),
+                inspection: draft.sourceDetails
+            )
+        }
+        try await durableQueueStore.appendWaitingItems(newItems)
+        selectedPersistentQueueItemID = newItems.first?.id
+        return SetupQueueAddResult(
+            addedCount: newItems.count,
+            duplicateDisplayNames: duplicateDisplayNames
+        )
+    }
+
+    @discardableResult
+    func startPersistentQueue() async -> Int {
+        let candidates = persistentQueueItems.filter { item in
+            switch item.status {
+            case .waiting, .interrupted, .stopped, .notStarted:
+                true
+            case let .failed(failure):
+                failure.retryable
+            case .inspecting, .processing, .stopping, .attention, .completed:
+                false
+            }
+        }
+        var adoptedCount = 0
+        for item in candidates {
+            if await adoptPersistentQueueItem(item.id) {
+                adoptedCount += 1
+            }
+        }
+        return adoptedCount
     }
 
     @discardableResult

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -112,7 +112,12 @@ struct PersistentQueueItem: Identifiable, Equatable {
     }
 
     var canRemove: Bool {
-        status == .waiting
+        switch status {
+        case .waiting, .interrupted, .attention, .failed, .stopped, .notStarted:
+            true
+        case .inspecting, .processing, .stopping, .completed:
+            false
+        }
     }
 
     var canRetry: Bool {

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -170,7 +170,7 @@ struct ContentView: View {
         }
     }
 
-    private var observedContent: some View {
+    private var lifecycleObservedContent: some View {
         baseContent
         .onAppear(perform: refreshDiscs)
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
@@ -195,6 +195,10 @@ struct ContentView: View {
                 persistentQueueRemovalToken = nil
             }
         }
+    }
+
+    private var settingsObservedContent: some View {
+        lifecycleObservedContent
         .onChange(of: viewModel.state.jobID) { previousJobID, currentJobID in
             if currentJobID != nil, currentJobID != previousJobID {
                 diagnosticReportViewModel.prepareForNewDiagnosticSession()
@@ -230,6 +234,10 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    private var observedContent: some View {
+        settingsObservedContent
         .onChange(of: viewModel.state.conversionResult) { _, result in
             guard viewModel.batchQueue == nil,
                   let result,

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -24,6 +24,11 @@ struct ContentView: View {
     @State private var newProfileName = ""
     @State private var profileErrorMessage: String?
     @State private var queueAdmissionNoticeMessage: String?
+    @State private var persistentQueueErrorMessage: String?
+    @State private var persistentQueueRemovalToken: PersistentQueueRemovalToken?
+    @State private var queueItemBeingEdited: PersistentQueueItem?
+    @State private var compactPersistentQueueRows = false
+    @State private var isConfiguringQueueSource = false
     @State private var preserveEncodingOnNextProfileChange = false
     @State private var isShowingPreview = false
     @State private var pendingReviewedPreview: PreviewDraft?
@@ -76,15 +81,36 @@ struct ContentView: View {
         VStack(spacing: 0) {
             noticeContent
 
-            HSplitView {
-                sourceOrQueueColumn
-                setupColumn
-            }
+            workspaceContent
 
             Divider()
             statusFooter
 
             activityContent
+        }
+    }
+
+    @ViewBuilder
+    private var workspaceContent: some View {
+        if usesPersistentQueueWorkspace {
+            HSplitView {
+                persistentQueueSidebar
+                    .frame(minWidth: 300, idealWidth: 330, maxWidth: 420)
+                PersistentQueueDetailView(
+                    item: viewModel.selectedPersistentQueueItem,
+                    activeProgress: viewModel.state.progress,
+                    activeElapsedText: viewModel.state.elapsedText,
+                    edit: { queueItemBeingEdited = $0 },
+                    changeDestination: changePersistentQueueDestination,
+                    retry: retryPersistentQueueItem
+                )
+                .frame(minWidth: 600, idealWidth: 760)
+            }
+        } else {
+            HSplitView {
+                sourceOrQueueColumn
+                setupColumn
+            }
         }
     }
 
@@ -130,7 +156,12 @@ struct ContentView: View {
                     .padding(8)
                     .allowsHitTesting(false)
                     .overlay {
-                        Label("Open this 3D Blu-ray source", systemImage: "arrow.down.doc.fill")
+                        Label(
+                            usesPersistentQueueWorkspace
+                                ? "Add these sources to the queue"
+                                : "Open this 3D Blu-ray source",
+                            systemImage: "arrow.down.doc.fill"
+                        )
                             .font(.title3.weight(.semibold))
                             .padding(14)
                             .background(.regularMaterial, in: Capsule())
@@ -152,6 +183,16 @@ struct ContentView: View {
         .onChange(of: viewModel.hasActiveWorker) { _, isActive in
             if !isActive {
                 refreshDiscs()
+            }
+        }
+        .onChange(of: viewModel.source) { _, source in
+            if source == nil {
+                isConfiguringQueueSource = false
+            }
+        }
+        .onChange(of: viewModel.persistentQueueItems) { previousItems, currentItems in
+            if persistentQueueRemovalToken != nil, currentItems.count >= previousItems.count {
+                persistentQueueRemovalToken = nil
             }
         }
         .onChange(of: viewModel.state.jobID) { previousJobID, currentJobID in
@@ -278,6 +319,20 @@ struct ContentView: View {
                 queueConflictForReview: heldConflictQueueAction
             )
         }
+        .sheet(item: $queueItemBeingEdited) { item in
+            SetupEditSheet(
+                initialProfile: item.draft.profile,
+                initialOptions: item.draft.options,
+                fallbackPipelineDefaults: defaultJobOptions.profilePipelineDefaults,
+                sourceKind: item.draft.source.kind,
+                profiles: profileStore.profiles,
+                profileStore: profileStore,
+                resolutionMemoryStore: resolutionMemoryStore,
+                applyToConversion: { profileID, editedOptions in
+                    updatePersistentQueueItem(item, profileID: profileID, options: editedOptions)
+                }
+            )
+        }
         .sheet(isPresented: $isShowingPreview, onDismiss: previewDidDismiss) {
             if let draft {
                 PreviewSheet(
@@ -327,6 +382,17 @@ struct ContentView: View {
         } message: {
             Text(queueAdmissionNoticeMessage ?? "This movie is already in the queue.")
         }
+        .alert(
+            "Queue Could Not Be Updated",
+            isPresented: Binding(
+                get: { persistentQueueErrorMessage != nil },
+                set: { if !$0 { persistentQueueErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(persistentQueueErrorMessage ?? "The queue could not be updated.")
+        }
     }
 
     @ViewBuilder
@@ -335,6 +401,53 @@ struct ContentView: View {
             queueSidebar
         } else {
             sourceWorkspace
+        }
+    }
+
+    private var usesPersistentQueueWorkspace: Bool {
+        !isConfiguringQueueSource
+            && (viewModel.source == nil || !viewModel.persistentQueueItems.isEmpty)
+            && viewModel.state.phase != .decisionRequired
+    }
+
+    private var persistentQueueSidebar: some View {
+        PersistentQueueSidebarView(
+            items: viewModel.persistentQueueItems,
+            selectedID: Binding(
+                get: { viewModel.selectedPersistentQueueItemID },
+                set: viewModel.selectPersistentQueueItem
+            ),
+            compactRows: $compactPersistentQueueRows,
+            insertedDiscs: insertedDiscs,
+            makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
+            activeProgress: viewModel.state.progress,
+            activeElapsedText: viewModel.state.elapsedText,
+            canStart: persistentQueueCanStart
+                && !viewModel.hasActiveWorker
+                && !previewViewModel.hasActiveWorker,
+            canUndo: persistentQueueRemovalToken != nil,
+            addSources: addSourcesToPersistentQueue,
+            addSourceFolder: addSourceFolderToPersistentQueue,
+            addDisc: { appendSourcesToPersistentQueue([$0]) },
+            move: movePersistentQueueItem,
+            moveNext: movePersistentQueueItemNext,
+            remove: removePersistentQueueItem,
+            clearCompleted: clearCompletedPersistentQueueItems,
+            undo: undoPersistentQueueRemoval,
+            start: startPersistentQueue
+        )
+    }
+
+    private var persistentQueueCanStart: Bool {
+        viewModel.persistentQueueItems.contains { item in
+            switch item.status {
+            case .waiting, .interrupted, .stopped, .notStarted:
+                true
+            case let .failed(failure):
+                failure.retryable
+            case .inspecting, .processing, .stopping, .attention, .completed:
+                false
+            }
         }
     }
 
@@ -556,8 +669,8 @@ struct ContentView: View {
             canAddToQueue: setupQueue.canAdd(drafts: conversionDrafts) && !viewModel.hasActiveWork,
             canStart: setupQueue.hasItems
                 ? setupQueue.canStart && !viewModel.hasActiveWork
-                : conversionCanStart,
-            showsStartAction: !setupQueue.hasItems
+                : conversionCanStart && viewModel.persistentQueueItems.isEmpty,
+            showsStartAction: !setupQueue.hasItems && viewModel.persistentQueueItems.isEmpty
         )
         .frame(minWidth: 500, idealWidth: 680)
     }
@@ -1078,6 +1191,9 @@ struct ContentView: View {
         guard canSelectSource else {
             return
         }
+        if !viewModel.persistentQueueItems.isEmpty {
+            isConfiguringQueueSource = true
+        }
         routeQualityState.reset()
         sourceResetMessage = nil
         if isNewSource(source) {
@@ -1113,6 +1229,35 @@ struct ContentView: View {
         selectSource(source)
     }
 
+    private func addSourcesToPersistentQueue() {
+        appendSourcesToPersistentQueue(SourcePicker.chooseQueueSources())
+    }
+
+    private func addSourceFolderToPersistentQueue() {
+        guard let source = SourcePicker.chooseFolder(kind: .sourceFolder) else {
+            return
+        }
+        appendSourcesToPersistentQueue([source])
+    }
+
+    private func appendSourcesToPersistentQueue(_ sources: [ConversionSource]) {
+        guard !sources.isEmpty else { return }
+        let drafts = sources.map { source in
+            var sourceOptions = options
+            if source.kind == .physicalDisc {
+                sourceOptions.job.removeOriginalAfterSuccess = false
+            }
+            return ConversionDraft(
+                source: source,
+                sourceDetails: nil,
+                profile: selectedProfile,
+                destinationURL: destinationURL,
+                options: sourceOptions
+            )
+        }
+        appendDraftsToPersistentQueue(drafts, clearConfiguredSource: false)
+    }
+
     private func chooseFile(_ kind: ConversionSourceKind) {
         guard canSelectSource, let source = SourcePicker.chooseFile(kind: kind) else {
             return
@@ -1134,13 +1279,17 @@ struct ContentView: View {
     }
 
     private func acceptDrop(_ urls: [URL], _ location: CGPoint) -> Bool {
-        guard canSelectSource,
-              let url = urls.first,
-              let source = ConversionSource.infer(from: url)
-        else {
+        let sources = urls.compactMap { ConversionSource.infer(from: $0) }
+        guard !sources.isEmpty else {
             return false
         }
-        selectSource(source)
+        if usesPersistentQueueWorkspace {
+            appendSourcesToPersistentQueue(sources)
+        } else if canSelectSource, let source = sources.first {
+            selectSource(source)
+        } else {
+            return false
+        }
         return true
     }
 
@@ -1185,8 +1334,150 @@ struct ContentView: View {
 
     private func addCurrentDraftsToQueue() {
         guard !conversionDrafts.isEmpty else { return }
-        let result = setupQueue.add(drafts: conversionDrafts)
-        queueAdmissionNoticeMessage = queueAdmissionMessage(for: result)
+        appendDraftsToPersistentQueue(conversionDrafts, clearConfiguredSource: true)
+    }
+
+    private func appendDraftsToPersistentQueue(
+        _ drafts: [ConversionDraft],
+        clearConfiguredSource: Bool
+    ) {
+        Task { @MainActor in
+            do {
+                let result = try await viewModel.appendPersistentQueueDrafts(drafts)
+                queueAdmissionNoticeMessage = queueAdmissionMessage(for: result)
+                if clearConfiguredSource, result.addedCount > 0 {
+                    viewModel.clearSource()
+                    isConfiguringQueueSource = false
+                }
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func movePersistentQueueItem(_ itemID: UUID, by offset: Int) {
+        let waitingItems = viewModel.persistentQueueItems.filter(\.canMove)
+        guard let index = waitingItems.firstIndex(where: { $0.id == itemID }) else { return }
+        let targetIndex = index + offset
+        guard waitingItems.indices.contains(targetIndex) else { return }
+        let targetID = waitingItems[targetIndex].id
+        Task { @MainActor in
+            do {
+                if offset < 0 {
+                    try await viewModel.movePersistentQueueItem(itemID, before: targetID)
+                } else {
+                    try await viewModel.movePersistentQueueItem(itemID, after: targetID)
+                }
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func movePersistentQueueItemNext(_ itemID: UUID) {
+        Task { @MainActor in
+            do {
+                try await viewModel.movePersistentQueueItemNext(itemID)
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func removePersistentQueueItem(_ itemID: UUID) {
+        Task { @MainActor in
+            do {
+                persistentQueueRemovalToken = try await viewModel.removePersistentQueueItems([itemID])
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func clearCompletedPersistentQueueItems() {
+        Task { @MainActor in
+            do {
+                persistentQueueRemovalToken = try await viewModel.clearCompletedPersistentQueueItems()
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func undoPersistentQueueRemoval() {
+        guard let token = persistentQueueRemovalToken else { return }
+        Task { @MainActor in
+            do {
+                try await viewModel.restorePersistentQueueItems(token)
+                persistentQueueRemovalToken = nil
+            } catch {
+                persistentQueueRemovalToken = nil
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func startPersistentQueue() {
+        Task { @MainActor in
+            if await viewModel.startPersistentQueue() == 0 {
+                persistentQueueErrorMessage = "No queued videos are currently ready to start."
+            }
+        }
+    }
+
+    private func retryPersistentQueueItem(
+        _ item: PersistentQueueItem,
+        recoveryChoice: WorkerRecoveryChoice?
+    ) {
+        Task { @MainActor in
+            if !(await viewModel.adoptPersistentQueueItem(item.id, recoveryChoice: recoveryChoice)) {
+                persistentQueueErrorMessage = "This queued video could not be restarted. Review its source and recovery choice."
+            }
+        }
+    }
+
+    private func updatePersistentQueueItem(
+        _ item: PersistentQueueItem,
+        profileID: String,
+        options editedOptions: ConversionOptions
+    ) {
+        let profile = profileStore.profile(withID: profileID)
+        let draft = ConversionDraft(
+            source: item.draft.source,
+            sourceDetails: item.draft.sourceDetails,
+            profile: profile,
+            destinationURL: item.draft.destinationURL,
+            options: editedOptions,
+            selectedTitle: item.draft.selectedTitle
+        )
+        Task { @MainActor in
+            do {
+                try await viewModel.updatePersistentQueueItem(item.id, draft: draft)
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func changePersistentQueueDestination(_ item: PersistentQueueItem) {
+        guard let destination = DestinationPicker.chooseDestination(startingAt: item.draft.destinationURL) else {
+            return
+        }
+        let draft = ConversionDraft(
+            source: item.draft.source,
+            sourceDetails: item.draft.sourceDetails,
+            profile: item.draft.profile,
+            destinationURL: destination,
+            options: item.draft.options,
+            selectedTitle: item.draft.selectedTitle
+        )
+        Task { @MainActor in
+            do {
+                try await viewModel.updatePersistentQueueItem(item.id, draft: draft)
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func queueAdmissionMessage(for result: SetupQueueAddResult) -> String? {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -1,0 +1,556 @@
+import AppKit
+import SwiftUI
+
+struct PersistentQueueSidebarView: View {
+    let items: [PersistentQueueItem]
+    @Binding var selectedID: UUID?
+    @Binding var compactRows: Bool
+    let insertedDiscs: [ConversionSource]
+    let makeMKVAvailable: Bool
+    let activeProgress: WorkerProgress?
+    let activeElapsedText: String?
+    let canStart: Bool
+    let canUndo: Bool
+    let addSources: () -> Void
+    let addSourceFolder: () -> Void
+    let addDisc: (ConversionSource) -> Void
+    let move: (UUID, Int) -> Void
+    let moveNext: (UUID) -> Void
+    let remove: (UUID) -> Void
+    let clearCompleted: () -> Void
+    let undo: () -> Void
+    let start: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if let banner {
+                Label(banner.title, systemImage: banner.systemImage)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(banner.tint)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(banner.tint.opacity(0.08))
+                    .accessibilityIdentifier("persistent-queue-banner")
+            }
+            if items.isEmpty {
+                emptyState
+            } else {
+                queueList
+            }
+            Divider()
+            actionBar
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+        .accessibilityIdentifier("persistent-queue-sidebar")
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("Queue")
+                .font(.headline)
+            Spacer()
+            if !items.isEmpty {
+                Text("\(items.count)")
+                    .font(.caption.monospacedDigit().weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.12), in: Capsule())
+            }
+            Menu {
+                Toggle("Compact Queue", isOn: $compactRows)
+                Divider()
+                Button("Clear Completed", action: clearCompleted)
+                    .disabled(completedItems.isEmpty)
+                if canUndo {
+                    Button("Undo Remove", action: undo)
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .menuStyle(.borderlessButton)
+            .accessibilityLabel("Queue options")
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 44)
+        .background { StructuralChromeBackground() }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "opticaldisc")
+                .font(.system(size: 42, weight: .light))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+            Text("Nothing in the queue")
+                .font(.title3.weight(.semibold))
+            Text("Add files, disc images, Blu-ray folders, movie folders, or an inserted disc.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Add Sources…", action: addSources)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .accessibilityIdentifier("queue-empty-add")
+            Label(
+                makeMKVAvailable ? "MakeMKV ready" : "MakeMKV is required for disc sources",
+                systemImage: makeMKVAvailable ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+            )
+                .font(.caption)
+                .foregroundStyle(makeMKVAvailable ? .green : .orange)
+            Text("Videos convert one at a time in the order shown.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var queueList: some View {
+        List(selection: $selectedID) {
+            if !activeItems.isEmpty {
+                Section("Now Converting") {
+                    rows(activeItems)
+                }
+            }
+            if !pendingItems.isEmpty {
+                Section(activeItems.isEmpty ? "Queue" : "Up Next") {
+                    rows(pendingItems)
+                }
+            }
+            if !completedItems.isEmpty {
+                Section("Completed") {
+                    rows(completedItems)
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .accessibilityLabel("Conversion queue")
+        .accessibilityIdentifier("persistent-queue-list")
+    }
+
+    @ViewBuilder
+    private func rows(_ sectionItems: [PersistentQueueItem]) -> some View {
+        ForEach(sectionItems) { item in
+            PersistentQueueRow(
+                item: item,
+                position: (items.firstIndex(where: { $0.id == item.id }) ?? 0) + 1,
+                total: items.count,
+                compact: compactRows,
+                progress: item.status.isActive ? activeProgress : nil,
+                move: move,
+                moveNext: moveNext,
+                remove: remove
+            )
+            .tag(item.id)
+        }
+    }
+
+    private var actionBar: some View {
+        VStack(spacing: 7) {
+            HStack(spacing: 8) {
+                Menu {
+                    Button("Add Files or Folders…", action: addSources)
+                    Button("Add Folder of Movies…", action: addSourceFolder)
+                    if !insertedDiscs.isEmpty {
+                        Divider()
+                        ForEach(insertedDiscs, id: \.url) { disc in
+                            Button("Add \(disc.displayName)") { addDisc(disc) }
+                        }
+                    }
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                .menuStyle(.borderlessButton)
+                .accessibilityIdentifier("persistent-queue-add")
+
+                Button {
+                    if let selectedID { remove(selectedID) }
+                } label: {
+                    Label("Remove", systemImage: "minus")
+                }
+                .buttonStyle(.borderless)
+                .disabled(selectedItem?.canRemove != true)
+                .accessibilityIdentifier("persistent-queue-remove")
+
+                Spacer()
+                if canUndo {
+                    Button("Undo", action: undo)
+                        .buttonStyle(.borderless)
+                }
+                if !completedItems.isEmpty {
+                    Button("Clear Completed", action: clearCompleted)
+                        .buttonStyle(.borderless)
+                }
+            }
+            Button(startButtonTitle, action: start)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canStart)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .accessibilityIdentifier("persistent-queue-start")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background { StructuralChromeBackground() }
+    }
+
+    private var activeItems: [PersistentQueueItem] { items.filter(\.status.isActive) }
+    private var completedItems: [PersistentQueueItem] { items.filter(\.status.isCompleted) }
+    private var pendingItems: [PersistentQueueItem] {
+        items.filter { !$0.status.isActive && !$0.status.isCompleted }
+    }
+    private var selectedItem: PersistentQueueItem? {
+        selectedID.flatMap { id in items.first(where: { $0.id == id }) }
+    }
+    private var startButtonTitle: String {
+        items.contains(where: { $0.isRestored || $0.status.isStopped }) ? "Resume Queue" : "Start Queue"
+    }
+
+    private var banner: (title: String, systemImage: String, tint: Color)? {
+        if items.contains(where: \.isRestored) {
+            return ("Queue restored — interrupted videos require an explicit restart.", "arrow.counterclockwise.circle.fill", .orange)
+        }
+        if items.contains(where: { item in
+            switch item.status {
+            case .attention, .failed:
+                true
+            default:
+                false
+            }
+        }) {
+            return ("Some videos need attention.", "exclamationmark.triangle.fill", .red)
+        }
+        return nil
+    }
+}
+
+private struct PersistentQueueRow: View {
+    let item: PersistentQueueItem
+    let position: Int
+    let total: Int
+    let compact: Bool
+    let progress: WorkerProgress?
+    let move: (UUID, Int) -> Void
+    let moveNext: (UUID) -> Void
+    let remove: (UUID) -> Void
+
+    var body: some View {
+        HStack(spacing: compact ? 7 : 9) {
+            Image(systemName: item.status.systemImage)
+                .font(.system(size: compact ? 13 : 15, weight: .medium))
+                .foregroundStyle(item.status.tint)
+                .frame(width: compact ? 15 : 18)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: compact ? 1 : 3) {
+                Text(item.displayName)
+                    .font(compact ? .callout : .callout.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(item.status.subtitle(for: item))
+                    .font(.caption)
+                    .foregroundStyle(item.status.tint)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if item.status.isActive, let progress {
+                    if let stageFraction = progress.stageFraction {
+                        ProgressView(value: stageFraction)
+                            .progressViewStyle(.linear)
+                            .controlSize(.small)
+                            .accessibilityLabel(progress.accessibilityValue)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityLabel(progress.accessibilityValue)
+                    }
+                }
+            }
+            Spacer(minLength: 4)
+            if item.isRestored {
+                Image(systemName: "arrow.counterclockwise.circle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.vertical, compact ? 2 : 4)
+        .contentShape(Rectangle())
+        .contextMenu {
+            if item.canMove {
+                Button("Convert Next") { moveNext(item.id) }
+                Button("Move Up") { move(item.id, -1) }
+                Button("Move Down") { move(item.id, 1) }
+                Divider()
+            }
+            Button("Remove from Queue", role: .destructive) { remove(item.id) }
+                .disabled(!item.canRemove)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(item.displayName), \(item.status.title), \(position) of \(total)")
+        .accessibilityAction(named: "Move Up") {
+            if item.canMove { move(item.id, -1) }
+        }
+        .accessibilityAction(named: "Move Down") {
+            if item.canMove { move(item.id, 1) }
+        }
+        .accessibilityAction(named: "Remove from Queue") {
+            if item.canRemove { remove(item.id) }
+        }
+    }
+}
+
+struct PersistentQueueDetailView: View {
+    let item: PersistentQueueItem?
+    let activeProgress: WorkerProgress?
+    let activeElapsedText: String?
+    let edit: (PersistentQueueItem) -> Void
+    let changeDestination: (PersistentQueueItem) -> Void
+    let retry: (PersistentQueueItem, WorkerRecoveryChoice?) -> Void
+
+    var body: some View {
+        Group {
+            if let item {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        header(item)
+                        statusBanner(item)
+                        Divider()
+                        settings(item)
+                    }
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            } else {
+                VStack(spacing: 12) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 34, weight: .light))
+                        .foregroundStyle(.secondary)
+                    Text("Select a video to configure it")
+                        .font(.title3.weight(.semibold))
+                    Text("Each queued video keeps its own profile, destination, and recovery settings.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .accessibilityIdentifier("persistent-queue-detail")
+    }
+
+    private func header(_ item: PersistentQueueItem) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.draft.source.kind.queueSystemImage)
+                .font(.system(size: 30, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 36)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.displayName)
+                    .font(.title2.weight(.semibold))
+                Text(item.draft.source.url.deletingLastPathComponent().path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Text(item.draft.source.kind.title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.quaternary, in: Capsule())
+        }
+    }
+
+    @ViewBuilder
+    private func statusBanner(_ item: PersistentQueueItem) -> some View {
+        HStack(spacing: 10) {
+            Label(item.status.detailTitle, systemImage: item.status.systemImage)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(item.status.tint)
+            Spacer()
+            if item.status.isActive, let activeProgress {
+                Text(activeProgress.compactText)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            if item.status.isActive, let activeElapsedText {
+                Label(activeElapsedText, systemImage: "clock")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            if item.canRetry {
+                if case let .attention(decision) = item.status, !decision.supportedChoices.isEmpty {
+                    Menu("Choose Action") {
+                        ForEach(decision.supportedChoices) { choice in
+                            Button(choice.title) { retry(item, choice) }
+                        }
+                    }
+                } else {
+                    Button(item.isRestored ? "Restart Safely" : "Retry") { retry(item, nil) }
+                }
+            }
+            if case let .completed(result) = item.status {
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: result.outputPath)])
+                }
+            }
+        }
+        .padding(10)
+        .background(item.status.tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func settings(_ item: PersistentQueueItem) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Conversion Setup")
+                        .font(.title3.weight(.semibold))
+                    Text(item.isEditable ? "Waiting items can be edited until they start." : "Settings are locked for this queue state.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Edit…") { edit(item) }
+                    .disabled(!item.isEditable)
+            }
+            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 10) {
+                GridRow {
+                    Text("Profile").foregroundStyle(.secondary)
+                    Text(item.draft.profile.name)
+                }
+                GridRow {
+                    Text("Destination").foregroundStyle(.secondary)
+                    HStack {
+                        Text(item.draft.destinationURL.path)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Button("Change…") { changeDestination(item) }
+                            .disabled(!item.isEditable)
+                    }
+                }
+                GridRow {
+                    Text("Planned file").foregroundStyle(.secondary)
+                    Text(item.draft.proposedOutputURL.lastPathComponent)
+                }
+                GridRow {
+                    Text("Output").foregroundStyle(.secondary)
+                    Text(item.draft.options.videoRoutePlan.qualityTitle)
+                }
+                GridRow {
+                    Text("Attempts").foregroundStyle(.secondary)
+                    Text("\(item.attemptCount)")
+                }
+            }
+            .font(.callout)
+        }
+    }
+}
+
+private extension PersistentQueueItemStatus {
+    var isActive: Bool {
+        switch self {
+        case .inspecting, .processing, .stopping:
+            true
+        default:
+            false
+        }
+    }
+
+    var isCompleted: Bool {
+        if case .completed = self { return true }
+        return false
+    }
+
+    var isStopped: Bool {
+        switch self {
+        case .stopped, .notStarted:
+            true
+        default:
+            false
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .waiting: "Waiting"
+        case .inspecting: "Reading Source"
+        case .processing: "Converting"
+        case .stopping: "Stopping"
+        case .interrupted: "Interrupted"
+        case .attention: "Needs Attention"
+        case .failed: "Failed"
+        case .completed: "Completed"
+        case .stopped: "Stopped"
+        case .notStarted: "Not Started"
+        }
+    }
+
+    var detailTitle: String {
+        switch self {
+        case let .attention(decision): decision.prompt
+        case let .failed(failure): failure.message
+        case let .completed(result): URL(fileURLWithPath: result.outputPath).lastPathComponent
+        case .interrupted: "Interrupted during the previous app session"
+        default: title
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .waiting: "clock"
+        case .inspecting: "doc.text.magnifyingglass"
+        case .processing: "gearshape.2"
+        case .stopping: "hourglass"
+        case .interrupted: "arrow.counterclockwise.circle"
+        case .attention: "exclamationmark.circle.fill"
+        case .failed: "exclamationmark.triangle.fill"
+        case .completed: "checkmark.circle.fill"
+        case .stopped, .notStarted: "stop.circle.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .waiting, .stopped, .notStarted: .secondary
+        case .inspecting, .processing, .stopping: .accentColor
+        case .interrupted, .attention: .orange
+        case .failed: .red
+        case .completed: .green
+        }
+    }
+
+    func subtitle(for item: PersistentQueueItem) -> String {
+        switch self {
+        case let .attention(decision): decision.prompt
+        case let .failed(failure): failure.message
+        case let .completed(result): URL(fileURLWithPath: result.outputPath).lastPathComponent
+        case .interrupted: "Will restart from the last safe stage"
+        case .processing: "\(item.draft.profile.name) · \(item.draft.proposedOutputURL.lastPathComponent)"
+        default: "\(item.draft.profile.name) · \(item.draft.proposedOutputURL.lastPathComponent)"
+        }
+    }
+}
+
+private extension ConversionSourceKind {
+    var queueSystemImage: String {
+        switch self {
+        case .discImage: "opticaldiscdrive"
+        case .matroska: "film.stack"
+        case .transportStream: "externaldrive"
+        case .bluRayFolder, .sourceFolder: "folder.badge.gearshape"
+        case .physicalDisc: "opticaldisc"
+        }
+    }
+}
+
+private extension DurableQueueDecision {
+    var supportedChoices: [WorkerRecoveryChoice] {
+        choices.compactMap(WorkerRecoveryChoice.init(rawValue:)).filter { $0 != .cancel }
+    }
+}

--- a/macos/BluRayToVisionPro/Views/SourcePicker.swift
+++ b/macos/BluRayToVisionPro/Views/SourcePicker.swift
@@ -19,6 +19,22 @@ enum SourcePicker {
     }
 
     @MainActor
+    static func chooseQueueSources() -> [ConversionSource] {
+        let panel = NSOpenPanel()
+        panel.title = "Add Sources to Queue"
+        panel.prompt = "Add to Queue"
+        panel.message = "Choose one or more Blu-ray folders, ISO, MKV, MTS, or M2TS sources."
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = true
+        panel.resolvesAliases = true
+        guard panel.runModal() == .OK else {
+            return []
+        }
+        return panel.urls.compactMap { ConversionSource.infer(from: $0.standardizedFileURL) }
+    }
+
+    @MainActor
     static func chooseFile(kind: ConversionSourceKind) -> ConversionSource? {
         let panel = NSOpenPanel()
         panel.title = "Open \(kind.title)"

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -429,6 +429,45 @@ final class ConversionQueueStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueAppendAndMoveAfterPreserveExistingRows() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let completed = makeItem(
+            ordinal: 0,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        let first = makeItem(ordinal: 0, sourcePath: "/tmp/first.mkv")
+        let second = makeItem(ordinal: 1, sourcePath: "/tmp/second.mkv")
+        try await store.replaceItems([completed])
+
+        try await store.appendWaitingItems([first, second])
+        XCTAssertEqual(store.items.map(\.id), [completed.id, first.id, second.id])
+        XCTAssertEqual(store.items.map(\.ordinal), [0, 1, 2])
+
+        try await store.moveWaitingItem(first.id, after: second.id)
+        XCTAssertEqual(store.items.map(\.id), [completed.id, second.id, first.id])
+        XCTAssertEqual(store.items.map(\.ordinal), [0, 1, 2])
+    }
+
+    @MainActor
+    func testPersistentQueueRemovalAllowsRecoverableTerminalRows() async throws {
+        let store = ConversionQueueStore.inMemory()
+        let failed = makeItem(
+            ordinal: 0,
+            sourcePath: "/tmp/failed.mkv",
+            state: .failed,
+            failure: DurableQueueFailure(code: "temporary", message: "Temporary", details: nil, retryable: true)
+        )
+        try await store.replaceItems([failed])
+
+        let token = try await store.removeRemovableItems([failed.id])
+        XCTAssertTrue(store.items.isEmpty)
+        try await store.restoreRemovedItems(token)
+        XCTAssertEqual(store.items, [failed])
+    }
+
+    @MainActor
     func testPersistentQueueRemovalTokenRestoresOriginalOrderAndIntents() async throws {
         let store = ConversionQueueStore.inMemory()
         let items = (0 ..< 4).map { offset in

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -3975,6 +3975,47 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueAppendThenStartUsesExistingDurableRow() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let sourceURL = directoryURL.appendingPathComponent("feature.mkv")
+        _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        let inspection = SourceInspection(
+            name: "Feature",
+            resolution: "1920x1080",
+            frameRate: "24/1",
+            interlaced: false
+        )
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: sourceURL),
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: directoryURL,
+            options: ConversionOptions()
+        )
+        let queueStore = ConversionQueueStore.inMemory()
+        let completed = expectation(description: "persistent queue conversion completed")
+        let worker = TwoPhaseWorkerClient(onConversionJobReceived: { _ in completed.fulfill() })
+        let viewModel = ConversionViewModel(clientFactory: { worker }, durableQueueStore: queueStore)
+
+        let appendResult = try await viewModel.appendPersistentQueueDrafts([draft])
+        XCTAssertEqual(appendResult.addedCount, 1)
+        XCTAssertEqual(queueStore.items.count, 1)
+        XCTAssertEqual(queueStore.items.first?.state, .waiting)
+        XCTAssertFalse(viewModel.hasActiveWork)
+
+        let adoptedCount = await viewModel.startPersistentQueue()
+        XCTAssertEqual(adoptedCount, 1)
+        await fulfillment(of: [completed], timeout: 2)
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        XCTAssertEqual(queueStore.items.count, 1)
+        XCTAssertEqual(queueStore.items.first?.state, .completed)
+    }
+
+    @MainActor
     func testPersistentQueueProjectionIncludesEveryOriginAndPreservesSelection() async throws {
         let queueStore = ConversionQueueStore.inMemory()
         let viewModel = ConversionViewModel(durableQueueStore: queueStore)

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class PersistentQueueWorkspaceRenderTests: XCTestCase {
+    func testQueueWorkspaceRendersEmptyAndDenseStatesAcrossAppearances() throws {
+        let items = try makeItems()
+        let appearances: [(ColorScheme, NSAppearance.Name)] = [
+            (.light, .aqua),
+            (.dark, .darkAqua),
+        ]
+
+        for (colorScheme, appearanceName) in appearances {
+            try render(
+                items: [],
+                selectedItem: nil,
+                compact: false,
+                colorScheme: colorScheme,
+                appearanceName: appearanceName
+            )
+            try render(
+                items: items,
+                selectedItem: items[1],
+                compact: true,
+                colorScheme: colorScheme,
+                appearanceName: appearanceName
+            )
+        }
+    }
+
+    private func render(
+        items: [PersistentQueueItem],
+        selectedItem: PersistentQueueItem?,
+        compact: Bool,
+        colorScheme: ColorScheme,
+        appearanceName: NSAppearance.Name
+    ) throws {
+        let content = HSplitView {
+            PersistentQueueSidebarView(
+                items: items,
+                selectedID: .constant(selectedItem?.id),
+                compactRows: .constant(compact),
+                insertedDiscs: [],
+                makeMKVAvailable: true,
+                activeProgress: WorkerProgress(currentStage: 3, totalStages: 5, stageFraction: 0.61),
+                activeElapsedText: "1:12:31",
+                canStart: !items.isEmpty,
+                canUndo: true,
+                addSources: {},
+                addSourceFolder: {},
+                addDisc: { _ in },
+                move: { _, _ in },
+                moveNext: { _ in },
+                remove: { _ in },
+                clearCompleted: {},
+                undo: {},
+                start: {}
+            )
+            .frame(minWidth: 300, idealWidth: 330, maxWidth: 420)
+            PersistentQueueDetailView(
+                item: selectedItem,
+                activeProgress: WorkerProgress(currentStage: 3, totalStages: 5, stageFraction: 0.61),
+                activeElapsedText: "1:12:31",
+                edit: { _ in },
+                changeDestination: { _ in },
+                retry: { _, _ in }
+            )
+            .frame(minWidth: 600)
+        }
+        .frame(width: 920, height: 620)
+        .preferredColorScheme(colorScheme)
+        let hostingView = NSHostingView(rootView: content)
+        hostingView.appearance = NSAppearance(named: appearanceName)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 920, height: 620)
+        hostingView.layoutSubtreeIfNeeded()
+        let bitmap = try XCTUnwrap(hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds))
+        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+        XCTAssertEqual(bitmap.pixelsWide, 920)
+        XCTAssertEqual(bitmap.pixelsHigh, 620)
+    }
+
+    private func makeItems() throws -> [PersistentQueueItem] {
+        let inspection = SourceInspection(
+            name: "Feature",
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            interlaced: false
+        )
+        return try (0..<12).map { offset in
+            let sourceURL = URL(fileURLWithPath: "/Volumes/Media/Rips/Feature-\(offset).mkv")
+            let draft = ConversionDraft(
+                source: ConversionSource(kind: .matroska, url: sourceURL),
+                sourceDetails: inspection,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                options: ConversionOptions()
+            )
+            let state: DurableQueueItemState
+            let failure: DurableQueueFailure?
+            let result: DurableQueueResult?
+            switch offset {
+            case 0:
+                state = .processing
+                failure = nil
+                result = nil
+            case 1:
+                state = .interrupted
+                failure = nil
+                result = nil
+            case 2:
+                state = .failed
+                failure = DurableQueueFailure(code: "temporary", message: "Source needs attention", details: nil, retryable: true)
+                result = nil
+            case 10, 11:
+                state = .completed
+                failure = nil
+                result = DurableQueueResult(outputPath: "/Movies/Feature-\(offset).mov")
+            default:
+                state = .waiting
+                failure = nil
+                result = nil
+            }
+            return try PersistentQueueItem(item: DurableConversionQueueItem(
+                ordinal: offset,
+                origin: .singleSource,
+                intent: DurableQueueItemIntent(draft: draft),
+                inspection: inspection,
+                state: state,
+                failure: failure,
+                result: result
+            ))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make the persistent queue the default pre-source workspace with approved empty, active, restored, attention, completed, and dense presentations
- append multiple files, folders, disc images, movie folders, and inserted discs through native pickers or drag and drop without replacing queued work
- add persistent selection/details, waiting-item edit and destination changes, reorder/move-next, removable recovery rows, Undo, clear-completed, and explicit Start/Resume adoption
- show active progress and elapsed time while preserving the existing Stop control and durable runtime ownership
- document the user-facing persistent queue behavior and raise the minimum workspace width to the approved 920-point contract

## Validation
- `uv run python scripts/native_app.py test` — 511 tests passed, zero failures
- persistent queue store/view-model regressions — passed
- light/dark empty and dense 920×620 render tests — passed
- real Development app empty-workspace visual review — passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — passed, including package validation and smoke checks
- final Opus review — approved with no blockers
- Gemini/Antigravity integration review attempt returned no usable output

## Readiness Notes
- JetBrains closeout was inconclusive because IntelliJ mutated `.idea` metadata and inspected project metadata as text; generated changes were removed and the worktree is clean.
- Mockup fixtures remain isolated under `design/queue-mockup`; production uses new queue presentation types only.

Refs #544