### PR TITLE
Make queue items identifiable and selection-driven

### DIFF
--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -122,6 +122,22 @@ struct PersistentQueueItem: Identifiable, Equatable {
         draft.selectedTitle?.name ?? draft.source.displayName
     }
 
+    var sourceIdentity: String {
+        draft.source.displayName
+    }
+
+    var selectedTitleIdentity: String {
+        draft.selectedTitle?.name ?? "No title selected"
+    }
+
+    var sourceKindName: String {
+        draft.source.kind.title
+    }
+
+    var sourceLocation: String {
+        draft.source.locationDescription
+    }
+
     var isRestored: Bool {
         switch status {
         case .interrupted:

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -127,7 +127,10 @@ struct PersistentQueueItem: Identifiable, Equatable {
     }
 
     var selectedTitleIdentity: String {
-        draft.selectedTitle?.name ?? "No title selected"
+        if let selectedTitle = draft.selectedTitle {
+            return selectedTitle.name
+        }
+        return draft.source.kind.isDiscWorkflow ? "Main movie (automatic)" : "Entire source"
     }
 
     var sourceKindName: String {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -430,12 +430,38 @@ private struct PersistentQueueRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .accessibilityLabel("Source: \(item.sourceIdentity)")
-                Text(rowMetadata)
+                if compact {
+                    Text("\(item.selectedTitleIdentity) · \(item.status.title)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .accessibilityLabel(
+                            "Selected title: \(item.selectedTitleIdentity). State: \(item.status.title)"
+                        )
+                } else {
+                    Text(item.selectedTitleIdentity)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .accessibilityLabel("Selected title: \(item.selectedTitleIdentity)")
+                    HStack(spacing: 4) {
+                        Text("\(item.sourceKindName) · \(item.draft.profile.name)")
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text("· \(item.status.title)")
+                            .foregroundStyle(item.status.tint)
+                            .lineLimit(1)
+                    }
                     .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .accessibilityLabel(rowAccessibilityMetadata)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(
+                        "Source kind: \(item.sourceKindName). Profile: \(item.draft.profile.name). "
+                            + "State: \(item.status.title)"
+                    )
+                }
                 if item.status.isActive, let progress {
                     if let stageFraction = progress.stageFraction {
                         ProgressView(value: stageFraction)
@@ -450,13 +476,6 @@ private struct PersistentQueueRow: View {
                 }
             }
             Spacer(minLength: 4)
-            if !compact {
-                Text(item.status.title)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(item.status.tint)
-                    .lineLimit(1)
-                    .accessibilityHidden(true)
-            }
             if item.isRestored {
                 Image(systemName: "arrow.counterclockwise.circle.fill")
                     .foregroundStyle(.orange)
@@ -492,22 +511,6 @@ private struct PersistentQueueRow: View {
         }
     }
 
-    private var rowMetadata: String {
-        if compact {
-            "\(item.selectedTitleIdentity) · \(item.status.title)"
-        } else {
-            "\(item.selectedTitleIdentity) · \(item.sourceKindName) · \(item.draft.profile.name)"
-        }
-    }
-
-    private var rowAccessibilityMetadata: String {
-        if compact {
-            "Selected title: \(item.selectedTitleIdentity). State: \(item.status.title)"
-        } else {
-            "Selected title: \(item.selectedTitleIdentity). Source kind: \(item.sourceKindName). "
-                + "Profile: \(item.draft.profile.name)"
-        }
-    }
 }
 
 struct PersistentQueueDetailView: View {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -425,15 +425,17 @@ private struct PersistentQueueRow: View {
                 .frame(width: compact ? 15 : 18)
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: compact ? 1 : 3) {
-                Text(item.displayName)
+                Text(item.sourceIdentity)
                     .font(compact ? .callout : .callout.weight(.medium))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text(item.status.subtitle(for: item))
+                    .accessibilityLabel("Source: \(item.sourceIdentity)")
+                Text(rowMetadata)
                     .font(.caption)
-                    .foregroundStyle(item.status.tint)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .accessibilityLabel(rowAccessibilityMetadata)
                 if item.status.isActive, let progress {
                     if let stageFraction = progress.stageFraction {
                         ProgressView(value: stageFraction)
@@ -448,6 +450,13 @@ private struct PersistentQueueRow: View {
                 }
             }
             Spacer(minLength: 4)
+            if !compact {
+                Text(item.status.title)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(item.status.tint)
+                    .lineLimit(1)
+                    .accessibilityHidden(true)
+            }
             if item.isRestored {
                 Image(systemName: "arrow.counterclockwise.circle.fill")
                     .foregroundStyle(.orange)
@@ -467,7 +476,11 @@ private struct PersistentQueueRow: View {
                 .disabled(!item.canRemove)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(item.displayName), \(item.status.title), \(position) of \(total)")
+        .accessibilityLabel(
+            "Source: \(item.sourceIdentity). Selected title: \(item.selectedTitleIdentity). "
+                + "Source kind: \(item.sourceKindName). Profile: \(item.draft.profile.name). "
+                + "State: \(item.status.title). Queue item \(position) of \(total)."
+        )
         .accessibilityAction(named: "Move Up") {
             if item.canMove { move(item.id, -1) }
         }
@@ -476,6 +489,23 @@ private struct PersistentQueueRow: View {
         }
         .accessibilityAction(named: "Remove from Queue") {
             if item.canRemove { remove(item.id) }
+        }
+    }
+
+    private var rowMetadata: String {
+        if compact {
+            "\(item.selectedTitleIdentity) · \(item.status.title)"
+        } else {
+            "\(item.selectedTitleIdentity) · \(item.sourceKindName) · \(item.draft.profile.name)"
+        }
+    }
+
+    private var rowAccessibilityMetadata: String {
+        if compact {
+            "Selected title: \(item.selectedTitleIdentity). State: \(item.status.title)"
+        } else {
+            "Selected title: \(item.selectedTitleIdentity). Source kind: \(item.sourceKindName). "
+                + "Profile: \(item.draft.profile.name)"
         }
     }
 }
@@ -536,16 +566,18 @@ struct PersistentQueueDetailView: View {
                 .foregroundStyle(Color.accentColor)
                 .frame(width: 36)
             VStack(alignment: .leading, spacing: 3) {
-                Text(item.displayName)
+                Text(item.sourceIdentity)
                     .font(.title2.weight(.semibold))
-                Text(item.draft.source.url.deletingLastPathComponent().path)
+                    .accessibilityLabel("Source: \(item.sourceIdentity)")
+                Text(item.sourceLocation)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .accessibilityLabel("Source location: \(item.sourceLocation)")
             }
             Spacer()
-            Text(item.draft.source.kind.title)
+            Text(item.sourceKindName)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
@@ -594,6 +626,8 @@ struct PersistentQueueDetailView: View {
 
     private func settings(_ item: PersistentQueueItem) -> some View {
         VStack(alignment: .leading, spacing: 16) {
+            itemDetails(item)
+            Divider()
             HStack {
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Conversion Setup")
@@ -609,21 +643,19 @@ struct PersistentQueueDetailView: View {
             Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 10) {
                 GridRow {
                     Text("Profile").foregroundStyle(.secondary)
-                    Text(item.draft.profile.name)
+                    detailValue(item.draft.profile.name, label: "Profile")
                 }
                 GridRow {
                     Text("Destination").foregroundStyle(.secondary)
                     HStack {
-                        Text(item.draft.destinationURL.path)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                        detailValue(item.draft.destinationURL.path, label: "Destination")
                         Button("Change…") { changeDestination(item) }
                             .disabled(!item.isEditable)
                     }
                 }
                 GridRow {
                     Text("Planned file").foregroundStyle(.secondary)
-                    Text(item.draft.proposedOutputURL.lastPathComponent)
+                    detailValue(item.draft.proposedOutputURL.lastPathComponent, label: "Planned file")
                 }
                 GridRow {
                     Text("Output").foregroundStyle(.secondary)
@@ -636,6 +668,43 @@ struct PersistentQueueDetailView: View {
             }
             .font(.callout)
         }
+    }
+
+    private func itemDetails(_ item: PersistentQueueItem) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Queue Item")
+                .font(.title3.weight(.semibold))
+            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 10) {
+                GridRow {
+                    Text("Source").foregroundStyle(.secondary)
+                    detailValue(item.sourceIdentity, label: "Source")
+                }
+                GridRow {
+                    Text("Source location").foregroundStyle(.secondary)
+                    detailValue(item.sourceLocation, label: "Source location")
+                }
+                GridRow {
+                    Text("Selected title").foregroundStyle(.secondary)
+                    detailValue(item.selectedTitleIdentity, label: "Selected title")
+                }
+                GridRow {
+                    Text("Source kind").foregroundStyle(.secondary)
+                    detailValue(item.sourceKindName, label: "Source kind")
+                }
+                GridRow {
+                    Text("State").foregroundStyle(.secondary)
+                    detailValue(item.status.title, label: "State")
+                }
+            }
+            .font(.callout)
+        }
+    }
+
+    private func detailValue(_ value: String, label: String) -> some View {
+        Text(value)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .accessibilityLabel("\(label): \(value)")
     }
 }
 
@@ -817,17 +886,6 @@ private extension PersistentQueueItemStatus {
         }
     }
 
-    func subtitle(for item: PersistentQueueItem) -> String {
-        switch self {
-        case let .needsChoice(conflict): conflict.reason
-        case let .attention(decision): decision.prompt
-        case let .failed(failure): failure.message
-        case let .completed(result): URL(fileURLWithPath: result.outputPath).lastPathComponent
-        case .interrupted: "Will restart from the last safe stage"
-        case .processing: "\(item.draft.profile.name) · \(item.draft.proposedOutputURL.lastPathComponent)"
-        default: "\(item.draft.profile.name) · \(item.draft.proposedOutputURL.lastPathComponent)"
-        }
-    }
 }
 
 private extension ConversionSourceKind {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -454,6 +454,8 @@ private struct PersistentQueueRow: View {
                         Text("· \(item.status.title)")
                             .foregroundStyle(item.status.tint)
                             .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .layoutPriority(1)
                     }
                     .font(.caption)
                     .accessibilityElement(children: .combine)
@@ -510,7 +512,6 @@ private struct PersistentQueueRow: View {
             if item.canRemove { remove(item.id) }
         }
     }
-
 }
 
 struct PersistentQueueDetailView: View {
@@ -888,7 +889,6 @@ private extension PersistentQueueItemStatus {
         case .completed: .green
         }
     }
-
 }
 
 private extension ConversionSourceKind {

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -1203,6 +1203,47 @@ final class ConversionQueueStoreTests: XCTestCase {
         XCTAssertNotEqual(first, other)
     }
 
+    func testPersistentQueueProjectionProvidesSourceFirstIdentity() throws {
+        let selectedTitle = SourceTitle(
+            id: "title-1",
+            name: "Main Movie",
+            outputName: "Main Movie",
+            durationSeconds: 7_200,
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            mainFeature: true
+        )
+        let item = DurableConversionQueueItem(
+            ordinal: 0,
+            origin: .multiTitle,
+            intent: DurableQueueItemIntent(
+                source: DurableQueueSource(
+                    kind: ConversionSourceKind.physicalDisc.rawValue,
+                    path: "/Volumes/Avatar 3D",
+                    displayName: "Avatar 3D",
+                    workerSourcePath: "/Volumes/Avatar 3D",
+                    mediaIdentifier: "disk4s1"
+                ),
+                profile: DurableQueueProfile(
+                    id: BuiltInProfile.balanced.id,
+                    name: BuiltInProfile.balanced.name,
+                    kind: .builtIn
+                ),
+                destinationPath: "/Movies",
+                options: ConversionOptions(),
+                selectedTitle: selectedTitle
+            ),
+            state: .waiting
+        )
+
+        let projection = try PersistentQueueItem(item: item)
+
+        XCTAssertEqual(projection.sourceIdentity, "Avatar 3D")
+        XCTAssertEqual(projection.selectedTitleIdentity, "Main Movie")
+        XCTAssertEqual(projection.sourceKindName, "3D Blu-ray Disc")
+        XCTAssertEqual(projection.sourceLocation, "/Volumes/Avatar 3D")
+    }
+
     private func makeItem(
         id: UUID = UUID(),
         ordinal: Int,

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -1244,6 +1244,27 @@ final class ConversionQueueStoreTests: XCTestCase {
         XCTAssertEqual(projection.sourceLocation, "/Volumes/Avatar 3D")
     }
 
+    func testPersistentQueueProjectionDescribesAutomaticAndWholeSourceSelection() throws {
+        var discItem = makeItem(ordinal: 0, origin: .singleSource)
+        discItem.intent.source = DurableQueueSource(
+            kind: ConversionSourceKind.physicalDisc.rawValue,
+            path: "/Volumes/Feature 3D",
+            displayName: "Feature 3D",
+            workerSourcePath: "/Volumes/Feature 3D",
+            mediaIdentifier: "disk4s1"
+        )
+        var fileItem = makeItem(ordinal: 0, origin: .singleSource)
+        fileItem.intent.source = DurableQueueSource(
+            kind: ConversionSourceKind.matroska.rawValue,
+            path: "/Movies/Feature.mkv",
+            displayName: "Feature.mkv",
+            workerSourcePath: "/Movies/Feature.mkv"
+        )
+
+        XCTAssertEqual(try PersistentQueueItem(item: discItem).selectedTitleIdentity, "Main movie (automatic)")
+        XCTAssertEqual(try PersistentQueueItem(item: fileItem).selectedTitleIdentity, "Entire source")
+    }
+
     private func makeItem(
         id: UUID = UUID(),
         ordinal: Int,

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -113,6 +113,38 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         )
     }
 
+    func testQueueWorkspaceRendersIdentifiableRowsForDuplicateTitlesAndMediaSources() throws {
+        let items = try makeIdentifiableItems()
+
+        XCTAssertEqual(items.map(\.sourceIdentity), [
+            "A Very Long Archive Name That Keeps Its Source Identity.mkv",
+            "Avatar 3D",
+            "Blade Runner 2049.iso",
+            "Avatar 3D",
+        ])
+        XCTAssertEqual(items.map(\.selectedTitleIdentity), [
+            "Main Movie",
+            "Main Movie",
+            "Main Movie",
+            "Bonus Features",
+        ])
+
+        try render(
+            items: items,
+            selectedItem: items[1],
+            compact: false,
+            colorScheme: .light,
+            appearanceName: .aqua
+        )
+        try render(
+            items: items,
+            selectedItem: items[2],
+            compact: true,
+            colorScheme: .dark,
+            appearanceName: .darkAqua
+        )
+    }
+
     private func render(
         items: [PersistentQueueItem],
         selectedItem: PersistentQueueItem?,
@@ -231,6 +263,83 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 state: state,
                 failure: failure,
                 result: result
+            ))
+        }
+    }
+
+    private func makeIdentifiableItems() throws -> [PersistentQueueItem] {
+        let title = SourceTitle(
+            id: "main",
+            name: "Main Movie",
+            outputName: "Main Movie",
+            durationSeconds: 7_200,
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            mainFeature: true
+        )
+        let bonusTitle = SourceTitle(
+            id: "bonus",
+            name: "Bonus Features",
+            outputName: "Bonus Features",
+            durationSeconds: 1_800,
+            resolution: "1920x1080",
+            frameRate: "24000/1001",
+            mainFeature: false
+        )
+        let fixtures: [(source: ConversionSource, title: SourceTitle, state: DurableQueueItemState)] = [
+            (
+                ConversionSource(
+                    kind: .matroska,
+                    url: URL(fileURLWithPath: "/Volumes/Archive/A Very Long Archive Name That Keeps Its Source Identity.mkv")
+                ),
+                title,
+                .waiting
+            ),
+            (
+                ConversionSource(
+                    kind: .physicalDisc,
+                    url: URL(fileURLWithPath: "/Volumes/Avatar 3D"),
+                    displayName: "Avatar 3D",
+                    mediaIdentifier: "disk4s1"
+                ),
+                title,
+                .processing
+            ),
+            (
+                ConversionSource(
+                    kind: .discImage,
+                    url: URL(fileURLWithPath: "/Volumes/Rips/Blade Runner 2049.iso")
+                ),
+                title,
+                .waiting
+            ),
+            (
+                ConversionSource(
+                    kind: .physicalDisc,
+                    url: URL(fileURLWithPath: "/Volumes/Avatar 3D"),
+                    displayName: "Avatar 3D",
+                    mediaIdentifier: "disk4s1"
+                ),
+                bonusTitle,
+                .completed
+            ),
+        ]
+
+        return try fixtures.enumerated().map { offset, fixture in
+            let draft = ConversionDraft(
+                source: fixture.source,
+                sourceDetails: nil,
+                profile: BuiltInProfile.balanced.profile,
+                destinationURL: URL(fileURLWithPath: "/Movies"),
+                options: ConversionOptions(),
+                selectedTitle: fixture.title
+            )
+            return try PersistentQueueItem(item: DurableConversionQueueItem(
+                ordinal: offset,
+                origin: .multiTitle,
+                intent: DurableQueueItemIntent(draft: draft),
+                state: fixture.state,
+                result: fixture.state == .completed ? DurableQueueResult(outputPath: "/Movies/Avatar Bonus Features.mov") : nil
             ))
         }
     }


### PR DESCRIPTION
# Summary

- make persistent queue rows source-first so repeated title names remain
  distinguishable
- show selected title, source kind, Profile, and state in a three-line regular
  hierarchy and a two-line compact hierarchy
- expose source, location, selected title, kind, state, Profile, destination,
  and planned output in the selected-item detail pane
- add accessible full-value labels for middle-truncated row and detail text
- add projection and render coverage for long names, duplicate titles,
  removable media, multi-title sources, and compact rows

# Validation

- `uv run python scripts/native_app.py test` — 530 tests passed
- focused queue model and render suites — 50 tests passed
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current`
- visually verified two source-first three-line rows and the expanded detail
  pane in the published app; removed the test rows afterward

Refs #679
