### PR TITLE
Add off-peak queue scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ cancels only the active video and leaves pending work waiting for an explicit
 resume. Failed videos and items needing attention stay parked so unrelated
 eligible queue work can continue.
 
+Use **Start Later…** to arm one editable, cancellable off-peak window for the
+queue. The app must remain open: it does not schedule a system wake and does
+not keep the Mac awake merely because a window is armed. If the Mac wakes while
+the window is still open, the queue starts late; reopening the app after the
+start time or evaluating after the end marks the window missed and never starts
+it automatically. A video already running may finish after the end, but no new
+video starts outside the window. Sources are rechecked at launch time, and
+missing removable media or the wrong physical disc is parked while unrelated
+available work continues.
+
 ## Terminal Usage
 
 Navigate to the tool's directory in your terminal and execute the command with the required and optional parameters:

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -41,9 +41,11 @@ struct BluRayToVisionProApp: App {
         let resolutionMemoryStore = ResolutionMemoryStore()
         let profileStore = ProfileStore(resolutionMemoryStore: resolutionMemoryStore)
         let durableQueueStore = ConversionQueueStore()
+        let offPeakScheduleStore = OffPeakScheduleStore()
         let viewModel = ConversionViewModel(
             observabilityEventStore: observabilityEventStore,
-            durableQueueStore: durableQueueStore
+            durableQueueStore: durableQueueStore,
+            offPeakScheduleStore: offPeakScheduleStore
         )
         let previewViewModel = PreviewViewModel(observabilityEventStore: observabilityEventStore)
         let workCoordinator = AppWorkCoordinator(conversion: viewModel, preview: previewViewModel)

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -377,26 +377,40 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         {
             return .waiting(schedule)
         }
+        var consumedSchedule: OffPeakQueueSchedule?
         do {
             let evaluation = try await offPeakScheduleStore.evaluate(
                 at: diagnosticClock(),
                 appLaunched: appLaunched
             )
             offPeakScheduleErrorMessage = nil
-            guard case let .start(consumedSchedule) = evaluation else {
+            guard case let .start(startedSchedule) = evaluation else {
                 return evaluation
             }
+            consumedSchedule = startedSchedule
             try await parkUnavailableScheduledQueueItems()
-            let outcome = await startPersistentQueue(windowEnd: consumedSchedule.endAt)
-            if case .rejected = outcome {
+            let outcome = await startPersistentQueue(windowEnd: startedSchedule.endAt)
+            if case let .rejected(rejection) = outcome {
                 offPeakRunWindowEnd = nil
-                try await offPeakScheduleStore.markStartedScheduleWithoutRunnableItems(
-                    scheduleID: consumedSchedule.id,
+                let reason: OffPeakScheduleMissReason = rejection == .noEligibleItems
+                    ? .noRunnableItems
+                    : .queueBecameActive
+                try await offPeakScheduleStore.markStartedScheduleMissed(
+                    scheduleID: startedSchedule.id,
+                    reason: reason,
                     at: diagnosticClock()
                 )
             }
+            consumedSchedule = nil
             return evaluation
         } catch {
+            if let consumedSchedule {
+                try? await offPeakScheduleStore.markStartedScheduleMissed(
+                    scheduleID: consumedSchedule.id,
+                    reason: .queuePersistenceFailed,
+                    at: diagnosticClock()
+                )
+            }
             offPeakScheduleErrorMessage = error.localizedDescription
             return .none
         }
@@ -459,6 +473,11 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                     items[index].state = offset == 0 ? .failed : .stopped
                     items[index].decision = nil
                     items[index].failure = offset == 0 ? failure : nil
+                    if offset == 0,
+                       let attemptIndex = items[index].attempts.lastIndex(where: { $0.endedAt == nil })
+                    {
+                        items[index].attempts[attemptIndex].endedAt = diagnosticClock()
+                    }
                     parkedItemIDs.insert(items[index].id)
                 }
             }

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -66,6 +66,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var durableQueueRuntimeDiagnostic: String?
     @Published private(set) var setupQueueStartFailureItemIDs: Set<UUID> = []
     @Published private(set) var persistentQueueRunState: PersistentQueueRunState = .idle
+    @Published private(set) var offPeakSchedule: OffPeakQueueSchedule?
+    @Published private(set) var offPeakScheduleOutcome: OffPeakScheduleOutcome?
+    @Published private(set) var offPeakScheduleErrorMessage: String?
 
     private let clientFactory: ClientFactory
     private let diagnosticClock: () -> Date
@@ -73,6 +76,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private let diagnosticBundleBuilder: DiagnosticBundleBuilder
     private let observabilityEventStore: any ObservabilityEventPersisting
     private let durableQueueStore: ConversionQueueStore
+    private let offPeakScheduleStore: OffPeakScheduleStore
     private let sourceAvailabilityResolver: SourceAvailabilityResolver
     private let diagnosticRecorder = DiagnosticSessionRecorder()
     private var client: (any WorkerProcessRunning)?
@@ -98,6 +102,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private var durableSingleJobIDs: [UUID: UUID] = [:]
     private var batchItemDiagnosticJobIDs: [UUID: UUID] = [:]
     private var durableQueueSubscription: AnyCancellable?
+    private var offPeakScheduleSubscription: AnyCancellable?
+    private var offPeakRunWindowEnd: Date?
 
     init(
         clientFactory: @escaping ClientFactory = {
@@ -108,6 +114,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         diagnosticBundleBuilder: DiagnosticBundleBuilder? = nil,
         observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared,
         durableQueueStore: ConversionQueueStore? = nil,
+        offPeakScheduleStore: OffPeakScheduleStore? = nil,
         sourceAvailabilityResolver: @escaping SourceAvailabilityResolver = ConversionViewModel.defaultSourceAvailability
     ) {
         self.clientFactory = clientFactory
@@ -117,10 +124,18 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             ?? DiagnosticBundleBuilder(storageProbe: diagnosticStorageProbe)
         self.observabilityEventStore = observabilityEventStore
         self.durableQueueStore = durableQueueStore ?? ConversionQueueStore.inMemory()
+        self.offPeakScheduleStore = offPeakScheduleStore ?? OffPeakScheduleStore.inMemory()
         self.sourceAvailabilityResolver = sourceAvailabilityResolver
         durableQueueSubscription = self.durableQueueStore.$document.sink { [weak self] document in
             self?.publishPersistentQueueProjection(items: document.items)
         }
+        offPeakScheduleSubscription = self.offPeakScheduleStore.$document.sink { [weak self] document in
+            self?.offPeakSchedule = document.schedule
+            self?.offPeakScheduleOutcome = document.lastOutcome
+        }
+        offPeakSchedule = self.offPeakScheduleStore.schedule
+        offPeakScheduleOutcome = self.offPeakScheduleStore.lastOutcome
+        offPeakScheduleErrorMessage = self.offPeakScheduleStore.loadErrorMessage
     }
 
     var isRunning: Bool {
@@ -314,8 +329,147 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         )
     }
 
+    func saveOffPeakSchedule(startAt: Date, endAt: Date) async throws {
+        guard !hasActiveWorker,
+              pendingQueueTransition == nil,
+              pendingBatchContinuation == nil,
+              !isBatchRunning,
+              state.phase != .decisionRequired,
+              persistentQueueRunState != .running,
+              persistentQueueRunState != .pauseAfterCurrent
+        else {
+            throw OffPeakScheduleStoreError.queueIsActive
+        }
+        guard durableQueueStore.items.contains(where: Self.isScheduleEligible) else {
+            throw OffPeakScheduleStoreError.noEligibleItems
+        }
+        guard startAt > diagnosticClock(), endAt > startAt else {
+            throw OffPeakScheduleStoreError.invalidWindow
+        }
+        try await offPeakScheduleStore.save(OffPeakQueueSchedule(
+            startAt: startAt,
+            endAt: endAt,
+            createdAt: diagnosticClock()
+        ))
+        offPeakScheduleErrorMessage = nil
+    }
+
+    func cancelOffPeakSchedule() async throws {
+        try await offPeakScheduleStore.cancel()
+        offPeakScheduleErrorMessage = nil
+    }
+
+    func clearOffPeakScheduleOutcome() async throws {
+        try await offPeakScheduleStore.clearOutcome()
+        offPeakScheduleErrorMessage = nil
+    }
+
     @discardableResult
-    func startPersistentQueue() async -> PersistentQueueCommandOutcome {
+    func evaluateOffPeakSchedule(appLaunched: Bool = false) async -> OffPeakScheduleEvaluation {
+        guard let schedule = offPeakScheduleStore.schedule else {
+            return .none
+        }
+        if hasActiveWorker
+            || pendingQueueTransition != nil
+            || state.phase == .decisionRequired
+            || persistentQueueRunState == .running
+            || persistentQueueRunState == .pauseAfterCurrent
+        {
+            return .waiting(schedule)
+        }
+        do {
+            let evaluation = try await offPeakScheduleStore.evaluate(
+                at: diagnosticClock(),
+                appLaunched: appLaunched
+            )
+            offPeakScheduleErrorMessage = nil
+            guard case let .start(consumedSchedule) = evaluation else {
+                return evaluation
+            }
+            try await parkUnavailableScheduledQueueItems()
+            let outcome = await startPersistentQueue(windowEnd: consumedSchedule.endAt)
+            if case .rejected = outcome {
+                offPeakRunWindowEnd = nil
+                try await offPeakScheduleStore.markStartedScheduleWithoutRunnableItems(
+                    scheduleID: consumedSchedule.id,
+                    at: diagnosticClock()
+                )
+            }
+            return evaluation
+        } catch {
+            offPeakScheduleErrorMessage = error.localizedDescription
+            return .none
+        }
+    }
+
+    private static func isScheduleEligible(_ item: DurableConversionQueueItem) -> Bool {
+        switch item.state {
+        case .waiting, .interrupted, .stopped, .notStarted:
+            true
+        case .inspecting, .processing, .stopping, .attention, .failed, .completed:
+            false
+        }
+    }
+
+    private func parkUnavailableScheduledQueueItems() async throws {
+        struct UnavailableSource: Hashable {
+            let kind: String
+            let path: String
+            let workerSourcePath: String?
+            let mediaIdentifier: String?
+        }
+
+        var unavailableSources: [UnavailableSource: DurableQueueFailure] = [:]
+        for item in durableQueueStore.items where Self.isScheduleEligible(item) {
+            let source = try? durableSource(for: item)
+            guard let source, sourceAvailabilityResolver(source) else {
+                let isPhysicalDisc = item.intent.source.kind == ConversionSourceKind.physicalDisc.rawValue
+                let sourceIdentity = UnavailableSource(
+                    kind: item.intent.source.kind,
+                    path: item.intent.source.path,
+                    workerSourcePath: item.intent.source.workerSourcePath,
+                    mediaIdentifier: item.intent.source.mediaIdentifier
+                )
+                unavailableSources[sourceIdentity] = DurableQueueFailure(
+                    code: isPhysicalDisc ? "scheduled_disc_unavailable" : "scheduled_source_unavailable",
+                    message: isPhysicalDisc
+                        ? "The required Blu-ray disc is not inserted."
+                        : "The scheduled source is no longer available.",
+                    details: item.intent.source.path,
+                    retryable: true
+                )
+                continue
+            }
+        }
+        guard !unavailableSources.isEmpty else {
+            return
+        }
+        var parkedItemIDs: Set<UUID> = []
+        try await durableQueueStore.mutateItems { items in
+            for (sourceIdentity, failure) in unavailableSources {
+                let matchingIndices = items.indices.filter { index in
+                    let source = items[index].intent.source
+                    return Self.isScheduleEligible(items[index])
+                        && source.kind == sourceIdentity.kind
+                        && source.path == sourceIdentity.path
+                        && source.workerSourcePath == sourceIdentity.workerSourcePath
+                        && source.mediaIdentifier == sourceIdentity.mediaIdentifier
+                }
+                for (offset, index) in matchingIndices.enumerated() {
+                    items[index].state = offset == 0 ? .failed : .stopped
+                    items[index].decision = nil
+                    items[index].failure = offset == 0 ? failure : nil
+                    parkedItemIDs.insert(items[index].id)
+                }
+            }
+        }
+        for itemID in parkedItemIDs {
+            releaseAdoption(itemID)
+        }
+    }
+
+    @discardableResult
+    func startPersistentQueue(windowEnd: Date? = nil) async -> PersistentQueueCommandOutcome {
         if persistentQueueRunState == .running {
             return .noChange(.running)
         }
@@ -338,7 +492,9 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         }
         let previousRunState = persistentQueueRunState
         let previousControlsActive = persistentQueueControlsActive
+        let previousWindowEnd = offPeakRunWindowEnd
         parkActiveDurableQueueItemForResume()
+        offPeakRunWindowEnd = windowEnd
         persistentQueueControlsActive = true
         persistentQueueRunState = .running
         durableQueueStopRequested = false
@@ -351,6 +507,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         guard adoptedCount > 0 else {
             persistentQueueRunState = previousRunState
             persistentQueueControlsActive = previousControlsActive
+            offPeakRunWindowEnd = previousWindowEnd
             return .rejected(.noEligibleItems)
         }
         return .accepted(.running)
@@ -1738,6 +1895,11 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         guard !hasActiveWorker, activeQueueItemID == nil else {
             return
         }
+        if let offPeakRunWindowEnd, diagnosticClock() >= offPeakRunWindowEnd {
+            self.offPeakRunWindowEnd = nil
+            await pauseDurableQueueNow()
+            return
+        }
         guard let item = durableQueueStore.items
             .filter({ adoptedItemIDs.contains($0.id) && $0.state == .waiting })
             .min(by: { $0.ordinal < $1.ordinal })
@@ -1746,6 +1908,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 persistentQueueRunState = .idle
             }
             persistentQueueControlsActive = false
+            offPeakRunWindowEnd = nil
             finishSourceFolderQueueIfNeeded()
             return
         }
@@ -2512,6 +2675,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         durableQueueRuntimeDiagnostic = "Queue changes are unavailable: \(error.localizedDescription)"
         persistentQueueRunState = .idle
         persistentQueueControlsActive = false
+        offPeakRunWindowEnd = nil
         if let projected = batchQueue {
             if sourceFolderQueueGroupID == nil {
                 batchQueue = SourceFolderQueueState(
@@ -3375,6 +3539,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         durableQueueRuntimeDiagnostic = "Queue changes are unavailable: \(error.localizedDescription)"
         persistentQueueRunState = .idle
         persistentQueueControlsActive = false
+        offPeakRunWindowEnd = nil
         publishSetupQueueStartFailure()
         activeQueueItemID = nil
         titleQueueGroupID = nil
@@ -3397,6 +3562,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         queueItems.removeAll()
         persistentQueueRunState = .idle
         persistentQueueControlsActive = false
+        offPeakRunWindowEnd = nil
         activeQueueItemID = nil
         titleQueueGroupID = nil
         titleQueueStopRequested = false

--- a/macos/BluRayToVisionPro/Feature/OffPeakScheduleStore.swift
+++ b/macos/BluRayToVisionPro/Feature/OffPeakScheduleStore.swift
@@ -1,0 +1,347 @@
+import Combine
+import Foundation
+
+struct OffPeakQueueSchedule: Codable, Equatable, Identifiable {
+    let id: UUID
+    let startAt: Date
+    let endAt: Date
+    let createdAt: Date
+
+    init(id: UUID = UUID(), startAt: Date, endAt: Date, createdAt: Date = Date()) {
+        self.id = id
+        self.startAt = startAt
+        self.endAt = endAt
+        self.createdAt = createdAt
+    }
+}
+
+enum OffPeakScheduleMissReason: String, Codable, Equatable {
+    case appRelaunchedAfterStart
+    case noRunnableItems
+    case windowEndedBeforeEvaluation
+
+    var message: String {
+        switch self {
+        case .appRelaunchedAfterStart:
+            "The scheduled window was missed because the app was reopened after it started."
+        case .noRunnableItems:
+            "The scheduled window opened, but no queued videos were available to start."
+        case .windowEndedBeforeEvaluation:
+            "The scheduled window was missed because the Mac was asleep or unavailable until after it ended."
+        }
+    }
+}
+
+enum OffPeakScheduleOutcomeKind: String, Codable, Equatable {
+    case started
+    case missed
+}
+
+struct OffPeakScheduleOutcome: Codable, Equatable {
+    let scheduleID: UUID
+    let kind: OffPeakScheduleOutcomeKind
+    let occurredAt: Date
+    let missReason: OffPeakScheduleMissReason?
+
+    static func started(scheduleID: UUID, at date: Date) -> OffPeakScheduleOutcome {
+        OffPeakScheduleOutcome(scheduleID: scheduleID, kind: .started, occurredAt: date, missReason: nil)
+    }
+
+    static func missed(
+        scheduleID: UUID,
+        reason: OffPeakScheduleMissReason,
+        at date: Date
+    ) -> OffPeakScheduleOutcome {
+        OffPeakScheduleOutcome(scheduleID: scheduleID, kind: .missed, occurredAt: date, missReason: reason)
+    }
+
+    var message: String {
+        switch kind {
+        case .started:
+            "Scheduled queue start was consumed."
+        case .missed:
+            missReason?.message ?? "The scheduled window was missed."
+        }
+    }
+}
+
+struct OffPeakScheduleDocument: Codable, Equatable {
+    static let currentVersion = 1
+
+    let version: Int
+    var schedule: OffPeakQueueSchedule?
+    var lastOutcome: OffPeakScheduleOutcome?
+
+    init(
+        version: Int = currentVersion,
+        schedule: OffPeakQueueSchedule? = nil,
+        lastOutcome: OffPeakScheduleOutcome? = nil
+    ) {
+        self.version = version
+        self.schedule = schedule
+        self.lastOutcome = lastOutcome
+    }
+
+    private enum CodingKeys: String, CodingKey { case version, schedule, lastOutcome }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try values.decode(Int.self, forKey: .version)
+        guard version == Self.currentVersion else {
+            throw OffPeakScheduleStoreError.unsupportedVersion(version)
+        }
+        self.init(
+            version: version,
+            schedule: try values.decodeIfPresent(OffPeakQueueSchedule.self, forKey: .schedule),
+            lastOutcome: try values.decodeIfPresent(OffPeakScheduleOutcome.self, forKey: .lastOutcome)
+        )
+    }
+}
+
+enum OffPeakScheduleEvaluation: Equatable {
+    case none
+    case waiting(OffPeakQueueSchedule)
+    case start(OffPeakQueueSchedule)
+    case missed(OffPeakScheduleMissReason)
+}
+
+enum OffPeakScheduleStoreError: LocalizedError, Equatable {
+    case invalidWindow
+    case noEligibleItems
+    case queueIsActive
+    case unsupportedVersion(Int)
+    case writesBlocked
+    case writeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidWindow:
+            "Choose a future start time and an end time after it."
+        case .noEligibleItems:
+            "Add or restore at least one runnable queue item before scheduling."
+        case .queueIsActive:
+            "Pause or finish the current queue before scheduling it."
+        case let .unsupportedVersion(version):
+            "Schedule data version \(version) is not supported."
+        case .writesBlocked:
+            "Schedule changes are disabled because its saved data could not be loaded safely."
+        case .writeFailed:
+            "The schedule could not be saved."
+        }
+    }
+}
+
+@MainActor
+final class OffPeakScheduleStore: ObservableObject {
+    @Published private(set) var document: OffPeakScheduleDocument
+    @Published private(set) var loadErrorMessage: String?
+    @Published private(set) var writesBlocked = false
+
+    private let fileURL: URL?
+    private let fileManager: FileManager
+    private let dataReader: (URL) throws -> Data
+    private let dataWriter: @Sendable (Data, URL) throws -> Void
+    private let mutationLock = OffPeakScheduleMutationLock()
+
+    init(
+        fileURL: URL? = nil,
+        fileManager: FileManager = .default,
+        dataReader: @escaping (URL) throws -> Data = { try Data(contentsOf: $0) },
+        dataWriter: @escaping @Sendable (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: .atomic)
+        },
+        inMemory: Bool = false
+    ) {
+        self.fileManager = fileManager
+        self.dataReader = dataReader
+        self.dataWriter = dataWriter
+        self.fileURL = inMemory ? nil : (fileURL ?? Self.defaultFileURL(fileManager: fileManager))
+        document = OffPeakScheduleDocument()
+        if let fileURL = self.fileURL {
+            load(from: fileURL)
+        }
+    }
+
+    static func inMemory() -> OffPeakScheduleStore {
+        OffPeakScheduleStore(inMemory: true)
+    }
+
+    var schedule: OffPeakQueueSchedule? { document.schedule }
+    var lastOutcome: OffPeakScheduleOutcome? { document.lastOutcome }
+
+    func save(_ schedule: OffPeakQueueSchedule) async throws {
+        guard schedule.endAt > schedule.startAt else {
+            throw OffPeakScheduleStoreError.invalidWindow
+        }
+        try await mutate { document in
+            document.schedule = schedule
+            document.lastOutcome = nil
+        }
+    }
+
+    func cancel() async throws {
+        try await mutate { document in
+            document.schedule = nil
+            document.lastOutcome = nil
+        }
+    }
+
+    func clearOutcome() async throws {
+        try await mutate { document in
+            document.lastOutcome = nil
+        }
+    }
+
+    func evaluate(at now: Date, appLaunched: Bool) async throws -> OffPeakScheduleEvaluation {
+        await mutationLock.lock()
+        do {
+            guard !writesBlocked else {
+                throw OffPeakScheduleStoreError.writesBlocked
+            }
+            guard let schedule = document.schedule else {
+                await mutationLock.unlock()
+                return .none
+            }
+            guard now >= schedule.startAt else {
+                await mutationLock.unlock()
+                return .waiting(schedule)
+            }
+
+            let evaluation: OffPeakScheduleEvaluation
+            if now >= schedule.endAt {
+                evaluation = .missed(.windowEndedBeforeEvaluation)
+            } else if appLaunched, now > schedule.startAt {
+                evaluation = .missed(.appRelaunchedAfterStart)
+            } else {
+                evaluation = .start(schedule)
+            }
+
+            var nextDocument = document
+            nextDocument.schedule = nil
+            switch evaluation {
+            case let .start(schedule):
+                nextDocument.lastOutcome = .started(scheduleID: schedule.id, at: now)
+            case let .missed(reason):
+                nextDocument.lastOutcome = .missed(scheduleID: schedule.id, reason: reason, at: now)
+            case .none, .waiting:
+                await mutationLock.unlock()
+                return evaluation
+            }
+            try persist(nextDocument)
+            document = nextDocument
+            await mutationLock.unlock()
+            return evaluation
+        } catch {
+            await mutationLock.unlock()
+            throw error
+        }
+    }
+
+    func markStartedScheduleWithoutRunnableItems(scheduleID: UUID, at date: Date) async throws {
+        try await mutate { document in
+            guard document.lastOutcome?.scheduleID == scheduleID,
+                  document.lastOutcome?.kind == .started
+            else {
+                return
+            }
+            document.lastOutcome = .missed(
+                scheduleID: scheduleID,
+                reason: .noRunnableItems,
+                at: date
+            )
+        }
+    }
+
+    private func mutate(_ mutation: (inout OffPeakScheduleDocument) throws -> Void) async throws {
+        await mutationLock.lock()
+        do {
+            guard !writesBlocked else {
+                throw OffPeakScheduleStoreError.writesBlocked
+            }
+            var nextDocument = document
+            try mutation(&nextDocument)
+            try persist(nextDocument)
+            document = nextDocument
+            await mutationLock.unlock()
+        } catch {
+            await mutationLock.unlock()
+            throw error
+        }
+    }
+
+    private func load(from fileURL: URL) {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return
+        }
+        do {
+            document = try Self.decoder().decode(OffPeakScheduleDocument.self, from: dataReader(fileURL))
+        } catch let error as OffPeakScheduleStoreError {
+            writesBlocked = true
+            loadErrorMessage = error.localizedDescription
+        } catch {
+            writesBlocked = true
+            loadErrorMessage = "Schedule data could not be loaded. Scheduling is disabled to avoid overwriting it."
+        }
+    }
+
+    private func persist(_ document: OffPeakScheduleDocument) throws {
+        guard let fileURL else {
+            return
+        }
+        do {
+            try fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try dataWriter(Self.encoder().encode(document), fileURL)
+        } catch {
+            throw OffPeakScheduleStoreError.writeFailed
+        }
+    }
+
+    private static func defaultFileURL(fileManager: FileManager) -> URL {
+        let applicationSupportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+        return applicationSupportURL
+            .appendingPathComponent("3D Blu-ray to Vision Pro", isDirectory: true)
+            .appendingPathComponent("queue.schedule.json")
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+private actor OffPeakScheduleMutationLock {
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func lock() async {
+        guard locked else {
+            locked = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func unlock() {
+        guard !waiters.isEmpty else {
+            locked = false
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/OffPeakScheduleStore.swift
+++ b/macos/BluRayToVisionPro/Feature/OffPeakScheduleStore.swift
@@ -18,6 +18,8 @@ struct OffPeakQueueSchedule: Codable, Equatable, Identifiable {
 enum OffPeakScheduleMissReason: String, Codable, Equatable {
     case appRelaunchedAfterStart
     case noRunnableItems
+    case queueBecameActive
+    case queuePersistenceFailed
     case windowEndedBeforeEvaluation
 
     var message: String {
@@ -26,6 +28,10 @@ enum OffPeakScheduleMissReason: String, Codable, Equatable {
             "The scheduled window was missed because the app was reopened after it started."
         case .noRunnableItems:
             "The scheduled window opened, but no queued videos were available to start."
+        case .queueBecameActive:
+            "The scheduled window opened, but other work became active before the queue could start."
+        case .queuePersistenceFailed:
+            "The scheduled window opened, but the queue could not be updated safely."
         case .windowEndedBeforeEvaluation:
             "The scheduled window was missed because the Mac was asleep or unavailable until after it ended."
         }
@@ -237,7 +243,11 @@ final class OffPeakScheduleStore: ObservableObject {
         }
     }
 
-    func markStartedScheduleWithoutRunnableItems(scheduleID: UUID, at date: Date) async throws {
+    func markStartedScheduleMissed(
+        scheduleID: UUID,
+        reason: OffPeakScheduleMissReason,
+        at date: Date
+    ) async throws {
         try await mutate { document in
             guard document.lastOutcome?.scheduleID == scheduleID,
                   document.lastOutcome?.kind == .started
@@ -246,7 +256,7 @@ final class OffPeakScheduleStore: ObservableObject {
             }
             document.lastOutcome = .missed(
                 scheduleID: scheduleID,
-                reason: .noRunnableItems,
+                reason: reason,
                 at: date
             )
         }

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -37,8 +37,15 @@ struct ContentView: View {
     @State private var isShowingTitleChooser = false
     @State private var isShowingDiagnosticReport = false
     @State private var isRefreshingDiscs = false
+    @State private var isShowingOffPeakSchedule = false
+    @State private var isEditingOffPeakSchedule = false
+    @State private var offPeakScheduleStartAt: Date
+    @State private var offPeakScheduleEndAt: Date
+    @State private var offPeakScheduleEditorError: String?
+    @State private var didEvaluateOffPeakScheduleAtLaunch = false
     @StateObject private var routeQualityState: RouteQualityResolutionState
     @StateObject private var setupQueue = SetupQueueAdmission()
+    private let offPeakScheduleTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     init(
         viewModel: ConversionViewModel,
@@ -70,6 +77,9 @@ struct ContentView: View {
         _selectedProfileID = State(initialValue: profile.id)
         _options = State(initialValue: initialOptions)
         _destinationURL = State(initialValue: settings.destinationURL)
+        let initialScheduleStart = Date().addingTimeInterval(15 * 60)
+        _offPeakScheduleStartAt = State(initialValue: initialScheduleStart)
+        _offPeakScheduleEndAt = State(initialValue: initialScheduleStart.addingTimeInterval(8 * 60 * 60))
         _routeQualityState = StateObject(wrappedValue: RouteQualityResolutionState())
     }
 
@@ -172,13 +182,32 @@ struct ContentView: View {
 
     private var lifecycleObservedContent: some View {
         baseContent
-        .onAppear(perform: refreshDiscs)
+        .onAppear {
+            refreshDiscs()
+            guard !didEvaluateOffPeakScheduleAtLaunch else { return }
+            didEvaluateOffPeakScheduleAtLaunch = true
+            evaluateOffPeakSchedule(appLaunched: true)
+        }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { _ in
             refreshDiscs()
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didUnmountNotification)) {
             notification in
             handleVolumeUnmount(notification)
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)) { _ in
+            evaluateOffPeakSchedule()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            evaluateOffPeakSchedule()
+        }
+        .onReceive(offPeakScheduleTimer) { _ in
+            evaluateOffPeakSchedule()
+        }
+        .onChange(of: previewViewModel.hasActiveWorker) { _, isActive in
+            if !isActive {
+                evaluateOffPeakSchedule()
+            }
         }
         .onChange(of: viewModel.hasActiveWorker) { _, isActive in
             if !isActive {
@@ -368,6 +397,19 @@ struct ContentView: View {
         .sheet(isPresented: $isShowingDiagnosticReport) {
             DiagnosticReportSheet(viewModel: diagnosticReportViewModel)
         }
+        .sheet(isPresented: $isShowingOffPeakSchedule) {
+            OffPeakScheduleSheet(
+                startAt: $offPeakScheduleStartAt,
+                endAt: $offPeakScheduleEndAt,
+                isEditing: isEditingOffPeakSchedule,
+                hasPhysicalDiscItems: viewModel.persistentQueueItems.contains {
+                    $0.draft.source.kind == .physicalDisc
+                },
+                errorMessage: offPeakScheduleEditorError,
+                cancel: { isShowingOffPeakSchedule = false },
+                save: saveOffPeakSchedule
+            )
+        }
         .alert(
             "Profile Could Not Be Saved",
             isPresented: Binding(
@@ -442,6 +484,9 @@ struct ContentView: View {
                 || viewModel.persistentQueueRunState == .pauseAfterCurrent)
                 && viewModel.hasActiveWorker,
             canUndo: persistentQueueRemovalToken != nil,
+            offPeakSchedule: viewModel.offPeakSchedule,
+            offPeakScheduleOutcome: viewModel.offPeakScheduleOutcome,
+            offPeakScheduleErrorMessage: viewModel.offPeakScheduleErrorMessage,
             addSources: addSourcesToPersistentQueue,
             addSourceFolder: addSourceFolderToPersistentQueue,
             addDisc: { appendSourcesToPersistentQueue([$0]) },
@@ -451,6 +496,10 @@ struct ContentView: View {
             clearCompleted: clearCompletedPersistentQueueItems,
             undo: undoPersistentQueueRemoval,
             start: startPersistentQueue,
+            startLater: presentNewOffPeakSchedule,
+            editSchedule: presentExistingOffPeakSchedule,
+            cancelSchedule: cancelOffPeakSchedule,
+            dismissScheduleOutcome: clearOffPeakScheduleOutcome,
             pauseAfterCurrent: pausePersistentQueueAfterCurrent,
             stopCurrent: stopCurrentPersistentQueueItem
         )
@@ -1435,10 +1484,77 @@ struct ContentView: View {
 
     private func startPersistentQueue() {
         Task { @MainActor in
+            if viewModel.offPeakSchedule != nil {
+                do {
+                    try await viewModel.cancelOffPeakSchedule()
+                } catch {
+                    persistentQueueErrorMessage = error.localizedDescription
+                    return
+                }
+            }
             let outcome = await viewModel.startPersistentQueue()
             if case let .rejected(rejection) = outcome {
                 persistentQueueErrorMessage = persistentQueueCommandMessage(for: rejection)
             }
+        }
+    }
+
+    private func presentNewOffPeakSchedule() {
+        let start = Date().addingTimeInterval(15 * 60)
+        offPeakScheduleStartAt = start
+        offPeakScheduleEndAt = start.addingTimeInterval(8 * 60 * 60)
+        offPeakScheduleEditorError = nil
+        isEditingOffPeakSchedule = false
+        isShowingOffPeakSchedule = true
+    }
+
+    private func presentExistingOffPeakSchedule() {
+        guard let schedule = viewModel.offPeakSchedule else { return }
+        offPeakScheduleStartAt = schedule.startAt
+        offPeakScheduleEndAt = schedule.endAt
+        offPeakScheduleEditorError = nil
+        isEditingOffPeakSchedule = true
+        isShowingOffPeakSchedule = true
+    }
+
+    private func saveOffPeakSchedule() {
+        Task { @MainActor in
+            do {
+                try await viewModel.saveOffPeakSchedule(
+                    startAt: offPeakScheduleStartAt,
+                    endAt: offPeakScheduleEndAt
+                )
+                isShowingOffPeakSchedule = false
+            } catch {
+                offPeakScheduleEditorError = error.localizedDescription
+            }
+        }
+    }
+
+    private func cancelOffPeakSchedule() {
+        Task { @MainActor in
+            do {
+                try await viewModel.cancelOffPeakSchedule()
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func clearOffPeakScheduleOutcome() {
+        Task { @MainActor in
+            do {
+                try await viewModel.clearOffPeakScheduleOutcome()
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func evaluateOffPeakSchedule(appLaunched: Bool = false) {
+        guard !previewViewModel.hasActiveWorker else { return }
+        Task { @MainActor in
+            _ = await viewModel.evaluateOffPeakSchedule(appLaunched: appLaunched)
         }
     }
 

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -43,9 +43,9 @@ struct ContentView: View {
     @State private var offPeakScheduleEndAt: Date
     @State private var offPeakScheduleEditorError: String?
     @State private var didEvaluateOffPeakScheduleAtLaunch = false
+    @State private var offPeakScheduleTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
     @StateObject private var routeQualityState: RouteQualityResolutionState
     @StateObject private var setupQueue = SetupQueueAdmission()
-    private let offPeakScheduleTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     init(
         viewModel: ConversionViewModel,
@@ -402,9 +402,7 @@ struct ContentView: View {
                 startAt: $offPeakScheduleStartAt,
                 endAt: $offPeakScheduleEndAt,
                 isEditing: isEditingOffPeakSchedule,
-                hasPhysicalDiscItems: viewModel.persistentQueueItems.contains {
-                    $0.draft.source.kind == .physicalDisc
-                },
+                hasPhysicalDiscItems: hasEligiblePhysicalDiscItems,
                 errorMessage: offPeakScheduleEditorError,
                 cancel: { isShowingOffPeakSchedule = false },
                 save: saveOffPeakSchedule
@@ -508,6 +506,18 @@ struct ContentView: View {
     private var persistentQueueCanStart: Bool {
         viewModel.persistentQueueItems.contains { item in
             switch item.status {
+            case .waiting, .interrupted, .stopped, .notStarted:
+                true
+            case .inspecting, .processing, .stopping, .attention, .failed, .completed:
+                false
+            }
+        }
+    }
+
+    private var hasEligiblePhysicalDiscItems: Bool {
+        viewModel.persistentQueueItems.contains { item in
+            guard item.draft.source.kind == .physicalDisc else { return false }
+            return switch item.status {
             case .waiting, .interrupted, .stopped, .notStarted:
                 true
             case .inspecting, .processing, .stopping, .attention, .failed, .completed:
@@ -1484,6 +1494,10 @@ struct ContentView: View {
 
     private func startPersistentQueue() {
         Task { @MainActor in
+            guard !previewViewModel.hasActiveWorker else {
+                persistentQueueErrorMessage = "Wait for the preview to finish before starting the queue."
+                return
+            }
             if viewModel.offPeakSchedule != nil {
                 do {
                     try await viewModel.cancelOffPeakSchedule()
@@ -1552,8 +1566,8 @@ struct ContentView: View {
     }
 
     private func evaluateOffPeakSchedule(appLaunched: Bool = false) {
-        guard !previewViewModel.hasActiveWorker else { return }
         Task { @MainActor in
+            guard !previewViewModel.hasActiveWorker else { return }
             _ = await viewModel.evaluateOffPeakSchedule(appLaunched: appLaunched)
         }
     }

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -14,6 +14,9 @@ struct PersistentQueueSidebarView: View {
     let canPauseAfterCurrent: Bool
     let canStopCurrent: Bool
     let canUndo: Bool
+    let offPeakSchedule: OffPeakQueueSchedule?
+    let offPeakScheduleOutcome: OffPeakScheduleOutcome?
+    let offPeakScheduleErrorMessage: String?
     let addSources: () -> Void
     let addSourceFolder: () -> Void
     let addDisc: (ConversionSource) -> Void
@@ -23,6 +26,10 @@ struct PersistentQueueSidebarView: View {
     let clearCompleted: () -> Void
     let undo: () -> Void
     let start: () -> Void
+    let startLater: () -> Void
+    let editSchedule: () -> Void
+    let cancelSchedule: () -> Void
+    let dismissScheduleOutcome: () -> Void
     let pauseAfterCurrent: () -> Void
     let stopCurrent: () -> Void
 
@@ -30,6 +37,7 @@ struct PersistentQueueSidebarView: View {
         VStack(spacing: 0) {
             header
             Divider()
+            scheduleBanner
             if let banner {
                 Label(banner.title, systemImage: banner.systemImage)
                     .font(.caption.weight(.medium))
@@ -50,6 +58,54 @@ struct PersistentQueueSidebarView: View {
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .accessibilityIdentifier("persistent-queue-sidebar")
+    }
+
+    @ViewBuilder
+    private var scheduleBanner: some View {
+        if let errorMessage = offPeakScheduleErrorMessage {
+            Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.red)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 9)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.red.opacity(0.08))
+                .accessibilityIdentifier("off-peak-schedule-error")
+        } else if let schedule = offPeakSchedule {
+            VStack(alignment: .leading, spacing: 4) {
+                Label(
+                    "Scheduled \(schedule.startAt.formatted(date: .abbreviated, time: .shortened))–\(schedule.endAt.formatted(date: .omitted, time: .shortened))",
+                    systemImage: "clock.badge.checkmark.fill"
+                )
+                    .font(.caption.weight(.semibold))
+                Text("Keep the app open. The Mac is not kept awake or woken automatically.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.accentColor.opacity(0.08))
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("off-peak-schedule-banner")
+        } else if let outcome = offPeakScheduleOutcome, outcome.kind == .missed {
+            HStack(alignment: .top, spacing: 8) {
+                Label(outcome.message, systemImage: "clock.badge.exclamationmark.fill")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.orange)
+                Spacer(minLength: 4)
+                Button(action: dismissScheduleOutcome) {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss missed schedule notice")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .background(Color.orange.opacity(0.08))
+            .accessibilityIdentifier("off-peak-schedule-missed")
+        }
     }
 
     private var header: some View {
@@ -195,12 +251,26 @@ struct PersistentQueueSidebarView: View {
                 }
             }
             VStack(alignment: .trailing, spacing: 8) {
-                Button(startButtonTitle, action: start)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!canStart)
-                    .frame(maxWidth: .infinity)
-                    .accessibilityIdentifier("persistent-queue-start")
-                    .accessibilityLabel(startButtonTitle)
+                HStack(spacing: 8) {
+                    Button(offPeakSchedule == nil ? startButtonTitle : "Start Now", action: start)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!canStart)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityIdentifier("persistent-queue-start")
+                    if offPeakSchedule == nil {
+                        Button("Start Later…", action: startLater)
+                            .disabled(!canStart)
+                            .accessibilityIdentifier("off-peak-schedule-create")
+                    }
+                }
+                if offPeakSchedule != nil {
+                    HStack(spacing: 8) {
+                        Button("Edit Schedule…", action: editSchedule)
+                            .accessibilityIdentifier("off-peak-schedule-edit")
+                        Button("Cancel Schedule", role: .destructive, action: cancelSchedule)
+                            .accessibilityIdentifier("off-peak-schedule-cancel")
+                    }
+                }
                 HStack(spacing: 8) {
                     Button("Pause After Current", action: pauseAfterCurrent)
                         .disabled(!canPauseAfterCurrent)
@@ -256,6 +326,78 @@ struct PersistentQueueSidebarView: View {
             return ("Some videos need attention.", "exclamationmark.triangle.fill", .red)
         }
         return nil
+    }
+}
+
+struct OffPeakScheduleSheet: View {
+    @Binding var startAt: Date
+    @Binding var endAt: Date
+    let isEditing: Bool
+    let hasPhysicalDiscItems: Bool
+    let errorMessage: String?
+    let cancel: () -> Void
+    let save: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(isEditing ? "Edit Scheduled Window" : "Start Queue Later")
+                    .font(.title2.weight(.semibold))
+                Text("The app must remain open. This schedule does not wake the Mac or keep it awake.")
+                    .foregroundStyle(.secondary)
+            }
+
+            Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 12) {
+                GridRow {
+                    Text("Start")
+                    DatePicker("Start", selection: $startAt, displayedComponents: [.date, .hourAndMinute])
+                        .labelsHidden()
+                        .accessibilityIdentifier("off-peak-start-date")
+                }
+                GridRow {
+                    Text("Stop starting new videos")
+                    DatePicker("End", selection: $endAt, displayedComponents: [.date, .hourAndMinute])
+                        .labelsHidden()
+                        .accessibilityIdentifier("off-peak-end-date")
+                }
+            }
+
+            Text("If the Mac sleeps, the queue can start late only while this window is still open. Reopening the app after the start time marks the schedule missed. A video already running may finish after the window ends.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if hasPhysicalDiscItems {
+                Label(
+                    "Physical-disc items run only if the same disc is inserted when the window opens. Missing discs are parked so other available videos can continue.",
+                    systemImage: "opticaldisc.fill"
+                )
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("off-peak-disc-warning")
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .accessibilityIdentifier("off-peak-editor-error")
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: cancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(isEditing ? "Save Changes" : "Schedule Queue", action: save)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("off-peak-schedule-save")
+            }
+        }
+        .padding(24)
+        .frame(width: 560)
+        .accessibilityIdentifier("off-peak-schedule-sheet")
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -94,6 +94,7 @@ struct PersistentQueueSidebarView: View {
                 Label(outcome.message, systemImage: "clock.badge.exclamationmark.fill")
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.orange)
+                    .accessibilityIdentifier("off-peak-schedule-missed-message")
                 Spacer(minLength: 4)
                 Button(action: dismissScheduleOutcome) {
                     Image(systemName: "xmark")
@@ -257,6 +258,7 @@ struct PersistentQueueSidebarView: View {
                         .disabled(!canStart)
                         .frame(maxWidth: .infinity)
                         .accessibilityIdentifier("persistent-queue-start")
+                        .accessibilityLabel(offPeakSchedule == nil ? startButtonTitle : "Start Now")
                     if offPeakSchedule == nil {
                         Button("Start Later…", action: startLater)
                             .disabled(!canStart)
@@ -356,7 +358,11 @@ struct OffPeakScheduleSheet: View {
                 }
                 GridRow {
                     Text("Stop starting new videos")
-                    DatePicker("End", selection: $endAt, displayedComponents: [.date, .hourAndMinute])
+                    DatePicker(
+                        "Stop starting new videos",
+                        selection: $endAt,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
                         .labelsHidden()
                         .accessibilityIdentifier("off-peak-end-date")
                 }

--- a/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionViewModelTests.swift
@@ -4781,6 +4781,156 @@ final class ConversionViewModelTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testOffPeakScheduleRequiresFutureStart() async throws {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let queueStore = ConversionQueueStore.inMemory()
+        try await queueStore.replaceItems([
+            makePersistentQueueFixture(ordinal: 0, state: .waiting),
+        ])
+        let viewModel = ConversionViewModel(
+            diagnosticClock: { now },
+            durableQueueStore: queueStore
+        )
+
+        do {
+            try await viewModel.saveOffPeakSchedule(
+                startAt: now,
+                endAt: now.addingTimeInterval(60)
+            )
+            XCTFail("Expected an invalid scheduling window")
+        } catch let error as OffPeakScheduleStoreError {
+            XCTAssertEqual(error, .invalidWindow)
+        }
+    }
+
+    @MainActor
+    func testOffPeakStartParksMissingDiscPeersAndContinuesAvailableWork() async throws {
+        let now = Date(timeIntervalSince1970: 150)
+        let scheduleStore = OffPeakScheduleStore.inMemory()
+        let schedule = OffPeakQueueSchedule(
+            startAt: Date(timeIntervalSince1970: 100),
+            endAt: Date(timeIntervalSince1970: 200),
+            createdAt: Date(timeIntervalSince1970: 50)
+        )
+        try await scheduleStore.save(schedule)
+
+        let discURL = URL(fileURLWithPath: "/Volumes/FEATURE")
+        let localURL = URL(fileURLWithPath: "/tmp/available.mkv")
+        let inspection = SourceInspection(
+            name: "Feature",
+            resolution: "1920x1080",
+            frameRate: "24/1",
+            interlaced: false,
+            sizeBytes: 10
+        )
+        let groupID = UUID()
+        let discDraft = ConversionDraft(
+            source: ConversionSource(
+                kind: .physicalDisc,
+                url: discURL,
+                mediaIdentifier: "disc-a"
+            ),
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/Output"),
+            options: ConversionOptions()
+        )
+        let localDraft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: localURL),
+            sourceDetails: inspection,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/tmp/Output"),
+            options: ConversionOptions()
+        )
+        let queueStore = ConversionQueueStore.inMemory()
+        try await queueStore.replaceItems([
+            DurableConversionQueueItem(
+                ordinal: 0,
+                groupID: groupID,
+                origin: .multiTitle,
+                intent: DurableQueueItemIntent(draft: discDraft)
+            ),
+            DurableConversionQueueItem(
+                ordinal: 1,
+                groupID: groupID,
+                origin: .multiTitle,
+                intent: DurableQueueItemIntent(draft: discDraft)
+            ),
+            DurableConversionQueueItem(
+                ordinal: 2,
+                origin: .singleSource,
+                intent: DurableQueueItemIntent(draft: localDraft)
+            ),
+        ])
+        let converted = expectation(description: "available item converted")
+        var convertedPaths: [String] = []
+        let worker = TwoPhaseWorkerClient(onConversionJobReceived: { job in
+            convertedPaths.append(job.source.path)
+            converted.fulfill()
+        })
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            diagnosticClock: { now },
+            durableQueueStore: queueStore,
+            offPeakScheduleStore: scheduleStore,
+            sourceAvailabilityResolver: { $0.kind != .physicalDisc }
+        )
+
+        let evaluation = await viewModel.evaluateOffPeakSchedule()
+        XCTAssertEqual(evaluation, .start(schedule))
+        await fulfillment(of: [converted], timeout: 2)
+        for _ in 0..<1_000 where queueStore.items.last?.state != .completed || viewModel.hasActiveWorker {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(convertedPaths, [localURL.path])
+        XCTAssertEqual(queueStore.items.map(\.state), [.failed, .stopped, .completed])
+        XCTAssertEqual(queueStore.items.first?.failure?.code, "scheduled_disc_unavailable")
+    }
+
+    @MainActor
+    func testOffPeakWindowPausesBeforeStartingNextItem() async throws {
+        let clock = LockedTestDate(Date(timeIntervalSince1970: 150))
+        let scheduleStore = OffPeakScheduleStore.inMemory()
+        let schedule = OffPeakQueueSchedule(
+            startAt: Date(timeIntervalSince1970: 100),
+            endAt: Date(timeIntervalSince1970: 200),
+            createdAt: Date(timeIntervalSince1970: 50)
+        )
+        try await scheduleStore.save(schedule)
+        let queueStore = ConversionQueueStore.inMemory()
+        try await queueStore.replaceItems([
+            makePersistentQueueFixture(ordinal: 0, state: .waiting),
+            makePersistentQueueFixture(ordinal: 1, state: .waiting),
+        ])
+        var conversionCount = 0
+        let firstConverted = expectation(description: "first item converted")
+        let worker = TwoPhaseWorkerClient(onConversionJobReceived: { _ in
+            conversionCount += 1
+            clock.value = schedule.endAt
+            firstConverted.fulfill()
+        })
+        let viewModel = ConversionViewModel(
+            clientFactory: { worker },
+            diagnosticClock: { clock.value },
+            durableQueueStore: queueStore,
+            offPeakScheduleStore: scheduleStore,
+            sourceAvailabilityResolver: { _ in true }
+        )
+
+        let evaluation = await viewModel.evaluateOffPeakSchedule()
+        XCTAssertEqual(evaluation, .start(schedule))
+        await fulfillment(of: [firstConverted], timeout: 2)
+        for _ in 0..<1_000 where viewModel.persistentQueueRunState != .paused || viewModel.hasActiveWorker {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(conversionCount, 1)
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+        XCTAssertEqual(queueStore.items.map(\.state), [.completed, .waiting])
+    }
+
     private func makeCompletedHistoryItems(
         count: Int,
         draft: ConversionDraft
@@ -4868,6 +5018,24 @@ final class ConversionViewModelTests: XCTestCase {
                     JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
                 )
             }
+    }
+}
+
+private final class LockedTestDate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Date
+
+    init(_ value: Date) {
+        storedValue = value
+    }
+
+    var value: Date {
+        get {
+            lock.withLock { storedValue }
+        }
+        set {
+            lock.withLock { storedValue = newValue }
+        }
     }
 }
 

--- a/macos/BluRayToVisionProTests/OffPeakScheduleStoreTests.swift
+++ b/macos/BluRayToVisionProTests/OffPeakScheduleStoreTests.swift
@@ -96,7 +96,11 @@ final class OffPeakScheduleStoreTests: XCTestCase {
         try await store.save(scheduled)
         _ = try await store.evaluate(at: date(150), appLaunched: false)
 
-        try await store.markStartedScheduleWithoutRunnableItems(scheduleID: scheduled.id, at: date(151))
+        try await store.markStartedScheduleMissed(
+            scheduleID: scheduled.id,
+            reason: .noRunnableItems,
+            at: date(151)
+        )
 
         XCTAssertEqual(store.lastOutcome?.kind, .missed)
         XCTAssertEqual(store.lastOutcome?.missReason, .noRunnableItems)

--- a/macos/BluRayToVisionProTests/OffPeakScheduleStoreTests.swift
+++ b/macos/BluRayToVisionProTests/OffPeakScheduleStoreTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class OffPeakScheduleStoreTests: XCTestCase {
+    func testSchedulePersistsEditsAndCancellation() async throws {
+        let fileURL = temporaryScheduleURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        let first = schedule(start: 100, end: 200)
+        let edited = schedule(start: 300, end: 500)
+        let store = OffPeakScheduleStore(fileURL: fileURL)
+
+        try await store.save(first)
+        XCTAssertEqual(OffPeakScheduleStore(fileURL: fileURL).schedule, first)
+
+        try await store.save(edited)
+        XCTAssertEqual(OffPeakScheduleStore(fileURL: fileURL).schedule, edited)
+
+        try await store.cancel()
+        XCTAssertNil(OffPeakScheduleStore(fileURL: fileURL).schedule)
+    }
+
+    func testUnsupportedDocumentFailsClosedWithoutOverwriting() async throws {
+        let fileURL = temporaryScheduleURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let original = Data(#"{"version":2,"schedule":null,"lastOutcome":null}"#.utf8)
+        try original.write(to: fileURL)
+        let store = OffPeakScheduleStore(fileURL: fileURL)
+
+        XCTAssertTrue(store.writesBlocked)
+        await XCTAssertThrowsErrorAsync {
+            try await store.save(self.schedule(start: 100, end: 200))
+        }
+        XCTAssertEqual(try Data(contentsOf: fileURL), original)
+    }
+
+    func testExactStartConsumesScheduleOnce() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        let scheduled = schedule(start: 100, end: 200)
+        try await store.save(scheduled)
+
+        let firstEvaluation = try await store.evaluate(at: date(100), appLaunched: false)
+        let secondEvaluation = try await store.evaluate(at: date(100), appLaunched: false)
+        XCTAssertEqual(firstEvaluation, .start(scheduled))
+        XCTAssertEqual(secondEvaluation, .none)
+        XCTAssertEqual(store.lastOutcome?.kind, .started)
+    }
+
+    func testInWindowWakeStartsLateWhileAppStayedOpen() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        let scheduled = schedule(start: 100, end: 200)
+        try await store.save(scheduled)
+
+        let evaluation = try await store.evaluate(at: date(150), appLaunched: false)
+        XCTAssertEqual(evaluation, .start(scheduled))
+    }
+
+    func testRelaunchAfterStartMarksScheduleMissed() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        try await store.save(schedule(start: 100, end: 200))
+
+        let evaluation = try await store.evaluate(at: date(150), appLaunched: true)
+        XCTAssertEqual(evaluation, .missed(.appRelaunchedAfterStart))
+        XCTAssertEqual(store.lastOutcome?.missReason, .appRelaunchedAfterStart)
+    }
+
+    func testEvaluationAfterEndMarksWindowMissed() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        try await store.save(schedule(start: 100, end: 200))
+
+        let evaluation = try await store.evaluate(at: date(200), appLaunched: true)
+        XCTAssertEqual(evaluation, .missed(.windowEndedBeforeEvaluation))
+    }
+
+    func testConcurrentEvaluationConsumesOnlyOnce() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        let scheduled = schedule(start: 100, end: 200)
+        try await store.save(scheduled)
+
+        async let first = store.evaluate(at: date(150), appLaunched: false)
+        async let second = store.evaluate(at: date(150), appLaunched: false)
+        let results = try await [first, second]
+
+        XCTAssertEqual(results.filter { $0 == .start(scheduled) }.count, 1)
+        XCTAssertEqual(results.filter { $0 == .none }.count, 1)
+    }
+
+    func testConsumedStartCanRecordNoRunnableItems() async throws {
+        let store = OffPeakScheduleStore.inMemory()
+        let scheduled = schedule(start: 100, end: 200)
+        try await store.save(scheduled)
+        _ = try await store.evaluate(at: date(150), appLaunched: false)
+
+        try await store.markStartedScheduleWithoutRunnableItems(scheduleID: scheduled.id, at: date(151))
+
+        XCTAssertEqual(store.lastOutcome?.kind, .missed)
+        XCTAssertEqual(store.lastOutcome?.missReason, .noRunnableItems)
+    }
+
+    private func schedule(start: TimeInterval, end: TimeInterval) -> OffPeakQueueSchedule {
+        OffPeakQueueSchedule(startAt: date(start), endAt: date(end), createdAt: date(0))
+    }
+
+    private func date(_ interval: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: interval)
+    }
+
+    private func temporaryScheduleURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("queue.schedule.json")
+    }
+}
+
+private func XCTAssertThrowsErrorAsync(
+    _ expression: () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await expression()
+        XCTFail("Expected expression to throw", file: file, line: line)
+    } catch {}
+}

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -53,12 +53,44 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         XCTAssertEqual(bitmap.pixelsHigh, 430)
     }
 
+    func testOffPeakScheduleArmedAndMissedBannersRender() throws {
+        let items = try makeItems()
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let schedule = OffPeakQueueSchedule(
+            startAt: start,
+            endAt: start.addingTimeInterval(8 * 60 * 60),
+            createdAt: start.addingTimeInterval(-60)
+        )
+        try render(
+            items: items,
+            selectedItem: items[1],
+            compact: false,
+            colorScheme: .light,
+            appearanceName: .aqua,
+            offPeakSchedule: schedule
+        )
+        try render(
+            items: items,
+            selectedItem: items[1],
+            compact: false,
+            colorScheme: .dark,
+            appearanceName: .darkAqua,
+            offPeakScheduleOutcome: .missed(
+                scheduleID: schedule.id,
+                reason: .windowEndedBeforeEvaluation,
+                at: schedule.endAt
+            )
+        )
+    }
+
     private func render(
         items: [PersistentQueueItem],
         selectedItem: PersistentQueueItem?,
         compact: Bool,
         colorScheme: ColorScheme,
-        appearanceName: NSAppearance.Name
+        appearanceName: NSAppearance.Name,
+        offPeakSchedule: OffPeakQueueSchedule? = nil,
+        offPeakScheduleOutcome: OffPeakScheduleOutcome? = nil
     ) throws {
         let content = HSplitView {
             PersistentQueueSidebarView(
@@ -74,8 +106,8 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 canPauseAfterCurrent: !items.isEmpty,
                 canStopCurrent: !items.isEmpty,
                 canUndo: true,
-                offPeakSchedule: nil,
-                offPeakScheduleOutcome: nil,
+                offPeakSchedule: offPeakSchedule,
+                offPeakScheduleOutcome: offPeakScheduleOutcome,
                 offPeakScheduleErrorMessage: nil,
                 addSources: {},
                 addSourceFolder: {},

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -30,6 +30,29 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         }
     }
 
+    func testOffPeakScheduleEditorRendersPhysicalDiscWarning() throws {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let content = OffPeakScheduleSheet(
+            startAt: .constant(start),
+            endAt: .constant(start.addingTimeInterval(8 * 60 * 60)),
+            isEditing: false,
+            hasPhysicalDiscItems: true,
+            errorMessage: nil,
+            cancel: {},
+            save: {}
+        )
+        .frame(width: 560, height: 430)
+        let hostingView = NSHostingView(rootView: content)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 560, height: 430)
+        hostingView.layoutSubtreeIfNeeded()
+
+        let bitmap = try XCTUnwrap(hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds))
+        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+
+        XCTAssertEqual(bitmap.pixelsWide, 560)
+        XCTAssertEqual(bitmap.pixelsHigh, 430)
+    }
+
     private func render(
         items: [PersistentQueueItem],
         selectedItem: PersistentQueueItem?,
@@ -51,6 +74,9 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 canPauseAfterCurrent: !items.isEmpty,
                 canStopCurrent: !items.isEmpty,
                 canUndo: true,
+                offPeakSchedule: nil,
+                offPeakScheduleOutcome: nil,
+                offPeakScheduleErrorMessage: nil,
                 addSources: {},
                 addSourceFolder: {},
                 addDisc: { _ in },
@@ -60,6 +86,10 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 clearCompleted: {},
                 undo: {},
                 start: {},
+                startLater: {},
+                editSchedule: {},
+                cancelSchedule: {},
+                dismissScheduleOutcome: {},
                 pauseAfterCurrent: {},
                 stopCurrent: {}
             )


### PR DESCRIPTION
## Summary
- add one editable, cancellable off-peak queue window persisted in a versioned atomic sidecar
- evaluate on launch, wake, activation, and a stable in-process timer without scheduling a system wake or keeping the Mac awake
- revalidate removable and physical-disc sources, park unavailable peers, and continue unrelated eligible work through the existing serialized queue pump
- add scheduling UI, missed-window messaging, accessibility identifiers, documentation, and regression coverage

## Validation
- `uv run python scripts/native_app.py test` — 531 tests passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py package` — passed
- packaged worker cancellation smoke — passed
- packaged preview presentation smoke — passed
- Opus exact-head review — READY, no blockers
- Gemini exact-head review — attempted twice; returned no output
- JetBrains inspection — UNKNOWN because the IDE mutated `.idea`; all generated mutations were removed

Closes #546