### PR TITLE
Add queue notifications and result summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,16 @@ while **Stop Current** cancels only the active video and leaves pending work
 waiting for an explicit resume. Runtime failures and recovery decisions remain
 parked according to their existing queue policy.
 
+The sidebar includes a compact **Results** strip once durable outcomes exist,
+with count buttons for completed, failed, and needs-action items. Needs action
+groups choices, interrupted work, and recovery decisions separately from failed
+items; selecting a count jumps to the first matching queued item.
+
+Queue notifications are optional and default off in Settings. The app can notify
+when a queue run finishes and/or when a queued item first needs attention during
+that run. macOS notification text is count-only: source names, file paths,
+destinations, technical details, and failure text stay inside the app.
+
 The queue also shows a coarse storage forecast grouped by destination. Each
 forecast separates estimated output, peak temporary/working space, retained
 intermediates, a visible safety margin, and total peak space. Forecasts use

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -1,8 +1,9 @@
 import AppKit
 import SwiftUI
+import UserNotifications
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNotificationCenterDelegate {
     nonisolated static let startupSmokeArgument = "--startup-smoke"
     nonisolated static let previewPresentationSmokeArgument = "--preview-presentation-smoke"
     nonisolated static let workerCancellationSmokeArgument = "--worker-cancellation-smoke"
@@ -18,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var workerCancellationSmokeTask: Task<Void, Never>?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        UNUserNotificationCenter.current().delegate = self
         let arguments = ProcessInfo.processInfo.arguments
         if let configuration = WorkerCancellationSmokeConfiguration.parse(arguments: arguments) {
             workerCancellationSmokeTask = Task {
@@ -46,6 +48,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         DispatchQueue.main.async {
             NSApp.terminate(nil)
         }
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        await Self.notificationPresentationOptions(isActive: NSApp.isActive)
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        await MainActor.run {
+            raiseManagedWindow()
+        }
+    }
+
+    nonisolated static func notificationPresentationOptions(isActive: Bool) -> UNNotificationPresentationOptions {
+        if isActive {
+            return [.list]
+        }
+        return [.banner, .list, .sound]
     }
 
     nonisolated static func isStartupSmoke(arguments: [String]) -> Bool {
@@ -77,6 +102,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         managedWindow = window
         originalWindowDelegate = window.delegate
         window.delegate = self
+    }
+
+    func raiseManagedWindow() {
+        NSApp.activate()
+        managedWindow?.makeKeyAndOrderFront(nil)
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {

--- a/macos/BluRayToVisionPro/App/AppDelegate.swift
+++ b/macos/BluRayToVisionPro/App/AppDelegate.swift
@@ -54,7 +54,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        await Self.notificationPresentationOptions(isActive: NSApp.isActive)
+        let isActive = await MainActor.run { NSApp.isActive }
+        return Self.notificationPresentationOptions(isActive: isActive)
     }
 
     nonisolated func userNotificationCenter(

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -136,7 +136,7 @@ struct BluRayToVisionProApp: App {
             )
             .focusedSceneValue(\.persistentQueueCommandActions, nil)
         }
-        .defaultSize(width: 900, height: 680)
+        .defaultSize(width: 900, height: 700)
         .windowResizability(.contentMinSize)
     }
 

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -106,6 +106,7 @@ struct BluRayToVisionProApp: App {
                 resolutionMemoryStore: resolutionMemoryStore,
                 capabilities: capabilities
             )
+                .environmentObject(queueNotificationCoordinator)
                 .frame(minWidth: 920, minHeight: 680)
                 .background(
                     WindowAccessor { window in

--- a/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
+++ b/macos/BluRayToVisionPro/App/BluRayToVisionProApp.swift
@@ -37,10 +37,11 @@ struct BluRayToVisionProApp: App {
     @StateObject private var previewViewModel: PreviewViewModel
     @StateObject private var diagnosticReportViewModel: DiagnosticReportViewModel
     @StateObject private var updater: UpdateController
-    @StateObject private var settings = AppSettings()
+    @StateObject private var settings: AppSettings
     @StateObject private var profileStore: ProfileStore
     @StateObject private var resolutionMemoryStore: ResolutionMemoryStore
     @StateObject private var durableQueueStore: ConversionQueueStore
+    @StateObject private var queueNotificationCoordinator: PersistentQueueNotificationCoordinator
 
     private let capabilities = AppCapabilities.current
     private let workCoordinator: AppWorkCoordinator
@@ -60,6 +61,7 @@ struct BluRayToVisionProApp: App {
             queueStoragePreflight: SystemQueueStoragePreflight()
         )
         let previewViewModel = PreviewViewModel(observabilityEventStore: observabilityEventStore)
+        let settings = AppSettings()
         let workCoordinator = AppWorkCoordinator(conversion: viewModel, preview: previewViewModel)
         let diagnosticConfiguration = DiagnosticServiceConfiguration.configured()
         let diagnosticUploader = diagnosticConfiguration.map {
@@ -78,9 +80,15 @@ struct BluRayToVisionProApp: App {
         _previewViewModel = StateObject(wrappedValue: previewViewModel)
         _diagnosticReportViewModel = StateObject(wrappedValue: diagnosticReportViewModel)
         _updater = StateObject(wrappedValue: UpdateController(installPostponer: workCoordinator))
+        _settings = StateObject(wrappedValue: settings)
         _durableQueueStore = StateObject(wrappedValue: durableQueueStore)
         _profileStore = StateObject(wrappedValue: profileStore)
         _resolutionMemoryStore = StateObject(wrappedValue: resolutionMemoryStore)
+        _queueNotificationCoordinator = StateObject(wrappedValue: PersistentQueueNotificationCoordinator(
+            viewModel: viewModel,
+            settings: settings,
+            delivery: UserNotificationsQueueNotificationDelivery()
+        ))
         self.workCoordinator = workCoordinator
         self.observabilityEventStore = observabilityEventStore
         suppressDefaultLaunch = AppDelegate.isAutomationSmoke(arguments: ProcessInfo.processInfo.arguments)

--- a/macos/BluRayToVisionPro/Feature/AppSettings.swift
+++ b/macos/BluRayToVisionPro/Feature/AppSettings.swift
@@ -11,6 +11,8 @@ final class AppSettings: ObservableObject {
         static let showTechnicalDetails = "native.showTechnicalDetails"
         static let keepIntermediateFiles = "native.keepIntermediateFiles"
         static let useSoftwareEncoder = "native.useSoftwareEncoder"
+        static let notifyWhenQueueFinishes = "native.notifyWhenQueueFinishes"
+        static let notifyWhenQueueNeedsAttention = "native.notifyWhenQueueNeedsAttention"
     }
 
     private let defaults: UserDefaults
@@ -53,6 +55,18 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(useSoftwareEncoder, forKey: Key.useSoftwareEncoder) }
     }
 
+    @Published var notifyWhenQueueFinishes: Bool {
+        didSet { defaults.set(notifyWhenQueueFinishes, forKey: Key.notifyWhenQueueFinishes) }
+    }
+
+    @Published var notifyWhenQueueNeedsAttention: Bool {
+        didSet { defaults.set(notifyWhenQueueNeedsAttention, forKey: Key.notifyWhenQueueNeedsAttention) }
+    }
+
+    var queueNotificationsEnabled: Bool {
+        notifyWhenQueueFinishes || notifyWhenQueueNeedsAttention
+    }
+
     init(
         defaults: UserDefaults = .standard,
         homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -72,6 +86,8 @@ final class AppSettings: ObservableObject {
             legacyKeepStageFiles: defaults.object(forKey: Key.keepIntermediateFiles) as? Bool ?? false
         )
         useSoftwareEncoder = defaults.object(forKey: Key.useSoftwareEncoder) as? Bool ?? false
+        notifyWhenQueueFinishes = defaults.object(forKey: Key.notifyWhenQueueFinishes) as? Bool ?? false
+        notifyWhenQueueNeedsAttention = defaults.object(forKey: Key.notifyWhenQueueNeedsAttention) as? Bool ?? false
     }
 
     func resetAdvancedSettings() {

--- a/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
+++ b/macos/BluRayToVisionPro/Feature/ConversionViewModel.swift
@@ -62,6 +62,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
     @Published private(set) var persistentQueueItems: [PersistentQueueItem] = []
     @Published private(set) var persistentQueueProjectionError: PersistentQueueProjectionError?
     @Published private(set) var selectedPersistentQueueItemID: UUID?
+    @Published private(set) var persistentQueueCompletionRevision: UInt = 0
     @Published private(set) var completedBatchResults: [ConversionResult]?
     @Published private(set) var durableQueueRuntimeDiagnostic: String?
     @Published private(set) var persistentQueueRunState: PersistentQueueRunState = .idle
@@ -2050,6 +2051,7 @@ final class ConversionViewModel: ObservableObject, UpdateInstallPostponing {
             .min(by: { $0.ordinal < $1.ordinal })
         else {
             if persistentQueueRunState == .running {
+                persistentQueueCompletionRevision &+= 1
                 persistentQueueRunState = .idle
             }
             persistentQueueControlsActive = false

--- a/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
+++ b/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
@@ -78,14 +78,6 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         )
         defer { lastSnapshot = snapshot }
 
-        if let session,
-           lastSnapshot.runState == .paused,
-           runState == .running,
-           sessionHasNoPendingItems(session, in: snapshot.items)
-        {
-            self.session = nil
-        }
-
         if session == nil,
            lastSnapshot.runState != .running,
            runState == .running
@@ -108,6 +100,11 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
             session = nil
         } else if runState == .idle, lastSnapshot.runState != .idle {
             session = nil
+        } else if runState != .running,
+                  let session,
+                  sessionHasNoPendingItems(session, in: snapshot.items)
+        {
+            self.session = nil
         }
     }
 

--- a/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
+++ b/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
@@ -1,0 +1,242 @@
+import Combine
+import Foundation
+
+@MainActor
+final class PersistentQueueNotificationCoordinator: ObservableObject {
+    private enum ThreadIdentifier {
+        static let attention = "queue.attention"
+        static let completion = "queue.completion"
+    }
+
+    private struct Snapshot: Equatable {
+        let items: [PersistentQueueItem]
+        let runState: PersistentQueueRunState
+
+        var itemsByID: [UUID: PersistentQueueItem] {
+            Dictionary(uniqueKeysWithValues: items.map { ($0.id, $0) })
+        }
+    }
+
+    private struct Session {
+        let id = UUID()
+        var participatingItemIDs: Set<UUID>
+        var baselineTerminalItemIDs: Set<UUID>
+        var sentAttention = false
+        var sentCompletion = false
+    }
+
+    private let settings: AppSettings
+    private let delivery: QueueNotificationDelivering
+    private var cancellables = Set<AnyCancellable>()
+    private var lastSnapshot: Snapshot
+    private var requestedAuthorization = false
+    private var session: Session?
+
+    init(
+        viewModel: ConversionViewModel,
+        settings: AppSettings,
+        delivery: QueueNotificationDelivering
+    ) {
+        self.settings = settings
+        self.delivery = delivery
+        lastSnapshot = Snapshot(
+            items: viewModel.persistentQueueItems,
+            runState: viewModel.persistentQueueRunState
+        )
+        bind(viewModel: viewModel)
+        bind(settings: settings)
+        requestAuthorizationIfNeeded()
+    }
+
+    init(
+        settings: AppSettings,
+        delivery: QueueNotificationDelivering,
+        initialItems: [PersistentQueueItem] = [],
+        initialRunState: PersistentQueueRunState = .idle
+    ) {
+        self.settings = settings
+        self.delivery = delivery
+        lastSnapshot = Snapshot(items: initialItems, runState: initialRunState)
+        bind(settings: settings)
+        requestAuthorizationIfNeeded()
+    }
+
+    func observe(items: [PersistentQueueItem], runState: PersistentQueueRunState) {
+        let snapshot = Snapshot(items: items, runState: runState)
+        defer { lastSnapshot = snapshot }
+
+        if session == nil,
+           lastSnapshot.runState != .running,
+           runState == .running
+        {
+            session = Session(
+                participatingItemIDs: Set(items.filter(\.isQueueNotificationParticipant).map(\.id)),
+                baselineTerminalItemIDs: Set(items.filter(\.isQueueNotificationBaselineTerminal).map(\.id))
+            )
+        }
+
+        guard session != nil else {
+            return
+        }
+
+        refreshParticipation(with: snapshot, previous: lastSnapshot)
+        deliverAttentionIfNeeded(items: snapshot.items)
+
+        if runState == .idle {
+            deliverCompletionIfNeeded(items: snapshot.items)
+            session = nil
+        }
+    }
+
+    func refreshAuthorizationPreference() {
+        requestAuthorizationIfNeeded()
+    }
+
+    private func bind(viewModel: ConversionViewModel) {
+        viewModel.$persistentQueueItems
+            .combineLatest(viewModel.$persistentQueueRunState)
+            .sink { [weak self] items, runState in
+                self?.observe(items: items, runState: runState)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func bind(settings: AppSettings) {
+        settings.$notifyWhenQueueFinishes
+            .sink { [weak self] _ in
+                self?.requestAuthorizationIfNeeded()
+            }
+            .store(in: &cancellables)
+        settings.$notifyWhenQueueNeedsAttention
+            .sink { [weak self] _ in
+                self?.requestAuthorizationIfNeeded()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func requestAuthorizationIfNeeded() {
+        guard settings.queueNotificationsEnabled, !requestedAuthorization else {
+            return
+        }
+        requestedAuthorization = true
+        Task { @MainActor [delivery] in
+            _ = await delivery.requestAuthorization()
+        }
+    }
+
+    private func refreshParticipation(with snapshot: Snapshot, previous: Snapshot) {
+        guard var session else {
+            return
+        }
+        let previousItems = previous.itemsByID
+        for item in snapshot.items {
+            let wasBaselineTerminal = session.baselineTerminalItemIDs.contains(item.id)
+            let previousStatus = previousItems[item.id]?.status
+            let changedFromBaselineTerminal = wasBaselineTerminal && previousStatus != item.status
+            if item.isQueueNotificationParticipant || changedFromBaselineTerminal {
+                session.participatingItemIDs.insert(item.id)
+                session.baselineTerminalItemIDs.remove(item.id)
+            }
+        }
+        self.session = session
+    }
+
+    private func deliverAttentionIfNeeded(items: [PersistentQueueItem]) {
+        guard var session, !session.sentAttention else {
+            return
+        }
+        let attentionCount = participatingItems(from: items, session: session).filter(\.isQueueNotificationAttentionTrigger).count
+        guard attentionCount > 0 else {
+            return
+        }
+
+        session.sentAttention = true
+        self.session = session
+        guard settings.notifyWhenQueueNeedsAttention else {
+            return
+        }
+
+        let body = attentionCount == 1
+            ? "1 queued item needs attention."
+            : "\(attentionCount) queued items need attention."
+        deliver(
+            identifier: "queue-attention-\(session.id.uuidString)",
+            threadIdentifier: ThreadIdentifier.attention,
+            title: "Queue Needs Attention",
+            body: body
+        )
+    }
+
+    private func deliverCompletionIfNeeded(items: [PersistentQueueItem]) {
+        guard var session, !session.sentCompletion else {
+            return
+        }
+        let summary = PersistentQueueOutcomeSummary(items: participatingItems(from: items, session: session))
+        guard summary.hasAnyResults else {
+            return
+        }
+
+        session.sentCompletion = true
+        self.session = session
+        guard settings.notifyWhenQueueFinishes else {
+            return
+        }
+
+        deliver(
+            identifier: "queue-completion-\(session.id.uuidString)",
+            threadIdentifier: ThreadIdentifier.completion,
+            title: "Queue Finished",
+            body: "Completed: \(summary.completedCount). Failed: \(summary.failedCount). Needs action: \(summary.needsActionCount)."
+        )
+    }
+
+    private func participatingItems(from items: [PersistentQueueItem], session: Session) -> [PersistentQueueItem] {
+        items.filter { session.participatingItemIDs.contains($0.id) }
+    }
+
+    private func deliver(
+        identifier: String,
+        threadIdentifier: String,
+        title: String,
+        body: String
+    ) {
+        let request = QueueNotificationRequest(
+            identifier: identifier,
+            threadIdentifier: threadIdentifier,
+            title: title,
+            body: body
+        )
+        Task { @MainActor [delivery] in
+            await delivery.deliver(request)
+        }
+    }
+}
+
+private extension PersistentQueueItem {
+    var isQueueNotificationParticipant: Bool {
+        switch status {
+        case .waiting, .inspecting, .processing, .stopping, .stopped, .notStarted:
+            true
+        case .needsChoice, .interrupted, .attention, .failed, .completed:
+            false
+        }
+    }
+
+    var isQueueNotificationBaselineTerminal: Bool {
+        switch status {
+        case .needsChoice, .interrupted, .attention, .failed, .completed:
+            true
+        case .waiting, .inspecting, .processing, .stopping, .stopped, .notStarted:
+            false
+        }
+    }
+
+    var isQueueNotificationAttentionTrigger: Bool {
+        switch status {
+        case .attention, .failed:
+            true
+        case .waiting, .needsChoice, .inspecting, .processing, .stopping, .interrupted, .completed, .stopped, .notStarted:
+            false
+        }
+    }
+}

--- a/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
+++ b/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
@@ -47,7 +47,6 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         )
         bind(viewModel: viewModel)
         bind(settings: settings)
-        requestAuthorizationIfNeeded()
     }
 
     init(
@@ -65,7 +64,6 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
             completionRevision: initialCompletionRevision
         )
         bind(settings: settings)
-        requestAuthorizationIfNeeded()
     }
 
     func observe(
@@ -79,6 +77,14 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
             completionRevision: completionRevision
         )
         defer { lastSnapshot = snapshot }
+
+        if let session,
+           lastSnapshot.runState == .paused,
+           runState == .running,
+           sessionHasNoPendingItems(session, in: snapshot.items)
+        {
+            self.session = nil
+        }
 
         if session == nil,
            lastSnapshot.runState != .running,
@@ -105,10 +111,6 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         }
     }
 
-    func refreshAuthorizationPreference() {
-        requestAuthorizationIfNeeded()
-    }
-
     private func bind(viewModel: ConversionViewModel) {
         Publishers.CombineLatest3(
             viewModel.$persistentQueueItems,
@@ -127,19 +129,17 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
 
     private func bind(settings: AppSettings) {
         settings.$notifyWhenQueueFinishes
-            .sink { [weak self] _ in
-                self?.requestAuthorizationIfNeeded()
-            }
-            .store(in: &cancellables)
-        settings.$notifyWhenQueueNeedsAttention
-            .sink { [weak self] _ in
-                self?.requestAuthorizationIfNeeded()
+            .combineLatest(settings.$notifyWhenQueueNeedsAttention)
+            .map { $0 || $1 }
+            .removeDuplicates()
+            .sink { [weak self] enabled in
+                self?.requestAuthorizationIfNeeded(enabled: enabled)
             }
             .store(in: &cancellables)
     }
 
-    private func requestAuthorizationIfNeeded() {
-        guard settings.queueNotificationsEnabled, !requestedAuthorization else {
+    private func requestAuthorizationIfNeeded(enabled: Bool) {
+        guard enabled, !requestedAuthorization else {
             return
         }
         requestedAuthorization = true
@@ -218,6 +218,13 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         items.filter { session.participatingItemIDs.contains($0.id) }
     }
 
+    private func sessionHasNoPendingItems(_ session: Session, in items: [PersistentQueueItem]) -> Bool {
+        let itemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, $0) })
+        return session.participatingItemIDs.allSatisfy { itemID in
+            itemsByID[itemID]?.isQueueNotificationTerminalForSession ?? true
+        }
+    }
+
     private func deliver(
         identifier: String,
         threadIdentifier: String,
@@ -257,9 +264,18 @@ private extension PersistentQueueItem {
 
     var isQueueNotificationAttentionTrigger: Bool {
         switch status {
-        case .attention, .failed:
+        case .needsChoice, .interrupted, .attention, .failed:
             true
-        case .waiting, .needsChoice, .inspecting, .processing, .stopping, .interrupted, .completed, .stopped, .notStarted:
+        case .waiting, .inspecting, .processing, .stopping, .completed, .stopped, .notStarted:
+            false
+        }
+    }
+
+    var isQueueNotificationTerminalForSession: Bool {
+        switch status {
+        case .needsChoice, .interrupted, .attention, .failed, .completed, .stopped, .notStarted:
+            true
+        case .waiting, .inspecting, .processing, .stopping:
             false
         }
     }

--- a/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
+++ b/macos/BluRayToVisionPro/Feature/PersistentQueueNotificationCoordinator.swift
@@ -11,6 +11,7 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
     private struct Snapshot: Equatable {
         let items: [PersistentQueueItem]
         let runState: PersistentQueueRunState
+        let completionRevision: UInt
 
         var itemsByID: [UUID: PersistentQueueItem] {
             Dictionary(uniqueKeysWithValues: items.map { ($0.id, $0) })
@@ -41,7 +42,8 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         self.delivery = delivery
         lastSnapshot = Snapshot(
             items: viewModel.persistentQueueItems,
-            runState: viewModel.persistentQueueRunState
+            runState: viewModel.persistentQueueRunState,
+            completionRevision: viewModel.persistentQueueCompletionRevision
         )
         bind(viewModel: viewModel)
         bind(settings: settings)
@@ -52,17 +54,30 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         settings: AppSettings,
         delivery: QueueNotificationDelivering,
         initialItems: [PersistentQueueItem] = [],
-        initialRunState: PersistentQueueRunState = .idle
+        initialRunState: PersistentQueueRunState = .idle,
+        initialCompletionRevision: UInt = 0
     ) {
         self.settings = settings
         self.delivery = delivery
-        lastSnapshot = Snapshot(items: initialItems, runState: initialRunState)
+        lastSnapshot = Snapshot(
+            items: initialItems,
+            runState: initialRunState,
+            completionRevision: initialCompletionRevision
+        )
         bind(settings: settings)
         requestAuthorizationIfNeeded()
     }
 
-    func observe(items: [PersistentQueueItem], runState: PersistentQueueRunState) {
-        let snapshot = Snapshot(items: items, runState: runState)
+    func observe(
+        items: [PersistentQueueItem],
+        runState: PersistentQueueRunState,
+        completionRevision: UInt = 0
+    ) {
+        let snapshot = Snapshot(
+            items: items,
+            runState: runState,
+            completionRevision: completionRevision
+        )
         defer { lastSnapshot = snapshot }
 
         if session == nil,
@@ -82,8 +97,10 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
         refreshParticipation(with: snapshot, previous: lastSnapshot)
         deliverAttentionIfNeeded(items: snapshot.items)
 
-        if runState == .idle {
+        if completionRevision != lastSnapshot.completionRevision {
             deliverCompletionIfNeeded(items: snapshot.items)
+            session = nil
+        } else if runState == .idle, lastSnapshot.runState != .idle {
             session = nil
         }
     }
@@ -93,10 +110,17 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
     }
 
     private func bind(viewModel: ConversionViewModel) {
-        viewModel.$persistentQueueItems
-            .combineLatest(viewModel.$persistentQueueRunState)
-            .sink { [weak self] items, runState in
-                self?.observe(items: items, runState: runState)
+        Publishers.CombineLatest3(
+            viewModel.$persistentQueueItems,
+            viewModel.$persistentQueueRunState,
+            viewModel.$persistentQueueCompletionRevision
+        )
+            .sink { [weak self] items, runState, completionRevision in
+                self?.observe(
+                    items: items,
+                    runState: runState,
+                    completionRevision: completionRevision
+                )
             }
             .store(in: &cancellables)
     }
@@ -186,7 +210,7 @@ final class PersistentQueueNotificationCoordinator: ObservableObject {
             identifier: "queue-completion-\(session.id.uuidString)",
             threadIdentifier: ThreadIdentifier.completion,
             title: "Queue Finished",
-            body: "Completed: \(summary.completedCount). Failed: \(summary.failedCount). Needs action: \(summary.needsActionCount)."
+            body: summary.notificationDescription
         )
     }
 

--- a/macos/BluRayToVisionPro/Feature/QueueNotificationDelivery.swift
+++ b/macos/BluRayToVisionPro/Feature/QueueNotificationDelivery.swift
@@ -1,0 +1,46 @@
+import Foundation
+import UserNotifications
+
+struct QueueNotificationRequest: Equatable {
+    let identifier: String
+    let threadIdentifier: String
+    let title: String
+    let body: String
+}
+
+@MainActor
+protocol QueueNotificationDelivering: AnyObject {
+    func requestAuthorization() async -> Bool
+    func deliver(_ request: QueueNotificationRequest) async
+}
+
+final class UserNotificationsQueueNotificationDelivery: QueueNotificationDelivering {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    func requestAuthorization() async -> Bool {
+        do {
+            return try await center.requestAuthorization(options: [.alert, .sound])
+        } catch {
+            return false
+        }
+    }
+
+    func deliver(_ request: QueueNotificationRequest) async {
+        let content = UNMutableNotificationContent()
+        content.title = request.title
+        content.body = request.body
+        content.threadIdentifier = request.threadIdentifier
+        content.sound = .default
+
+        let notification = UNNotificationRequest(
+            identifier: request.identifier,
+            content: content,
+            trigger: nil
+        )
+        try? await center.add(notification)
+    }
+}

--- a/macos/BluRayToVisionPro/Models/PersistentQueueOutcomeSummary.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueueOutcomeSummary.swift
@@ -35,4 +35,18 @@ struct PersistentQueueOutcomeSummary: Equatable {
     var hasAnyResults: Bool {
         completedCount > 0 || failedCount > 0 || needsActionCount > 0
     }
+
+    var notificationDescription: String {
+        var parts: [String] = []
+        if completedCount > 0 {
+            parts.append("\(completedCount) completed.")
+        }
+        if failedCount > 0 {
+            parts.append("\(failedCount) failed.")
+        }
+        if needsActionCount > 0 {
+            parts.append("\(needsActionCount) needs action.")
+        }
+        return parts.joined(separator: " ")
+    }
 }

--- a/macos/BluRayToVisionPro/Models/PersistentQueueOutcomeSummary.swift
+++ b/macos/BluRayToVisionPro/Models/PersistentQueueOutcomeSummary.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct PersistentQueueOutcomeSummary: Equatable {
+    let completedItemIDs: [UUID]
+    let failedItemIDs: [UUID]
+    let needsActionItemIDs: [UUID]
+
+    init(items: [PersistentQueueItem]) {
+        var completedItemIDs: [UUID] = []
+        var failedItemIDs: [UUID] = []
+        var needsActionItemIDs: [UUID] = []
+
+        for item in items.sorted(by: { $0.ordinal < $1.ordinal }) {
+            switch item.status {
+            case .completed:
+                completedItemIDs.append(item.id)
+            case .failed:
+                failedItemIDs.append(item.id)
+            case .needsChoice, .interrupted, .attention:
+                needsActionItemIDs.append(item.id)
+            case .waiting, .inspecting, .processing, .stopping, .stopped, .notStarted:
+                break
+            }
+        }
+
+        self.completedItemIDs = completedItemIDs
+        self.failedItemIDs = failedItemIDs
+        self.needsActionItemIDs = needsActionItemIDs
+    }
+
+    var completedCount: Int { completedItemIDs.count }
+    var failedCount: Int { failedItemIDs.count }
+    var needsActionCount: Int { needsActionItemIDs.count }
+
+    var hasAnyResults: Bool {
+        completedCount > 0 || failedCount > 0 || needsActionCount > 0
+    }
+}

--- a/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
+++ b/macos/BluRayToVisionPro/Views/PersistentQueueWorkspaceView.swift
@@ -55,6 +55,7 @@ struct PersistentQueueSidebarView: View {
             Divider()
             scheduleBanner
             storageSummaryView
+            outcomeSummaryView
             if let banner {
                 Label(banner.title, systemImage: banner.systemImage)
                     .font(.caption.weight(.medium))
@@ -251,6 +252,79 @@ struct PersistentQueueSidebarView: View {
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var outcomeSummaryView: some View {
+        let summary = PersistentQueueOutcomeSummary(items: items)
+        if summary.hasAnyResults {
+            VStack(alignment: .leading, spacing: 7) {
+                Text("Results")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    outcomeButton(
+                        title: "Completed",
+                        count: summary.completedCount,
+                        itemIDs: summary.completedItemIDs,
+                        tint: .green,
+                        systemImage: "checkmark.circle.fill"
+                    )
+                    outcomeButton(
+                        title: "Failed",
+                        count: summary.failedCount,
+                        itemIDs: summary.failedItemIDs,
+                        tint: .red,
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    outcomeButton(
+                        title: "Needs Action",
+                        count: summary.needsActionCount,
+                        itemIDs: summary.needsActionItemIDs,
+                        tint: .orange,
+                        systemImage: "exclamationmark.circle.fill"
+                    )
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.secondary.opacity(0.06))
+            .accessibilityIdentifier("persistent-queue-results-summary")
+        }
+    }
+
+    @ViewBuilder
+    private func outcomeButton(
+        title: String,
+        count: Int,
+        itemIDs: [UUID],
+        tint: Color,
+        systemImage: String
+    ) -> some View {
+        if count > 0, let firstID = itemIDs.first {
+            Button {
+                selectedID = firstID
+            } label: {
+                VStack(spacing: 2) {
+                    Label(title, systemImage: systemImage)
+                        .labelStyle(.iconOnly)
+                        .font(.caption.weight(.semibold))
+                    Text("\(count)")
+                        .font(.caption.monospacedDigit().weight(.semibold))
+                    Text(title)
+                        .font(.caption2)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+                .frame(maxWidth: .infinity, minHeight: 48)
+                .foregroundStyle(tint)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(title): \(count)")
+            .accessibilityIdentifier("persistent-queue-results-\(title.lowercased().replacingOccurrences(of: " ", with: "-"))")
+        }
     }
 
     private var queueList: some View {

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -27,8 +27,8 @@ struct SettingsView: View {
             minWidth: 820,
             idealWidth: 900,
             maxWidth: .infinity,
-            minHeight: 560,
-            idealHeight: 680,
+            minHeight: 620,
+            idealHeight: 700,
             maxHeight: .infinity
         )
     }

--- a/macos/BluRayToVisionPro/Views/SettingsView.swift
+++ b/macos/BluRayToVisionPro/Views/SettingsView.swift
@@ -75,6 +75,15 @@ private struct GeneralSettingsPane: View {
                 Toggle("Play a sound", isOn: $settings.playSound)
                 Toggle("Keep the Mac awake while converting", isOn: $settings.keepAwake)
             }
+
+            Section("Queue Notifications") {
+                Toggle("Notify when the queue finishes", isOn: $settings.notifyWhenQueueFinishes)
+                Toggle("Notify when a queued item needs attention", isOn: $settings.notifyWhenQueueNeedsAttention)
+                Text("Notifications include queue counts only. Source names, file paths, destinations, and error details stay in the app.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
     }

--- a/macos/BluRayToVisionProTests/AppDelegateTests.swift
+++ b/macos/BluRayToVisionProTests/AppDelegateTests.swift
@@ -42,17 +42,4 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertEqual(AppDelegate.notificationPresentationOptions(isActive: false), [.banner, .list, .sound])
     }
 
-    func testQueueNotificationRequestContainsOnlySafeDisplayFields() {
-        let request = QueueNotificationRequest(
-            identifier: "queue-completion-id",
-            threadIdentifier: "queue.completion",
-            title: "Queue Finished",
-            body: "Completed: 2. Failed: 0. Needs action: 0."
-        )
-
-        XCTAssertEqual(request.identifier, "queue-completion-id")
-        XCTAssertEqual(request.threadIdentifier, "queue.completion")
-        XCTAssertEqual(request.title, "Queue Finished")
-        XCTAssertEqual(request.body, "Completed: 2. Failed: 0. Needs action: 0.")
-    }
 }

--- a/macos/BluRayToVisionProTests/AppDelegateTests.swift
+++ b/macos/BluRayToVisionProTests/AppDelegateTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UserNotifications
 @testable import BluRayToVisionPro
 
 final class AppDelegateTests: XCTestCase {
@@ -34,5 +35,24 @@ final class AppDelegateTests: XCTestCase {
             AppDelegate.isAutomationSmoke(arguments: ["app", AppDelegate.workerCancellationSmokeArgument])
         )
         XCTAssertFalse(AppDelegate.isAutomationSmoke(arguments: ["app"]))
+    }
+
+    func testNotificationPresentationPolicyMatchesAppActivity() {
+        XCTAssertEqual(AppDelegate.notificationPresentationOptions(isActive: true), [.list])
+        XCTAssertEqual(AppDelegate.notificationPresentationOptions(isActive: false), [.banner, .list, .sound])
+    }
+
+    func testQueueNotificationRequestContainsOnlySafeDisplayFields() {
+        let request = QueueNotificationRequest(
+            identifier: "queue-completion-id",
+            threadIdentifier: "queue.completion",
+            title: "Queue Finished",
+            body: "Completed: 2. Failed: 0. Needs action: 0."
+        )
+
+        XCTAssertEqual(request.identifier, "queue-completion-id")
+        XCTAssertEqual(request.threadIdentifier, "queue.completion")
+        XCTAssertEqual(request.title, "Queue Finished")
+        XCTAssertEqual(request.body, "Completed: 2. Failed: 0. Needs action: 0.")
     }
 }

--- a/macos/BluRayToVisionProTests/AppSettingsTests.swift
+++ b/macos/BluRayToVisionProTests/AppSettingsTests.swift
@@ -16,6 +16,8 @@ final class AppSettingsTests: XCTestCase {
         settings.showTechnicalDetails = true
         settings.intermediatePolicy = .reusable
         settings.useSoftwareEncoder = true
+        settings.notifyWhenQueueFinishes = true
+        settings.notifyWhenQueueNeedsAttention = true
 
         let restored = AppSettings(defaults: defaults, homeDirectoryURL: homeURL)
 
@@ -24,7 +26,25 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(restored.showTechnicalDetails)
         XCTAssertEqual(restored.intermediatePolicy, .reusable)
         XCTAssertTrue(restored.useSoftwareEncoder)
+        XCTAssertTrue(restored.notifyWhenQueueFinishes)
+        XCTAssertTrue(restored.notifyWhenQueueNeedsAttention)
+        XCTAssertTrue(restored.queueNotificationsEnabled)
         XCTAssertEqual(defaults.object(forKey: "native.keepIntermediateFiles") as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: "native.notifyWhenQueueFinishes") as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: "native.notifyWhenQueueNeedsAttention") as? Bool, true)
+    }
+
+    @MainActor
+    func testQueueNotificationsDefaultOff() {
+        let suiteName = "AppSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertFalse(settings.notifyWhenQueueFinishes)
+        XCTAssertFalse(settings.notifyWhenQueueNeedsAttention)
+        XCTAssertFalse(settings.queueNotificationsEnabled)
     }
 
     @MainActor

--- a/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
@@ -49,12 +49,16 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         let failed = try second.replacingStatus(.failed)
 
         coordinator.observe(items: [first, second, stopped], runState: .running)
-        coordinator.observe(items: [completed, failed, stopped], runState: .idle)
+        coordinator.observe(
+            items: [completed, failed, stopped],
+            runState: .idle,
+            completionRevision: 1
+        )
         await Task.yield()
 
         XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Finished"])
         XCTAssertEqual(delivery.deliveredRequests.first?.threadIdentifier, "queue.completion")
-        XCTAssertEqual(delivery.deliveredRequests.first?.body, "Completed: 1. Failed: 1. Needs action: 0.")
+        XCTAssertEqual(delivery.deliveredRequests.first?.body, "1 completed. 1 failed.")
     }
 
     func testPauseStatesPreserveSingleNotificationSession() async throws {
@@ -68,11 +72,29 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         coordinator.observe(items: [item], runState: .pauseAfterCurrent)
         coordinator.observe(items: [item], runState: .paused)
         coordinator.observe(items: [item], runState: .running)
-        coordinator.observe(items: [completed], runState: .idle)
+        coordinator.observe(items: [completed], runState: .idle, completionRevision: 1)
         await Task.yield()
 
         XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Finished"])
-        XCTAssertEqual(delivery.deliveredRequests.first?.body, "Completed: 1. Failed: 0. Needs action: 0.")
+        XCTAssertEqual(delivery.deliveredRequests.first?.body, "1 completed.")
+    }
+
+    func testExplicitStopDoesNotSendCompletionNotification() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: false)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let first = try makeItem(ordinal: 0, state: .waiting)
+        let second = try makeItem(ordinal: 1, state: .waiting)
+        let completed = try first.replacingStatus(.completed)
+        let processing = try second.replacingStatus(.processing)
+        let stopped = try second.replacingStatus(.stopped)
+
+        coordinator.observe(items: [first, second], runState: .running)
+        coordinator.observe(items: [completed, processing], runState: .running)
+        coordinator.observe(items: [completed, stopped], runState: .idle)
+        await Task.yield()
+
+        XCTAssertTrue(delivery.deliveredRequests.isEmpty)
     }
 
     func testDisabledPreferencesRequestAuthorizationOnlyWhenEnabled() async throws {
@@ -104,7 +126,7 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         let failed = try waiting.replacingStatus(.failed, message: "ffmpeg failed at /tmp/private-output.mov")
 
         coordinator.observe(items: [waiting], runState: .running)
-        coordinator.observe(items: [failed], runState: .idle)
+        coordinator.observe(items: [failed], runState: .idle, completionRevision: 1)
         await Task.yield()
 
         let copy = delivery.deliveredRequests.flatMap { [$0.title, $0.body, $0.threadIdentifier, $0.identifier] }.joined(separator: " ")

--- a/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
@@ -79,22 +79,51 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         XCTAssertEqual(delivery.deliveredRequests.first?.body, "1 completed.")
     }
 
-    func testTerminalPausedSessionResetsBeforeNewRun() async throws {
+    func testTerminalPausedSessionResetsBeforeStoreFirstRetry() async throws {
         let delivery = CapturingQueueNotificationDelivery()
         let settings = makeSettings(finish: true, attention: true)
         let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
         let first = try makeItem(ordinal: 0, state: .waiting)
         let firstFailed = try first.replacingStatus(.failed)
-        let second = try makeItem(ordinal: 1, state: .waiting)
-        let secondFailed = try second.replacingStatus(.failed)
+        let retried = try firstFailed.replacingStatus(.waiting)
+        let completed = try retried.replacingStatus(.completed)
 
         coordinator.observe(items: [first], runState: .running)
         coordinator.observe(items: [firstFailed], runState: .pauseAfterCurrent)
         coordinator.observe(items: [firstFailed], runState: .paused)
-        coordinator.observe(items: [firstFailed, second], runState: .running)
-        coordinator.observe(items: [firstFailed, secondFailed], runState: .running)
+        coordinator.observe(items: [retried], runState: .paused)
+        coordinator.observe(items: [retried], runState: .running)
+        coordinator.observe(items: [completed], runState: .running)
         coordinator.observe(
-            items: [firstFailed, secondFailed],
+            items: [completed],
+            runState: .idle,
+            completionRevision: 1
+        )
+        await Task.yield()
+
+        XCTAssertEqual(
+            delivery.deliveredRequests.map(\.title),
+            ["Queue Needs Attention", "Queue Finished"]
+        )
+        XCTAssertEqual(delivery.deliveredRequests.last?.body, "1 completed.")
+    }
+
+    func testTerminalPauseAfterCurrentSessionResetsBeforeStoreFirstRetry() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: true)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let first = try makeItem(ordinal: 0, state: .waiting)
+        let firstFailed = try first.replacingStatus(.failed)
+        let retried = try firstFailed.replacingStatus(.waiting)
+        let failedAgain = try retried.replacingStatus(.failed)
+
+        coordinator.observe(items: [first], runState: .running)
+        coordinator.observe(items: [firstFailed], runState: .pauseAfterCurrent)
+        coordinator.observe(items: [retried], runState: .pauseAfterCurrent)
+        coordinator.observe(items: [retried], runState: .running)
+        coordinator.observe(items: [failedAgain], runState: .running)
+        coordinator.observe(
+            items: [failedAgain],
             runState: .idle,
             completionRevision: 1
         )

--- a/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
@@ -79,6 +79,34 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         XCTAssertEqual(delivery.deliveredRequests.first?.body, "1 completed.")
     }
 
+    func testTerminalPausedSessionResetsBeforeNewRun() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: true)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let first = try makeItem(ordinal: 0, state: .waiting)
+        let firstFailed = try first.replacingStatus(.failed)
+        let second = try makeItem(ordinal: 1, state: .waiting)
+        let secondFailed = try second.replacingStatus(.failed)
+
+        coordinator.observe(items: [first], runState: .running)
+        coordinator.observe(items: [firstFailed], runState: .pauseAfterCurrent)
+        coordinator.observe(items: [firstFailed], runState: .paused)
+        coordinator.observe(items: [firstFailed, second], runState: .running)
+        coordinator.observe(items: [firstFailed, secondFailed], runState: .running)
+        coordinator.observe(
+            items: [firstFailed, secondFailed],
+            runState: .idle,
+            completionRevision: 1
+        )
+        await Task.yield()
+
+        XCTAssertEqual(
+            delivery.deliveredRequests.map(\.title),
+            ["Queue Needs Attention", "Queue Needs Attention", "Queue Finished"]
+        )
+        XCTAssertEqual(delivery.deliveredRequests.last?.body, "1 failed.")
+    }
+
     func testExplicitStopDoesNotSendCompletionNotification() async throws {
         let delivery = CapturingQueueNotificationDelivery()
         let settings = makeSettings(finish: true, attention: false)
@@ -107,15 +135,33 @@ final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
         let authorizationRequested = expectation(description: "authorization requested")
         delivery.authorizationRequested = authorizationRequested
         settings.notifyWhenQueueFinishes = true
-        coordinator.refreshAuthorizationPreference()
         await fulfillment(of: [authorizationRequested], timeout: 1)
         XCTAssertEqual(delivery.authorizationRequestCount, 1)
 
         settings.notifyWhenQueueNeedsAttention = true
-        coordinator.refreshAuthorizationPreference()
         await Task.yield()
         XCTAssertEqual(delivery.authorizationRequestCount, 1)
         _ = coordinator
+    }
+
+    func testRestoredFailedItemCanTriggerAttentionAfterRetry() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: false, attention: true)
+        let failed = try makeItem(ordinal: 0, state: .failed)
+        let waiting = try failed.replacingStatus(.waiting)
+        let coordinator = PersistentQueueNotificationCoordinator(
+            settings: settings,
+            delivery: delivery,
+            initialItems: [failed],
+            initialRunState: .idle
+        )
+
+        coordinator.observe(items: [failed], runState: .running)
+        coordinator.observe(items: [waiting], runState: .running)
+        coordinator.observe(items: [failed], runState: .running)
+        await Task.yield()
+
+        XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Needs Attention"])
     }
 
     func testNotificationCopyIsPrivacySafe() async throws {

--- a/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueNotificationCoordinatorTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+@MainActor
+final class PersistentQueueNotificationCoordinatorTests: XCTestCase {
+    func testInitialRestoredTerminalStateIsBaselineOnly() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: true)
+        let failed = try makeItem(ordinal: 0, state: .failed, sourcePath: "/Private/Restored.mkv")
+        let coordinator = PersistentQueueNotificationCoordinator(
+            settings: settings,
+            delivery: delivery,
+            initialItems: [failed],
+            initialRunState: .idle
+        )
+
+        coordinator.observe(items: [failed], runState: .idle)
+        await Task.yield()
+
+        XCTAssertEqual(delivery.deliveredRequests.count, 0)
+    }
+
+    func testSendsOneAttentionAlertPerRunAndIgnoresProjectionRefreshes() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: false, attention: true)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let waiting = try makeItem(ordinal: 0, state: .waiting)
+        let failed = try waiting.replacingStatus(.failed)
+
+        coordinator.observe(items: [waiting], runState: .running)
+        coordinator.observe(items: [failed], runState: .running)
+        coordinator.observe(items: [failed], runState: .running)
+        await Task.yield()
+
+        XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Needs Attention"])
+        XCTAssertEqual(delivery.deliveredRequests.first?.threadIdentifier, "queue.attention")
+        XCTAssertEqual(delivery.deliveredRequests.first?.body, "1 queued item needs attention.")
+    }
+
+    func testCompletionUsesFinalDurableStatesForParticipatingItems() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: false)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let first = try makeItem(ordinal: 0, state: .waiting)
+        let second = try makeItem(ordinal: 1, state: .waiting)
+        let stopped = try makeItem(ordinal: 2, state: .notStarted)
+        let completed = try first.replacingStatus(.completed)
+        let failed = try second.replacingStatus(.failed)
+
+        coordinator.observe(items: [first, second, stopped], runState: .running)
+        coordinator.observe(items: [completed, failed, stopped], runState: .idle)
+        await Task.yield()
+
+        XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Finished"])
+        XCTAssertEqual(delivery.deliveredRequests.first?.threadIdentifier, "queue.completion")
+        XCTAssertEqual(delivery.deliveredRequests.first?.body, "Completed: 1. Failed: 1. Needs action: 0.")
+    }
+
+    func testPauseStatesPreserveSingleNotificationSession() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: true)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let item = try makeItem(ordinal: 0, state: .waiting)
+        let completed = try item.replacingStatus(.completed)
+
+        coordinator.observe(items: [item], runState: .running)
+        coordinator.observe(items: [item], runState: .pauseAfterCurrent)
+        coordinator.observe(items: [item], runState: .paused)
+        coordinator.observe(items: [item], runState: .running)
+        coordinator.observe(items: [completed], runState: .idle)
+        await Task.yield()
+
+        XCTAssertEqual(delivery.deliveredRequests.map(\.title), ["Queue Finished"])
+        XCTAssertEqual(delivery.deliveredRequests.first?.body, "Completed: 1. Failed: 0. Needs action: 0.")
+    }
+
+    func testDisabledPreferencesRequestAuthorizationOnlyWhenEnabled() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: false, attention: false)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        await Task.yield()
+        XCTAssertEqual(delivery.authorizationRequestCount, 0)
+
+        let authorizationRequested = expectation(description: "authorization requested")
+        delivery.authorizationRequested = authorizationRequested
+        settings.notifyWhenQueueFinishes = true
+        coordinator.refreshAuthorizationPreference()
+        await fulfillment(of: [authorizationRequested], timeout: 1)
+        XCTAssertEqual(delivery.authorizationRequestCount, 1)
+
+        settings.notifyWhenQueueNeedsAttention = true
+        coordinator.refreshAuthorizationPreference()
+        await Task.yield()
+        XCTAssertEqual(delivery.authorizationRequestCount, 1)
+        _ = coordinator
+    }
+
+    func testNotificationCopyIsPrivacySafe() async throws {
+        let delivery = CapturingQueueNotificationDelivery()
+        let settings = makeSettings(finish: true, attention: true)
+        let coordinator = PersistentQueueNotificationCoordinator(settings: settings, delivery: delivery)
+        let waiting = try makeItem(ordinal: 0, state: .waiting, sourcePath: "/Volumes/Private Movie/Secret Feature.mkv")
+        let failed = try waiting.replacingStatus(.failed, message: "ffmpeg failed at /tmp/private-output.mov")
+
+        coordinator.observe(items: [waiting], runState: .running)
+        coordinator.observe(items: [failed], runState: .idle)
+        await Task.yield()
+
+        let copy = delivery.deliveredRequests.flatMap { [$0.title, $0.body, $0.threadIdentifier, $0.identifier] }.joined(separator: " ")
+        XCTAssertFalse(copy.contains("Secret Feature"))
+        XCTAssertFalse(copy.contains("/Volumes"))
+        XCTAssertFalse(copy.contains("/tmp"))
+        XCTAssertFalse(copy.localizedCaseInsensitiveContains("ffmpeg"))
+    }
+
+    private func makeSettings(finish: Bool, attention: Bool) -> AppSettings {
+        let suiteName = "PersistentQueueNotificationCoordinatorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(finish, forKey: "native.notifyWhenQueueFinishes")
+        defaults.set(attention, forKey: "native.notifyWhenQueueNeedsAttention")
+        return AppSettings(defaults: defaults, homeDirectoryURL: URL(fileURLWithPath: "/Users/example"))
+    }
+
+    private func makeItem(
+        ordinal: Int,
+        state: DurableQueueItemState,
+        sourcePath: String? = nil,
+        message: String = "Temporary failure"
+    ) throws -> PersistentQueueItem {
+        let path = sourcePath ?? "/Sources/Feature-\(ordinal).mkv"
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: path)),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            options: ConversionOptions()
+        )
+        return try PersistentQueueItem(item: DurableConversionQueueItem(
+            ordinal: ordinal,
+            origin: .singleSource,
+            intent: DurableQueueItemIntent(draft: draft),
+            state: state,
+            decision: state == .attention ? DurableQueueDecision(
+                identifier: "source_missing",
+                prompt: "Reconnect the source.",
+                choices: [WorkerRecoveryChoice.retryContinueOnError.rawValue]
+            ) : nil,
+            failure: state == .failed ? DurableQueueFailure(
+                code: "temporary",
+                message: message,
+                details: nil,
+                retryable: true
+            ) : nil,
+            result: state == .completed ? DurableQueueResult(outputPath: "/Movies/Feature-\(ordinal).mov") : nil
+        ))
+    }
+}
+
+@MainActor
+private final class CapturingQueueNotificationDelivery: QueueNotificationDelivering {
+    private(set) var authorizationRequestCount = 0
+    private(set) var deliveredRequests: [QueueNotificationRequest] = []
+    var authorizationRequested: XCTestExpectation?
+
+    func requestAuthorization() async -> Bool {
+        authorizationRequestCount += 1
+        authorizationRequested?.fulfill()
+        return true
+    }
+
+    func deliver(_ request: QueueNotificationRequest) async {
+        deliveredRequests.append(request)
+    }
+}
+
+private extension PersistentQueueItem {
+    func replacingStatus(_ state: DurableQueueItemState, message: String = "Temporary failure") throws -> PersistentQueueItem {
+        try PersistentQueueItem(item: DurableConversionQueueItem(
+            id: id,
+            ordinal: ordinal,
+            groupID: groupID,
+            origin: origin,
+            intent: DurableQueueItemIntent(draft: draft),
+            inspection: draft.sourceDetails,
+            state: state,
+            attempts: [],
+            decision: state == .attention ? DurableQueueDecision(
+                identifier: "source_missing",
+                prompt: "Reconnect the source.",
+                choices: [WorkerRecoveryChoice.retryContinueOnError.rawValue]
+            ) : nil,
+            failure: state == .failed ? DurableQueueFailure(
+                code: "temporary",
+                message: message,
+                details: nil,
+                retryable: true
+            ) : nil,
+            result: state == .completed ? DurableQueueResult(outputPath: "/Movies/Feature.mov") : nil,
+            resolutionTrace: resolutionTrace
+        ))
+    }
+}

--- a/macos/BluRayToVisionProTests/PersistentQueueOutcomeSummaryTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueOutcomeSummaryTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import XCTest
+@testable import BluRayToVisionPro
+
+final class PersistentQueueOutcomeSummaryTests: XCTestCase {
+    func testCategorizesCompletedFailedAndNeedsActionSeparately() throws {
+        let completed = try makeItem(ordinal: 5, state: .completed)
+        let failed = try makeItem(ordinal: 1, state: .failed)
+        let needsChoice = try makeItem(ordinal: 4, state: .needsChoice)
+        let interrupted = try makeItem(ordinal: 2, state: .interrupted)
+        let attention = try makeItem(ordinal: 3, state: .attention)
+        let stopped = try makeItem(ordinal: 0, state: .stopped)
+        let notStarted = try makeItem(ordinal: 6, state: .notStarted)
+
+        let summary = PersistentQueueOutcomeSummary(items: [completed, failed, needsChoice, interrupted, attention, stopped, notStarted])
+
+        XCTAssertEqual(summary.completedItemIDs, [completed.id])
+        XCTAssertEqual(summary.failedItemIDs, [failed.id])
+        XCTAssertEqual(summary.needsActionItemIDs, [interrupted.id, attention.id, needsChoice.id])
+        XCTAssertTrue(summary.hasAnyResults)
+    }
+
+    private func makeItem(ordinal: Int, state: DurableQueueItemState) throws -> PersistentQueueItem {
+        let draft = ConversionDraft(
+            source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/Feature-\(ordinal).mkv")),
+            sourceDetails: nil,
+            profile: BuiltInProfile.balanced.profile,
+            destinationURL: URL(fileURLWithPath: "/Movies"),
+            options: ConversionOptions()
+        )
+        return try PersistentQueueItem(item: DurableConversionQueueItem(
+            ordinal: ordinal,
+            origin: .singleSource,
+            intent: DurableQueueItemIntent(draft: draft),
+            state: state,
+            decision: state == .attention ? DurableQueueDecision(
+                identifier: "source_missing",
+                prompt: "Reconnect the source.",
+                choices: [WorkerRecoveryChoice.retryContinueOnError.rawValue]
+            ) : nil,
+            failure: state == .failed ? DurableQueueFailure(
+                code: "temporary",
+                message: "Temporary failure",
+                details: nil,
+                retryable: true
+            ) : nil,
+            result: state == .completed ? DurableQueueResult(outputPath: "/Movies/Feature-\(ordinal).mov") : nil,
+            routeQualityConflict: state == .needsChoice ? DurableRouteQualityConflict(conflict: makeRouteQualityConflict()) : nil
+        ))
+    }
+
+    private func makeRouteQualityConflict() throws -> RouteQualityConflict {
+        var options = ConversionOptions()
+        try options.encoding.selectQualityStep(.maximumDetail)
+        guard case let .conflict(conflict) = RouteQualityEngine.propose(
+            options: options,
+            edit: .reusableIntermediates(true)
+        ) else {
+            throw NSError(domain: "PersistentQueueOutcomeSummaryTests", code: 1)
+        }
+        return conflict
+    }
+}

--- a/macos/BluRayToVisionProTests/PersistentQueueOutcomeSummaryTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueOutcomeSummaryTests.swift
@@ -20,6 +20,16 @@ final class PersistentQueueOutcomeSummaryTests: XCTestCase {
         XCTAssertTrue(summary.hasAnyResults)
     }
 
+    func testNotificationDescriptionOmitsZeroCategories() throws {
+        let completed = try makeItem(ordinal: 0, state: .completed)
+        let failed = try makeItem(ordinal: 1, state: .failed)
+
+        XCTAssertEqual(
+            PersistentQueueOutcomeSummary(items: [completed, failed]).notificationDescription,
+            "1 completed. 1 failed."
+        )
+    }
+
     private func makeItem(ordinal: Int, state: DurableQueueItemState) throws -> PersistentQueueItem {
         let draft = ConversionDraft(
             source: ConversionSource(kind: .matroska, url: URL(fileURLWithPath: "/Sources/Feature-\(ordinal).mkv")),

--- a/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
+++ b/macos/BluRayToVisionProTests/PersistentQueueWorkspaceRenderTests.swift
@@ -151,6 +151,10 @@ final class PersistentQueueWorkspaceRenderTests: XCTestCase {
 
     func testQueueWorkspaceRendersQueueManipulationAtMinimumSidebarWidth() throws {
         let items = try makeItems()
+        let outcome = PersistentQueueOutcomeSummary(items: items)
+        XCTAssertEqual(outcome.completedCount, 2)
+        XCTAssertEqual(outcome.failedCount, 1)
+        XCTAssertEqual(outcome.needsActionCount, 1)
         XCTAssertEqual(
             items[0].queueManipulationLockReason,
             "This item is active and cannot move or be edited until it finishes."

--- a/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
@@ -32,6 +32,7 @@ final class StoragePreflightViewModelTests: XCTestCase {
         XCTAssertEqual(workerFactory.count, 0)
         XCTAssertEqual(queueStore.items.first?.failure?.code, "destination_insufficient_capacity")
         XCTAssertEqual(viewModel.persistentQueueRunState, .paused)
+        XCTAssertEqual(viewModel.persistentQueueCompletionRevision, 0)
         XCTAssertTrue(queueStore.items.first?.attempts.isEmpty == true)
         XCTAssertEqual(itemID, queueStore.items.first?.id)
     }
@@ -66,6 +67,7 @@ final class StoragePreflightViewModelTests: XCTestCase {
         XCTAssertEqual(queueStore.items[0].failure?.code, "destination_unavailable")
         XCTAssertNotEqual(queueStore.items[1].failure?.code, "destination_unavailable")
         XCTAssertTrue(preflight.paths.contains("/Volumes/Available"))
+        XCTAssertEqual(viewModel.persistentQueueCompletionRevision, 1)
     }
 
     func testRetryableStorageFailureCanBeReadoptedAfterDestinationRecovers() async throws {

--- a/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
+++ b/macos/BluRayToVisionProTests/StoragePreflightViewModelTests.swift
@@ -62,6 +62,9 @@ final class StoragePreflightViewModelTests: XCTestCase {
         while queueStore.items.contains(where: { $0.state == .waiting || $0.state == .processing }) {
             await Task.yield()
         }
+        while viewModel.persistentQueueCompletionRevision == 0 {
+            await Task.yield()
+        }
 
         XCTAssertEqual(workerFactory.count, 1)
         XCTAssertEqual(queueStore.items[0].failure?.code, "destination_unavailable")


### PR DESCRIPTION
## Summary
- add independent default-off macOS preferences for grouped queue-completion and needs-attention notifications
- keep notification content count-only and privacy-safe, with restored history suppressed and explicit stops excluded from completion
- add a durable Results strip for completed, failed, and needs-action outcomes with direct item selection
- publish natural queue completion explicitly so notification semantics never infer completion from the shared idle state

## Validation
- `uv run python scripts/native_app.py test` — 567 tests, 0 failures
- `BD_TO_AVP_SUPPORT_DIAGNOSTICS_ENDPOINT=https://diagnostics.shinycomputers.com uv run python scripts/native_app.py publish-current` — Release package, worker-cancellation smoke, and preview-presentation smoke passed at `3b4405d7f097d6fc0e6f6c6f1c85328fc72f0fa6`
- isolated-home visual QA — Results strip remained readable at the 300-point sidebar minimum; queue controls and storage forecast remained visible; Settings showed both toggles and the full privacy explanation at minimum size
- exact-head Opus review — GO; prior authorization timing and terminal-session contamination blockers verified fixed
- Antigravity review was requested twice but returned no review text, so it is not counted as positive evidence
- JetBrains inspection was inconclusive because of helper-generated IDE routing/lifecycle noise; no helper-created IDE artifacts are retained

Closes #547