### PR TITLE
Restore direct queue ordering and item manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ resolution prompt. Editing a waiting row can also park that row as **Needs a
 Choice** instead of losing the unresolved route-quality decision.
 
 Waiting videos can be selected, edited, dragged into a new order, or arranged
-from the queue's **Arrange** menu with **Move Up** (`⌘⌥↑`), **Move Down**
-(`⌘⌥↓`), and **Convert Next** (`⌘⌥↩`). They can also be removed and restored
+from the menu bar's **Queue** menu and the sidebar's **Arrange** menu. The Queue
+commands include **Move Up** (`⌘⌥↑`), **Move Down** (`⌘⌥↓`), and **Convert
+Next** (`⌘⌥↩`). They can also be removed and restored
 with Undo. Locked rows explain why they cannot move or edit while active and
 completed settings remain locked. Work restored after an app restart never starts automatically; interrupted or
 stopped videos require an explicit **Resume Queue**, **Restart Safely**, or

--- a/README.md
+++ b/README.md
@@ -228,9 +228,11 @@ scoped to the matching source and Profile and can be forgotten from the
 resolution prompt. Editing a waiting row can also park that row as **Needs a
 Choice** instead of losing the unresolved route-quality decision.
 
-Waiting videos can be selected, edited, reordered, moved next, removed, and
-restored with Undo while active and completed settings remain locked. Work
-restored after an app restart never starts automatically; interrupted or
+Waiting videos can be selected, edited, dragged into a new order, or arranged
+from the queue's **Arrange** menu with **Move Up** (`⌘⌥↑`), **Move Down**
+(`⌘⌥↓`), and **Convert Next** (`⌘⌥↩`). They can also be removed and restored
+with Undo. Locked rows explain why they cannot move or edit while active and
+completed settings remain locked. Work restored after an app restart never starts automatically; interrupted or
 stopped videos require an explicit **Resume Queue**, **Restart Safely**, or
 recovery choice. **Pause After Current** lets the active video finish without
 starting another, while **Stop Current** cancels only the active video and

--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ Choice** instead of losing the unresolved route-quality decision.
 Waiting videos can be selected, edited, dragged into a new order, or arranged
 from the menu bar's **Queue** menu and the sidebar's **Arrange** menu. The Queue
 commands include **Move Up** (`⌘⌥↑`), **Move Down** (`⌘⌥↓`), and **Convert
-Next** (`⌘⌥↩`). They can also be removed and restored
-with Undo. Locked rows explain why they cannot move or edit while active and
-completed settings remain locked. Work restored after an app restart never starts automatically; interrupted or
+Next** (`⌘⌥↩`). They can also be removed and restored with Undo. Locked rows
+explain why they cannot move or edit, while active and completed settings remain
+locked. Work restored after an app restart never starts automatically; interrupted or
 stopped videos require an explicit **Resume Queue**, **Restart Safely**, or
 recovery choice. **Pause After Current** lets the active video finish without
 starting another, while **Stop Current** cancels only the active video and

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -8,14 +8,32 @@ struct ConversionSourceSelectionAction {
     let perform: () -> Void
 }
 
+struct PersistentQueueCommandActions {
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let canConvertNext: Bool
+    let moveUp: () -> Void
+    let moveDown: () -> Void
+    let convertNext: () -> Void
+}
+
 private struct ConversionSourceSelectionActionKey: FocusedValueKey {
     typealias Value = ConversionSourceSelectionAction
+}
+
+private struct PersistentQueueCommandActionsKey: FocusedValueKey {
+    typealias Value = PersistentQueueCommandActions
 }
 
 extension FocusedValues {
     var conversionSourceSelectionAction: ConversionSourceSelectionAction? {
         get { self[ConversionSourceSelectionActionKey.self] }
         set { self[ConversionSourceSelectionActionKey.self] = newValue }
+    }
+
+    var persistentQueueCommandActions: PersistentQueueCommandActions? {
+        get { self[PersistentQueueCommandActionsKey.self] }
+        set { self[PersistentQueueCommandActionsKey.self] = newValue }
     }
 }
 
@@ -106,6 +124,7 @@ struct BluRayToVisionProApp: App {
             SettingsWindowCommands()
             UpdateCommands(updater: updater)
             SourceCommands()
+            PersistentQueueCommands()
         }
 
         Window("Settings", id: AppWindowID.settings) {
@@ -119,6 +138,34 @@ struct BluRayToVisionProApp: App {
         .windowResizability(.contentMinSize)
     }
 
+}
+
+private struct PersistentQueueCommands: Commands {
+    @FocusedValue(\.persistentQueueCommandActions) private var actions
+
+    var body: some Commands {
+        CommandMenu("Queue") {
+            Button("Move Up") {
+                actions?.moveUp()
+            }
+            .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+            .disabled(actions?.canMoveUp != true)
+
+            Button("Move Down") {
+                actions?.moveDown()
+            }
+            .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+            .disabled(actions?.canMoveDown != true)
+
+            Divider()
+
+            Button("Convert Next") {
+                actions?.convertNext()
+            }
+            .keyboardShortcut(.return, modifiers: [.command, .option])
+            .disabled(actions?.canConvertNext != true)
+        }
+    }
 }
 
 private struct SourceCommands: Commands {

--- a/macos/BluRayToVisionPro/Info-Release.plist
+++ b/macos/BluRayToVisionPro/Info-Release.plist
@@ -42,5 +42,18 @@
 	<string>nJv1BH0mc2KFORVIDLlSI2A9mvGpVWdLcxlmz++OODU=</string>
 	<key>SUVerifyUpdateBeforeExtraction</key>
 	<true/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Persistent Queue Item</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.shinycomputers.bd-to-avp.queue-item</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/macos/BluRayToVisionPro/Info.plist
+++ b/macos/BluRayToVisionPro/Info.plist
@@ -32,5 +32,18 @@
 	<string>bd_to_avp.worker</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Persistent Queue Item</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.shinycomputers.bd-to-avp.queue-item</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -160,6 +160,31 @@ struct PersistentQueueItem: Identifiable, Equatable {
         status == .waiting
     }
 
+    var queueManipulationLockReason: String? {
+        switch status {
+        case .waiting:
+            nil
+        case .needsChoice:
+            "Resolve this item's required choice before moving or editing it."
+        case .inspecting, .processing:
+            "This item is active and cannot move or be edited until it finishes."
+        case .stopping:
+            "This item is stopping and cannot move or be edited until it has stopped."
+        case .interrupted:
+            "Restart this interrupted item before changing its position or settings."
+        case .attention:
+            "Resolve the required action before moving or editing this item."
+        case .failed:
+            "Retry this failed item before changing its position or settings."
+        case .completed:
+            "Completed items cannot move or be edited."
+        case .stopped:
+            "Restart this stopped item before changing its position or settings."
+        case .notStarted:
+            "This item is not ready to move or edit yet."
+        }
+    }
+
     var canRemove: Bool {
         switch status {
         case .waiting, .needsChoice, .interrupted, .attention, .failed, .stopped, .notStarted:

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -434,6 +434,7 @@ struct ContentView: View {
             addSources: addSourcesToPersistentQueue,
             addSourceFolder: addSourceFolderToPersistentQueue,
             addDisc: { appendSourcesToPersistentQueue([$0]) },
+            addDroppedURLs: acceptDrop,
             move: movePersistentQueueItem,
             moveRelative: movePersistentQueueItem,
             moveNext: movePersistentQueueItemNext,

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -139,6 +139,7 @@ struct ContentView: View {
         mainContent
         .accessibilityIdentifier("main-window-content")
         .focusedSceneValue(\.conversionSourceSelectionAction, sourceSelectionAction)
+        .focusedSceneValue(\.persistentQueueCommandActions, persistentQueueCommandActions)
         .toolbar { toolbarContent }
         .animation(.easeInOut(duration: 0.18), value: isShowingActivity)
         .dropDestination(for: URL.self, action: acceptDrop) { targeted in
@@ -456,6 +457,33 @@ struct ContentView: View {
         return viewModel.persistentQueueResolutionGroups.first { group in
             group.candidates.contains(where: { $0.id == selectedItemID })
         }
+    }
+
+    private var persistentQueueCommandActions: PersistentQueueCommandActions {
+        let waitingItems = viewModel.persistentQueueItems.filter(\.canMove)
+        let selectedID = viewModel.selectedPersistentQueueItemID
+        let selectedIndex = selectedID.flatMap { id in
+            waitingItems.firstIndex(where: { $0.id == id })
+        }
+
+        return PersistentQueueCommandActions(
+            canMoveUp: selectedIndex.map { $0 > waitingItems.startIndex } ?? false,
+            canMoveDown: selectedIndex.map { $0 < waitingItems.index(before: waitingItems.endIndex) } ?? false,
+            canConvertNext: selectedIndex.map { $0 > waitingItems.startIndex } ?? false,
+            moveUp: { moveSelectedPersistentQueueItem(by: -1) },
+            moveDown: { moveSelectedPersistentQueueItem(by: 1) },
+            convertNext: moveSelectedPersistentQueueItemNext
+        )
+    }
+
+    private func moveSelectedPersistentQueueItem(by offset: Int) {
+        guard let selectedID = viewModel.selectedPersistentQueueItemID else { return }
+        movePersistentQueueItem(selectedID, by: offset)
+    }
+
+    private func moveSelectedPersistentQueueItemNext() {
+        guard let selectedID = viewModel.selectedPersistentQueueItemID else { return }
+        movePersistentQueueItemNext(selectedID)
     }
 
     private func resolvePersistentQueueRouteQuality(

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -434,6 +434,7 @@ struct ContentView: View {
             addSourceFolder: addSourceFolderToPersistentQueue,
             addDisc: { appendSourcesToPersistentQueue([$0]) },
             move: movePersistentQueueItem,
+            moveRelative: movePersistentQueueItem,
             moveNext: movePersistentQueueItemNext,
             remove: removePersistentQueueItem,
             clearCompleted: clearCompletedPersistentQueueItems,
@@ -1179,6 +1180,25 @@ struct ContentView: View {
                 if offset < 0 {
                     try await viewModel.movePersistentQueueItem(itemID, before: targetID)
                 } else {
+                    try await viewModel.movePersistentQueueItem(itemID, after: targetID)
+                }
+            } catch {
+                persistentQueueErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func movePersistentQueueItem(
+        _ itemID: UUID,
+        relativeTo targetID: UUID,
+        placement: PersistentQueueMovePlacement
+    ) {
+        Task { @MainActor in
+            do {
+                switch placement {
+                case .before:
+                    try await viewModel.movePersistentQueueItem(itemID, before: targetID)
+                case .after:
                     try await viewModel.movePersistentQueueItem(itemID, after: targetID)
                 }
             } catch {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -12,8 +12,13 @@ private struct PersistentQueueDropInsertion: Equatable {
     let placement: PersistentQueueMovePlacement
 }
 
+private extension UTType {
+    static let persistentQueueItem = UTType(exportedAs: "com.shinycomputers.bd-to-avp.queue-item")
+}
+
 struct PersistentQueueSidebarView: View {
     @State private var dropInsertion: PersistentQueueDropInsertion?
+    @State private var draggedItemID: UUID?
 
     let items: [PersistentQueueItem]
     @Binding var selectedID: UUID?
@@ -224,6 +229,7 @@ struct PersistentQueueSidebarView: View {
                 canMoveDown: canMove(item, by: 1),
                 canConvertNext: canMoveToNext(item),
                 dropInsertion: $dropInsertion,
+                draggedItemID: $draggedItemID,
                 move: move,
                 moveRelative: moveRelative,
                 moveNext: moveNext,
@@ -265,13 +271,10 @@ struct PersistentQueueSidebarView: View {
                         if selectedItem.canMove {
                             Button("Convert Next") { moveNext(selectedItem.id) }
                                 .disabled(!canMoveToNext(selectedItem))
-                                .keyboardShortcut(.return, modifiers: [.command, .option])
                             Button("Move Up") { move(selectedItem.id, -1) }
                                 .disabled(!canMove(selectedItem, by: -1))
-                                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
                             Button("Move Down") { move(selectedItem.id, 1) }
                                 .disabled(!canMove(selectedItem, by: 1))
-                                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
                         } else if let reason = selectedItem.queueManipulationLockReason {
                             Text(reason)
                         }
@@ -478,6 +481,7 @@ private struct PersistentQueueRow: View {
     let canMoveDown: Bool
     let canConvertNext: Bool
     @Binding var dropInsertion: PersistentQueueDropInsertion?
+    @Binding var draggedItemID: UUID?
     let move: (UUID, Int) -> Void
     let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
     let moveNext: (UUID) -> Void
@@ -492,7 +496,11 @@ private struct PersistentQueueRow: View {
         if item.canMove {
             baseRow
                 .onDrag {
-                    NSItemProvider(object: item.id.uuidString as NSString)
+                    draggedItemID = item.id
+                    return NSItemProvider(
+                        item: item.id.uuidString as NSString,
+                        typeIdentifier: UTType.persistentQueueItem.identifier
+                    )
                 }
                 .background {
                     GeometryReader { proxy in
@@ -504,11 +512,12 @@ private struct PersistentQueueRow: View {
                     }
                 }
                 .onDrop(
-                    of: [UTType.plainText],
+                    of: [UTType.persistentQueueItem],
                     delegate: PersistentQueueRowDropDelegate(
                         targetID: item.id,
                         rowHeight: rowHeight,
                         dropInsertion: $dropInsertion,
+                        draggedItemID: $draggedItemID,
                         moveRelative: moveRelative
                     )
                 )
@@ -641,13 +650,20 @@ private struct PersistentQueueRowDropDelegate: DropDelegate {
     let targetID: UUID
     let rowHeight: CGFloat
     @Binding var dropInsertion: PersistentQueueDropInsertion?
+    @Binding var draggedItemID: UUID?
     let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
 
     func validateDrop(info: DropInfo) -> Bool {
-        info.hasItemsConforming(to: [UTType.plainText])
+        guard let draggedItemID, draggedItemID != targetID else {
+            return false
+        }
+        return info.hasItemsConforming(to: [UTType.persistentQueueItem])
     }
 
     func dropEntered(info: DropInfo) {
+        guard validateDrop(info: info) else {
+            return
+        }
         updateInsertion(for: info)
     }
 
@@ -659,27 +675,23 @@ private struct PersistentQueueRowDropDelegate: DropDelegate {
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
+        guard validateDrop(info: info) else {
+            dropInsertion = nil
+            return DropProposal(operation: .forbidden)
+        }
         updateInsertion(for: info)
         return DropProposal(operation: .move)
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { dropInsertion = nil }
-        guard let provider = info.itemProviders(for: [UTType.plainText]).first else {
+        defer {
+            dropInsertion = nil
+            draggedItemID = nil
+        }
+        guard validateDrop(info: info), let sourceID = draggedItemID else {
             return false
         }
-        let targetPlacement = placement(for: info)
-        provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, error in
-            guard error == nil,
-                  let sourceID = persistentQueueItemID(from: item),
-                  sourceID != targetID
-            else {
-                return
-            }
-            DispatchQueue.main.async {
-                moveRelative(sourceID, targetID, targetPlacement)
-            }
-        }
+        moveRelative(sourceID, targetID, placement(for: info))
         return true
     }
 
@@ -688,22 +700,8 @@ private struct PersistentQueueRowDropDelegate: DropDelegate {
     }
 
     private func placement(for info: DropInfo) -> PersistentQueueMovePlacement {
-        info.location.y < rowHeight / 2 ? .before : .after
-    }
-
-    private func persistentQueueItemID(from item: NSSecureCoding?) -> UUID? {
-        let value: String?
-        switch item {
-        case let string as String:
-            value = string
-        case let string as NSString:
-            value = string as String
-        case let data as Data:
-            value = String(data: data, encoding: .utf8)
-        default:
-            value = nil
-        }
-        return value.flatMap(UUID.init(uuidString:))
+        let measuredHeight = rowHeight > 0 ? rowHeight : 44
+        return info.location.y < measuredHeight / 2 ? .before : .after
     }
 }
 

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -1,7 +1,20 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
+
+enum PersistentQueueMovePlacement: Equatable {
+    case before
+    case after
+}
+
+private struct PersistentQueueDropInsertion: Equatable {
+    let targetID: UUID
+    let placement: PersistentQueueMovePlacement
+}
 
 struct PersistentQueueSidebarView: View {
+    @State private var dropInsertion: PersistentQueueDropInsertion?
+
     let items: [PersistentQueueItem]
     @Binding var selectedID: UUID?
     @Binding var compactRows: Bool
@@ -21,6 +34,7 @@ struct PersistentQueueSidebarView: View {
     let addSourceFolder: () -> Void
     let addDisc: (ConversionSource) -> Void
     let move: (UUID, Int) -> Void
+    let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
     let moveNext: (UUID) -> Void
     let remove: (UUID) -> Void
     let clearCompleted: () -> Void
@@ -206,7 +220,12 @@ struct PersistentQueueSidebarView: View {
                 total: items.count,
                 compact: compactRows,
                 progress: item.status.isActive ? activeProgress : nil,
+                canMoveUp: canMove(item, by: -1),
+                canMoveDown: canMove(item, by: 1),
+                canConvertNext: canMoveToNext(item),
+                dropInsertion: $dropInsertion,
                 move: move,
+                moveRelative: moveRelative,
                 moveNext: moveNext,
                 remove: remove
             )
@@ -240,6 +259,31 @@ struct PersistentQueueSidebarView: View {
                 .buttonStyle(.borderless)
                 .disabled(selectedItem?.canRemove != true)
                 .accessibilityIdentifier("persistent-queue-remove")
+
+                Menu {
+                    if let selectedItem {
+                        if selectedItem.canMove {
+                            Button("Convert Next") { moveNext(selectedItem.id) }
+                                .disabled(!canMoveToNext(selectedItem))
+                                .keyboardShortcut(.return, modifiers: [.command, .option])
+                            Button("Move Up") { move(selectedItem.id, -1) }
+                                .disabled(!canMove(selectedItem, by: -1))
+                                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                            Button("Move Down") { move(selectedItem.id, 1) }
+                                .disabled(!canMove(selectedItem, by: 1))
+                                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                        } else if let reason = selectedItem.queueManipulationLockReason {
+                            Text(reason)
+                        }
+                    } else {
+                        Text("Select a waiting item to arrange it.")
+                    }
+                } label: {
+                    Label("Arrange", systemImage: "arrow.up.arrow.down")
+                }
+                .menuStyle(.borderlessButton)
+                .accessibilityHint("Move the selected waiting item with Command-Option-Up Arrow or Command-Option-Down Arrow.")
+                .accessibilityIdentifier("persistent-queue-arrange")
 
                 Spacer()
                 if canUndo {
@@ -295,6 +339,21 @@ struct PersistentQueueSidebarView: View {
     private var completedItems: [PersistentQueueItem] { items.filter(\.status.isCompleted) }
     private var pendingItems: [PersistentQueueItem] {
         items.filter { !$0.status.isActive && !$0.status.isCompleted }
+    }
+
+    private var waitingItems: [PersistentQueueItem] {
+        items.filter(\.canMove)
+    }
+
+    private func canMove(_ item: PersistentQueueItem, by offset: Int) -> Bool {
+        guard let index = waitingItems.firstIndex(where: { $0.id == item.id }) else {
+            return false
+        }
+        return waitingItems.indices.contains(index + offset)
+    }
+
+    private func canMoveToNext(_ item: PersistentQueueItem) -> Bool {
+        waitingItems.first?.id != item.id
     }
     private var selectedItem: PersistentQueueItem? {
         selectedID.flatMap { id in items.first(where: { $0.id == id }) }
@@ -408,16 +467,67 @@ struct OffPeakScheduleSheet: View {
 }
 
 private struct PersistentQueueRow: View {
+    @State private var rowHeight: CGFloat = 0
+
     let item: PersistentQueueItem
     let position: Int
     let total: Int
     let compact: Bool
     let progress: WorkerProgress?
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let canConvertNext: Bool
+    @Binding var dropInsertion: PersistentQueueDropInsertion?
     let move: (UUID, Int) -> Void
+    let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
     let moveNext: (UUID) -> Void
     let remove: (UUID) -> Void
 
     var body: some View {
+        interactiveRow
+    }
+
+    @ViewBuilder
+    private var interactiveRow: some View {
+        if item.canMove {
+            baseRow
+                .onDrag {
+                    NSItemProvider(object: item.id.uuidString as NSString)
+                }
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear { rowHeight = proxy.size.height }
+                            .onChange(of: proxy.size) { _, size in
+                                rowHeight = size.height
+                            }
+                    }
+                }
+                .onDrop(
+                    of: [UTType.plainText],
+                    delegate: PersistentQueueRowDropDelegate(
+                        targetID: item.id,
+                        rowHeight: rowHeight,
+                        dropInsertion: $dropInsertion,
+                        moveRelative: moveRelative
+                    )
+                )
+                .accessibilityAction(named: "Convert Next") {
+                    if canConvertNext { moveNext(item.id) }
+                }
+                .accessibilityAction(named: "Move Up") {
+                    if canMoveUp { move(item.id, -1) }
+                }
+                .accessibilityAction(named: "Move Down") {
+                    if canMoveDown { move(item.id, 1) }
+                }
+        } else {
+            baseRow
+                .accessibilityHint(item.queueManipulationLockReason ?? "This item cannot move or be edited.")
+        }
+    }
+
+    private var baseRow: some View {
         HStack(spacing: compact ? 7 : 9) {
             Image(systemName: item.status.systemImage)
                 .font(.system(size: compact ? 13 : 15, weight: .medium))
@@ -489,8 +599,14 @@ private struct PersistentQueueRow: View {
         .contextMenu {
             if item.canMove {
                 Button("Convert Next") { moveNext(item.id) }
+                    .disabled(!canConvertNext)
                 Button("Move Up") { move(item.id, -1) }
+                    .disabled(!canMoveUp)
                 Button("Move Down") { move(item.id, 1) }
+                    .disabled(!canMoveDown)
+                Divider()
+            } else if let reason = item.queueManipulationLockReason {
+                Text(reason)
                 Divider()
             }
             Button("Remove from Queue", role: .destructive) { remove(item.id) }
@@ -502,15 +618,92 @@ private struct PersistentQueueRow: View {
                 + "Source kind: \(item.sourceKindName). Profile: \(item.draft.profile.name). "
                 + "State: \(item.status.title). Queue item \(position) of \(total)."
         )
-        .accessibilityAction(named: "Move Up") {
-            if item.canMove { move(item.id, -1) }
-        }
-        .accessibilityAction(named: "Move Down") {
-            if item.canMove { move(item.id, 1) }
-        }
         .accessibilityAction(named: "Remove from Queue") {
             if item.canRemove { remove(item.id) }
         }
+        .overlay(alignment: insertionAlignment) {
+            if dropInsertion?.targetID == item.id {
+                Color.accentColor
+                    .frame(height: 2)
+                    .padding(.horizontal, 4)
+                    .accessibilityHidden(true)
+            }
+        }
+        .animation(.easeInOut(duration: 0.15), value: dropInsertion)
+    }
+
+    private var insertionAlignment: Alignment {
+        dropInsertion?.placement == .before ? .top : .bottom
+    }
+}
+
+private struct PersistentQueueRowDropDelegate: DropDelegate {
+    let targetID: UUID
+    let rowHeight: CGFloat
+    @Binding var dropInsertion: PersistentQueueDropInsertion?
+    let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [UTType.plainText])
+    }
+
+    func dropEntered(info: DropInfo) {
+        updateInsertion(for: info)
+    }
+
+    func dropExited(info _: DropInfo) {
+        guard dropInsertion?.targetID == targetID else {
+            return
+        }
+        dropInsertion = nil
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        updateInsertion(for: info)
+        return DropProposal(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        defer { dropInsertion = nil }
+        guard let provider = info.itemProviders(for: [UTType.plainText]).first else {
+            return false
+        }
+        let targetPlacement = placement(for: info)
+        provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, error in
+            guard error == nil,
+                  let sourceID = persistentQueueItemID(from: item),
+                  sourceID != targetID
+            else {
+                return
+            }
+            DispatchQueue.main.async {
+                moveRelative(sourceID, targetID, targetPlacement)
+            }
+        }
+        return true
+    }
+
+    private func updateInsertion(for info: DropInfo) {
+        dropInsertion = PersistentQueueDropInsertion(targetID: targetID, placement: placement(for: info))
+    }
+
+    private func placement(for info: DropInfo) -> PersistentQueueMovePlacement {
+        info.location.y < rowHeight / 2 ? .before : .after
+    }
+
+    private func persistentQueueItemID(from item: NSSecureCoding?) -> UUID? {
+        let value: String?
+        switch item {
+        case let string as String:
+            value = string
+        case let string as NSString:
+            value = string as String
+        case let data as Data:
+            value = String(data: data, encoding: .utf8)
+        default:
+            value = nil
+        }
+        return value.flatMap(UUID.init(uuidString:))
     }
 }
 
@@ -636,13 +829,16 @@ struct PersistentQueueDetailView: View {
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Conversion Setup")
                         .font(.title3.weight(.semibold))
-                    Text(item.isEditable ? "Waiting items can be edited until they start." : "Settings are locked for this queue state.")
+                    Text(item.isEditable
+                        ? "Waiting items can be edited until they start."
+                        : (item.queueManipulationLockReason ?? "Settings are locked for this queue state."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 Button("Edit…") { edit(item) }
                     .disabled(!item.isEditable)
+                    .help(item.isEditable ? "Edit this waiting item." : (item.queueManipulationLockReason ?? "Settings are locked."))
             }
             Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 10) {
                 GridRow {
@@ -655,6 +851,7 @@ struct PersistentQueueDetailView: View {
                         detailValue(item.draft.destinationURL.path, label: "Destination")
                         Button("Change…") { changeDestination(item) }
                             .disabled(!item.isEditable)
+                            .help(item.isEditable ? "Change this waiting item's destination." : (item.queueManipulationLockReason ?? "Settings are locked."))
                     }
                 }
                 GridRow {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
-enum PersistentQueueMovePlacement: Equatable {
+enum PersistentQueueMovePlacement: Equatable, Sendable {
     case before
     case after
 }
@@ -13,12 +13,14 @@ private struct PersistentQueueDropInsertion: Equatable {
 }
 
 private extension UTType {
-    static let persistentQueueItem = UTType(exportedAs: "com.shinycomputers.bd-to-avp.queue-item")
+    static let persistentQueueItem = UTType(
+        exportedAs: "com.shinycomputers.bd-to-avp.queue-item",
+        conformingTo: .data
+    )
 }
 
 struct PersistentQueueSidebarView: View {
     @State private var dropInsertion: PersistentQueueDropInsertion?
-    @State private var draggedItemID: UUID?
 
     let items: [PersistentQueueItem]
     @Binding var selectedID: UUID?
@@ -38,6 +40,7 @@ struct PersistentQueueSidebarView: View {
     let addSources: () -> Void
     let addSourceFolder: () -> Void
     let addDisc: (ConversionSource) -> Void
+    let addDroppedURLs: ([URL], CGPoint) -> Bool
     let move: (UUID, Int) -> Void
     let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
     let moveNext: (UUID) -> Void
@@ -77,6 +80,9 @@ struct PersistentQueueSidebarView: View {
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .accessibilityIdentifier("persistent-queue-sidebar")
+        .onChange(of: items.map(\.id)) { _, _ in
+            dropInsertion = nil
+        }
     }
 
     @ViewBuilder
@@ -229,7 +235,7 @@ struct PersistentQueueSidebarView: View {
                 canMoveDown: canMove(item, by: 1),
                 canConvertNext: canMoveToNext(item),
                 dropInsertion: $dropInsertion,
-                draggedItemID: $draggedItemID,
+                addDroppedURLs: addDroppedURLs,
                 move: move,
                 moveRelative: moveRelative,
                 moveNext: moveNext,
@@ -269,12 +275,13 @@ struct PersistentQueueSidebarView: View {
                 Menu {
                     if let selectedItem {
                         if selectedItem.canMove {
-                            Button("Convert Next") { moveNext(selectedItem.id) }
-                                .disabled(!canMoveToNext(selectedItem))
                             Button("Move Up") { move(selectedItem.id, -1) }
                                 .disabled(!canMove(selectedItem, by: -1))
                             Button("Move Down") { move(selectedItem.id, 1) }
                                 .disabled(!canMove(selectedItem, by: 1))
+                            Divider()
+                            Button("Convert Next") { moveNext(selectedItem.id) }
+                                .disabled(!canMoveToNext(selectedItem))
                         } else if let reason = selectedItem.queueManipulationLockReason {
                             Text(reason)
                         }
@@ -481,7 +488,7 @@ private struct PersistentQueueRow: View {
     let canMoveDown: Bool
     let canConvertNext: Bool
     @Binding var dropInsertion: PersistentQueueDropInsertion?
-    @Binding var draggedItemID: UUID?
+    let addDroppedURLs: ([URL], CGPoint) -> Bool
     let move: (UUID, Int) -> Void
     let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
     let moveNext: (UUID) -> Void
@@ -495,13 +502,7 @@ private struct PersistentQueueRow: View {
     private var interactiveRow: some View {
         if item.canMove {
             baseRow
-                .onDrag {
-                    draggedItemID = item.id
-                    return NSItemProvider(
-                        item: item.id.uuidString as NSString,
-                        typeIdentifier: UTType.persistentQueueItem.identifier
-                    )
-                }
+                .onDrag { queueItemProvider() }
                 .background {
                     GeometryReader { proxy in
                         Color.clear
@@ -512,12 +513,12 @@ private struct PersistentQueueRow: View {
                     }
                 }
                 .onDrop(
-                    of: [UTType.persistentQueueItem],
+                    of: [UTType.persistentQueueItem, UTType.fileURL],
                     delegate: PersistentQueueRowDropDelegate(
                         targetID: item.id,
                         rowHeight: rowHeight,
                         dropInsertion: $dropInsertion,
-                        draggedItemID: $draggedItemID,
+                        addDroppedURLs: addDroppedURLs,
                         moveRelative: moveRelative
                     )
                 )
@@ -534,6 +535,19 @@ private struct PersistentQueueRow: View {
             baseRow
                 .accessibilityHint(item.queueManipulationLockReason ?? "This item cannot move or be edited.")
         }
+    }
+
+    private func queueItemProvider() -> NSItemProvider {
+        let provider = NSItemProvider()
+        let itemData = Data(item.id.uuidString.utf8)
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.persistentQueueItem.identifier,
+            visibility: .ownProcess
+        ) { completion in
+            completion(itemData, nil)
+            return nil
+        }
+        return provider
     }
 
     private var baseRow: some View {
@@ -607,12 +621,13 @@ private struct PersistentQueueRow: View {
         .contentShape(Rectangle())
         .contextMenu {
             if item.canMove {
-                Button("Convert Next") { moveNext(item.id) }
-                    .disabled(!canConvertNext)
                 Button("Move Up") { move(item.id, -1) }
                     .disabled(!canMoveUp)
                 Button("Move Down") { move(item.id, 1) }
                     .disabled(!canMoveDown)
+                Divider()
+                Button("Convert Next") { moveNext(item.id) }
+                    .disabled(!canConvertNext)
                 Divider()
             } else if let reason = item.queueManipulationLockReason {
                 Text(reason)
@@ -650,18 +665,15 @@ private struct PersistentQueueRowDropDelegate: DropDelegate {
     let targetID: UUID
     let rowHeight: CGFloat
     @Binding var dropInsertion: PersistentQueueDropInsertion?
-    @Binding var draggedItemID: UUID?
+    let addDroppedURLs: ([URL], CGPoint) -> Bool
     let moveRelative: (UUID, UUID, PersistentQueueMovePlacement) -> Void
 
     func validateDrop(info: DropInfo) -> Bool {
-        guard let draggedItemID, draggedItemID != targetID else {
-            return false
-        }
-        return info.hasItemsConforming(to: [UTType.persistentQueueItem])
+        info.hasItemsConforming(to: [UTType.persistentQueueItem, UTType.fileURL])
     }
 
     func dropEntered(info: DropInfo) {
-        guard validateDrop(info: info) else {
+        guard info.hasItemsConforming(to: [UTType.persistentQueueItem]) else {
             return
         }
         updateInsertion(for: info)
@@ -675,24 +687,58 @@ private struct PersistentQueueRowDropDelegate: DropDelegate {
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        guard validateDrop(info: info) else {
-            dropInsertion = nil
-            return DropProposal(operation: .forbidden)
+        if info.hasItemsConforming(to: [UTType.persistentQueueItem]) {
+            updateInsertion(for: info)
+            return DropProposal(operation: .move)
         }
-        updateInsertion(for: info)
-        return DropProposal(operation: .move)
+        dropInsertion = nil
+        return info.hasItemsConforming(to: [UTType.fileURL])
+            ? DropProposal(operation: .copy)
+            : DropProposal(operation: .forbidden)
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer {
-            dropInsertion = nil
-            draggedItemID = nil
+        defer { dropInsertion = nil }
+        if let provider = info.itemProviders(for: [UTType.persistentQueueItem]).first {
+            return performQueueItemDrop(provider: provider, info: info)
         }
-        guard validateDrop(info: info), let sourceID = draggedItemID else {
+        return performFileURLDrop(info: info)
+    }
+
+    private func performQueueItemDrop(provider: NSItemProvider, info: DropInfo) -> Bool {
+        guard validateDrop(info: info) else {
             return false
         }
-        moveRelative(sourceID, targetID, placement(for: info))
+        let targetID = targetID
+        let targetPlacement = placement(for: info)
+        let moveRelative = moveRelative
+        provider.loadDataRepresentation(forTypeIdentifier: UTType.persistentQueueItem.identifier) { data, error in
+            guard error == nil,
+                  let data,
+                  let value = String(data: data, encoding: .utf8),
+                  let sourceID = UUID(uuidString: value),
+                  sourceID != targetID
+            else {
+                return
+            }
+            DispatchQueue.main.async {
+                moveRelative(sourceID, targetID, targetPlacement)
+            }
+        }
         return true
+    }
+
+    private func performFileURLDrop(info: DropInfo) -> Bool {
+        guard info.hasItemsConforming(to: [UTType.fileURL]) else {
+            return false
+        }
+        let pasteboardURLs = NSPasteboard(name: .drag)
+            .readObjects(forClasses: [NSURL.self]) as? [NSURL] ?? []
+        let fileURLs = pasteboardURLs.compactMap { $0.filePathURL as URL? }
+        guard !fileURLs.isEmpty else {
+            return false
+        }
+        return addDroppedURLs(fileURLs, info.location)
     }
 
     private func updateInsertion(for info: DropInfo) {

--- a/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
+++ b/macos/BluRayToVisionProTests/ConversionQueueStoreTests.swift
@@ -477,6 +477,32 @@ final class ConversionQueueStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testPersistentQueueMovePersistsMixedRowOrderAcrossReload() async throws {
+        let directoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent("queue.json")
+        let active = makeItem(ordinal: 0, sourcePath: "/tmp/active.mkv", state: .processing)
+        let completed = makeItem(
+            ordinal: 1,
+            sourcePath: "/tmp/completed.mkv",
+            state: .completed,
+            result: DurableQueueResult(outputPath: "/tmp/completed.mov")
+        )
+        let first = makeItem(ordinal: 2, sourcePath: "/tmp/first.mkv")
+        let second = makeItem(ordinal: 3, sourcePath: "/tmp/second.mkv")
+        let third = makeItem(ordinal: 4, sourcePath: "/tmp/third.mkv")
+        let store = ConversionQueueStore(fileURL: fileURL)
+        try await store.replaceItems([active, completed, first, second, third])
+
+        try await store.moveWaitingItem(third.id, before: first.id)
+
+        let reloadedStore = ConversionQueueStore(fileURL: fileURL)
+        XCTAssertEqual(reloadedStore.items.map(\.id), [active.id, completed.id, third.id, first.id, second.id])
+        XCTAssertEqual(reloadedStore.items.map(\.ordinal), Array(reloadedStore.items.indices))
+        XCTAssertEqual(reloadedStore.items.map(\.state), [.interrupted, .completed, .waiting, .waiting, .waiting])
+    }
+
+    @MainActor
     func testPersistentQueueRemovalAllowsRecoverableTerminalRows() async throws {
         let store = ConversionQueueStore.inMemory()
         let failed = makeItem(

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -102,6 +102,10 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         let group = try XCTUnwrap(QueueResolutionGroup.group([
             QueueResolutionCandidate(id: item.id, draft: item.draft, conflict: conflict),
         ]).first)
+        XCTAssertEqual(
+            item.queueManipulationLockReason,
+            "Resolve this item's required choice before moving or editing it."
+        )
 
         try render(
             items: [item],
@@ -145,6 +149,37 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         )
     }
 
+    func testQueueWorkspaceRendersQueueManipulationAtMinimumSidebarWidth() throws {
+        let items = try makeItems()
+        XCTAssertEqual(
+            items[0].queueManipulationLockReason,
+            "This item is active and cannot move or be edited until it finishes."
+        )
+        XCTAssertEqual(
+            items[1].queueManipulationLockReason,
+            "Restart this interrupted item before changing its position or settings."
+        )
+        XCTAssertEqual(
+            items[2].queueManipulationLockReason,
+            "Retry this failed item before changing its position or settings."
+        )
+        XCTAssertEqual(
+            items[3].queueManipulationLockReason,
+            "This item is stopping and cannot move or be edited until it has stopped."
+        )
+        XCTAssertNil(items[4].queueManipulationLockReason)
+        XCTAssertEqual(items[10].queueManipulationLockReason, "Completed items cannot move or be edited.")
+
+        try render(
+            items: items,
+            selectedItem: items[4],
+            compact: true,
+            colorScheme: .dark,
+            appearanceName: .darkAqua,
+            sidebarWidth: 300
+        )
+    }
+
     private func render(
         items: [PersistentQueueItem],
         selectedItem: PersistentQueueItem?,
@@ -153,7 +188,8 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         appearanceName: NSAppearance.Name,
         offPeakSchedule: OffPeakQueueSchedule? = nil,
         offPeakScheduleOutcome: OffPeakScheduleOutcome? = nil,
-        resolutionGroup: QueueResolutionGroup? = nil
+        resolutionGroup: QueueResolutionGroup? = nil,
+        sidebarWidth: CGFloat = 330
     ) throws {
         let content = HSplitView {
             PersistentQueueSidebarView(
@@ -176,6 +212,7 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 addSourceFolder: {},
                 addDisc: { _ in },
                 move: { _, _ in },
+                moveRelative: { _, _, _ in },
                 moveNext: { _ in },
                 remove: { _ in },
                 clearCompleted: {},
@@ -188,7 +225,7 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 pauseAfterCurrent: {},
                 stopCurrent: {}
             )
-            .frame(minWidth: 300, idealWidth: 330, maxWidth: 420)
+            .frame(width: sidebarWidth)
             PersistentQueueDetailView(
                 item: selectedItem,
                 resolutionGroup: resolutionGroup,
@@ -245,6 +282,10 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
             case 2:
                 state = .failed
                 failure = DurableQueueFailure(code: "temporary", message: "Source needs attention", details: nil, retryable: true)
+                result = nil
+            case 3:
+                state = .stopping
+                failure = nil
                 result = nil
             case 10, 11:
                 state = .completed

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -211,6 +211,7 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 addSources: {},
                 addSourceFolder: {},
                 addDisc: { _ in },
+                addDroppedURLs: { _, _ in true },
                 move: { _, _ in },
                 moveRelative: { _, _, _ in },
                 moveNext: { _ in },


### PR DESCRIPTION
## Summary
- add drag reordering for waiting queue rows with top/bottom insertion feedback
- add context, accessibility, sidebar Arrange, and application menu-bar Queue commands
- explain locked-row manipulation limits and preserve reordered state across relaunch

## Validation
- `uv run python scripts/native_app.py test` — 532 tests, 0 failures
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current`
- published app verified with two MKV queue items: menu shortcuts enabled correctly and `⌘⌥↑` reordered the selected row
- `git diff --check`

Refs #680