### PR TITLE
Add safe persistent queue execution controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ the native picker or drag and drop. Waiting videos can be selected, edited,
 reordered, moved next, removed, and restored with Undo while active and
 completed settings remain locked. Work restored after an app restart never
 starts automatically; interrupted or stopped videos require an explicit
-**Resume Queue**, **Restart Safely**, or recovery choice.
+**Resume Queue**, **Restart Safely**, or recovery choice. **Pause After Current**
+lets the active video finish without starting another, while **Stop Current**
+cancels only the active video and leaves pending work waiting for an explicit
+resume. Failed videos and items needing attention stay parked so unrelated
+eligible queue work can continue.
 
 ## Terminal Usage
 

--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -13,6 +13,7 @@ final class ConversionQueueStore: ObservableObject {
     private let fileURL: URL?
     private let fileManager: FileManager
     private let dataReader: (URL) throws -> Data
+    private let dataWriter: @Sendable (Data, URL) throws -> Void
     private let dataMover: (URL, URL) throws -> Void
     private let writer: ConversionQueueFileWriter?
     private let mutationLock = ConversionQueueMutationLock()
@@ -31,6 +32,7 @@ final class ConversionQueueStore: ObservableObject {
     ) {
         self.fileManager = fileManager
         self.dataReader = dataReader
+        self.dataWriter = dataWriter
         self.dataMover = dataMover ?? { sourceURL, destinationURL in
             try fileManager.moveItem(at: sourceURL, to: destinationURL)
         }
@@ -382,7 +384,23 @@ final class ConversionQueueStore: ObservableObject {
             }
             let loadedDocument = try Self.decoder().decode(ConversionQueueDocument.self, from: data)
             try validate(loadedDocument.items)
-            document = loadedDocument.restoredAfterLaunch()
+            let restoredDocument = loadedDocument.restoredAfterLaunch()
+            try validate(restoredDocument.items)
+            document = restoredDocument
+            guard restoredDocument != loadedDocument else {
+                return
+            }
+            do {
+                try fileManager.createDirectory(
+                    at: fileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try dataWriter(Self.encoder().encode(restoredDocument), fileURL)
+                documentRevision += 1
+            } catch {
+                writesBlocked = true
+                loadErrorMessage = "Queue recovery could not be saved. Queue changes are disabled to avoid losing its interrupted state."
+            }
         } catch let error as ConversionQueueStoreError {
             if case let .unsupportedVersion(version) = error {
                 writesBlocked = true

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -65,6 +65,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var completedBatchResults: [ConversionResult]?
     @Published private(set) var durableQueueRuntimeDiagnostic: String?
     @Published private(set) var setupQueueStartFailureItemIDs: Set<UUID> = []
+    @Published private(set) var persistentQueueRunState: PersistentQueueRunState = .idle
 
     private let clientFactory: ClientFactory
     private let diagnosticClock: () -> Date
@@ -313,24 +314,76 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     @discardableResult
-    func startPersistentQueue() async -> Int {
+    func startPersistentQueue() async -> PersistentQueueCommandOutcome {
+        guard !hasActiveWorker || activeDurableQueueItem != nil else {
+            return .rejected(.otherWorkIsActive)
+        }
+        if persistentQueueRunState == .running {
+            return .noChange(.running)
+        }
         let candidates = persistentQueueItems.filter { item in
             switch item.status {
             case .waiting, .interrupted, .stopped, .notStarted:
                 true
-            case let .failed(failure):
-                failure.retryable
-            case .inspecting, .processing, .stopping, .attention, .completed:
+            case .inspecting, .processing, .stopping, .attention, .failed, .completed:
                 false
             }
         }
+        guard !candidates.isEmpty else {
+            return .rejected(.noEligibleItems)
+        }
+        parkActiveDurableQueueItemForResume()
+        persistentQueueRunState = .running
+        durableQueueStopRequested = false
         var adoptedCount = 0
         for item in candidates {
             if await adoptPersistentQueueItem(item.id) {
                 adoptedCount += 1
             }
         }
-        return adoptedCount
+        guard adoptedCount > 0 else {
+            persistentQueueRunState = .paused
+            return .rejected(.noEligibleItems)
+        }
+        return .accepted(.running)
+    }
+
+    @discardableResult
+    func pausePersistentQueueAfterCurrent() -> PersistentQueueCommandOutcome {
+        switch persistentQueueRunState {
+        case .pauseAfterCurrent:
+            return .noChange(.pauseAfterCurrent)
+        case .paused:
+            return .noChange(.paused)
+        case .idle:
+            return .rejected(.queueIsNotRunning)
+        case .running:
+            persistentQueueRunState = .pauseAfterCurrent
+            if !hasActiveWorker, activeQueueItemID == nil {
+                enqueueQueueTransition { [weak self] in
+                    await self?.pauseDurableQueueNow()
+                }
+            }
+            return .accepted(.pauseAfterCurrent)
+        }
+    }
+
+    @discardableResult
+    func stopCurrentPersistentQueueItem() -> PersistentQueueCommandOutcome {
+        guard persistentQueueRunState == .running || persistentQueueRunState == .pauseAfterCurrent else {
+            return .rejected(.queueIsNotRunning)
+        }
+        guard hasActiveWorker, let item = activeDurableQueueItem else {
+            return .rejected(.noActiveItem)
+        }
+        persistentQueueRunState = .paused
+        state.requestStop()
+        recordDiagnosticWorkflow(name: "cancel.requested", mode: activeRunMode, jobID: state.jobID)
+        client?.cancel()
+        enqueueQueueTransition { [weak self] in
+            await self?.persistCurrentDurableQueueStop(itemID: item.id)
+        }
+        return .accepted(.paused)
     }
 
     @discardableResult
@@ -409,6 +462,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 }
             }
             adoptedItemIDs.insert(itemID)
+            persistentQueueRunState = .running
             if let recoveryChoiceValue {
                 sourceFolderRecoveryChoices[itemID] = recoveryChoiceValue
             }
@@ -964,6 +1018,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         guard hasStoppableWork else {
             return
         }
+        persistentQueueRunState = .idle
         if hasActiveWorker {
             state.requestStop()
             recordDiagnosticWorkflow(name: "cancel.requested", mode: activeRunMode, jobID: state.jobID)
@@ -1033,6 +1088,15 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         enqueueQueueTransition { [weak self] in
             await self?.stopUnstartedAdoptedItems()
         }
+    }
+
+    @discardableResult
+    func stopAllPersistentQueue() -> PersistentQueueCommandOutcome {
+        guard hasStoppableWork else {
+            return .rejected(.noActiveItem)
+        }
+        stopActiveWorker()
+        return .accepted(.idle)
     }
 
     func prepareForRetry() {
@@ -1643,7 +1707,16 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private func pumpDurableQueue() async {
         if durableQueueStopRequested {
             await stopUnstartedAdoptedItems()
+            persistentQueueRunState = .idle
             finishSourceFolderQueueIfNeeded()
+            return
+        }
+        if persistentQueueRunState == .paused {
+            await pauseDurableQueueNow()
+            return
+        }
+        if persistentQueueRunState == .pauseAfterCurrent {
+            await pauseDurableQueueNow()
             return
         }
         guard !hasActiveWorker, activeQueueItemID == nil else {
@@ -1653,6 +1726,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             .filter({ adoptedItemIDs.contains($0.id) && $0.state == .waiting })
             .min(by: { $0.ordinal < $1.ordinal })
         else {
+            if persistentQueueRunState == .running {
+                persistentQueueRunState = .idle
+            }
             finishSourceFolderQueueIfNeeded()
             return
         }
@@ -2082,6 +2158,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
+                persistentQueueRunState = .paused
                 return
             }
             activeQueueItemID = nil
@@ -2128,10 +2205,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 items[index].result = result
                 items[index].decision = nil
                 items[index].failure = nil
-            } else if let decision = snapshot.decision {
-                items[index].state = .failed
-                items[index].failure = snapshot.failure
-                items[index].decision = DurableQueueDecision(decision: decision)
+                } else if let decision = snapshot.decision {
+                    items[index].state = .attention
+                    items[index].failure = nil
+                    items[index].decision = DurableQueueDecision(decision: decision)
             } else {
                 items[index].state = .failed
                 items[index].failure = snapshot.failure
@@ -2542,6 +2619,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
+                persistentQueueRunState = .paused
                 return
             }
             activeQueueItemID = nil
@@ -2639,7 +2717,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             case .decisionRequired:
                 publishTitleQueueProjection()
             case .cancelled, .failed:
-                try await stopWaitingTitleQueueItems()
+                if durableQueueStopRequested || titleQueueStopRequested {
+                    try await stopWaitingTitleQueueItems()
+                }
                 publishTitleQueueProjection()
                 activeQueueItemID = nil
                 releaseAdoption(itemID)
@@ -2659,6 +2739,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return
         }
         do {
+            var stoppedItemIDs: Set<UUID> = []
             try await durableQueueStore.mutateItems { items in
                 guard let index = items.firstIndex(where: { $0.id == itemID }) else {
                     throw ConversionQueueStoreError.invalidDocument
@@ -2686,6 +2767,25 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 items[index].state = .stopping
                 items[index].decision = nil
             }
+        } catch {
+            durableQueueRuntimeDiagnostic = "Queue stop state could not be saved: \(error.localizedDescription)"
+        }
+    }
+
+    private func persistCurrentDurableQueueStop(itemID: UUID) async {
+        guard activeQueueItemID == itemID else {
+            return
+        }
+        do {
+            try await durableQueueStore.mutateItems { items in
+                guard let index = items.firstIndex(where: { $0.id == itemID }) else {
+                    throw ConversionQueueStoreError.invalidDocument
+                }
+                items[index].state = .stopping
+                items[index].decision = nil
+            }
+            publishTitleQueueProjection()
+            publishSourceFolderQueueProjection()
         } catch {
             durableQueueRuntimeDiagnostic = "Queue stop state could not be saved: \(error.localizedDescription)"
         }
@@ -2843,6 +2943,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 ))
             }
             durableQueueStopRequested = false
+            persistentQueueRunState = .running
             state.prepareQueuedConversion(sourceURL: draft.source.url, inspection: draft.sourceDetails)
             source = draft.source
             _ = startConversion(draft: draft, mode: .durableSingleConversion(itemID: itemID))
@@ -2876,6 +2977,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 ))
             }
             publishTitleQueueProjection()
+            persistentQueueRunState = .running
             if titleQueueStopRequested {
                 await stopDurableTitleQueueBeforeSpawn(itemID: itemID)
                 return
@@ -3012,7 +3114,6 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         do {
             var origin: DurableQueueItemOrigin?
             var groupID: UUID?
-            var stoppedItemIDs: Set<UUID> = []
             try await durableQueueStore.mutateItems { items in
                 guard let index = items.firstIndex(where: { $0.id == itemID }) else {
                     throw ConversionQueueStoreError.invalidDocument
@@ -3030,18 +3131,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 if let attemptIndex = items[index].attempts.lastIndex(where: { $0.endedAt == nil }) {
                     items[index].attempts[attemptIndex].endedAt = diagnosticClock()
                 }
-                if items[index].origin == .multiTitle, let groupID {
-                    for pendingIndex in items.indices where items[pendingIndex].groupID == groupID && items[pendingIndex].state == .waiting {
-                        items[pendingIndex].state = .stopped
-                        stoppedItemIDs.insert(items[pendingIndex].id)
-                    }
-                }
             }
             activeQueueItemID = nil
             releaseAdoption(itemID)
-            for stoppedItemID in stoppedItemIDs {
-                releaseAdoption(stoppedItemID)
-            }
             state.failTransport(message: "The queued source is no longer available.", retryable: true)
             switch origin {
             case .multiTitle:
@@ -3071,6 +3163,35 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         adoptedItemIDs.remove(itemID)
         durableSingleJobIDs.removeValue(forKey: itemID)
         sourceFolderRecoveryChoices.removeValue(forKey: itemID)
+    }
+
+    private func parkActiveDurableQueueItemForResume() {
+        guard let item = activeDurableQueueItem,
+              item.state == .attention
+        else {
+            return
+        }
+        activeQueueItemID = nil
+        releaseAdoption(item.id)
+        if state.phase == .decisionRequired {
+            state.clear()
+        }
+    }
+
+    private func pauseDurableQueueNow() async {
+        guard !hasActiveWorker, activeQueueItemID == nil else {
+            return
+        }
+        let pendingItemIDs = durableQueueStore.items.compactMap { item in
+            adoptedItemIDs.contains(item.id) && item.state == .waiting ? item.id : nil
+        }
+        for itemID in pendingItemIDs {
+            releaseAdoption(itemID)
+        }
+        persistentQueueRunState = .paused
+        publishTitleQueueProjection()
+        publishSourceFolderQueueProjection()
+        finishSourceFolderQueueIfNeeded()
     }
 
     private func stopUnstartedAdoptedItems() async {

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -91,6 +91,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private var sourceFolderQueueGroupID: UUID?
     private var sourceFolderStopRequested = false
     private var durableQueueStopRequested = false
+    private var persistentQueueControlsActive = false
     private var adoptedItemIDs: Set<UUID> = []
     private var sourceFolderQueueCompletionPending = false
     private var sourceFolderRecoveryChoices: [UUID: String] = [:]
@@ -332,7 +333,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         guard !candidates.isEmpty else {
             return .rejected(.noEligibleItems)
         }
+        let previousRunState = persistentQueueRunState
+        let previousControlsActive = persistentQueueControlsActive
         parkActiveDurableQueueItemForResume()
+        persistentQueueControlsActive = true
         persistentQueueRunState = .running
         durableQueueStopRequested = false
         var adoptedCount = 0
@@ -342,7 +346,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
         }
         guard adoptedCount > 0 else {
-            persistentQueueRunState = .paused
+            persistentQueueRunState = previousRunState
+            persistentQueueControlsActive = previousControlsActive
             return .rejected(.noEligibleItems)
         }
         return .accepted(.running)
@@ -465,6 +470,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 }
             }
             adoptedItemIDs.insert(itemID)
+            persistentQueueControlsActive = true
             persistentQueueRunState = .running
             if let recoveryChoiceValue {
                 sourceFolderRecoveryChoices[itemID] = recoveryChoiceValue
@@ -1022,6 +1028,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return
         }
         persistentQueueRunState = .idle
+        persistentQueueControlsActive = false
         if hasActiveWorker {
             state.requestStop()
             recordDiagnosticWorkflow(name: "cancel.requested", mode: activeRunMode, jobID: state.jobID)
@@ -1732,6 +1739,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             if persistentQueueRunState == .running {
                 persistentQueueRunState = .idle
             }
+            persistentQueueControlsActive = false
             finishSourceFolderQueueIfNeeded()
             return
         }
@@ -2169,7 +2177,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
-                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                if persistentQueueControlsActive || hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
                     parkActiveDurableQueueItemForResume()
                     await pumpDurableQueue()
                 }
@@ -2219,10 +2227,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 items[index].result = result
                 items[index].decision = nil
                 items[index].failure = nil
-                } else if let decision = snapshot.decision {
-                    items[index].state = .attention
-                    items[index].failure = nil
-                    items[index].decision = DurableQueueDecision(decision: decision)
+            } else if let decision = snapshot.decision {
+                items[index].state = .attention
+                items[index].failure = nil
+                items[index].decision = DurableQueueDecision(decision: decision)
             } else {
                 items[index].state = .failed
                 items[index].failure = snapshot.failure
@@ -2494,6 +2502,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     private func failClosedSourceFolderQueuePersistence(_ error: Error) {
         durableQueueRuntimeDiagnostic = "Queue changes are unavailable: \(error.localizedDescription)"
+        persistentQueueRunState = .idle
+        persistentQueueControlsActive = false
         if let projected = batchQueue {
             if sourceFolderQueueGroupID == nil {
                 batchQueue = SourceFolderQueueState(
@@ -2640,7 +2650,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
-                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                if persistentQueueControlsActive || hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
                     parkActiveDurableQueueItemForResume()
                     await pumpDurableQueue()
                 }
@@ -2740,7 +2750,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 }
             case .decisionRequired:
                 publishTitleQueueProjection()
-                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                if persistentQueueControlsActive || hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
                     parkActiveDurableQueueItemForResume()
                     await pumpDurableQueue()
                 }
@@ -2767,7 +2777,6 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return
         }
         do {
-            var stoppedItemIDs: Set<UUID> = []
             try await durableQueueStore.mutateItems { items in
                 guard let index = items.firstIndex(where: { $0.id == itemID }) else {
                     throw ConversionQueueStoreError.invalidDocument
@@ -3142,26 +3151,41 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         do {
             var origin: DurableQueueItemOrigin?
             var groupID: UUID?
+            var parkedItemIDs: Set<UUID> = []
             try await durableQueueStore.mutateItems { items in
                 guard let index = items.firstIndex(where: { $0.id == itemID }) else {
                     throw ConversionQueueStoreError.invalidDocument
                 }
                 origin = items[index].origin
                 groupID = items[index].groupID
-                items[index].state = .failed
-                items[index].decision = nil
-                items[index].failure = DurableQueueFailure(
+                let unavailableSourcePath = items[index].intent.source.path
+                let failure = DurableQueueFailure(
                     code: "source_unavailable",
                     message: "The queued source is no longer available.",
-                    details: items[index].intent.source.path,
+                    details: unavailableSourcePath,
                     retryable: true
                 )
+                items[index].state = .failed
+                items[index].decision = nil
+                items[index].failure = failure
                 if let attemptIndex = items[index].attempts.lastIndex(where: { $0.endedAt == nil }) {
                     items[index].attempts[attemptIndex].endedAt = diagnosticClock()
+                }
+                for peerIndex in items.indices where peerIndex != index
+                    && items[peerIndex].state == .waiting
+                    && items[peerIndex].intent.source.path == unavailableSourcePath
+                {
+                    items[peerIndex].state = .failed
+                    items[peerIndex].decision = nil
+                    items[peerIndex].failure = failure
+                    parkedItemIDs.insert(items[peerIndex].id)
                 }
             }
             activeQueueItemID = nil
             releaseAdoption(itemID)
+            for parkedItemID in parkedItemIDs {
+                releaseAdoption(parkedItemID)
+            }
             state.failTransport(message: "The queued source is no longer available.", retryable: true)
             switch origin {
             case .multiTitle:
@@ -3341,6 +3365,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     private func failClosedTitleQueuePersistence(_ error: Error) {
         durableQueueRuntimeDiagnostic = "Queue changes are unavailable: \(error.localizedDescription)"
+        persistentQueueRunState = .idle
+        persistentQueueControlsActive = false
         publishSetupQueueStartFailure()
         activeQueueItemID = nil
         titleQueueGroupID = nil
@@ -3361,6 +3387,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     private func resetQueue() {
         queueItems.removeAll()
+        persistentQueueRunState = .idle
+        persistentQueueControlsActive = false
         activeQueueItemID = nil
         titleQueueGroupID = nil
         titleQueueStopRequested = false

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -315,11 +315,11 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     @discardableResult
     func startPersistentQueue() async -> PersistentQueueCommandOutcome {
-        guard !hasActiveWorker || activeDurableQueueItem != nil else {
-            return .rejected(.otherWorkIsActive)
-        }
         if persistentQueueRunState == .running {
             return .noChange(.running)
+        }
+        guard !hasActiveWorker || activeDurableQueueItem != nil else {
+            return .rejected(.otherWorkIsActive)
         }
         let candidates = persistentQueueItems.filter { item in
             switch item.status {
@@ -370,6 +370,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
 
     @discardableResult
     func stopCurrentPersistentQueueItem() -> PersistentQueueCommandOutcome {
+        if persistentQueueRunState == .paused {
+            return .noChange(.paused)
+        }
         guard persistentQueueRunState == .running || persistentQueueRunState == .pauseAfterCurrent else {
             return .rejected(.queueIsNotRunning)
         }
@@ -1805,6 +1808,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                         recoveryChoice: sourceFolderRecoveryChoices.removeValue(forKey: item.id)
                     ))
                 }
+                activeQueueItemID = item.id
                 publishSourceFolderQueueProjection()
                 if sourceFolderStopRequested {
                     await stopSourceFolderQueueBeforeSpawn(itemID: item.id)
@@ -1829,6 +1833,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                     recoveryChoice: sourceFolderRecoveryChoices.removeValue(forKey: item.id)
                 ))
             }
+            activeQueueItemID = item.id
             publishSourceFolderQueueProjection()
             if sourceFolderStopRequested {
                 await stopSourceFolderQueueBeforeSpawn(itemID: item.id)
@@ -2068,10 +2073,16 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private func startPersistedSourceFolderConversion(itemID: UUID) async throws {
         let updated = sourceFolderQueueItem(id: itemID)
         guard let updated else {
+            if activeQueueItemID == itemID {
+                activeQueueItemID = nil
+            }
             await pumpSourceFolderQueue()
             return
         }
         guard updated.state == .processing else {
+            if activeQueueItemID == itemID {
+                activeQueueItemID = nil
+            }
             await pumpSourceFolderQueue()
             return
         }
@@ -2158,7 +2169,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
-                persistentQueueRunState = .paused
+                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                    parkActiveDurableQueueItemForResume()
+                    await pumpDurableQueue()
+                }
                 return
             }
             activeQueueItemID = nil
@@ -2214,6 +2228,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 items[index].failure = snapshot.failure
                 items[index].decision = nil
             }
+        }
+        if activeQueueItemID == itemID {
+            activeQueueItemID = nil
         }
         releaseAdoption(itemID)
         publishSourceFolderQueueProjection()
@@ -2286,6 +2303,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             for stoppedItemID in stoppedItemIDs {
                 releaseAdoption(stoppedItemID)
+            }
+            if activeQueueItemID == itemID {
+                activeQueueItemID = nil
             }
             await stopUnstartedAdoptedItems()
             publishSourceFolderQueueProjection()
@@ -2487,6 +2507,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
         }
         sourceFolderQueueGroupID = nil
+        activeQueueItemID = nil
         sourceFolderStopRequested = false
         sourceFolderQueueCompletionPending = false
         adoptedItemIDs.removeAll()
@@ -2619,7 +2640,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             }
             publishTitleQueueProjection()
             if requiresDecision {
-                persistentQueueRunState = .paused
+                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                    parkActiveDurableQueueItemForResume()
+                    await pumpDurableQueue()
+                }
                 return
             }
             activeQueueItemID = nil
@@ -2716,6 +2740,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 }
             case .decisionRequired:
                 publishTitleQueueProjection()
+                if hasAdoptedWaitingDurableQueueItem(excluding: itemID) {
+                    parkActiveDurableQueueItemForResume()
+                    await pumpDurableQueue()
+                }
             case .cancelled, .failed:
                 if durableQueueStopRequested || titleQueueStopRequested {
                     try await stopWaitingTitleQueueItems()
@@ -3175,6 +3203,18 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         releaseAdoption(item.id)
         if state.phase == .decisionRequired {
             state.clear()
+        }
+    }
+
+    private func hasAdoptedWaitingDurableQueueItem(excluding itemID: UUID) -> Bool {
+        guard let parkedItem = durableQueueStore.items.first(where: { $0.id == itemID }) else {
+            return false
+        }
+        return durableQueueStore.items.contains { item in
+            item.id != itemID
+                && adoptedItemIDs.contains(item.id)
+                && item.state == .waiting
+                && item.intent.source.path != parkedItem.intent.source.path
         }
     }
 

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -319,6 +319,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         if persistentQueueRunState == .running {
             return .noChange(.running)
         }
+        if persistentQueueRunState == .pauseAfterCurrent {
+            return .noChange(.pauseAfterCurrent)
+        }
         guard !hasActiveWorker || activeDurableQueueItem != nil else {
             return .rejected(.otherWorkIsActive)
         }
@@ -399,6 +402,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         _ itemID: UUID,
         recoveryChoice: WorkerRecoveryChoice? = nil
     ) async -> Bool {
+        if persistentQueueRunState == .pauseAfterCurrent, hasActiveWorker {
+            return false
+        }
         if hasActiveWorker {
             switch activeRunMode {
             case .singleInspection, .singleConversion, nil:
@@ -2379,6 +2385,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 sourceFolderRecoveryChoices[itemID] = recoveryChoice.rawValue
             }
             adoptedItemIDs.insert(itemID)
+            persistentQueueControlsActive = true
+            persistentQueueRunState = .running
             publishSourceFolderQueueProjection()
             await pumpSourceFolderQueue()
         } catch {

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -3183,9 +3183,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                     && items[peerIndex].state == .waiting
                     && items[peerIndex].intent.source.path == unavailableSourcePath
                 {
-                    items[peerIndex].state = .failed
+                    items[peerIndex].state = .stopped
                     items[peerIndex].decision = nil
-                    items[peerIndex].failure = failure
+                    items[peerIndex].failure = nil
                     parkedItemIDs.insert(items[peerIndex].id)
                 }
             }

--- a/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
+++ b/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
@@ -23,10 +23,10 @@ struct ConversionQueueDocument: Codable, Equatable {
         self.init(version: Self.currentVersion, items: items)
     }
 
-    func restoredAfterLaunch() -> ConversionQueueDocument {
+    func restoredAfterLaunch(at restoredAt: Date = Date()) -> ConversionQueueDocument {
         ConversionQueueDocument(
             version: version,
-            items: items.map { $0.restoredAfterLaunch() }
+            items: items.map { $0.restoredAfterLaunch(at: restoredAt) }
         )
     }
 }
@@ -73,8 +73,11 @@ struct DurableConversionQueueItem: Codable, Equatable, Identifiable {
         self.resolutionTrace = resolutionTrace
     }
 
-    func restoredAfterLaunch() -> DurableConversionQueueItem {
+    func restoredAfterLaunch(at restoredAt: Date = Date()) -> DurableConversionQueueItem {
         var restored = self
+        for index in restored.attempts.indices where restored.attempts[index].endedAt == nil {
+            restored.attempts[index].endedAt = restoredAt
+        }
         switch state {
         case .inspecting, .processing, .stopping:
             restored.state = .interrupted

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+enum PersistentQueueRunState: Equatable {
+    case idle
+    case running
+    case pauseAfterCurrent
+    case paused
+}
+
+enum PersistentQueueCommandOutcome: Equatable {
+    case accepted(PersistentQueueRunState)
+    case noChange(PersistentQueueRunState)
+    case rejected(PersistentQueueCommandRejection)
+}
+
+enum PersistentQueueCommandRejection: Equatable {
+    case noEligibleItems
+    case noActiveItem
+    case queueIsNotRunning
+    case otherWorkIsActive
+}
+
 enum PersistentQueueItemStatus: Equatable {
     case waiting
     case inspecting

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -430,9 +430,17 @@ struct ContentView: View {
             makeMKVAvailable: DiscSourceDetector.makeMKVAvailable,
             activeProgress: viewModel.state.progress,
             activeElapsedText: viewModel.state.elapsedText,
+            runState: viewModel.persistentQueueRunState,
             canStart: persistentQueueCanStart
+                && viewModel.persistentQueueRunState != .running
+                && viewModel.persistentQueueRunState != .pauseAfterCurrent
                 && !viewModel.hasActiveWorker
                 && !previewViewModel.hasActiveWorker,
+            canPauseAfterCurrent: viewModel.persistentQueueRunState == .running
+                && viewModel.hasActiveWorker,
+            canStopCurrent: (viewModel.persistentQueueRunState == .running
+                || viewModel.persistentQueueRunState == .pauseAfterCurrent)
+                && viewModel.hasActiveWorker,
             canUndo: persistentQueueRemovalToken != nil,
             addSources: addSourcesToPersistentQueue,
             addSourceFolder: addSourceFolderToPersistentQueue,
@@ -442,7 +450,9 @@ struct ContentView: View {
             remove: removePersistentQueueItem,
             clearCompleted: clearCompletedPersistentQueueItems,
             undo: undoPersistentQueueRemoval,
-            start: startPersistentQueue
+            start: startPersistentQueue,
+            pauseAfterCurrent: pausePersistentQueueAfterCurrent,
+            stopCurrent: stopCurrentPersistentQueueItem
         )
     }
 
@@ -1427,9 +1437,35 @@ struct ContentView: View {
 
     private func startPersistentQueue() {
         Task { @MainActor in
-            if await viewModel.startPersistentQueue() == 0 {
-                persistentQueueErrorMessage = "No queued videos are currently ready to start."
+            let outcome = await viewModel.startPersistentQueue()
+            if case let .rejected(rejection) = outcome {
+                persistentQueueErrorMessage = persistentQueueCommandMessage(for: rejection)
             }
+        }
+    }
+
+    private func pausePersistentQueueAfterCurrent() {
+        if case let .rejected(rejection) = viewModel.pausePersistentQueueAfterCurrent() {
+            persistentQueueErrorMessage = persistentQueueCommandMessage(for: rejection)
+        }
+    }
+
+    private func stopCurrentPersistentQueueItem() {
+        if case let .rejected(rejection) = viewModel.stopCurrentPersistentQueueItem() {
+            persistentQueueErrorMessage = persistentQueueCommandMessage(for: rejection)
+        }
+    }
+
+    private func persistentQueueCommandMessage(for rejection: PersistentQueueCommandRejection) -> String {
+        switch rejection {
+        case .noEligibleItems:
+            "No queued videos are currently ready to start."
+        case .noActiveItem:
+            "No queue video is currently running."
+        case .queueIsNotRunning:
+            "Start or resume the queue before using this control."
+        case .otherWorkIsActive:
+            "Wait for the current conversion to finish before starting the queue."
         }
     }
 

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1471,6 +1471,10 @@ struct ContentView: View {
         _ item: PersistentQueueItem,
         recoveryChoice: WorkerRecoveryChoice?
     ) {
+        if viewModel.persistentQueueRunState == .pauseAfterCurrent, viewModel.hasActiveWorker {
+            persistentQueueErrorMessage = "Wait for the current video to finish and the queue to pause before restarting this item."
+            return
+        }
         Task { @MainActor in
             if !(await viewModel.adoptPersistentQueueItem(item.id, recoveryChoice: recoveryChoice)) {
                 persistentQueueErrorMessage = "This queued video could not be restarted. Review its source and recovery choice."

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -461,9 +461,7 @@ struct ContentView: View {
             switch item.status {
             case .waiting, .interrupted, .stopped, .notStarted:
                 true
-            case let .failed(failure):
-                failure.retryable
-            case .inspecting, .processing, .stopping, .attention, .completed:
+            case .inspecting, .processing, .stopping, .attention, .failed, .completed:
                 false
             }
         }

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -9,7 +9,10 @@ struct PersistentQueueSidebarView: View {
     let makeMKVAvailable: Bool
     let activeProgress: WorkerProgress?
     let activeElapsedText: String?
+    let runState: PersistentQueueRunState
     let canStart: Bool
+    let canPauseAfterCurrent: Bool
+    let canStopCurrent: Bool
     let canUndo: Bool
     let addSources: () -> Void
     let addSourceFolder: () -> Void
@@ -20,6 +23,8 @@ struct PersistentQueueSidebarView: View {
     let clearCompleted: () -> Void
     let undo: () -> Void
     let start: () -> Void
+    let pauseAfterCurrent: () -> Void
+    let stopCurrent: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -189,11 +194,22 @@ struct PersistentQueueSidebarView: View {
                         .buttonStyle(.borderless)
                 }
             }
-            Button(startButtonTitle, action: start)
-                .buttonStyle(.borderedProminent)
-                .disabled(!canStart)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .accessibilityIdentifier("persistent-queue-start")
+            HStack(spacing: 8) {
+                Button(startButtonTitle, action: start)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canStart)
+                    .accessibilityIdentifier("persistent-queue-start")
+                    .accessibilityLabel(startButtonTitle)
+                Button("Pause After Current", action: pauseAfterCurrent)
+                    .disabled(!canPauseAfterCurrent)
+                    .accessibilityIdentifier("persistent-queue-pause-after-current")
+                    .accessibilityLabel("Pause queue after the current video")
+                Button("Stop Current", role: .destructive, action: stopCurrent)
+                    .disabled(!canStopCurrent)
+                    .accessibilityIdentifier("persistent-queue-stop-current")
+                    .accessibilityLabel("Stop only the current video")
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -209,10 +225,20 @@ struct PersistentQueueSidebarView: View {
         selectedID.flatMap { id in items.first(where: { $0.id == id }) }
     }
     private var startButtonTitle: String {
-        items.contains(where: { $0.isRestored || $0.status.isStopped }) ? "Resume Queue" : "Start Queue"
+        runState == .paused || items.contains(where: { $0.isRestored || $0.status.isStopped })
+            ? "Resume Queue"
+            : "Start Queue"
     }
 
     private var banner: (title: String, systemImage: String, tint: Color)? {
+        switch runState {
+        case .pauseAfterCurrent:
+            return ("Pause requested — the current video will finish before the queue pauses.", "pause.circle.fill", .orange)
+        case .paused:
+            return ("Queue paused — pending videos remain waiting until you resume.", "pause.circle.fill", .secondary)
+        case .idle, .running:
+            break
+        }
         if items.contains(where: \.isRestored) {
             return ("Queue restored — interrupted videos require an explicit restart.", "arrow.counterclockwise.circle.fill", .orange)
         }

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -194,20 +194,23 @@ struct PersistentQueueSidebarView: View {
                         .buttonStyle(.borderless)
                 }
             }
-            HStack(spacing: 8) {
+            VStack(alignment: .trailing, spacing: 8) {
                 Button(startButtonTitle, action: start)
                     .buttonStyle(.borderedProminent)
                     .disabled(!canStart)
+                    .frame(maxWidth: .infinity)
                     .accessibilityIdentifier("persistent-queue-start")
                     .accessibilityLabel(startButtonTitle)
-                Button("Pause After Current", action: pauseAfterCurrent)
-                    .disabled(!canPauseAfterCurrent)
-                    .accessibilityIdentifier("persistent-queue-pause-after-current")
-                    .accessibilityLabel("Pause queue after the current video")
-                Button("Stop Current", role: .destructive, action: stopCurrent)
-                    .disabled(!canStopCurrent)
-                    .accessibilityIdentifier("persistent-queue-stop-current")
-                    .accessibilityLabel("Stop only the current video")
+                HStack(spacing: 8) {
+                    Button("Pause After Current", action: pauseAfterCurrent)
+                        .disabled(!canPauseAfterCurrent)
+                        .accessibilityIdentifier("persistent-queue-pause-after-current")
+                        .accessibilityLabel("Pause queue after the current video")
+                    Button("Stop Current", role: .destructive, action: stopCurrent)
+                        .disabled(!canStopCurrent)
+                        .accessibilityIdentifier("persistent-queue-stop-current")
+                        .accessibilityLabel("Stop only the current video")
+                }
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         }

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -95,12 +95,12 @@ final class ConversionQueueStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testEphemeralStatesRestoreAsInterruptedWithoutChangingDurableStates() async throws {
+    func testEphemeralStatesRestoreAsInterruptedAndPersistClosedAttempts() async throws {
         let directoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let fileURL = directoryURL.appendingPathComponent("queue.json")
         let states = DurableQueueItemState.allCases
-        let items = states.enumerated().map { offset, state in
+        var items = states.enumerated().map { offset, state in
             makeItem(
                 ordinal: offset,
                 sourcePath: "/tmp/source-\(offset).mkv",
@@ -123,6 +123,9 @@ final class ConversionQueueStoreTests: XCTestCase {
                 result: state == .completed ? DurableQueueResult(outputPath: "/tmp/output.mov") : nil
             )
         }
+        for index in items.indices where [.inspecting, .processing, .stopping].contains(items[index].state) {
+            items[index].attempts = [DurableQueueAttempt(startedAt: Date(timeIntervalSince1970: 1))]
+        }
         let store = ConversionQueueStore(fileURL: fileURL)
         try await store.replaceItems(items)
 
@@ -139,6 +142,15 @@ final class ConversionQueueStoreTests: XCTestCase {
         }
         let attention = try XCTUnwrap(restored.first(where: { $0.state == .attention }))
         XCTAssertTrue(try XCTUnwrap(attention.decision).staleAfterRestore)
+        XCTAssertTrue(restored
+            .filter { $0.state == .interrupted }
+            .allSatisfy { $0.attempts.allSatisfy { $0.endedAt != nil } })
+
+        let reopened = ConversionQueueStore(fileURL: fileURL).items
+        XCTAssertEqual(reopened.map(\.state), restored.map(\.state))
+        XCTAssertTrue(reopened
+            .filter { $0.state == .interrupted }
+            .allSatisfy { $0.attempts.allSatisfy { $0.endedAt != nil } })
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -3298,6 +3298,40 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueAttentionParksWithoutStrandingRunState() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let item = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        try await queueStore.replaceItems([item])
+        let conversionStarted = expectation(description: "conversion started")
+        let worker = TwoPhaseWorkerClient(
+            onConversionJobReceived: { _ in conversionStarted.fulfill() },
+            recoveryDecision: WorkerDecision(
+                identifier: "subtitle_decision_required",
+                prompt: "Retry without subtitles?",
+                choices: [WorkerRecoveryChoice.retryWithoutSubtitles.rawValue],
+                details: nil
+            )
+        )
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [conversionStarted], timeout: 2)
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        XCTAssertEqual(queueStore.items.first?.state, .attention)
+        XCTAssertNil(viewModel.state.recoveryDecision)
+        XCTAssertEqual(viewModel.persistentQueueRunState, .idle)
+        let rejectedRestart = await viewModel.startPersistentQueue()
+        XCTAssertEqual(rejectedRestart, .rejected(.noEligibleItems))
+        XCTAssertEqual(viewModel.persistentQueueRunState, .idle)
+    }
+
+    @MainActor
     func testAdoptedMixedOriginsSerializeThroughGlobalPump() async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -4037,6 +4071,7 @@ final class ConversionViewModelTests: XCTestCase {
 
         let startOutcome = await viewModel.startPersistentQueue()
         XCTAssertEqual(startOutcome, .rejected(.noEligibleItems))
+        XCTAssertEqual(viewModel.persistentQueueRunState, .idle)
         XCTAssertEqual(viewModel.pausePersistentQueueAfterCurrent(), .rejected(.queueIsNotRunning))
         XCTAssertEqual(viewModel.stopCurrentPersistentQueueItem(), .rejected(.queueIsNotRunning))
         XCTAssertEqual(viewModel.stopAllPersistentQueue(), .rejected(.noActiveItem))
@@ -4607,6 +4642,7 @@ final class ConversionViewModelTests: XCTestCase {
         if case .failed = viewModel.queueItems[1].status {} else {
             XCTFail("The remaining queue item should park when its shared source becomes unavailable.")
         }
+        XCTAssertTrue(viewModel.restoredDurableQueueItems[1].attempts.isEmpty)
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -3206,13 +3206,15 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testDurableSingleDecisionPausesPumpAndRetriesOwnedItem() async throws {
+    func testDurableSingleDecisionParksItemContinuesPeerAndRetriesExplicitly() async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let sourceURL = directoryURL.appendingPathComponent("feature.mkv")
+        let peerURL = directoryURL.appendingPathComponent("peer.mkv")
         _ = FileManager.default.createFile(atPath: sourceURL.path, contents: Data("video".utf8))
+        _ = FileManager.default.createFile(atPath: peerURL.path, contents: Data("peer".utf8))
         let inspection = SourceInspection(
             name: "Feature",
             resolution: "1920x1080",
@@ -3231,8 +3233,21 @@ final class ConversionViewModelTests: XCTestCase {
             origin: .singleSource,
             intent: DurableQueueItemIntent(draft: draft),
             inspection: inspection,
-            state: .failed,
-            failure: DurableQueueFailure(code: "temporary", message: "Temporary", details: nil, retryable: true)
+            state: .waiting
+        )
+        let peerDraft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: peerURL),
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: directoryURL,
+            options: ConversionOptions()
+        )
+        let peer = DurableConversionQueueItem(
+            ordinal: 1,
+            origin: .singleSource,
+            intent: DurableQueueItemIntent(draft: peerDraft),
+            inspection: inspection,
+            state: .waiting
         )
         let decision = WorkerDecision(
             identifier: "subtitle_decision_required",
@@ -3241,8 +3256,9 @@ final class ConversionViewModelTests: XCTestCase {
             details: nil
         )
         let queueStore = ConversionQueueStore.inMemory()
-        try await queueStore.replaceItems([item])
+        try await queueStore.replaceItems([item, peer])
         let firstStarted = expectation(description: "first conversion started")
+        let peerStarted = expectation(description: "eligible peer started")
         let retryStarted = expectation(description: "retry conversion started")
         var conversionCount = 0
         let worker = TwoPhaseWorkerClient(
@@ -3250,6 +3266,8 @@ final class ConversionViewModelTests: XCTestCase {
                 conversionCount += 1
                 if conversionCount == 1 {
                     firstStarted.fulfill()
+                } else if conversionCount == 2 {
+                    peerStarted.fulfill()
                 } else {
                     retryStarted.fulfill()
                 }
@@ -3258,25 +3276,23 @@ final class ConversionViewModelTests: XCTestCase {
         )
         let viewModel = ConversionViewModel(clientFactory: { worker }, durableQueueStore: queueStore)
 
-        let adopted = await viewModel.adoptPersistentQueueItem(item.id)
-        XCTAssertTrue(adopted)
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
         await fulfillment(of: [firstStarted], timeout: 2)
-        while viewModel.state.phase != WorkerPhase.decisionRequired || queueStore.items.first?.state != .attention {
-            await Task.yield()
-        }
+        await fulfillment(of: [peerStarted], timeout: 2)
+        while viewModel.hasActiveWork { await Task.yield() }
 
-        XCTAssertEqual(viewModel.state.recoveryDecision, decision)
-        let readoptedActiveItem = await viewModel.adoptPersistentQueueItem(
+        XCTAssertEqual(queueStore.items.map(\.state), [.attention, .completed])
+        XCTAssertNil(viewModel.state.recoveryDecision)
+        let readoptedParkedItem = await viewModel.adoptPersistentQueueItem(
             item.id,
             recoveryChoice: .retryWithoutSubtitles
         )
-        XCTAssertFalse(readoptedActiveItem)
-        XCTAssertEqual(queueStore.items.first?.state, .attention)
-        XCTAssertTrue(viewModel.resolveRecoveryChoice(.retryWithoutSubtitles))
+        XCTAssertTrue(readoptedParkedItem)
         await fulfillment(of: [retryStarted], timeout: 2)
         while viewModel.hasActiveWork { await Task.yield() }
 
-        XCTAssertEqual(queueStore.items.first?.state, .completed)
+        XCTAssertEqual(queueStore.items.map(\.state), [.completed, .completed])
         XCTAssertEqual(queueStore.items.first?.intent.options.encoding.subtitles.mode, .off)
         XCTAssertEqual(queueStore.items.first?.attempts.count, 2)
     }
@@ -4101,6 +4117,36 @@ final class ConversionViewModelTests: XCTestCase {
         let second = makePersistentQueueFixture(ordinal: 1, state: .waiting)
         try await queueStore.replaceItems([first, second])
         let started = expectation(description: "queue item started")
+        let worker = CancellableInspectionWorkerClient(onStarted: { started.fulfill() })
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertEqual(viewModel.stopCurrentPersistentQueueItem(), .accepted(.paused))
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        XCTAssertEqual(queueStore.items.map(\.state), [.stopped, .waiting])
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+        XCTAssertEqual(viewModel.stopCurrentPersistentQueueItem(), .noChange(.paused))
+    }
+
+    @MainActor
+    func testStopCurrentIdentifiesActiveSourceFolderItem() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let sourceFolderItem = makePersistentQueueFixture(
+            ordinal: 0,
+            groupID: UUID(),
+            origin: .sourceFolder,
+            state: .waiting
+        )
+        let waitingPeer = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        try await queueStore.replaceItems([sourceFolderItem, waitingPeer])
+        let started = expectation(description: "source folder queue item started")
         let worker = CancellableInspectionWorkerClient(onStarted: { started.fulfill() })
         let viewModel = ConversionViewModel(
             clientFactory: { worker },

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -3609,7 +3609,7 @@ final class ConversionViewModelTests: XCTestCase {
                 convertedTitleIDs.append(job.source.titleID ?? "")
                 if conversionNumber == 1 {
                     firstStarted.fulfill()
-                } else {
+                } else if job.source.titleID == "B1" {
                     secondStarted.fulfill()
                 }
             },
@@ -3629,8 +3629,8 @@ final class ConversionViewModelTests: XCTestCase {
         await fulfillment(of: [secondStarted], timeout: 2)
         while viewModel.hasActiveWork { await Task.yield() }
 
-        XCTAssertEqual(convertedTitleIDs, ["A1", "B1"])
-        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .stopped, .completed])
+        XCTAssertEqual(convertedTitleIDs, ["A1", "A2", "B1"])
+        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .completed, .completed])
     }
 
     @MainActor
@@ -4006,13 +4006,116 @@ final class ConversionViewModelTests: XCTestCase {
         XCTAssertEqual(queueStore.items.first?.state, .waiting)
         XCTAssertFalse(viewModel.hasActiveWork)
 
-        let adoptedCount = await viewModel.startPersistentQueue()
-        XCTAssertEqual(adoptedCount, 1)
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
         await fulfillment(of: [completed], timeout: 2)
         while viewModel.hasActiveWork { await Task.yield() }
 
         XCTAssertEqual(queueStore.items.count, 1)
         XCTAssertEqual(queueStore.items.first?.state, .completed)
+    }
+
+    @MainActor
+    func testPersistentQueueCommandsRejectInvalidTransitions() async throws {
+        let viewModel = ConversionViewModel(durableQueueStore: .inMemory())
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .rejected(.noEligibleItems))
+        XCTAssertEqual(viewModel.pausePersistentQueueAfterCurrent(), .rejected(.queueIsNotRunning))
+        XCTAssertEqual(viewModel.stopCurrentPersistentQueueItem(), .rejected(.queueIsNotRunning))
+        XCTAssertEqual(viewModel.stopAllPersistentQueue(), .rejected(.noActiveItem))
+    }
+
+    @MainActor
+    func testResumeSkipsParkedFailureAndRunsEligiblePeer() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        var failed = makePersistentQueueFixture(ordinal: 0, state: .failed)
+        failed.failure = DurableQueueFailure(
+            code: "temporary_failure",
+            message: "Temporary failure",
+            details: nil,
+            retryable: true
+        )
+        let waiting = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        try await queueStore.replaceItems([failed, waiting])
+        let completed = expectation(description: "eligible peer completed")
+        let worker = TwoPhaseWorkerClient(onConversionJobReceived: { _ in completed.fulfill() })
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [completed], timeout: 2)
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .completed])
+    }
+
+    @MainActor
+    func testPauseAfterCurrentKeepsPendingRowsWaitingUntilResume() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let first = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        let second = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        try await queueStore.replaceItems([first, second])
+        let firstStarted = expectation(description: "first queue item started")
+        let secondStarted = expectation(description: "second queue item started")
+        secondStarted.isInverted = true
+        let gate = QueueTestGate()
+        let worker = ReorderableQueueWorkerClient(
+            inspectionDone: {},
+            conversionStarted: { _, conversionNumber in
+                if conversionNumber == 1 {
+                    firstStarted.fulfill()
+                } else {
+                    secondStarted.fulfill()
+                }
+            },
+            conversionGate: gate
+        )
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [firstStarted], timeout: 2)
+        XCTAssertEqual(viewModel.pausePersistentQueueAfterCurrent(), .accepted(.pauseAfterCurrent))
+        XCTAssertEqual(viewModel.pausePersistentQueueAfterCurrent(), .noChange(.pauseAfterCurrent))
+        await gate.open()
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        await fulfillment(of: [secondStarted], timeout: 0.1)
+        XCTAssertEqual(queueStore.items.map(\.state), [.completed, .waiting])
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+    }
+
+    @MainActor
+    func testStopCurrentPausesWithoutDemotingWaitingPeers() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let first = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        let second = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        try await queueStore.replaceItems([first, second])
+        let started = expectation(description: "queue item started")
+        let worker = CancellableInspectionWorkerClient(onStarted: { started.fulfill() })
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertEqual(viewModel.stopCurrentPersistentQueueItem(), .accepted(.paused))
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        XCTAssertEqual(queueStore.items.map(\.state), [.stopped, .waiting])
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
     }
 
     @MainActor
@@ -4158,7 +4261,7 @@ final class ConversionViewModelTests: XCTestCase {
         viewModel.startConversionQueue(drafts: makeDiscQueueDrafts(source: source, destinationURL: directoryURL))
         while viewModel.hasActiveWork { await Task.yield() }
 
-        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .stopped])
+        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .failed])
         XCTAssertEqual(queueStore.items.first?.failure?.message, RuntimePersistenceTestError.workerLaunchFailed.localizedDescription)
         XCTAssertNotNil(queueStore.items.first?.attempts.last?.endedAt)
     }
@@ -4455,8 +4558,8 @@ final class ConversionViewModelTests: XCTestCase {
         if case .failed = viewModel.queueItems[0].status {} else {
             XCTFail("The active queue item should be marked failed.")
         }
-        if case .cancelled = viewModel.queueItems[1].status {} else {
-            XCTFail("The pending queue item should be marked cancelled.")
+        if case .failed = viewModel.queueItems[1].status {} else {
+            XCTFail("The remaining queue item should park when its shared source becomes unavailable.")
         }
     }
 

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -4146,6 +4146,60 @@ final class ConversionViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testPauseAfterCurrentRejectsAttentionRetryUntilActiveItemFinishes() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let active = makePersistentQueueFixture(ordinal: 0, state: .waiting)
+        let waiting = makePersistentQueueFixture(ordinal: 1, state: .waiting)
+        var attention = makePersistentQueueFixture(ordinal: 2, state: .attention)
+        attention.decision = DurableQueueDecision(
+            identifier: "subtitle_decision_required",
+            prompt: "Retry without subtitles?",
+            choices: [WorkerRecoveryChoice.retryWithoutSubtitles.rawValue]
+        )
+        try await queueStore.replaceItems([active, waiting, attention])
+        let firstStarted = expectation(description: "active item started")
+        let secondStarted = expectation(description: "waiting item started")
+        secondStarted.isInverted = true
+        let gate = QueueTestGate()
+        let worker = ReorderableQueueWorkerClient(
+            inspectionDone: {},
+            conversionStarted: { _, conversionNumber in
+                if conversionNumber == 1 {
+                    firstStarted.fulfill()
+                } else {
+                    secondStarted.fulfill()
+                }
+            },
+            conversionGate: gate
+        )
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let startOutcome = await viewModel.startPersistentQueue()
+        XCTAssertEqual(startOutcome, .accepted(.running))
+        await fulfillment(of: [firstStarted], timeout: 2)
+        XCTAssertEqual(viewModel.pausePersistentQueueAfterCurrent(), .accepted(.pauseAfterCurrent))
+
+        let retryAccepted = await viewModel.adoptPersistentQueueItem(
+            attention.id,
+            recoveryChoice: .retryWithoutSubtitles
+        )
+        XCTAssertFalse(retryAccepted)
+        XCTAssertEqual(viewModel.persistentQueueRunState, .pauseAfterCurrent)
+        XCTAssertEqual(queueStore.items[2].state, .attention)
+
+        await gate.open()
+        while viewModel.hasActiveWork { await Task.yield() }
+
+        await fulfillment(of: [secondStarted], timeout: 0.1)
+        XCTAssertEqual(queueStore.items.map(\.state), [.completed, .waiting, .attention])
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+    }
+
+    @MainActor
     func testStopCurrentPausesWithoutDemotingWaitingPeers() async throws {
         let queueStore = ConversionQueueStore.inMemory()
         let first = makePersistentQueueFixture(ordinal: 0, state: .waiting)

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -4693,8 +4693,8 @@ final class ConversionViewModelTests: XCTestCase {
         if case .failed = viewModel.queueItems[0].status {} else {
             XCTFail("The active queue item should be marked failed.")
         }
-        if case .failed = viewModel.queueItems[1].status {} else {
-            XCTFail("The remaining queue item should park when its shared source becomes unavailable.")
+        if case .cancelled = viewModel.queueItems[1].status {} else {
+            XCTFail("The remaining queue item should remain resumable when its shared source becomes unavailable.")
         }
         XCTAssertTrue(viewModel.restoredDurableQueueItems[1].attempts.isEmpty)
     }

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -46,7 +46,10 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 makeMKVAvailable: true,
                 activeProgress: WorkerProgress(currentStage: 3, totalStages: 5, stageFraction: 0.61),
                 activeElapsedText: "1:12:31",
+                runState: .running,
                 canStart: !items.isEmpty,
+                canPauseAfterCurrent: !items.isEmpty,
+                canStopCurrent: !items.isEmpty,
                 canUndo: true,
                 addSources: {},
                 addSourceFolder: {},
@@ -56,7 +59,9 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 remove: { _ in },
                 clearCompleted: {},
                 undo: {},
-                start: {}
+                start: {},
+                pauseAfterCurrent: {},
+                stopCurrent: {}
             )
             .frame(minWidth: 300, idealWidth: 330, maxWidth: 420)
             PersistentQueueDetailView(


### PR DESCRIPTION
## Summary
- add typed persistent-queue command outcomes and explicit run states
- add Start/Resume, Pause After Current, and Stop Current controls
- park failures and attention without blocking unrelated eligible sources
- persist honest interrupted recovery with closed attempts across relaunch
- keep same-source unavailable peers resumable without spawning redundant workers

## Validation
- `uv run python scripts/native_app.py test` — 518 tests passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — passed, including packaged worker-cancellation and preview-presentation smokes
- Opus exact-head final review — ready to merge, no blockers
- Gemini/Antigravity exact-head final review attempted — returned no output
- JetBrains changed-files inspection — UNKNOWN because IDE lifecycle mutated `.idea`; generated mutations were removed and the exact worktree is clean

Refs #545
