### PR TITLE
Potential fix for code scanning alert no. 110: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -8,7 +8,8 @@ import time
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
-from unittest import mock
+
+mock = unittest.mock
 
 from bd_to_avp.observability import (
     ObservabilityContext,


### PR DESCRIPTION
Potential fix for [https://github.com/cbusillo/BD_to_AVP/security/code-scanning/110](https://github.com/cbusillo/BD_to_AVP/security/code-scanning/110)

Use a single import style for `unittest` in `tests/test_process_runner.py`.  
The least invasive fix is to remove `from unittest import mock` and alias `mock` from the existing module import:

- Keep `import unittest` (needed for `unittest.TestCase` and `unittest.main()` already present).
- Delete `from unittest import mock`.
- Add `mock = unittest.mock` immediately after imports (or where module-level constants/aliases are defined).

This preserves existing functionality and avoids touching all downstream `mock` usages in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
