### PR TITLE
Forecast queue storage and prevent low-space failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,23 @@ while **Stop Current** cancels only the active video and leaves pending work
 waiting for an explicit resume. Runtime failures and recovery decisions remain
 parked according to their existing queue policy.
 
+The queue also shows a coarse storage forecast grouped by destination. Each
+forecast separates estimated output, peak temporary/working space, retained
+intermediates, a visible safety margin, and total peak space. Forecasts use
+known source duration and route information when available; content-dependent
+or artifact-based routes remain explicitly unestimated rather than turning an
+assumption into a capacity block. The safety margin is 10% of peak working
+space, rounded up to whole GiB and clamped between 2 GiB and 20 GiB.
+
+Immediately before each queued item starts inspecting or converting, the app
+rechecks that its destination exists, is a writable directory, and has enough
+confirmed free space for the coarse total peak estimate. Unknown or conflicting
+capacity readings are advisory and do not block an item. A disconnected or
+read-only destination parks only that item with a retryable reconnect/check-
+writable message; known insufficient space parks the item with required and
+available coarse sizes and pauses the remaining queue. Fix the destination or
+free space, then retry the parked item through its existing retry action.
+
 Use **Start Later…** to arm one editable, cancellable off-peak window for the
 queue. The app must remain open: it does not schedule a system wake and does
 not keep the Mac awake merely because a window is armed. If the Mac wakes while

--- a/README.md
+++ b/README.md
@@ -259,8 +259,10 @@ confirmed free space for the coarse total peak estimate. Unknown or conflicting
 capacity readings are advisory and do not block an item. A disconnected or
 read-only destination parks only that item with a retryable reconnect/check-
 writable message; known insufficient space parks the item with required and
-available coarse sizes and pauses the remaining queue. Reconnect the volume,
-free space, or change the parked item's destination, then resume the queue.
+available coarse sizes and pauses the remaining queue. Reconnect the volume or
+free space and retry the parked item, or change its destination and resume the
+queue. The queue-level forecast covers remaining not-yet-active work; held
+route-quality and recovery choices are listed as unestimated until resolved.
 
 Use **Start Later…** to arm one editable, cancellable off-peak window for the
 queue. The app must remain open: it does not schedule a system wake and does

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ confirmed free space for the coarse total peak estimate. Unknown or conflicting
 capacity readings are advisory and do not block an item. A disconnected or
 read-only destination parks only that item with a retryable reconnect/check-
 writable message; known insufficient space parks the item with required and
-available coarse sizes and pauses the remaining queue. Fix the destination or
-free space, then retry the parked item through its existing retry action.
+available coarse sizes and pauses the remaining queue. Reconnect the volume,
+free space, or change the parked item's destination, then resume the queue.
 
 Use **Start Later…** to arm one editable, cancellable off-peak window for the
 queue. The app must remain open: it does not schedule a system wake and does

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -56,7 +56,8 @@ struct BluRayToVisionProApp: App {
         let viewModel = ConversionViewModel(
             observabilityEventStore: observabilityEventStore,
             durableQueueStore: durableQueueStore,
-            offPeakScheduleStore: offPeakScheduleStore
+            offPeakScheduleStore: offPeakScheduleStore,
+            queueStoragePreflight: SystemQueueStoragePreflight()
         )
         let previewViewModel = PreviewViewModel(observabilityEventStore: observabilityEventStore)
         let workCoordinator = AppWorkCoordinator(conversion: viewModel, preview: previewViewModel)

--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -283,8 +283,8 @@ final class ConversionQueueStore: ObservableObject {
             case .waiting:
                 canUpdate = true
             case .failed:
-                canUpdate = items[index].failure?.code == "destination_unavailable"
-                    || items[index].failure?.code == "destination_insufficient_capacity"
+                canUpdate = items[index].failure?.code == DurableQueueFailureCode.destinationUnavailable
+                    || items[index].failure?.code == DurableQueueFailureCode.destinationInsufficientCapacity
             case .needsChoice, .inspecting, .processing, .stopping, .interrupted, .attention,
                  .completed, .stopped, .notStarted:
                 canUpdate = false

--- a/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionQueueStore.swift
@@ -273,6 +273,40 @@ final class ConversionQueueStore: ObservableObject {
         }
     }
 
+    func updateRecoverableItemDestination(_ itemID: UUID, destinationPath: String) async throws {
+        try await mutateItems { items in
+            guard let index = items.firstIndex(where: { $0.id == itemID }) else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            let canUpdate: Bool
+            switch items[index].state {
+            case .waiting:
+                canUpdate = true
+            case .failed:
+                canUpdate = items[index].failure?.code == "destination_unavailable"
+                    || items[index].failure?.code == "destination_insufficient_capacity"
+            case .needsChoice, .inspecting, .processing, .stopping, .interrupted, .attention,
+                 .completed, .stopped, .notStarted:
+                canUpdate = false
+            }
+            guard canUpdate else {
+                throw ConversionQueueStoreError.invalidDocument
+            }
+            items[index].intent.destinationPath = destinationPath
+            if items[index].state == .failed {
+                items[index].state = .waiting
+                items[index].failure = nil
+                items[index].decision = nil
+                items[index].result = nil
+            }
+            let groupIDs = Set(items[index].groupID.map { [$0] } ?? [])
+            Self.normalizeMultiTitleSourceRemoval(
+                in: &items,
+                requests: Self.multiTitleSourceRemovalRequests(in: items, groupIDs: groupIDs)
+            )
+        }
+    }
+
     func resolveHeldItems(
         _ itemIDs: Set<UUID>,
         intents: [UUID: DurableQueueItemIntent],

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -2068,8 +2068,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             case let .unavailable(reason):
                 await parkWaitingDurableQueueItemForStorage(
                     item,
-                    code: "destination_unavailable",
-                    message: "Destination unavailable. Reconnect it and retry this item, or choose another writable destination and resume the queue.",
+                    code: DurableQueueFailureCode.destinationUnavailable,
+                    message: "Destination unavailable. Reconnect it and retry this item, or choose another writable destination. It will rejoin a running queue automatically; otherwise start the queue when ready.",
                     details: reason,
                     pauseQueue: false
                 )
@@ -2080,7 +2080,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 let availableDescription = StorageForecastFormatting.coarse(availableBytes)
                 await parkWaitingDurableQueueItemForStorage(
                     item,
-                    code: "destination_insufficient_capacity",
+                    code: DurableQueueFailureCode.destinationInsufficientCapacity,
                     message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space and retry this item, or choose another destination and resume the queue.",
                     details: "Required: \(requiredDescription). Available: \(availableDescription).",
                     pauseQueue: true

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -77,6 +77,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     private let durableQueueStore: ConversionQueueStore
     private let offPeakScheduleStore: OffPeakScheduleStore
     private let sourceAvailabilityResolver: SourceAvailabilityResolver
+    private let queueStoragePreflight: (any QueueStoragePreflighting)?
     private let diagnosticRecorder = DiagnosticSessionRecorder()
     private var client: (any WorkerProcessRunning)?
     private var runTask: Task<Void, Never>?
@@ -113,7 +114,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         observabilityEventStore: any ObservabilityEventPersisting = NullObservabilityEventStore.shared,
         durableQueueStore: ConversionQueueStore? = nil,
         offPeakScheduleStore: OffPeakScheduleStore? = nil,
-        sourceAvailabilityResolver: @escaping SourceAvailabilityResolver = ConversionViewModel.defaultSourceAvailability
+        sourceAvailabilityResolver: @escaping SourceAvailabilityResolver = ConversionViewModel.defaultSourceAvailability,
+        queueStoragePreflight: (any QueueStoragePreflighting)? = nil
     ) {
         self.clientFactory = clientFactory
         self.diagnosticClock = diagnosticClock
@@ -124,6 +126,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         self.durableQueueStore = durableQueueStore ?? ConversionQueueStore.inMemory()
         self.offPeakScheduleStore = offPeakScheduleStore ?? OffPeakScheduleStore.inMemory()
         self.sourceAvailabilityResolver = sourceAvailabilityResolver
+        self.queueStoragePreflight = queueStoragePreflight
         durableQueueSubscription = self.durableQueueStore.$document.sink { [weak self] document in
             self?.publishPersistentQueueProjection(items: document.items)
         }
@@ -637,7 +640,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         durableQueueStopRequested = false
         var adoptedCount = 0
         for item in candidates {
-            if await adoptPersistentQueueItem(item.id) {
+            if await adoptPersistentQueueItem(item.id, pump: false) {
                 adoptedCount += 1
             }
         }
@@ -647,6 +650,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             offPeakRunWindowEnd = previousWindowEnd
             return .rejected(.noEligibleItems)
         }
+        await pumpDurableQueue()
         return .accepted(.running)
     }
 
@@ -694,7 +698,8 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @discardableResult
     func adoptPersistentQueueItem(
         _ itemID: UUID,
-        recoveryChoice: WorkerRecoveryChoice? = nil
+        recoveryChoice: WorkerRecoveryChoice? = nil,
+        pump: Bool = true
     ) async -> Bool {
         if persistentQueueRunState == .pauseAfterCurrent, hasActiveWorker {
             return false
@@ -786,8 +791,10 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                     publishSourceFolderQueueProjection()
                 }
             }
-            enqueueQueueTransition { [weak self] in
-                await self?.pumpDurableQueue()
+            if pump {
+                enqueueQueueTransition { [weak self] in
+                    await self?.pumpDurableQueue()
+                }
             }
             return true
         } catch {
@@ -2032,6 +2039,37 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             return
         }
 
+        let destinationURL = URL(fileURLWithPath: item.intent.destinationPath)
+        let requiredBytes = (try? conversionDraft(for: item, preserveStoredSourceRemoval: true))
+            .flatMap { StorageForecastItem(draft: $0).totalPeakRequiredBytes }
+        if let queueStoragePreflight {
+            switch queueStoragePreflight.preflight(destinationURL: destinationURL, requiredBytes: requiredBytes) {
+            case .available, .unconfirmed:
+                break
+            case let .unavailable(reason):
+                await parkWaitingDurableQueueItemForStorage(
+                    item,
+                    code: "destination_unavailable",
+                    message: "Destination unavailable. Reconnect the destination and check that the folder is writable, then retry this item.",
+                    details: reason,
+                    pauseQueue: false
+                )
+                await pumpDurableQueue()
+                return
+            case let .insufficient(requiredBytes, availableBytes):
+                let requiredDescription = StorageForecastFormatting.coarse(requiredBytes)
+                let availableDescription = StorageForecastFormatting.coarse(availableBytes)
+                await parkWaitingDurableQueueItemForStorage(
+                    item,
+                    code: "destination_insufficient_capacity",
+                    message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space or choose another destination, then retry this item.",
+                    details: "Required: \(requiredDescription). Available: \(availableDescription).",
+                    pauseQueue: true
+                )
+                return
+            }
+        }
+
         switch item.origin {
         case .multiTitle:
             await startDurableTitleQueueItem(item)
@@ -2039,6 +2077,39 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             await startDurableSourceFolderQueueItem(item)
         case .singleSource:
             await startDurableSingleSourceItem(item)
+        }
+    }
+
+    private func parkWaitingDurableQueueItemForStorage(
+        _ item: DurableConversionQueueItem,
+        code: String,
+        message: String,
+        details: String,
+        pauseQueue: Bool
+    ) async {
+        do {
+            try await durableQueueStore.mutateItems { items in
+                guard let index = items.firstIndex(where: { $0.id == item.id }),
+                      items[index].state == .waiting
+                else {
+                    throw ConversionQueueStoreError.invalidDocument
+                }
+                items[index].state = .failed
+                items[index].decision = nil
+                items[index].failure = DurableQueueFailure(
+                    code: code,
+                    message: message,
+                    details: details,
+                    retryable: true
+                )
+            }
+            releaseAdoption(item.id)
+            if pauseQueue {
+                persistentQueueRunState = .pauseAfterCurrent
+                await pauseDurableQueueNow()
+            }
+        } catch {
+            failClosedTitleQueuePersistence(error)
         }
     }
 

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -265,6 +265,13 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         }
     }
 
+    func updatePersistentQueueItemDestination(_ itemID: UUID, destinationURL: URL) async throws {
+        try await durableQueueStore.updateRecoverableItemDestination(
+            itemID,
+            destinationPath: destinationURL.standardizedFileURL.path
+        )
+    }
+
     func clearCompletedPersistentQueueItems() async throws -> PersistentQueueRemovalToken {
         try await durableQueueStore.clearCompletedItems()
     }
@@ -640,7 +647,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
         durableQueueStopRequested = false
         var adoptedCount = 0
         for item in candidates {
-            if await adoptPersistentQueueItem(item.id, pump: false) {
+            if await adoptPersistentQueueItem(item.id, recoveryChoice: nil, pump: false) {
                 adoptedCount += 1
             }
         }
@@ -698,8 +705,15 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @discardableResult
     func adoptPersistentQueueItem(
         _ itemID: UUID,
-        recoveryChoice: WorkerRecoveryChoice? = nil,
-        pump: Bool = true
+        recoveryChoice: WorkerRecoveryChoice? = nil
+    ) async -> Bool {
+        await adoptPersistentQueueItem(itemID, recoveryChoice: recoveryChoice, pump: true)
+    }
+
+    private func adoptPersistentQueueItem(
+        _ itemID: UUID,
+        recoveryChoice: WorkerRecoveryChoice?,
+        pump: Bool
     ) async -> Bool {
         if persistentQueueRunState == .pauseAfterCurrent, hasActiveWorker {
             return false
@@ -2050,7 +2064,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 await parkWaitingDurableQueueItemForStorage(
                     item,
                     code: "destination_unavailable",
-                    message: "Destination unavailable. Reconnect the destination and check that the folder is writable, then retry this item.",
+                    message: "Destination unavailable. Reconnect it or choose another writable destination, then resume the queue.",
                     details: reason,
                     pauseQueue: false
                 )
@@ -2062,7 +2076,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 await parkWaitingDurableQueueItemForStorage(
                     item,
                     code: "destination_insufficient_capacity",
-                    message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space or choose another destination, then retry this item.",
+                    message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space or choose another destination, then resume the queue.",
                     details: "Required: \(requiredDescription). Available: \(availableDescription).",
                     pauseQueue: true
                 )

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -266,10 +266,15 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     }
 
     func updatePersistentQueueItemDestination(_ itemID: UUID, destinationURL: URL) async throws {
+        let shouldRejoinRunningQueue = persistentQueueRunState == .running
+            && persistentQueueItems.first(where: { $0.id == itemID })?.hasStorageDestinationFailure == true
         try await durableQueueStore.updateRecoverableItemDestination(
             itemID,
             destinationPath: destinationURL.standardizedFileURL.path
         )
+        if shouldRejoinRunningQueue {
+            _ = await adoptPersistentQueueItem(itemID)
+        }
     }
 
     func clearCompletedPersistentQueueItems() async throws -> PersistentQueueRemovalToken {

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -2064,7 +2064,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 await parkWaitingDurableQueueItemForStorage(
                     item,
                     code: "destination_unavailable",
-                    message: "Destination unavailable. Reconnect it or choose another writable destination, then resume the queue.",
+                    message: "Destination unavailable. Reconnect it and retry this item, or choose another writable destination and resume the queue.",
                     details: reason,
                     pauseQueue: false
                 )
@@ -2076,7 +2076,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
                 await parkWaitingDurableQueueItemForStorage(
                     item,
                     code: "destination_insufficient_capacity",
-                    message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space or choose another destination, then resume the queue.",
+                    message: "Not enough free space at \(destinationURL.path). Needs about \(requiredDescription), but only \(availableDescription) is available. Free space and retry this item, or choose another destination and resume the queue.",
                     details: "Required: \(requiredDescription). Available: \(availableDescription).",
                     pauseQueue: true
                 )

--- a/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
+++ b/macos/BluRayToVisionPro/Models/DurableConversionQueue.swift
@@ -382,6 +382,11 @@ struct DurableQueueFailure: Codable, Equatable {
     let retryable: Bool
 }
 
+enum DurableQueueFailureCode {
+    static let destinationUnavailable = "destination_unavailable"
+    static let destinationInsufficientCapacity = "destination_insufficient_capacity"
+}
+
 struct DurableQueueResult: Codable, Equatable {
     let outputPath: String
     let durationSeconds: Double?

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -180,8 +180,8 @@ struct PersistentQueueItem: Identifiable, Equatable {
         guard case let .failed(failure) = status else {
             return false
         }
-        return failure.code == "destination_unavailable"
-            || failure.code == "destination_insufficient_capacity"
+        return failure.code == DurableQueueFailureCode.destinationUnavailable
+            || failure.code == DurableQueueFailureCode.destinationInsufficientCapacity
     }
 
     var canChangeDestination: Bool {

--- a/macos/BluRayToVisionPro/Models/PersistentQueue.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueue.swift
@@ -176,6 +176,18 @@ struct PersistentQueueItem: Identifiable, Equatable {
         status == .waiting
     }
 
+    var hasStorageDestinationFailure: Bool {
+        guard case let .failed(failure) = status else {
+            return false
+        }
+        return failure.code == "destination_unavailable"
+            || failure.code == "destination_insufficient_capacity"
+    }
+
+    var canChangeDestination: Bool {
+        isEditable || hasStorageDestinationFailure
+    }
+
     var canMove: Bool {
         status == .waiting
     }

--- a/macos/BluRayToVisionPro/Models/StorageForecast.swift
+++ b/macos/BluRayToVisionPro/Models/StorageForecast.swift
@@ -12,7 +12,7 @@ enum StorageForecastFormatting {
     }
 
     static func about(_ bytes: Int64?) -> String {
-        guard let bytes else {
+        guard let bytes, bytes >= 0 else {
             return "Unavailable"
         }
         return "About \(coarse(bytes))"
@@ -30,6 +30,7 @@ struct StorageForecastItem: Equatable, Sendable {
     let safetyMarginBytes: Int64?
     let totalPeakRequiredBytes: Int64?
     let unavailableReason: String?
+    let conservativeUpperBound: Bool
 
     init(draft: ConversionDraft) {
         let estimate = VideoStorageEstimate(drafts: [draft])
@@ -40,6 +41,7 @@ struct StorageForecastItem: Equatable, Sendable {
         )
         retainedIntermediateBytes = estimate.retainedIntermediateBytes
         unavailableReason = estimate.unavailableReason
+        conservativeUpperBound = estimate.conservativeFallbackReserve
 
         guard let peakWorkingBytes = estimate.peakWorkingBytes,
               let safetyMarginBytes = Self.safetyMargin(for: peakWorkingBytes),
@@ -58,11 +60,11 @@ struct StorageForecastItem: Equatable, Sendable {
     }
 
     var outputDescription: String {
-        Self.estimateDescription(estimatedOutputBytes)
+        estimateDescription(estimatedOutputBytes)
     }
 
     var temporaryWorkingDescription: String {
-        Self.estimateDescription(temporaryWorkingBytes)
+        estimateDescription(temporaryWorkingBytes)
     }
 
     var retainedIntermediateDescription: String {
@@ -71,7 +73,7 @@ struct StorageForecastItem: Equatable, Sendable {
         }
         return retainedIntermediateBytes == 0
             ? "None after success"
-            : Self.estimateDescription(retainedIntermediateBytes)
+            : estimateDescription(retainedIntermediateBytes)
     }
 
     var safetyMarginDescription: String {
@@ -85,7 +87,7 @@ struct StorageForecastItem: Equatable, Sendable {
         guard let totalPeakRequiredBytes else {
             return unavailableReason ?? "Unavailable"
         }
-        return Self.estimateDescription(totalPeakRequiredBytes)
+        return estimateDescription(totalPeakRequiredBytes)
     }
 
     var assumptionDescription: String {
@@ -131,11 +133,12 @@ struct StorageForecastItem: Equatable, Sendable {
         return first + second
     }
 
-    private static func estimateDescription(_ bytes: Int64?) -> String {
+    private func estimateDescription(_ bytes: Int64?) -> String {
         guard let bytes else {
             return "Unavailable"
         }
-        return "About \(StorageForecastFormatting.coarse(bytes))"
+        let qualifier = conservativeUpperBound ? "Up to" : "About"
+        return "\(qualifier) \(StorageForecastFormatting.coarse(bytes))"
     }
 }
 
@@ -149,6 +152,7 @@ struct StorageForecastDestinationSummary: Identifiable, Equatable, Sendable {
     let estimatedItemCount: Int
     let unestimatedItemCount: Int
     let unestimatedReasons: [String]
+    let conservativeUpperBound: Bool
 
     var id: String { destinationPath }
 
@@ -157,17 +161,17 @@ struct StorageForecastDestinationSummary: Identifiable, Equatable, Sendable {
     }
 
     var outputDescription: String {
-        StorageForecastFormatting.about(estimatedOutputBytes)
+        estimateDescription(estimatedOutputBytes)
     }
 
     var temporaryWorkingDescription: String {
-        StorageForecastFormatting.about(temporaryWorkingBytes)
+        estimateDescription(temporaryWorkingBytes)
     }
 
     var retainedIntermediateDescription: String {
         retainedIntermediateBytes == 0
             ? "None after success"
-            : StorageForecastFormatting.about(retainedIntermediateBytes)
+            : estimateDescription(retainedIntermediateBytes)
     }
 
     var safetyMarginDescription: String {
@@ -175,7 +179,15 @@ struct StorageForecastDestinationSummary: Identifiable, Equatable, Sendable {
     }
 
     var totalPeakDescription: String {
-        StorageForecastFormatting.about(totalPeakRequiredBytes)
+        estimateDescription(totalPeakRequiredBytes)
+    }
+
+    private func estimateDescription(_ bytes: Int64?) -> String {
+        guard let bytes, bytes >= 0 else {
+            return "Unavailable"
+        }
+        let qualifier = conservativeUpperBound ? "Up to" : "About"
+        return "\(qualifier) \(StorageForecastFormatting.coarse(bytes))"
     }
 }
 
@@ -194,9 +206,18 @@ struct QueueStorageSummary: Equatable, Sendable {
             var unestimatedReasons: [String] = []
             var committedBytes: Int64 = 0
             var hasOverflow = false
+            var conservativeUpperBound = false
 
             mutating func add(_ item: PersistentQueueItem) {
+                if let deferredReason = item.storageForecastDeferredReason {
+                    unestimatedItemCount += 1
+                    if !unestimatedReasons.contains(deferredReason) {
+                        unestimatedReasons.append(deferredReason)
+                    }
+                    return
+                }
                 let forecast = StorageForecastItem(draft: item.draft)
+                conservativeUpperBound = conservativeUpperBound || forecast.conservativeUpperBound
                 var itemOverflow = false
                 if let outputBytes = forecast.estimatedOutputBytes,
                    let temporaryBytes = forecast.temporaryWorkingBytes,
@@ -246,7 +267,8 @@ struct QueueStorageSummary: Equatable, Sendable {
                     totalPeakRequiredBytes: total,
                     estimatedItemCount: estimatedItemCount,
                     unestimatedItemCount: unestimatedItemCount,
-                    unestimatedReasons: unestimatedReasons
+                    unestimatedReasons: unestimatedReasons,
+                    conservativeUpperBound: conservativeUpperBound
                 )
             }
 
@@ -275,12 +297,23 @@ struct QueueStorageSummary: Equatable, Sendable {
 private extension PersistentQueueItem {
     var isEligibleForStorageForecast: Bool {
         switch status {
-        case .waiting, .interrupted, .stopped, .notStarted:
+        case .waiting, .needsChoice, .interrupted, .attention, .stopped, .notStarted:
             true
         case let .failed(failure):
             failure.retryable
-        case .needsChoice, .inspecting, .processing, .stopping, .attention, .completed:
+        case .inspecting, .processing, .stopping, .completed:
             false
+        }
+    }
+
+    var storageForecastDeferredReason: String? {
+        switch status {
+        case .needsChoice:
+            "Resolve the queued route-quality choice before its storage can be estimated."
+        case .attention:
+            "Choose the queued recovery action before its storage can be estimated."
+        default:
+            nil
         }
     }
 }

--- a/macos/BluRayToVisionPro/Models/StorageForecast.swift
+++ b/macos/BluRayToVisionPro/Models/StorageForecast.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+enum StorageForecastFormatting {
+    static let gibibyte: Int64 = 1_024 * 1_024 * 1_024
+
+    static func coarse(_ bytes: Int64?) -> String {
+        guard let bytes, bytes >= 0 else {
+            return "Unavailable"
+        }
+        let gibibytes = bytes == 0 ? 0 : ((bytes - 1) / gibibyte) + 1
+        return "\(gibibytes) GiB"
+    }
+
+    static func about(_ bytes: Int64?) -> String {
+        guard let bytes else {
+            return "Unavailable"
+        }
+        return "About \(coarse(bytes))"
+    }
+}
+
+struct StorageForecastItem: Equatable, Sendable {
+    static let safetyMarginRate = 0.10
+    static let minimumSafetyMarginBytes: Int64 = 2 * StorageForecastFormatting.gibibyte
+    static let maximumSafetyMarginBytes: Int64 = 20 * StorageForecastFormatting.gibibyte
+
+    let estimatedOutputBytes: Int64?
+    let temporaryWorkingBytes: Int64?
+    let retainedIntermediateBytes: Int64?
+    let safetyMarginBytes: Int64?
+    let totalPeakRequiredBytes: Int64?
+    let unavailableReason: String?
+
+    init(draft: ConversionDraft) {
+        let estimate = VideoStorageEstimate(drafts: [draft])
+        estimatedOutputBytes = estimate.finalOutputBytes
+        temporaryWorkingBytes = Self.temporaryBytes(
+            peakWorkingBytes: estimate.peakWorkingBytes,
+            finalOutputBytes: estimate.finalOutputBytes
+        )
+        retainedIntermediateBytes = estimate.retainedIntermediateBytes
+        unavailableReason = estimate.unavailableReason
+
+        guard let peakWorkingBytes = estimate.peakWorkingBytes,
+              let safetyMarginBytes = Self.safetyMargin(for: peakWorkingBytes),
+              let totalPeakRequiredBytes = Self.adding(peakWorkingBytes, safetyMarginBytes)
+        else {
+            self.safetyMarginBytes = nil
+            self.totalPeakRequiredBytes = nil
+            return
+        }
+        self.safetyMarginBytes = safetyMarginBytes
+        self.totalPeakRequiredBytes = totalPeakRequiredBytes
+    }
+
+    var isEstimated: Bool {
+        totalPeakRequiredBytes != nil
+    }
+
+    var outputDescription: String {
+        Self.estimateDescription(estimatedOutputBytes)
+    }
+
+    var temporaryWorkingDescription: String {
+        Self.estimateDescription(temporaryWorkingBytes)
+    }
+
+    var retainedIntermediateDescription: String {
+        guard let retainedIntermediateBytes else {
+            return unavailableReason ?? "Unavailable"
+        }
+        return retainedIntermediateBytes == 0
+            ? "None after success"
+            : Self.estimateDescription(retainedIntermediateBytes)
+    }
+
+    var safetyMarginDescription: String {
+        guard let safetyMarginBytes else {
+            return unavailableReason ?? "Unavailable"
+        }
+        return "\(StorageForecastFormatting.coarse(safetyMarginBytes)) safety margin"
+    }
+
+    var totalPeakDescription: String {
+        guard let totalPeakRequiredBytes else {
+            return unavailableReason ?? "Unavailable"
+        }
+        return Self.estimateDescription(totalPeakRequiredBytes)
+    }
+
+    var assumptionDescription: String {
+        if let unavailableReason {
+            return unavailableReason
+        }
+        return "Video-only forecast with a coarse 10% safety margin, rounded to whole GiB. Audio, subtitles, and source preparation may add space."
+    }
+
+    static func safetyMargin(for peakWorkingBytes: Int64) -> Int64? {
+        guard peakWorkingBytes >= 0 else {
+            return nil
+        }
+        let rawMargin = Double(peakWorkingBytes) * safetyMarginRate
+        guard rawMargin.isFinite, rawMargin <= Double(Int64.max) else {
+            return nil
+        }
+        let roundedMargin = Int64(rawMargin.rounded(.up))
+        let quantizedMargin: Int64
+        if roundedMargin == 0 {
+            quantizedMargin = minimumSafetyMarginBytes
+        } else {
+            let quotient = (roundedMargin - 1) / StorageForecastFormatting.gibibyte + 1
+            guard quotient <= Int64.max / StorageForecastFormatting.gibibyte else {
+                return nil
+            }
+            quantizedMargin = quotient * StorageForecastFormatting.gibibyte
+        }
+        return min(max(quantizedMargin, minimumSafetyMarginBytes), maximumSafetyMarginBytes)
+    }
+
+    private static func temporaryBytes(peakWorkingBytes: Int64?, finalOutputBytes: Int64?) -> Int64? {
+        guard let peakWorkingBytes, let finalOutputBytes else {
+            return nil
+        }
+        return max(0, peakWorkingBytes - finalOutputBytes)
+    }
+
+    private static func adding(_ first: Int64, _ second: Int64) -> Int64? {
+        guard first <= Int64.max - second else {
+            return nil
+        }
+        return first + second
+    }
+
+    private static func estimateDescription(_ bytes: Int64?) -> String {
+        guard let bytes else {
+            return "Unavailable"
+        }
+        return "About \(StorageForecastFormatting.coarse(bytes))"
+    }
+}
+
+struct StorageForecastDestinationSummary: Identifiable, Equatable, Sendable {
+    let destinationPath: String
+    let estimatedOutputBytes: Int64?
+    let temporaryWorkingBytes: Int64?
+    let retainedIntermediateBytes: Int64?
+    let safetyMarginBytes: Int64?
+    let totalPeakRequiredBytes: Int64?
+    let estimatedItemCount: Int
+    let unestimatedItemCount: Int
+    let unestimatedReasons: [String]
+
+    var id: String { destinationPath }
+
+    var hasUnestimatedItems: Bool {
+        unestimatedItemCount > 0
+    }
+
+    var outputDescription: String {
+        StorageForecastFormatting.about(estimatedOutputBytes)
+    }
+
+    var temporaryWorkingDescription: String {
+        StorageForecastFormatting.about(temporaryWorkingBytes)
+    }
+
+    var retainedIntermediateDescription: String {
+        retainedIntermediateBytes == 0
+            ? "None after success"
+            : StorageForecastFormatting.about(retainedIntermediateBytes)
+    }
+
+    var safetyMarginDescription: String {
+        StorageForecastFormatting.about(safetyMarginBytes)
+    }
+
+    var totalPeakDescription: String {
+        StorageForecastFormatting.about(totalPeakRequiredBytes)
+    }
+}
+
+struct QueueStorageSummary: Equatable, Sendable {
+    let destinations: [StorageForecastDestinationSummary]
+
+    init(items: [PersistentQueueItem]) {
+        struct Accumulator {
+            let destinationPath: String
+            var estimatedOutputBytes: Int64 = 0
+            var temporaryWorkingBytes: Int64 = 0
+            var retainedIntermediateBytes: Int64 = 0
+            var peakRequiredBytes: Int64 = 0
+            var estimatedItemCount = 0
+            var unestimatedItemCount = 0
+            var unestimatedReasons: [String] = []
+            var committedBytes: Int64 = 0
+            var hasOverflow = false
+
+            mutating func add(_ item: PersistentQueueItem) {
+                let forecast = StorageForecastItem(draft: item.draft)
+                var itemOverflow = false
+                if let outputBytes = forecast.estimatedOutputBytes,
+                   let temporaryBytes = forecast.temporaryWorkingBytes,
+                   let retainedBytes = forecast.retainedIntermediateBytes,
+                   let itemPeakBytes = Self.adding(outputBytes, temporaryBytes),
+                   let candidatePeakBytes = Self.adding(committedBytes, itemPeakBytes),
+                   let nextOutputBytes = Self.adding(estimatedOutputBytes, outputBytes),
+                   let nextRetainedBytes = Self.adding(retainedIntermediateBytes, retainedBytes),
+                   let nextCommittedBytes = Self.adding(committedBytes, outputBytes),
+                   let finalCommittedBytes = Self.adding(nextCommittedBytes, retainedBytes)
+                {
+                    estimatedOutputBytes = nextOutputBytes
+                    temporaryWorkingBytes = max(temporaryWorkingBytes, temporaryBytes)
+                    retainedIntermediateBytes = nextRetainedBytes
+                    peakRequiredBytes = max(peakRequiredBytes, candidatePeakBytes)
+                    committedBytes = finalCommittedBytes
+                    estimatedItemCount += 1
+                } else {
+                    hasOverflow = true
+                    itemOverflow = true
+                }
+                if let unavailableReason = forecast.unavailableReason {
+                    unestimatedItemCount += 1
+                    if !unestimatedReasons.contains(unavailableReason) {
+                        unestimatedReasons.append(unavailableReason)
+                    }
+                } else if itemOverflow {
+                    unestimatedItemCount += 1
+                    let reason = "The storage forecast exceeds the supported size range."
+                    if !unestimatedReasons.contains(reason) {
+                        unestimatedReasons.append(reason)
+                    }
+                }
+            }
+
+            func summary() -> StorageForecastDestinationSummary {
+                let margin = hasOverflow || unestimatedItemCount > 0
+                    ? nil
+                    : StorageForecastItem.safetyMargin(for: peakRequiredBytes)
+                let total = margin.flatMap { Self.adding(peakRequiredBytes, $0) }
+                return StorageForecastDestinationSummary(
+                    destinationPath: destinationPath,
+                    estimatedOutputBytes: estimatedItemCount > 0 ? estimatedOutputBytes : nil,
+                    temporaryWorkingBytes: estimatedItemCount > 0 ? temporaryWorkingBytes : nil,
+                    retainedIntermediateBytes: estimatedItemCount > 0 ? retainedIntermediateBytes : nil,
+                    safetyMarginBytes: margin,
+                    totalPeakRequiredBytes: total,
+                    estimatedItemCount: estimatedItemCount,
+                    unestimatedItemCount: unestimatedItemCount,
+                    unestimatedReasons: unestimatedReasons
+                )
+            }
+
+            private static func adding(_ first: Int64, _ second: Int64) -> Int64? {
+                guard first <= Int64.max - second else {
+                    return nil
+                }
+                return first + second
+            }
+        }
+
+        var accumulators: [String: Accumulator] = [:]
+        var order: [String] = []
+        for item in items.sorted(by: { $0.ordinal < $1.ordinal }) where item.isEligibleForStorageForecast {
+            let destinationPath = item.draft.destinationURL.standardizedFileURL.path
+            if accumulators[destinationPath] == nil {
+                accumulators[destinationPath] = Accumulator(destinationPath: destinationPath)
+                order.append(destinationPath)
+            }
+            accumulators[destinationPath]?.add(item)
+        }
+        destinations = order.compactMap { accumulators[$0]?.summary() }
+    }
+}
+
+private extension PersistentQueueItem {
+    var isEligibleForStorageForecast: Bool {
+        switch status {
+        case .waiting, .interrupted, .stopped, .notStarted:
+            true
+        case let .failed(failure):
+            failure.retryable
+        case .needsChoice, .inspecting, .processing, .stopping, .attention, .completed:
+            false
+        }
+    }
+}
+
+enum QueueStoragePreflightVerdict: Equatable, Sendable {
+    case available
+    case unconfirmed(String)
+    case unavailable(String)
+    case insufficient(requiredBytes: Int64, availableBytes: Int64)
+}
+
+protocol QueueStoragePreflighting: Sendable {
+    func preflight(destinationURL: URL, requiredBytes: Int64?) -> QueueStoragePreflightVerdict
+}
+
+struct SystemQueueStoragePreflight: QueueStoragePreflighting, @unchecked Sendable {
+    let fileManager: FileManager
+    let capacityProvider: any PreviewCapacityProviding
+
+    init(
+        fileManager: FileManager = .default,
+        capacityProvider: (any PreviewCapacityProviding)? = nil
+    ) {
+        self.fileManager = fileManager
+        self.capacityProvider = capacityProvider ?? SystemPreviewCapacityProvider(fileManager: fileManager)
+    }
+
+    func preflight(destinationURL: URL, requiredBytes: Int64?) -> QueueStoragePreflightVerdict {
+        let destinationURL = destinationURL.standardizedFileURL
+        let path = destinationURL.path
+        guard fileManager.fileExists(atPath: path) else {
+            return .unavailable("Destination \(path) is not connected or no longer exists.")
+        }
+        guard let values = try? destinationURL.resourceValues(forKeys: [.isDirectoryKey, .isWritableKey, .volumeIsReadOnlyKey]),
+              values.isDirectory == true
+        else {
+            return .unavailable("Destination \(path) is not an accessible folder.")
+        }
+        if values.volumeIsReadOnly == true || values.isWritable == false || !fileManager.isWritableFile(atPath: path) {
+            return .unavailable("Destination \(path) is read-only or not writable.")
+        }
+
+        let readings = capacityProvider.readings(for: destinationURL)
+        if readings.readOnly == true || readings.writable == false {
+            return .unavailable("Destination \(path) is read-only or not writable.")
+        }
+        let result = StorageCapacityResult.evaluate(
+            requiredBytes: requiredBytes,
+            evidence: readings.evidence
+        )
+        if result.isKnownInsufficient,
+           let requiredBytes = result.requiredBytes,
+           let availableBytes = result.availableBytes
+        {
+            return .insufficient(requiredBytes: requiredBytes, availableBytes: availableBytes)
+        }
+        switch result.state {
+        case .known where result.sufficiency == .sufficient:
+            return .available
+        case .known where requiredBytes == nil:
+            return .unconfirmed("Destination is writable, but the required output size is not estimated.")
+        case .unknown:
+            return .unconfirmed("Destination is writable, but free space could not be confirmed.")
+        case .conflicting:
+            return .unconfirmed("Destination is writable, but its free-space readings conflict.")
+        case .known:
+            return .unconfirmed("Destination is writable, but free space could not be confirmed.")
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1437,19 +1437,11 @@ struct ContentView: View {
         guard let destination = DestinationPicker.chooseDestination(startingAt: item.draft.destinationURL) else {
             return
         }
-        let draft = ConversionDraft(
-            source: item.draft.source,
-            sourceDetails: item.draft.sourceDetails,
-            profile: item.draft.profile,
-            destinationURL: destination,
-            options: item.draft.options,
-            selectedTitle: item.draft.selectedTitle
-        )
         Task { @MainActor in
             do {
                 try await viewModel.updatePersistentQueueItemDestination(
                     item.id,
-                    destinationURL: draft.destinationURL
+                    destinationURL: destination
                 )
             } catch {
                 persistentQueueErrorMessage = error.localizedDescription

--- a/macos/BluRayToVisionPro/Views/ContentView.swift
+++ b/macos/BluRayToVisionPro/Views/ContentView.swift
@@ -1447,7 +1447,10 @@ struct ContentView: View {
         )
         Task { @MainActor in
             do {
-                try await viewModel.updatePersistentQueueItem(item.id, draft: draft)
+                try await viewModel.updatePersistentQueueItemDestination(
+                    item.id,
+                    destinationURL: draft.destinationURL
+                )
             } catch {
                 persistentQueueErrorMessage = error.localizedDescription
             }

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -974,29 +974,13 @@ struct PersistentQueueDetailView: View {
         return VStack(alignment: .leading, spacing: 10) {
             Text("Storage")
                 .font(.title3.weight(.semibold))
-            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 8) {
-                GridRow {
-                    Text("Output").foregroundStyle(.secondary)
-                    Text(forecast.outputDescription)
-                }
-                GridRow {
-                    Text("Temporary / working").foregroundStyle(.secondary)
-                    Text(forecast.temporaryWorkingDescription)
-                }
-                GridRow {
-                    Text("Retained intermediates").foregroundStyle(.secondary)
-                    Text(forecast.retainedIntermediateDescription)
-                }
-                GridRow {
-                    Text("Safety margin").foregroundStyle(.secondary)
-                    Text(forecast.safetyMarginDescription)
-                }
-                GridRow {
-                    Text("Total peak").foregroundStyle(.secondary)
-                    Text(forecast.totalPeakDescription)
-                }
+            VStack(alignment: .leading, spacing: 8) {
+                storageDetailRow("Output", value: forecast.outputDescription)
+                storageDetailRow("Temporary / working", value: forecast.temporaryWorkingDescription)
+                storageDetailRow("Retained intermediates", value: forecast.retainedIntermediateDescription)
+                storageDetailRow("Safety margin", value: forecast.safetyMarginDescription)
+                storageDetailRow("Total peak", value: forecast.totalPeakDescription)
             }
-            .font(.callout)
             Text(forecast.assumptionDescription)
                 .font(.caption)
                 .foregroundStyle(forecast.isEstimated ? Color.secondary : Color.orange)
@@ -1005,6 +989,18 @@ struct PersistentQueueDetailView: View {
         .padding(12)
         .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
         .accessibilityIdentifier("persistent-queue-storage-detail")
+    }
+
+    private func storageDetailRow(_ title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 24) {
+            Text(title)
+                .foregroundStyle(.secondary)
+                .frame(width: 150, alignment: .leading)
+            Text(value)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(.callout)
     }
 
     private func itemDetails(_ item: PersistentQueueItem) -> some View {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -208,14 +208,20 @@ struct PersistentQueueSidebarView: View {
                             .font(.caption.weight(.medium))
                             .lineLimit(1)
                             .truncationMode(.middle)
+                        Text(destination.destinationPath)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
                         HStack(spacing: 8) {
                             storageMetric("Output", destination.outputDescription)
                             storageMetric("Working", destination.temporaryWorkingDescription)
                         }
                         HStack(spacing: 8) {
+                            storageMetric("Retained", destination.retainedIntermediateDescription)
                             storageMetric("Margin", destination.safetyMarginDescription)
-                            storageMetric("Peak", destination.totalPeakDescription)
                         }
+                        storageMetric("Peak", destination.totalPeakDescription)
                         if destination.hasUnestimatedItems {
                             Text("\(destination.unestimatedItemCount) item\(destination.unestimatedItemCount == 1 ? "" : "s") not estimated; totals are partial.")
                                 .font(.caption2)
@@ -223,6 +229,7 @@ struct PersistentQueueSidebarView: View {
                         }
                     }
                     .accessibilityElement(children: .combine)
+                    .help(destination.destinationPath)
                     .accessibilityIdentifier("storage-summary-\(destination.id)")
                 }
             }

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -54,6 +54,7 @@ struct PersistentQueueSidebarView: View {
             header
             Divider()
             scheduleBanner
+            storageSummaryView
             if let banner {
                 Label(banner.title, systemImage: banner.systemImage)
                     .font(.caption.weight(.medium))
@@ -191,6 +192,58 @@ struct PersistentQueueSidebarView: View {
         }
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var storageSummaryView: some View {
+        let summary = QueueStorageSummary(items: items)
+        if !summary.destinations.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Storage Forecast")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(summary.destinations) { destination in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(URL(fileURLWithPath: destination.destinationPath).lastPathComponent)
+                            .font(.caption.weight(.medium))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        HStack(spacing: 8) {
+                            storageMetric("Output", destination.outputDescription)
+                            storageMetric("Working", destination.temporaryWorkingDescription)
+                        }
+                        HStack(spacing: 8) {
+                            storageMetric("Margin", destination.safetyMarginDescription)
+                            storageMetric("Peak", destination.totalPeakDescription)
+                        }
+                        if destination.hasUnestimatedItems {
+                            Text("\(destination.unestimatedItemCount) item\(destination.unestimatedItemCount == 1 ? "" : "s") not estimated; totals are partial.")
+                                .font(.caption2)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("storage-summary-\(destination.id)")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.accentColor.opacity(0.05))
+            .accessibilityIdentifier("persistent-queue-storage-summary")
+        }
+    }
+
+    private func storageMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption2.monospacedDigit())
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var queueList: some View {
@@ -764,6 +817,7 @@ struct PersistentQueueDetailView: View {
                                 apply: resolveRouteQuality
                             )
                         }
+                        storageSection(item)
                         Divider()
                         settings(item)
                     }
@@ -901,6 +955,44 @@ struct PersistentQueueDetailView: View {
             }
             .font(.callout)
         }
+    }
+
+    private func storageSection(_ item: PersistentQueueItem) -> some View {
+        let forecast = StorageForecastItem(draft: item.draft)
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Storage")
+                .font(.title3.weight(.semibold))
+            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 8) {
+                GridRow {
+                    Text("Output").foregroundStyle(.secondary)
+                    Text(forecast.outputDescription)
+                }
+                GridRow {
+                    Text("Temporary / working").foregroundStyle(.secondary)
+                    Text(forecast.temporaryWorkingDescription)
+                }
+                GridRow {
+                    Text("Retained intermediates").foregroundStyle(.secondary)
+                    Text(forecast.retainedIntermediateDescription)
+                }
+                GridRow {
+                    Text("Safety margin").foregroundStyle(.secondary)
+                    Text(forecast.safetyMarginDescription)
+                }
+                GridRow {
+                    Text("Total peak").foregroundStyle(.secondary)
+                    Text(forecast.totalPeakDescription)
+                }
+            }
+            .font(.callout)
+            Text(forecast.assumptionDescription)
+                .font(.caption)
+                .foregroundStyle(forecast.isEstimated ? Color.secondary : Color.orange)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier("persistent-queue-storage-detail")
     }
 
     private func itemDetails(_ item: PersistentQueueItem) -> some View {

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -897,6 +897,9 @@ struct PersistentQueueDetailView: View {
                     Button(item.isRestored ? "Restart Safely" : "Retry") { retry(item, nil) }
                 }
             }
+            if item.hasStorageDestinationFailure {
+                Button("Change Destination…") { changeDestination(item) }
+            }
             if case let .completed(result) = item.status {
                 Button("Reveal in Finder") {
                     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: result.outputPath)])
@@ -936,8 +939,10 @@ struct PersistentQueueDetailView: View {
                     HStack {
                         detailValue(item.draft.destinationURL.path, label: "Destination")
                         Button("Change…") { changeDestination(item) }
-                            .disabled(!item.isEditable)
-                            .help(item.isEditable ? "Change this waiting item's destination." : (item.queueManipulationLockReason ?? "Settings are locked."))
+                            .disabled(!item.canChangeDestination)
+                            .help(item.canChangeDestination
+                                ? "Change this item's destination."
+                                : (item.queueManipulationLockReason ?? "Settings are locked."))
                     }
                 }
                 GridRow {

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -180,6 +180,20 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
         )
     }
 
+    func testStorageForecastRendersHealthyPartialAndParkedStates() throws {
+        let items = try makeStorageRenderItems()
+
+        for item in items {
+            try render(
+                items: [item],
+                selectedItem: item,
+                compact: true,
+                colorScheme: .dark,
+                appearanceName: .darkAqua
+            )
+        }
+    }
+
     private func render(
         items: [PersistentQueueItem],
         selectedItem: PersistentQueueItem?,
@@ -310,6 +324,61 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
                 result: result
             ))
         }
+    }
+
+    private func makeStorageRenderItems() throws -> [PersistentQueueItem] {
+        var knownOptions = ConversionOptions()
+        knownOptions.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+        let knownDraft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/known.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            options: knownOptions,
+            selectedTitle: SourceTitle(
+                id: "known",
+                name: "Known",
+                outputName: "Known",
+                durationSeconds: 3_600,
+                resolution: "1920x1080",
+                frameRate: "24/1",
+                mainFeature: true
+            )
+        )
+        var unknownOptions = ConversionOptions()
+        unknownOptions.encoding.videoOutputMode = .av1Stereo
+        let unknownDraft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/unknown.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            options: unknownOptions
+        )
+        let failure = DurableQueueFailure(
+            code: "destination_unavailable",
+            message: "Destination unavailable. Reconnect the destination and check that the folder is writable, then retry this item.",
+            details: nil,
+            retryable: true
+        )
+        return try [
+            PersistentQueueItem(item: DurableConversionQueueItem(
+                ordinal: 0,
+                origin: .singleSource,
+                intent: DurableQueueItemIntent(draft: knownDraft)
+            )),
+            PersistentQueueItem(item: DurableConversionQueueItem(
+                ordinal: 1,
+                origin: .singleSource,
+                intent: DurableQueueItemIntent(draft: unknownDraft)
+            )),
+            PersistentQueueItem(item: DurableConversionQueueItem(
+                ordinal: 2,
+                origin: .singleSource,
+                intent: DurableQueueItemIntent(draft: knownDraft),
+                state: .failed,
+                failure: failure
+            )),
+        ]
     }
 
     private func makeIdentifiableItems() throws -> [PersistentQueueItem] {

--- a/macos/BluRayToVisionProTests/StorageForecastTests.swift
+++ b/macos/BluRayToVisionProTests/StorageForecastTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class StorageForecastTests: XCTestCase {
+    func testKnownForecastSeparatesWorkingRetainedMarginAndPeak() {
+        let draft = makeDraft(durationSeconds: 7_200)
+        let forecast = StorageForecastItem(draft: draft)
+
+        XCTAssertNotNil(forecast.estimatedOutputBytes)
+        XCTAssertNotNil(forecast.temporaryWorkingBytes)
+        XCTAssertEqual(forecast.retainedIntermediateBytes, 0)
+        XCTAssertEqual(
+            forecast.safetyMarginBytes,
+            StorageForecastItem.safetyMargin(for: forecast.estimatedOutputBytes! + forecast.temporaryWorkingBytes!)
+        )
+        XCTAssertEqual(
+            forecast.totalPeakRequiredBytes,
+            (forecast.estimatedOutputBytes ?? 0)
+                + (forecast.temporaryWorkingBytes ?? 0)
+                + (forecast.safetyMarginBytes ?? 0)
+        )
+    }
+
+    func testUnknownForecastNeverProducesBlockingRequiredBytes() {
+        var options = ConversionOptions()
+        options.encoding.videoOutputMode = .av1Stereo
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            options: options
+        )
+
+        let forecast = StorageForecastItem(draft: draft)
+
+        XCTAssertNil(forecast.totalPeakRequiredBytes)
+        XCTAssertFalse(forecast.isEstimated)
+        XCTAssertTrue(forecast.assumptionDescription.contains("CRF"))
+    }
+
+    func testSafetyMarginQuantizesAndClampsConservatively() {
+        let gibibyte = StorageForecastFormatting.gibibyte
+
+        XCTAssertEqual(StorageForecastItem.safetyMargin(for: 1), 2 * gibibyte)
+        XCTAssertEqual(StorageForecastItem.safetyMargin(for: 25 * gibibyte), 3 * gibibyte)
+        XCTAssertEqual(StorageForecastItem.safetyMargin(for: 500 * gibibyte), 20 * gibibyte)
+    }
+
+    func testReusableIntermediatesAreReported() {
+        var options = ConversionOptions()
+        options.job.intermediatePolicy = .reusable
+        let forecast = StorageForecastItem(draft: makeDraft(durationSeconds: 3_600, options: options))
+
+        XCTAssertNotNil(forecast.retainedIntermediateBytes)
+        XCTAssertGreaterThan(forecast.retainedIntermediateBytes ?? 0, 0)
+    }
+
+    func testQueueSummaryGroupsDestinationsInOrdinalOrderAndMarksPartialTotals() throws {
+        let first = try makeItem(
+            ordinal: 2,
+            destination: "/Volumes/B",
+            durationSeconds: 3_600
+        )
+        let second = try makeItem(
+            ordinal: 0,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600
+        )
+        let unknown = try makeItem(
+            ordinal: 1,
+            destination: "/Volumes/A",
+            durationSeconds: nil,
+            av1: true
+        )
+
+        let summary = QueueStorageSummary(items: [first, second, unknown])
+
+        XCTAssertEqual(summary.destinations.map(\.destinationPath), ["/Volumes/A", "/Volumes/B"])
+        XCTAssertEqual(summary.destinations[0].estimatedItemCount, 1)
+        XCTAssertEqual(summary.destinations[0].unestimatedItemCount, 1)
+        XCTAssertNil(summary.destinations[0].totalPeakRequiredBytes)
+        XCTAssertNotNil(summary.destinations[1].totalPeakRequiredBytes)
+    }
+
+    func testSystemPreflightDistinguishesAvailabilityAndCapacity() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("storage-preflight-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let available = SystemQueueStoragePreflight(
+            capacityProvider: StubCapacityProvider(
+                readings: PreviewCapacityReadings(
+                    importantUsageBytes: 100 * StorageForecastFormatting.gibibyte,
+                    availableBytes: 100 * StorageForecastFormatting.gibibyte,
+                    writable: true
+                )
+            )
+        )
+        XCTAssertEqual(
+            available.preflight(destinationURL: directory, requiredBytes: 10 * StorageForecastFormatting.gibibyte),
+            .available
+        )
+
+        let unconfirmed = SystemQueueStoragePreflight(
+            capacityProvider: StubCapacityProvider(
+                readings: PreviewCapacityReadings(importantUsageBytes: nil, availableBytes: nil, writable: true)
+            )
+        )
+        guard case .unconfirmed = unconfirmed.preflight(destinationURL: directory, requiredBytes: nil) else {
+            return XCTFail("Expected an unconfirmed capacity verdict")
+        }
+
+        let insufficient = SystemQueueStoragePreflight(
+            capacityProvider: StubCapacityProvider(
+                readings: PreviewCapacityReadings(
+                    importantUsageBytes: 5 * StorageForecastFormatting.gibibyte,
+                    availableBytes: 5 * StorageForecastFormatting.gibibyte,
+                    writable: true
+                )
+            )
+        )
+        XCTAssertEqual(
+            insufficient.preflight(destinationURL: directory, requiredBytes: 10 * StorageForecastFormatting.gibibyte),
+            .insufficient(
+                requiredBytes: 10 * StorageForecastFormatting.gibibyte,
+                availableBytes: 5 * StorageForecastFormatting.gibibyte
+            )
+        )
+
+        let unavailable = SystemQueueStoragePreflight(
+            capacityProvider: StubCapacityProvider(
+                readings: PreviewCapacityReadings(
+                    importantUsageBytes: 100 * StorageForecastFormatting.gibibyte,
+                    availableBytes: 100 * StorageForecastFormatting.gibibyte,
+                    readOnly: true
+                )
+            )
+        )
+        guard case .unavailable = unavailable.preflight(destinationURL: directory, requiredBytes: nil) else {
+            return XCTFail("Expected an unavailable destination verdict")
+        }
+
+        guard case .unavailable = available.preflight(
+            destinationURL: directory.appendingPathComponent("missing", isDirectory: true),
+            requiredBytes: nil
+        ) else {
+            return XCTFail("Expected a missing destination verdict")
+        }
+    }
+
+    private func makeDraft(
+        durationSeconds: Double,
+        options: ConversionOptions = ConversionOptions()
+    ) -> ConversionDraft {
+        var options = options
+        options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+        return ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/movie.mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies", isDirectory: true),
+            options: options,
+            selectedTitle: SourceTitle(
+                id: "title-1",
+                name: "Movie",
+                outputName: "Movie",
+                durationSeconds: durationSeconds,
+                resolution: "1920x1080",
+                frameRate: "24/1",
+                mainFeature: true
+            )
+        )
+    }
+
+    private func makeItem(
+        ordinal: Int,
+        destination: String,
+        durationSeconds: Double?,
+        av1: Bool = false
+    ) throws -> PersistentQueueItem {
+        var options = ConversionOptions()
+        options.encoding.videoOutputMode = av1 ? .av1Stereo : .mvHEVC
+        if !av1 {
+            options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+        }
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/movie-\(ordinal).mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: destination, isDirectory: true),
+            options: options,
+            selectedTitle: durationSeconds.map {
+                SourceTitle(
+                    id: "title-\(ordinal)",
+                    name: "Movie \(ordinal)",
+                    outputName: "Movie \(ordinal)",
+                    durationSeconds: $0,
+                    resolution: "1920x1080",
+                    frameRate: "24/1",
+                    mainFeature: true
+                )
+            }
+        )
+        return try PersistentQueueItem(item: DurableConversionQueueItem(
+            ordinal: ordinal,
+            origin: .singleSource,
+            intent: DurableQueueItemIntent(draft: draft)
+        ))
+    }
+}
+
+private struct StubCapacityProvider: PreviewCapacityProviding {
+    let readings: PreviewCapacityReadings
+
+    func readings(for workspaceURL: URL) -> PreviewCapacityReadings {
+        readings
+    }
+}

--- a/macos/BluRayToVisionProTests/StorageForecastTests.swift
+++ b/macos/BluRayToVisionProTests/StorageForecastTests.swift
@@ -20,6 +20,7 @@ final class StorageForecastTests: XCTestCase {
                 + (forecast.temporaryWorkingBytes ?? 0)
                 + (forecast.safetyMarginBytes ?? 0)
         )
+        XCTAssertTrue(forecast.totalPeakDescription.hasPrefix("Up to "))
     }
 
     func testUnknownForecastNeverProducesBlockingRequiredBytes() {
@@ -126,6 +127,31 @@ final class StorageForecastTests: XCTestCase {
         XCTAssertNotEqual(original.totalPeakRequiredBytes, reordered.totalPeakRequiredBytes)
         XCTAssertGreaterThan(edited.estimatedOutputBytes ?? 0, original.estimatedOutputBytes ?? 0)
         XCTAssertGreaterThan(edited.totalPeakRequiredBytes ?? 0, original.totalPeakRequiredBytes ?? 0)
+    }
+
+    func testHeldItemsRemainVisibleAsUnestimated() throws {
+        let item = try makeItem(
+            ordinal: 0,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600
+        )
+        let held = PersistentQueueItem(
+            id: item.id,
+            ordinal: item.ordinal,
+            draft: item.draft,
+            status: .attention(DurableQueueDecision(
+                identifier: "subtitle_decision_required",
+                prompt: "Choose subtitle handling.",
+                choices: ["continue_without_subtitles"]
+            ))
+        )
+
+        let destination = try XCTUnwrap(QueueStorageSummary(items: [held]).destinations.first)
+
+        XCTAssertEqual(destination.estimatedItemCount, 0)
+        XCTAssertEqual(destination.unestimatedItemCount, 1)
+        XCTAssertTrue(destination.unestimatedReasons.first?.contains("recovery action") == true)
+        XCTAssertNil(destination.totalPeakRequiredBytes)
     }
 
     func testSystemPreflightDistinguishesAvailabilityAndCapacity() throws {

--- a/macos/BluRayToVisionProTests/StorageForecastTests.swift
+++ b/macos/BluRayToVisionProTests/StorageForecastTests.swift
@@ -84,6 +84,50 @@ final class StorageForecastTests: XCTestCase {
         XCTAssertNotNil(summary.destinations[1].totalPeakRequiredBytes)
     }
 
+    func testQueueSummaryRecomputesWhenOrderOrSettingsChange() throws {
+        let lowBitrate = try makeItem(
+            ordinal: 0,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600,
+            bitrateMbps: 40
+        )
+        let highBitrate = try makeItem(
+            ordinal: 1,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600,
+            bitrateMbps: 200
+        )
+        let original = try XCTUnwrap(QueueStorageSummary(items: [lowBitrate, highBitrate]).destinations.first)
+
+        let reorderedLow = try makeItem(
+            ordinal: 1,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600,
+            bitrateMbps: 40
+        )
+        let reorderedHigh = try makeItem(
+            ordinal: 0,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600,
+            bitrateMbps: 200
+        )
+        let reordered = try XCTUnwrap(
+            QueueStorageSummary(items: [reorderedLow, reorderedHigh]).destinations.first
+        )
+
+        let editedHigh = try makeItem(
+            ordinal: 1,
+            destination: "/Volumes/A",
+            durationSeconds: 3_600,
+            bitrateMbps: 300
+        )
+        let edited = try XCTUnwrap(QueueStorageSummary(items: [lowBitrate, editedHigh]).destinations.first)
+
+        XCTAssertNotEqual(original.totalPeakRequiredBytes, reordered.totalPeakRequiredBytes)
+        XCTAssertGreaterThan(edited.estimatedOutputBytes ?? 0, original.estimatedOutputBytes ?? 0)
+        XCTAssertGreaterThan(edited.totalPeakRequiredBytes ?? 0, original.totalPeakRequiredBytes ?? 0)
+    }
+
     func testSystemPreflightDistinguishesAvailabilityAndCapacity() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("storage-preflight-\(UUID().uuidString)", isDirectory: true)
@@ -179,12 +223,16 @@ final class StorageForecastTests: XCTestCase {
         ordinal: Int,
         destination: String,
         durationSeconds: Double?,
-        av1: Bool = false
+        av1: Bool = false,
+        bitrateMbps: Int = 40
     ) throws -> PersistentQueueItem {
         var options = ConversionOptions()
         options.encoding.videoOutputMode = av1 ? .av1Stereo : .mvHEVC
         if !av1 {
-            options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+            options.encoding.mvHEVC.directFinalBitrate = BitratePreference(
+                mode: .custom,
+                customMbps: bitrateMbps
+            )
         }
         let draft = ConversionDraft(
             source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/movie-\(ordinal).mkv")),

--- a/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class StoragePreflightViewModelTests: XCTestCase {
+    func testInsufficientStorageIsParkedBeforeWorkerSpawnAndPausesQueue() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let preflight = StubQueueStoragePreflight(verdict: .insufficient(requiredBytes: 12, availableBytes: 4))
+        let workerFactory = WorkerFactoryCounter()
+        let viewModel = ConversionViewModel(
+            clientFactory: {
+                workerFactory.count += 1
+                throw StoragePreflightTestError.workerSpawned
+            },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true },
+            queueStoragePreflight: preflight
+        )
+        let draft = makeDraft(destination: "/Volumes/Full")
+        _ = try await viewModel.appendPersistentQueueDrafts([draft])
+        let itemID = try XCTUnwrap(queueStore.items.first?.id)
+
+        _ = await viewModel.startPersistentQueue()
+        while queueStore.items.first?.state != .failed {
+            await Task.yield()
+        }
+        while viewModel.persistentQueueRunState != .paused {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(workerFactory.count, 0)
+        XCTAssertEqual(queueStore.items.first?.failure?.code, "destination_insufficient_capacity")
+        XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+        XCTAssertTrue(queueStore.items.first?.attempts.isEmpty == true)
+        XCTAssertEqual(itemID, queueStore.items.first?.id)
+    }
+
+    func testUnavailableDestinationContinuesToAnUnrelatedAdoptedItem() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let preflight = StubQueueStoragePreflight(verdicts: [
+            "/Volumes/Missing": .unavailable("Destination is disconnected."),
+            "/Volumes/Available": .unconfirmed("Free space is advisory."),
+        ])
+        let workerFactory = WorkerFactoryCounter()
+        let viewModel = ConversionViewModel(
+            clientFactory: {
+                workerFactory.count += 1
+                throw StoragePreflightTestError.workerSpawned
+            },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true },
+            queueStoragePreflight: preflight
+        )
+        _ = try await viewModel.appendPersistentQueueDrafts([
+            makeDraft(destination: "/Volumes/Missing", sourcePath: "/Sources/missing.mkv"),
+            makeDraft(destination: "/Volumes/Available", sourcePath: "/Sources/available.mkv"),
+        ])
+
+        _ = await viewModel.startPersistentQueue()
+        while queueStore.items.contains(where: { $0.state == .waiting || $0.state == .processing }) {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(workerFactory.count, 1)
+        XCTAssertEqual(queueStore.items[0].failure?.code, "destination_unavailable")
+        XCTAssertNotEqual(queueStore.items[1].failure?.code, "destination_unavailable")
+        XCTAssertTrue(preflight.paths.contains("/Volumes/Available"))
+    }
+
+    func testRetryableStorageFailureCanBeReadoptedAfterDestinationRecovers() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let preflight = StubQueueStoragePreflight(verdict: .unavailable("Destination is disconnected."))
+        let viewModel = ConversionViewModel(
+            clientFactory: { throw StoragePreflightTestError.workerSpawned },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true },
+            queueStoragePreflight: preflight
+        )
+        _ = try await viewModel.appendPersistentQueueDrafts([makeDraft(destination: "/Volumes/Recovering")])
+        let itemID = try XCTUnwrap(queueStore.items.first?.id)
+
+        _ = await viewModel.startPersistentQueue()
+        while queueStore.items.first?.state != .failed {
+            await Task.yield()
+        }
+        XCTAssertEqual(queueStore.items.first?.failure?.retryable, true)
+
+        preflight.verdict = .unconfirmed("Free space is advisory.")
+        let adopted = await viewModel.adoptPersistentQueueItem(itemID)
+        XCTAssertTrue(adopted)
+        while queueStore.items.first?.state == .waiting {
+            await Task.yield()
+        }
+        XCTAssertNotEqual(queueStore.items.first?.failure?.code, "destination_unavailable")
+    }
+
+    private func makeDraft(destination: String, sourcePath: String = "/Sources/movie.mkv") -> ConversionDraft {
+        var options = ConversionOptions()
+        options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+        return ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: sourcePath)),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: destination, isDirectory: true),
+            options: options,
+            selectedTitle: SourceTitle(
+                id: "title-1",
+                name: "Movie",
+                outputName: "Movie",
+                durationSeconds: 3_600,
+                resolution: "1920x1080",
+                frameRate: "24/1",
+                mainFeature: true
+            )
+        )
+    }
+}
+
+private enum StoragePreflightTestError: Error {
+    case workerSpawned
+}
+
+private final class WorkerFactoryCounter: @unchecked Sendable {
+    var count = 0
+}
+
+private final class StubQueueStoragePreflight: QueueStoragePreflighting, @unchecked Sendable {
+    var verdict: QueueStoragePreflightVerdict = .unconfirmed("Free space is advisory.")
+    var verdicts: [String: QueueStoragePreflightVerdict] = [:]
+    private(set) var paths: [String] = []
+
+    init(verdict: QueueStoragePreflightVerdict) {
+        self.verdict = verdict
+    }
+
+    init(verdicts: [String: QueueStoragePreflightVerdict]) {
+        self.verdicts = verdicts
+    }
+
+    func preflight(destinationURL: URL, requiredBytes: Int64?) -> QueueStoragePreflightVerdict {
+        paths.append(destinationURL.standardizedFileURL.path)
+        return verdicts[destinationURL.standardizedFileURL.path] ?? verdict
+    }
+}

--- a/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
@@ -122,24 +122,84 @@ final class StoragePreflightViewModelTests: XCTestCase {
         XCTAssertEqual(queueStore.items.first?.intent.destinationPath, "/Volumes/Recovered")
     }
 
-    private func makeDraft(destination: String, sourcePath: String = "/Sources/movie.mkv") -> ConversionDraft {
+    func testChangedUnavailableDestinationRejoinsRunningQueue() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let preflight = StubQueueStoragePreflight(verdicts: [
+            "/Volumes/Missing": .unavailable("Destination is disconnected."),
+            "/Volumes/Available": .unconfirmed("Free space is advisory."),
+            "/Volumes/Recovered": .unconfirmed("Free space is advisory."),
+        ])
+        let holdingWorker = HoldingConversionWorkerClient()
+        let workerFactory = WorkerFactoryCounter()
+        let viewModel = ConversionViewModel(
+            clientFactory: {
+                workerFactory.count += 1
+                if workerFactory.count == 1 {
+                    return holdingWorker
+                }
+                throw StoragePreflightTestError.workerSpawned
+            },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true },
+            queueStoragePreflight: preflight
+        )
+        _ = try await viewModel.appendPersistentQueueDrafts([
+            makeDraft(destination: "/Volumes/Missing", sourcePath: "/Sources/missing.mkv", inspected: true),
+            makeDraft(destination: "/Volumes/Available", sourcePath: "/Sources/available.mkv", inspected: true),
+        ])
+        let itemID = try XCTUnwrap(queueStore.items.first?.id)
+
+        _ = await viewModel.startPersistentQueue()
+        while queueStore.items[0].state != .failed || queueStore.items[1].state != .processing {
+            await Task.yield()
+        }
+        XCTAssertEqual(viewModel.persistentQueueRunState, .running)
+
+        try await viewModel.updatePersistentQueueItemDestination(
+            itemID,
+            destinationURL: URL(fileURLWithPath: "/Volumes/Recovered", isDirectory: true)
+        )
+        holdingWorker.release()
+        while workerFactory.count < 2 {
+            await Task.yield()
+        }
+
+        XCTAssertTrue(preflight.paths.contains("/Volumes/Recovered"))
+        XCTAssertNotEqual(queueStore.items[0].failure?.code, "destination_unavailable")
+    }
+
+    private func makeDraft(
+        destination: String,
+        sourcePath: String = "/Sources/movie.mkv",
+        inspected: Bool = false
+    ) -> ConversionDraft {
         var options = ConversionOptions()
         options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)
+        let selectedTitle = SourceTitle(
+            id: "title-1",
+            name: "Movie",
+            outputName: "Movie",
+            durationSeconds: 3_600,
+            resolution: "1920x1080",
+            frameRate: "24/1",
+            mainFeature: true
+        )
         return ConversionDraft(
             source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: sourcePath)),
-            sourceDetails: nil,
+            sourceDetails: inspected
+                ? SourceInspection(
+                    name: "Movie",
+                    resolution: "1920x1080",
+                    frameRate: "24/1",
+                    interlaced: false,
+                    durationSeconds: 3_600,
+                    titles: [selectedTitle]
+                )
+                : nil,
             profile: BuiltInProfile.balanced.profile,
             destinationURL: URL(fileURLWithPath: destination, isDirectory: true),
             options: options,
-            selectedTitle: SourceTitle(
-                id: "title-1",
-                name: "Movie",
-                outputName: "Movie",
-                durationSeconds: 3_600,
-                resolution: "1920x1080",
-                frameRate: "24/1",
-                mainFeature: true
-            )
+            selectedTitle: selectedTitle
         )
     }
 }
@@ -150,6 +210,65 @@ private enum StoragePreflightTestError: Error {
 
 private final class WorkerFactoryCounter: @unchecked Sendable {
     var count = 0
+}
+
+private final class HoldingConversionWorkerClient: WorkerProcessRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func run(
+        job: WorkerJobSpec,
+        onEvent: @escaping (WorkerEvent) async throws -> Void
+    ) async throws -> WorkerRunResult {
+        let ready = WorkerEvent(
+            protocolVersion: WorkerJobSpec.protocolVersion,
+            type: .workerReady,
+            jobID: job.jobID,
+            sequence: 0,
+            payload: WorkerEventPayload(workerVersion: "test", processGroupID: 1)
+        )
+        try await onEvent(ready)
+        await waitForRelease()
+        let completed = WorkerEvent(
+            protocolVersion: WorkerJobSpec.protocolVersion,
+            type: .jobCompleted,
+            jobID: job.jobID,
+            sequence: 1,
+            payload: WorkerEventPayload(
+                conversionResult: ConversionResult(outputPath: "/Volumes/Available/Movie_AVP.mov")
+            )
+        )
+        try await onEvent(completed)
+        return WorkerRunResult(terminalEvent: completed, exitStatus: 0, diagnostics: "")
+    }
+
+    func cancel() {
+        release()
+    }
+
+    func release() {
+        let continuation: CheckedContinuation<Void, Never>?
+        lock.lock()
+        released = true
+        continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume()
+    }
+
+    private func waitForRelease() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if released {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
 }
 
 private final class StubQueueStoragePreflight: QueueStoragePreflighting, @unchecked Sendable {

--- a/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
@@ -95,6 +95,33 @@ final class StoragePreflightViewModelTests: XCTestCase {
         XCTAssertNotEqual(queueStore.items.first?.failure?.code, "destination_unavailable")
     }
 
+    func testStorageFailureDestinationChangeReturnsItemToWaiting() async throws {
+        let queueStore = ConversionQueueStore.inMemory()
+        let preflight = StubQueueStoragePreflight(verdict: .unavailable("Destination is disconnected."))
+        let viewModel = ConversionViewModel(
+            clientFactory: { throw StoragePreflightTestError.workerSpawned },
+            durableQueueStore: queueStore,
+            sourceAvailabilityResolver: { _ in true },
+            queueStoragePreflight: preflight
+        )
+        _ = try await viewModel.appendPersistentQueueDrafts([makeDraft(destination: "/Volumes/Missing")])
+        let itemID = try XCTUnwrap(queueStore.items.first?.id)
+
+        _ = await viewModel.startPersistentQueue()
+        while queueStore.items.first?.state != .failed {
+            await Task.yield()
+        }
+
+        try await viewModel.updatePersistentQueueItemDestination(
+            itemID,
+            destinationURL: URL(fileURLWithPath: "/Volumes/Recovered", isDirectory: true)
+        )
+
+        XCTAssertEqual(queueStore.items.first?.state, .waiting)
+        XCTAssertNil(queueStore.items.first?.failure)
+        XCTAssertEqual(queueStore.items.first?.intent.destinationPath, "/Volumes/Recovered")
+    }
+
     private func makeDraft(destination: String, sourcePath: String = "/Sources/movie.mkv") -> ConversionDraft {
         var options = ConversionOptions()
         options.encoding.mvHEVC.directFinalBitrate = BitratePreference(mode: .custom, customMbps: 40)


### PR DESCRIPTION
## Summary
- add queue storage forecasts by destination with output, temporary/working, retained intermediates, safety margin, peak requirement, and explicit uncertainty
- revalidate destination writability and live volume capacity immediately before every queued worker starts
- park unavailable destinations without blocking unrelated work; pause safely on confirmed insufficient capacity
- allow storage-failed items to change destination, return to waiting, and rejoin an already-running queue automatically

## Validation
- `uv run python scripts/native_app.py test` — 553 tests, 0 failures
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current` — Release package succeeded
- packaged worker-cancellation smoke — passed
- packaged preview-presentation smoke — passed
- exact immutable app: `~/Applications/BD to AVP Builds/ec2788f78cfa7ffc083d308e7223fc5ca55e176c/3D Blu-ray to Vision Pro.app`
- visual QA at the default 1400×1000 workspace confirmed the storage summary, full destination path, all five metrics, queue rows, and queue controls remain readable without clipping

## Review
- Claude Opus exact-head review at `ec2788f78cfa7ffc083d308e7223fc5ca55e176c`: GO, no findings
- Antigravity exact-head review completed but returned no output
- JetBrains inspection remained inconclusive because the local helper could not establish reliable IDE/worktree routing; native build, canonical tests, packaging, and runtime visual QA are authoritative

Closes #548