### PR TITLE
Redesign Vision Pro player UI for headset quality

### DIFF
--- a/docs/test-audit/classifications-v1.json
+++ b/docs/test-audit/classifications-v1.json
@@ -195,6 +195,7 @@
         "macos/BDToAVPPlayerTests/LibraryStoreTests.swift",
         "macos/BDToAVPPlayerTests/MediaFormatInspectorTests.swift",
         "macos/BDToAVPPlayerTests/MediaLibraryModelTests.swift",
+        "macos/BDToAVPPlayerTests/MediaThumbnailTests.swift",
         "macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift",
         "macos/BDToAVPPlayerTests/PlayerAppModelTests.swift",
         "macos/BDToAVPPlayerTests/ResumeStoreTests.swift"

--- a/docs/test-audit/inventory-v1.json
+++ b/docs/test-audit/inventory-v1.json
@@ -327,7 +327,8 @@
         "macos/project.yml"
       ],
       "test_targets": [
-        "BDToAVPPlayerTests"
+        "BDToAVPPlayerTests",
+        "BDToAVPPlayerUITests"
       ],
       "underlying_scheme": "BDToAVPPlayer"
     },
@@ -400,7 +401,7 @@
   },
   "summary": {
     "bundle_file_counts": {
-      "BDToAVPPlayerTests": 7,
+      "BDToAVPPlayerTests": 8,
       "BluRayToVisionProTests": 39,
       "BluRayToVisionProUITests": 1,
       "SpatialPlaybackProbeTests": 1,
@@ -408,19 +409,19 @@
       "python-unittest-discovery": 106,
       "support-diagnostics-vitest": 1
     },
-    "ci_test_case_count": 2608,
+    "ci_test_case_count": 2616,
     "classification_counts": {
       "accepted-cost": 54,
-      "valuable": 172
+      "valuable": 173
     },
     "language_file_counts": {
       "Python": 106,
-      "Swift": 49,
+      "Swift": 50,
       "TypeScript": 1
     },
     "support_fixture_count": 70,
-    "test_case_count": 2630,
-    "test_file_count": 156,
+    "test_case_count": 2638,
+    "test_file_count": 157,
     "unmapped_test_file_count": 0
   },
   "support_fixtures": [
@@ -1290,6 +1291,25 @@
       "classification_evidence_ids": [
         "ci-visionos-player-build"
       ],
+      "classification_rationale": "macos/BDToAVPPlayerTests/MediaThumbnailTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available.",
+      "lane_ids": [
+        "ci.visionos.bd_to_avp_player"
+      ],
+      "language": "Swift",
+      "path": "macos/BDToAVPPlayerTests/MediaThumbnailTests.swift",
+      "special_requirements": [
+        "visionOS simulator or physical Apple Vision Pro, depending on evidence"
+      ],
+      "static_brittleness_signals": [],
+      "test_case_count": 5
+    },
+    {
+      "bundle": "BDToAVPPlayerTests",
+      "classification": "valuable",
+      "classification_cohort": "visionos-player-unit-tests",
+      "classification_evidence_ids": [
+        "ci-visionos-player-build"
+      ],
       "classification_rationale": "macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available.",
       "lane_ids": [
         "ci.visionos.bd_to_avp_player"
@@ -1305,7 +1325,7 @@
           "signal": "filesystem_access"
         }
       ],
-      "test_case_count": 14
+      "test_case_count": 17
     },
     {
       "bundle": "BDToAVPPlayerTests",

--- a/docs/test-audit/inventory-v1.md
+++ b/docs/test-audit/inventory-v1.md
@@ -1,9 +1,9 @@
 # Test Audit Inventory v1
 
 - Baseline reference: `7210339cef4aad1e23721a43e0b5055d869c4e76`
-- Test files: **156**
+- Test files: **157**
 - Support fixtures: **70**
-- Test cases counted: **2630**
+- Test cases counted: **2638**
 - Classification source: `docs/test-audit/classifications-v1.json`
 
 ## Lanes
@@ -64,7 +64,7 @@ CODE_SIGNING_ALLOWED=NO` | `.github/workflows/ci.yml`, `macos/project.yml` |
 ## Disposition Summary
 
 - `accepted-cost`: **54** rows.
-- `valuable`: **172** rows.
+- `valuable`: **173** rows.
 - High-confidence implementation candidates are recorded in the JSON artifact.
 - Non-actionable review observations: **1**.
 - Milestone #10 disposition: Close after final review if the exact-head isolation sweep and broad gates remain green.
@@ -121,7 +121,8 @@ Exact-head evidence captured from `257fd21f38e49031b9fa96a733875702313ebd5c`:
 | `macos/BDToAVPPlayerTests/LibraryStoreTests.swift` | Swift | `BDToAVPPlayerTests` | 3 | `valuable` | macos/BDToAVPPlayerTests/LibraryStoreTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | filesystem_access (2) |
 | `macos/BDToAVPPlayerTests/MediaFormatInspectorTests.swift` | Swift | `BDToAVPPlayerTests` | 4 | `valuable` | macos/BDToAVPPlayerTests/MediaFormatInspectorTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | real-media or SSIF/ISO fixture may be required; visionOS simulator or physical Apple Vision Pro, depending on evidence | — |
 | `macos/BDToAVPPlayerTests/MediaLibraryModelTests.swift` | Swift | `BDToAVPPlayerTests` | 1 | `valuable` | macos/BDToAVPPlayerTests/MediaLibraryModelTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | — |
-| `macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift` | Swift | `BDToAVPPlayerTests` | 14 | `valuable` | macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | filesystem_access (6) |
+| `macos/BDToAVPPlayerTests/MediaThumbnailTests.swift` | Swift | `BDToAVPPlayerTests` | 5 | `valuable` | macos/BDToAVPPlayerTests/MediaThumbnailTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | — |
+| `macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift` | Swift | `BDToAVPPlayerTests` | 17 | `valuable` | macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | filesystem_access (6) |
 | `macos/BDToAVPPlayerTests/PlayerAppModelTests.swift` | Swift | `BDToAVPPlayerTests` | 6 | `valuable` | macos/BDToAVPPlayerTests/PlayerAppModelTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | filesystem_access (10) |
 | `macos/BDToAVPPlayerTests/ResumeStoreTests.swift` | Swift | `BDToAVPPlayerTests` | 4 | `valuable` | macos/BDToAVPPlayerTests/ResumeStoreTests.swift protects maintained BDToAVPPlayer visionOS behavior; CI compiles its unit-test bundle with pinned Xcode 26.5 and conditionally executes it on a temporary Apple Vision Pro simulator when the required runtime and device type are available. | `ci-visionos-player-build` | visionOS simulator or physical Apple Vision Pro, depending on evidence | filesystem_access (2) |
 | `macos/BluRayToVisionProTests/ActivityDrawerRenderTests.swift` | Swift | `BluRayToVisionProTests` | 1 | `valuable` | macos/BluRayToVisionProTests/ActivityDrawerRenderTests.swift runs in the maintained macOS app unit target and asserts an application behavior or explicit model/render contract. The inventory found no concrete duplicate or obsolete-contract evidence. | `ci-macos-app-unit` | — | — |

--- a/docs/visionos-player.md
+++ b/docs/visionos-player.md
@@ -54,8 +54,9 @@ below the same window keeps controls off the stereo image and provides:
 - Done, which persists progress and releases the session.
 
 The ornament remains visible while playback is paused, loading, failed, or being
-scrubbed. During uninterrupted playback it hides after three seconds. Looking
-back at or pinching the video surface reveals the controls again.
+scrubbed, and automatic hiding is disabled while VoiceOver or Switch Control is
+active. During uninterrupted playback it hides after three seconds. Pinching the
+video surface reveals the controls again.
 
 The app saves in-progress playback positions and restores them when the same
 library item is opened again. Any non-active scene phase pauses playback and
@@ -91,7 +92,7 @@ xcodebuild test \
 The same scheme also contains `BDToAVPPlayerUITests`. Its seeded-media flow is
 skipped when `PlayerLongFixture.mov` is absent from the simulator app Documents
 directory; when present, it verifies Library → Details → Play and ornament
-auto-hide behavior.
+auto-hide behavior, including that Done returns to the movie's Details page.
 
 CI pins Xcode 26.5, regenerates the project, and always runs
 `build-for-testing` against the generic visionOS Simulator destination. When an

--- a/docs/visionos-player.md
+++ b/docs/visionos-player.md
@@ -8,8 +8,13 @@ validator.
 ## Product Scope
 
 - One plain SwiftUI window contains the library, movie details, and player.
-- The library supports poster and file views, format filtering, title or
-  filename sorting, missing-source recovery, and removal.
+- The library presents one content-first **Movies** grid with 16:9 source-frame
+  thumbnails, title or filename sorting, and a typography-first fallback when a
+  frame cannot be generated.
+- Selecting a movie opens a full in-window details page with system Back
+  navigation, source status, missing-source recovery, removal, and one prominent
+  Play action for supported media. A tile context menu provides optional quick
+  playback for experienced users.
 - **Add Movie** imports one movie through the system Files picker.
 - Supported `.mov`, `.mp4`, and `.m4v` files already present in the app's
   Documents directory are indexed on launch. File Sharing and opening documents
@@ -38,8 +43,8 @@ proof of MV-HEVC.
 
 `MVHEVCPlayerSession` owns one `AVPlayer`, `AVPlayerItem`, RealityKit entity, and
 source lease. Its `VideoPlayerComponent` requests stereo viewing, screen spatial
-video mode, and portal immersive viewing mode. A glass HUD rendered inside the
-same window provides:
+video mode, and portal immersive viewing mode. A native glass ornament attached
+below the same window keeps controls off the stereo image and provides:
 
 - play and pause;
 - 10-second backward and 30-second forward seeks;
@@ -47,6 +52,10 @@ same window provides:
 - audio-track selection;
 - subtitle selection, including Off; and
 - Done, which persists progress and releases the session.
+
+The ornament remains visible while playback is paused, loading, failed, or being
+scrubbed. During uninterrupted playback it hides after three seconds. Looking
+back at or pinching the video surface reveals the controls again.
 
 The app saves in-progress playback positions and restores them when the same
 library item is opened again. Any non-active scene phase pauses playback and
@@ -78,6 +87,11 @@ xcodebuild test \
   -derivedDataPath macos/build/BDToAVPPlayerDerivedData \
   CODE_SIGNING_ALLOWED=NO
 ```
+
+The same scheme also contains `BDToAVPPlayerUITests`. Its seeded-media flow is
+skipped when `PlayerLongFixture.mov` is absent from the simulator app Documents
+directory; when present, it verifies Library → Details → Play and ornament
+auto-hide behavior.
 
 CI pins Xcode 26.5, regenerates the project, and always runs
 `build-for-testing` against the generic visionOS Simulator destination. When an

--- a/docs/visionos-player.md
+++ b/docs/visionos-player.md
@@ -7,14 +7,16 @@ validator.
 
 ## Product Scope
 
-- One plain SwiftUI window contains the library, movie details, and player.
-- The library presents one content-first **Movies** grid with 16:9 source-frame
-  thumbnails, title or filename sorting, and a typography-first fallback when a
-  frame cannot be generated.
-- Selecting a movie opens a full in-window details page with system Back
-  navigation, source status, missing-source recovery, removal, and one prominent
-  Play action for supported media. A tile context menu provides optional quick
-  playback for experienced users.
+- One plain SwiftUI window contains a split-view library, modal movie details,
+  and the player.
+- The library presents an **On My Vision Pro** source sidebar and a **Your
+  movies** collection with Posters and Files modes, format filtering, title or
+  filename sorting, 16:9 source-frame thumbnails, and a typography-first
+  fallback when a frame cannot be generated.
+- Playable movies expose a visible direct Play action in both library modes.
+  Selecting the movie content opens a compact modal Details view with source
+  status, missing-source recovery, removal, technical metadata, and one
+  prominent Play action that remains visible without scrolling.
 - **Add Movie** imports one movie through the system Files picker.
 - Supported `.mov`, `.mp4`, and `.m4v` files already present in the app's
   Documents directory are indexed on launch. File Sharing and opening documents
@@ -91,8 +93,9 @@ xcodebuild test \
 
 The same scheme also contains `BDToAVPPlayerUITests`. Its seeded-media flow is
 skipped when `PlayerLongFixture.mov` is absent from the simulator app Documents
-directory; when present, it verifies Library → Details → Play and ornament
-auto-hide behavior, including that Done returns to the movie's Details page.
+directory; when present, it verifies direct Library → Play → Library, Library →
+Details → Play, Details Done → Library, player Done → Details, replay, and
+ornament auto-hide behavior.
 
 CI pins Xcode 26.5, regenerates the project, and always runs
 `build-for-testing` against the generic visionOS Simulator destination. When an
@@ -115,5 +118,8 @@ xcodebuild build \
 ```
 
 Simulator tests and screenshots do not prove stereoscopic depth, eye order,
-comfort, long-session thermals, or headset-visible interaction. Those remain
-physical Vision Pro validation boundaries.
+comfort, long-session thermals, or headset-visible interaction. The accepted
+physical layout keeps the RealityKit video surface at the playback probe's
+conservative scale and depth offset so foreground stereo content remains behind
+the native ornament; changes to that geometry still require physical Vision Pro
+validation.

--- a/macos/BDToAVPPlayer/App/PlayerAppModel.swift
+++ b/macos/BDToAVPPlayer/App/PlayerAppModel.swift
@@ -2,53 +2,6 @@ import AVFoundation
 import Combine
 import Foundation
 
-enum LibraryViewMode: String, CaseIterable, Sendable {
-    case posters
-    case files
-
-    var title: String {
-        rawValue.capitalized
-    }
-}
-
-enum MediaFormatFilter: String, CaseIterable, Sendable {
-    case all
-    case mvHEVC
-    case sideBySide
-    case overUnder
-    case unsupported
-
-    var title: String {
-        switch self {
-        case .all:
-            return "All Formats"
-        case .mvHEVC:
-            return "MV-HEVC"
-        case .sideBySide:
-            return "SBS"
-        case .overUnder:
-            return "OVER-UNDER"
-        case .unsupported:
-            return "Unsupported"
-        }
-    }
-
-    func matches(_ item: MediaItem) -> Bool {
-        switch self {
-        case .all:
-            return true
-        case .mvHEVC:
-            return item.format == .mvHEVC
-        case .sideBySide:
-            return item.format == .sideBySide
-        case .overUnder:
-            return item.format == .overUnder
-        case .unsupported:
-            return item.format == .unsupported
-        }
-    }
-}
-
 enum MediaSortOrder: String, CaseIterable, Sendable {
     case title
     case fileName
@@ -96,8 +49,6 @@ final class PlayerAppModel: ObservableObject {
 
     @Published private(set) var library: MediaLibraryModel
     @Published private(set) var sourceStatuses: [String: MediaSourceStatus]
-    @Published var viewMode: LibraryViewMode = .posters
-    @Published var formatFilter: MediaFormatFilter = .all
     @Published var sortOrder: MediaSortOrder = .title
     @Published var selectedItemID: String?
     @Published var isShowingDetails = false
@@ -131,7 +82,6 @@ final class PlayerAppModel: ObservableObject {
 
     var visibleItems: [MediaItem] {
         library.items
-            .filter { formatFilter.matches($0) }
             .sorted {
                 switch sortOrder {
                 case .title:
@@ -185,7 +135,6 @@ final class PlayerAppModel: ObservableObject {
         }
         let request = PlaybackRequest(item: item)
         playbackRequest = request
-        closeDetails()
         onPlaybackRequested?(item)
     }
 

--- a/macos/BDToAVPPlayer/App/PlayerAppModel.swift
+++ b/macos/BDToAVPPlayer/App/PlayerAppModel.swift
@@ -2,6 +2,53 @@ import AVFoundation
 import Combine
 import Foundation
 
+enum LibraryViewMode: String, CaseIterable, Sendable {
+    case posters
+    case files
+
+    var title: String {
+        rawValue.capitalized
+    }
+}
+
+enum MediaFormatFilter: String, CaseIterable, Sendable {
+    case all
+    case mvHEVC
+    case sideBySide
+    case overUnder
+    case unsupported
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All Formats"
+        case .mvHEVC:
+            return "MV-HEVC"
+        case .sideBySide:
+            return "SBS"
+        case .overUnder:
+            return "OVER-UNDER"
+        case .unsupported:
+            return "Unsupported"
+        }
+    }
+
+    func matches(_ item: MediaItem) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .mvHEVC:
+            return item.format == .mvHEVC
+        case .sideBySide:
+            return item.format == .sideBySide
+        case .overUnder:
+            return item.format == .overUnder
+        case .unsupported:
+            return item.format == .unsupported
+        }
+    }
+}
+
 enum MediaSortOrder: String, CaseIterable, Sendable {
     case title
     case fileName
@@ -49,6 +96,8 @@ final class PlayerAppModel: ObservableObject {
 
     @Published private(set) var library: MediaLibraryModel
     @Published private(set) var sourceStatuses: [String: MediaSourceStatus]
+    @Published var viewMode: LibraryViewMode = .posters
+    @Published var formatFilter: MediaFormatFilter = .all
     @Published var sortOrder: MediaSortOrder = .title
     @Published var selectedItemID: String?
     @Published var isShowingDetails = false
@@ -82,6 +131,7 @@ final class PlayerAppModel: ObservableObject {
 
     var visibleItems: [MediaItem] {
         library.items
+            .filter { formatFilter.matches($0) }
             .sorted {
                 switch sortOrder {
                 case .title:
@@ -99,6 +149,10 @@ final class PlayerAppModel: ObservableObject {
 
     func item(id: String) -> MediaItem? {
         library.items.first { $0.id == id }
+    }
+
+    func sourceTitle(for item: MediaItem) -> String {
+        item.id.hasPrefix("documents:") ? "On My Vision Pro" : "Files"
     }
 
     func showDetails(for id: String) {

--- a/macos/BDToAVPPlayer/App/PlayerAppModel.swift
+++ b/macos/BDToAVPPlayer/App/PlayerAppModel.swift
@@ -247,7 +247,7 @@ final class PlayerAppModel: ObservableObject {
         return "documents:\(fileURL.lastPathComponent.lowercased())"
     }
 
-    private func refreshSourceStatuses() {
+    func refreshSourceStatuses() {
         var statuses: [String: MediaSourceStatus] = [:]
         for item in library.items {
             do {

--- a/macos/BDToAVPPlayer/App/PlayerAppModel.swift
+++ b/macos/BDToAVPPlayer/App/PlayerAppModel.swift
@@ -171,9 +171,9 @@ final class PlayerAppModel: ObservableObject {
         case .mvHEVC:
             return .playable
         case .sideBySide:
-            return .planned("SBS playback is planned for a later slice.")
+            return .planned("Side-by-side movies are not playable yet.")
         case .overUnder:
-            return .planned("Over-under playback is planned for a later slice.")
+            return .planned("Over-under movies are not playable yet.")
         case .unsupported:
             return .unavailable("This media format is not supported for playback.")
         }

--- a/macos/BDToAVPPlayer/Playback/PlaybackPresentation.swift
+++ b/macos/BDToAVPPlayer/Playback/PlaybackPresentation.swift
@@ -74,6 +74,82 @@ struct PlaybackScrubState: Equatable {
     }
 }
 
+struct PlaybackHUDVisibilityState: Equatable {
+    static let autoHideDelay: TimeInterval = 3
+
+    private(set) var isVisible = true
+    private(set) var isAutoHideScheduled = false
+    private(set) var autoHideGeneration = 0
+    private var isInteracting = false
+    private var isHovered = false
+
+    mutating func reconcile(isPlaying: Bool) {
+        guard PlaybackHUDVisibilityPolicy.shouldAutoHide(
+            isPlaying: isPlaying,
+            isInteracting: isInteracting,
+            isHovered: isHovered
+        )
+        else {
+            showAndCancelAutomaticHiding()
+            return
+        }
+
+        if isVisible, !isAutoHideScheduled {
+            scheduleAutomaticHiding()
+        }
+    }
+
+    mutating func setInteracting(_ isInteracting: Bool, isPlaying: Bool) {
+        self.isInteracting = isInteracting
+        reconcile(isPlaying: isPlaying)
+    }
+
+    mutating func setHovered(_ isHovered: Bool, isPlaying: Bool) {
+        self.isHovered = isHovered
+        reconcile(isPlaying: isPlaying)
+    }
+
+    mutating func reveal(isPlaying: Bool) {
+        isVisible = true
+        cancelAutomaticHiding()
+        reconcile(isPlaying: isPlaying)
+    }
+
+    mutating func autoHideTimerFired(generation: Int) {
+        guard generation == autoHideGeneration, isAutoHideScheduled else {
+            return
+        }
+
+        isAutoHideScheduled = false
+        isVisible = false
+    }
+
+    private mutating func showAndCancelAutomaticHiding() {
+        isVisible = true
+        cancelAutomaticHiding()
+    }
+
+    private mutating func scheduleAutomaticHiding() {
+        autoHideGeneration += 1
+        isAutoHideScheduled = true
+    }
+
+    private mutating func cancelAutomaticHiding() {
+        guard isAutoHideScheduled else {
+            return
+        }
+
+        autoHideGeneration += 1
+        isAutoHideScheduled = false
+    }
+}
+
+enum PlaybackHUDVisibilityPolicy {
+    static func shouldAutoHide(isPlaying: Bool, isInteracting: Bool, isHovered: Bool) -> Bool {
+        isPlaying && !isInteracting && !isHovered
+    }
+}
+
 enum ResumeWriteDecision: Equatable {
     case write(TimeInterval)
     case remove

--- a/macos/BDToAVPPlayer/Views/AppShellView.swift
+++ b/macos/BDToAVPPlayer/Views/AppShellView.swift
@@ -5,6 +5,7 @@ struct AppShellView: View {
     @ObservedObject var playerSession: MVHEVCPlayerSession
     let resumeStore: ResumeStore
 
+    @Environment(\.scenePhase) private var scenePhase
     @State private var navigationPath: [String] = []
     @State private var preparationTask: Task<Void, Never>?
 
@@ -12,14 +13,10 @@ struct AppShellView: View {
         NavigationStack(path: $navigationPath) {
             Group {
                 if model.playbackRequest != nil || playerSession.state != .idle {
-                    if playerSession.state == .idle {
-                        Color.black
-                    } else {
-                        PlayerView(session: playerSession) {
-                            preparationTask?.cancel()
-                            preparationTask = nil
-                            model.clearPlaybackRequest()
-                        }
+                    PlayerView(session: playerSession) {
+                        preparationTask?.cancel()
+                        preparationTask = nil
+                        model.clearPlaybackRequest()
                     }
                 } else {
                     LibraryView(model: model)
@@ -49,11 +46,12 @@ struct AppShellView: View {
             guard let request else {
                 synchronizeNavigationPath(
                     selectedItemID: model.selectedItemID,
-                    isShowingDetails: model.isShowingDetails
+                    isShowingDetails: model.isShowingDetails,
+                    animated: false
                 )
                 return
             }
-            navigationPath.removeAll()
+            setNavigationPath([], animated: false)
             preparationTask?.cancel()
             preparationTask = Task {
                 await playerSession.prepare(
@@ -65,6 +63,11 @@ struct AppShellView: View {
         }
         .onDisappear {
             preparationTask?.cancel()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                model.refreshSourceStatuses()
+            }
         }
         .task {
             await model.bootstrap()
@@ -78,16 +81,33 @@ struct AppShellView: View {
         )
     }
 
-    private func synchronizeNavigationPath(selectedItemID: String?, isShowingDetails: Bool) {
+    private func synchronizeNavigationPath(
+        selectedItemID: String?,
+        isShowingDetails: Bool,
+        animated: Bool = true
+    ) {
         guard model.playbackRequest == nil, isShowingDetails, let selectedItemID else {
             if !navigationPath.isEmpty {
-                navigationPath.removeAll()
+                setNavigationPath([], animated: animated)
             }
             return
         }
 
         if navigationPath.last != selectedItemID {
-            navigationPath = [selectedItemID]
+            setNavigationPath([selectedItemID], animated: animated)
+        }
+    }
+
+    private func setNavigationPath(_ path: [String], animated: Bool) {
+        guard !animated else {
+            navigationPath = path
+            return
+        }
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            navigationPath = path
         }
     }
 

--- a/macos/BDToAVPPlayer/Views/AppShellView.swift
+++ b/macos/BDToAVPPlayer/Views/AppShellView.swift
@@ -12,10 +12,14 @@ struct AppShellView: View {
         NavigationStack(path: $navigationPath) {
             Group {
                 if model.playbackRequest != nil || playerSession.state != .idle {
-                    PlayerView(session: playerSession) {
-                        preparationTask?.cancel()
-                        preparationTask = nil
-                        model.clearPlaybackRequest()
+                    if playerSession.state == .idle {
+                        Color.black
+                    } else {
+                        PlayerView(session: playerSession) {
+                            preparationTask?.cancel()
+                            preparationTask = nil
+                            model.clearPlaybackRequest()
+                        }
                     }
                 } else {
                     LibraryView(model: model)
@@ -33,18 +37,23 @@ struct AppShellView: View {
             Text(model.errorMessage ?? "Please try again.")
         }
         .onChange(of: model.selectedItemID) { _, itemID in
-            guard model.isShowingDetails, let itemID else { return }
-            if navigationPath.last != itemID {
-                navigationPath.append(itemID)
-            }
+            synchronizeNavigationPath(selectedItemID: itemID, isShowingDetails: model.isShowingDetails)
         }
         .onChange(of: model.isShowingDetails) { _, isShowingDetails in
-            if !isShowingDetails {
-                navigationPath.removeAll()
-            }
+            synchronizeNavigationPath(selectedItemID: model.selectedItemID, isShowingDetails: isShowingDetails)
+        }
+        .onChange(of: navigationPath) { _, path in
+            synchronizeDetailsState(navigationPath: path)
         }
         .onChange(of: model.playbackRequest) { _, request in
-            guard let request else { return }
+            guard let request else {
+                synchronizeNavigationPath(
+                    selectedItemID: model.selectedItemID,
+                    isShowingDetails: model.isShowingDetails
+                )
+                return
+            }
+            navigationPath.removeAll()
             preparationTask?.cancel()
             preparationTask = Task {
                 await playerSession.prepare(
@@ -67,5 +76,31 @@ struct AppShellView: View {
             get: { model.errorMessage != nil },
             set: { if !$0 { model.clearError() } }
         )
+    }
+
+    private func synchronizeNavigationPath(selectedItemID: String?, isShowingDetails: Bool) {
+        guard model.playbackRequest == nil, isShowingDetails, let selectedItemID else {
+            if !navigationPath.isEmpty {
+                navigationPath.removeAll()
+            }
+            return
+        }
+
+        if navigationPath.last != selectedItemID {
+            navigationPath = [selectedItemID]
+        }
+    }
+
+    private func synchronizeDetailsState(navigationPath: [String]) {
+        guard model.playbackRequest == nil else { return }
+
+        if let itemID = navigationPath.last {
+            if model.selectedItemID != itemID || !model.isShowingDetails {
+                model.selectedItemID = itemID
+                model.isShowingDetails = true
+            }
+        } else if model.selectedItemID != nil || model.isShowingDetails {
+            model.closeDetails()
+        }
     }
 }

--- a/macos/BDToAVPPlayer/Views/AppShellView.swift
+++ b/macos/BDToAVPPlayer/Views/AppShellView.swift
@@ -6,23 +6,33 @@ struct AppShellView: View {
     let resumeStore: ResumeStore
 
     @Environment(\.scenePhase) private var scenePhase
-    @State private var navigationPath: [String] = []
     @State private var preparationTask: Task<Void, Never>?
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            Group {
-                if model.playbackRequest != nil || playerSession.state != .idle {
-                    PlayerView(session: playerSession) {
-                        preparationTask?.cancel()
-                        preparationTask = nil
-                        model.clearPlaybackRequest()
+        Group {
+            if model.playbackRequest != nil || playerSession.state != .idle {
+                PlayerView(session: playerSession) {
+                    preparationTask?.cancel()
+                    preparationTask = nil
+                    model.clearPlaybackRequest()
+                }
+            } else {
+                NavigationSplitView {
+                    List {
+                        Section("Sources") {
+                            Label("On My Vision Pro", systemImage: "visionpro")
+                                .font(.headline)
+                        }
                     }
-                } else {
+                    .listStyle(.sidebar)
+                    .navigationTitle("Library")
+                } detail: {
                     LibraryView(model: model)
                 }
             }
-            .navigationDestination(for: String.self) { itemID in
+        }
+        .sheet(isPresented: detailsPresented) {
+            if let itemID = model.selectedItemID {
                 MediaDetailsView(model: model, itemID: itemID)
             }
         }
@@ -33,25 +43,8 @@ struct AppShellView: View {
         } message: {
             Text(model.errorMessage ?? "Please try again.")
         }
-        .onChange(of: model.selectedItemID) { _, itemID in
-            synchronizeNavigationPath(selectedItemID: itemID, isShowingDetails: model.isShowingDetails)
-        }
-        .onChange(of: model.isShowingDetails) { _, isShowingDetails in
-            synchronizeNavigationPath(selectedItemID: model.selectedItemID, isShowingDetails: isShowingDetails)
-        }
-        .onChange(of: navigationPath) { _, path in
-            synchronizeDetailsState(navigationPath: path)
-        }
         .onChange(of: model.playbackRequest) { _, request in
-            guard let request else {
-                synchronizeNavigationPath(
-                    selectedItemID: model.selectedItemID,
-                    isShowingDetails: model.isShowingDetails,
-                    animated: false
-                )
-                return
-            }
-            setNavigationPath([], animated: false)
+            guard let request else { return }
             preparationTask?.cancel()
             preparationTask = Task {
                 await playerSession.prepare(
@@ -81,46 +74,18 @@ struct AppShellView: View {
         )
     }
 
-    private func synchronizeNavigationPath(
-        selectedItemID: String?,
-        isShowingDetails: Bool,
-        animated: Bool = true
-    ) {
-        guard model.playbackRequest == nil, isShowingDetails, let selectedItemID else {
-            if !navigationPath.isEmpty {
-                setNavigationPath([], animated: animated)
+    private var detailsPresented: Binding<Bool> {
+        Binding(
+            get: {
+                model.isShowingDetails
+                    && model.selectedItemID != nil
+                    && model.playbackRequest == nil
+            },
+            set: { isPresented in
+                if !isPresented && model.playbackRequest == nil {
+                    model.closeDetails()
+                }
             }
-            return
-        }
-
-        if navigationPath.last != selectedItemID {
-            setNavigationPath([selectedItemID], animated: animated)
-        }
-    }
-
-    private func setNavigationPath(_ path: [String], animated: Bool) {
-        guard !animated else {
-            navigationPath = path
-            return
-        }
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            navigationPath = path
-        }
-    }
-
-    private func synchronizeDetailsState(navigationPath: [String]) {
-        guard model.playbackRequest == nil else { return }
-
-        if let itemID = navigationPath.last {
-            if model.selectedItemID != itemID || !model.isShowingDetails {
-                model.selectedItemID = itemID
-                model.isShowingDetails = true
-            }
-        } else if model.selectedItemID != nil || model.isShowingDetails {
-            model.closeDetails()
-        }
+        )
     }
 }

--- a/macos/BDToAVPPlayer/Views/AppShellView.swift
+++ b/macos/BDToAVPPlayer/Views/AppShellView.swift
@@ -5,34 +5,24 @@ struct AppShellView: View {
     @ObservedObject var playerSession: MVHEVCPlayerSession
     let resumeStore: ResumeStore
 
+    @State private var navigationPath: [String] = []
     @State private var preparationTask: Task<Void, Never>?
 
     var body: some View {
-        Group {
-            if model.playbackRequest != nil || playerSession.state != .idle {
-                PlayerView(session: playerSession) {
-                    preparationTask?.cancel()
-                    preparationTask = nil
-                    model.clearPlaybackRequest()
-                }
-            } else {
-                NavigationSplitView {
-                    List {
-                        Section("Sources") {
-                            Label("On My Vision Pro", systemImage: "visionpro")
-                                .font(.headline)
-                        }
+        NavigationStack(path: $navigationPath) {
+            Group {
+                if model.playbackRequest != nil || playerSession.state != .idle {
+                    PlayerView(session: playerSession) {
+                        preparationTask?.cancel()
+                        preparationTask = nil
+                        model.clearPlaybackRequest()
                     }
-                    .listStyle(.sidebar)
-                    .navigationTitle("Library")
-                } detail: {
+                } else {
                     LibraryView(model: model)
                 }
             }
-        }
-        .sheet(isPresented: $model.isShowingDetails) {
-            if let selectedItemID = model.selectedItemID {
-                MediaDetailsView(model: model, itemID: selectedItemID)
+            .navigationDestination(for: String.self) { itemID in
+                MediaDetailsView(model: model, itemID: itemID)
             }
         }
         .alert("Something went wrong", isPresented: errorPresented) {
@@ -41,6 +31,17 @@ struct AppShellView: View {
             }
         } message: {
             Text(model.errorMessage ?? "Please try again.")
+        }
+        .onChange(of: model.selectedItemID) { _, itemID in
+            guard model.isShowingDetails, let itemID else { return }
+            if navigationPath.last != itemID {
+                navigationPath.append(itemID)
+            }
+        }
+        .onChange(of: model.isShowingDetails) { _, isShowingDetails in
+            if !isShowingDetails {
+                navigationPath.removeAll()
+            }
         }
         .onChange(of: model.playbackRequest) { _, request in
             guard let request else { return }

--- a/macos/BDToAVPPlayer/Views/LibraryTheme.swift
+++ b/macos/BDToAVPPlayer/Views/LibraryTheme.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+enum LibraryTheme {
+    static let contentPadding: CGFloat = 28
+    static let gridSpacing: CGFloat = 22
+    static let minimumTileWidth: CGFloat = 240
+    static let tileCornerRadius: CGFloat = 24
+    static let tilePadding: CGFloat = 12
+    static let tileTextSpacing: CGFloat = 10
+}

--- a/macos/BDToAVPPlayer/Views/LibraryView.swift
+++ b/macos/BDToAVPPlayer/Views/LibraryView.swift
@@ -24,7 +24,12 @@ struct LibraryView: View {
                             )
                         }
                         .buttonStyle(.plain)
+                        .contentShape(
+                            .hoverEffect,
+                            RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius, style: .continuous)
+                        )
                         .hoverEffect(.highlight)
+                        .accessibilityIdentifier("movie-tile-\(item.id)")
                         .contextMenu {
                             if model.playbackAvailability(for: item) == .playable {
                                 Button {

--- a/macos/BDToAVPPlayer/Views/LibraryView.swift
+++ b/macos/BDToAVPPlayer/Views/LibraryView.swift
@@ -7,48 +7,28 @@ struct LibraryView: View {
 
     var body: some View {
         ScrollView {
-            if model.visibleItems.isEmpty {
-                emptyState
-                    .frame(maxWidth: .infinity, minHeight: 420)
-            } else {
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: LibraryTheme.minimumTileWidth), spacing: LibraryTheme.gridSpacing)],
-                    spacing: LibraryTheme.gridSpacing
-                ) {
-                    ForEach(model.visibleItems) { item in
-                        NavigationLink(value: item.id) {
-                            MediaMovieTile(
-                                item: item,
-                                sourceStatus: model.sourceStatuses[item.id],
-                                bookmarkStore: model.bookmarkStore
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .contentShape(
-                            .hoverEffect,
-                            RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius, style: .continuous)
-                        )
-                        .hoverEffect(.highlight)
-                        .accessibilityIdentifier("movie-tile-\(item.id)")
-                        .contextMenu {
-                            if model.playbackAvailability(for: item) == .playable {
-                                Button {
-                                    model.requestPlayback(for: item.id)
-                                } label: {
-                                    Label("Play", systemImage: "play.fill")
-                                }
-                            }
-                        }
-                    }
+            VStack(alignment: .leading, spacing: 28) {
+                header
+
+                if model.library.items.isEmpty {
+                    emptyState
+                } else if model.visibleItems.isEmpty {
+                    noMatchesState
+                } else if model.viewMode == .posters {
+                    posterGrid
+                } else {
+                    fileList
                 }
             }
+            .padding(.horizontal, 34)
+            .padding(.vertical, 28)
         }
         .scrollIndicators(.hidden)
-        .contentMargins(.horizontal, LibraryTheme.contentPadding, for: .scrollContent)
-        .contentMargins(.vertical, LibraryTheme.contentPadding, for: .scrollContent)
-        .navigationTitle("Movies")
+        .navigationTitle("All Movies")
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
+                viewControls
+                filterMenu
                 sortMenu
                 addMovieButton
             }
@@ -63,14 +43,129 @@ struct LibraryView: View {
         }
     }
 
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Your movies")
+                .font(.largeTitle.weight(.semibold))
+            Text("Choose a movie to review its source, format, and playback options.")
+                .foregroundStyle(.secondary)
+        }
+    }
+
     private var emptyState: some View {
         ContentUnavailableView {
             Label("No movies yet", systemImage: "film.stack")
         } description: {
-            Text("Add a movie to see it here.")
+            Text("Add a movie file to start building your library.")
         } actions: {
             addMovieButton
         }
+        .frame(maxWidth: .infinity, minHeight: 360)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+    }
+
+    private var noMatchesState: some View {
+        ContentUnavailableView {
+            Label("No matching movies", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text("No movies match the \(model.formatFilter.title) filter.")
+        } actions: {
+            Button("Show All Movies") {
+                model.formatFilter = .all
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 360)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+    }
+
+    private var posterGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: LibraryTheme.minimumTileWidth), spacing: LibraryTheme.gridSpacing)],
+            spacing: LibraryTheme.gridSpacing
+        ) {
+            ForEach(model.visibleItems) { item in
+                MediaPosterCard(
+                    item: item,
+                    sourceStatus: model.sourceStatuses[item.id],
+                    sourceTitle: model.sourceTitle(for: item),
+                    bookmarkStore: model.bookmarkStore,
+                    showDetails: { model.showDetails(for: item.id) },
+                    play: model.playbackAvailability(for: item) == .playable
+                        ? { model.requestPlayback(for: item.id) }
+                        : nil
+                )
+            }
+        }
+    }
+
+    private var fileList: some View {
+        LazyVStack(spacing: 10) {
+            ForEach(model.visibleItems) { item in
+                HStack(spacing: 12) {
+                    Button {
+                        model.showDetails(for: item.id)
+                    } label: {
+                        MediaFileRow(
+                            item: item,
+                            sourceStatus: model.sourceStatuses[item.id],
+                            sourceTitle: model.sourceTitle(for: item),
+                            bookmarkStore: model.bookmarkStore
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .hoverEffect(.highlight)
+                    .accessibilityIdentifier("movie-tile-\(item.id)")
+
+                    if model.playbackAvailability(for: item) == .playable {
+                        libraryPlayButton(for: item)
+                    }
+                }
+            }
+        }
+    }
+
+    private func libraryPlayButton(for item: MediaItem) -> some View {
+        Button {
+            model.requestPlayback(for: item.id)
+        } label: {
+            Label("Play", systemImage: "play.fill")
+                .frame(minWidth: 72, minHeight: 60)
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityIdentifier("play-library-\(item.id)")
+        .accessibilityHint("Starts playback without opening movie details.")
+    }
+
+    private var viewControls: some View {
+        Picker("Library view", selection: $model.viewMode) {
+            ForEach(LibraryViewMode.allCases, id: \.self) { mode in
+                Text(mode.title).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 180)
+        .accessibilityLabel("Library view")
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            ForEach(MediaFormatFilter.allCases, id: \.self) { filter in
+                Button {
+                    model.formatFilter = filter
+                } label: {
+                    if model.formatFilter == filter {
+                        Label(filter.title, systemImage: "checkmark")
+                    } else {
+                        Text(filter.title)
+                    }
+                }
+            }
+        } label: {
+            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+        }
+        .accessibilityLabel("Filter movies")
     }
 
     private var sortMenu: some View {
@@ -99,17 +194,59 @@ struct LibraryView: View {
             Label("Add Movie", systemImage: "plus")
         }
         .buttonStyle(.borderedProminent)
+        .disabled(model.isImporting)
         .accessibilityHint("Choose one movie file from Files.")
     }
 }
 
-struct MediaMovieTile: View {
+struct MediaPosterCard: View {
     let item: MediaItem
     let sourceStatus: MediaSourceStatus?
+    let sourceTitle: String
     let bookmarkStore: BookmarkStore
+    let showDetails: () -> Void
+    let play: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: LibraryTheme.tileTextSpacing) {
+        VStack(alignment: .leading, spacing: 12) {
+            Button(action: showDetails) {
+                cardContent
+            }
+            .buttonStyle(.plain)
+            .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .hoverEffect(.highlight)
+            .accessibilityIdentifier("movie-tile-\(item.id)")
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint("Opens movie details.")
+
+            HStack(spacing: 10) {
+                Label(sourceTitle, systemImage: sourceTitle == "On My Vision Pro" ? "visionpro" : "folder")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 8)
+
+                if let play {
+                    Button(action: play) {
+                        Label("Play", systemImage: "play.fill")
+                            .frame(minHeight: 60)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("play-library-\(item.id)")
+                    .accessibilityLabel("Play \(item.title)")
+                    .accessibilityHint("Starts playback without opening movie details.")
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(14)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .accessibilityElement(children: .contain)
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
             MediaThumbnailView(
                 item: item,
                 bookmarkStore: bookmarkStore,
@@ -122,6 +259,11 @@ struct MediaMovieTile: View {
                 .lineLimit(2)
                 .frame(maxWidth: .infinity, minHeight: 44, alignment: .topLeading)
 
+            Text(item.fileName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
             if sourceStatus != .available {
                 Label(sourceStatus?.title ?? "Source unavailable", systemImage: "exclamationmark.triangle")
                     .font(.caption)
@@ -130,17 +272,59 @@ struct MediaMovieTile: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .padding(LibraryTheme.tilePadding)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius, style: .continuous))
+    }
+
+    private var accessibilityLabel: String {
+        let status = sourceStatus ?? .missing
+        return "\(item.title), \(item.fileName), \(item.format.displayName), \(sourceTitle), \(status.title)"
+    }
+}
+
+struct MediaFileRow: View {
+    let item: MediaItem
+    let sourceStatus: MediaSourceStatus?
+    let sourceTitle: String
+    let bookmarkStore: BookmarkStore
+
+    var body: some View {
+        HStack(spacing: 16) {
+            MediaThumbnailView(
+                item: item,
+                bookmarkStore: bookmarkStore,
+                sourceStatus: sourceStatus
+            )
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .frame(width: 120)
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text(item.title)
+                    .font(.headline)
+                Text(item.fileName)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    FormatPill(format: item.format)
+                    if sourceStatus != .available {
+                        Text(sourceStatus?.title ?? "Source unavailable")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .foregroundStyle(.tertiary)
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(tileAccessibilityLabel)
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Opens movie details.")
     }
 
-    private var tileAccessibilityLabel: String {
-        if sourceStatus == .available {
-            return "\(item.title), \(item.format.displayName)"
-        }
-        return "\(item.title), \(item.format.displayName), \(sourceStatus?.title ?? "Source unavailable")"
+    private var accessibilityLabel: String {
+        let status = sourceStatus ?? .missing
+        return "\(item.title), \(item.fileName), \(item.format.displayName), \(sourceTitle), \(status.title)"
     }
 }

--- a/macos/BDToAVPPlayer/Views/LibraryView.swift
+++ b/macos/BDToAVPPlayer/Views/LibraryView.swift
@@ -7,25 +7,43 @@ struct LibraryView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
-                header
-
-                if model.visibleItems.isEmpty {
-                    emptyState
-                } else if model.viewMode == .posters {
-                    posterGrid
-                } else {
-                    fileList
+            if model.visibleItems.isEmpty {
+                emptyState
+                    .frame(maxWidth: .infinity, minHeight: 420)
+            } else {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: LibraryTheme.minimumTileWidth), spacing: LibraryTheme.gridSpacing)],
+                    spacing: LibraryTheme.gridSpacing
+                ) {
+                    ForEach(model.visibleItems) { item in
+                        NavigationLink(value: item.id) {
+                            MediaMovieTile(
+                                item: item,
+                                sourceStatus: model.sourceStatuses[item.id],
+                                bookmarkStore: model.bookmarkStore
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .hoverEffect(.highlight)
+                        .contextMenu {
+                            if model.playbackAvailability(for: item) == .playable {
+                                Button {
+                                    model.requestPlayback(for: item.id)
+                                } label: {
+                                    Label("Play", systemImage: "play.fill")
+                                }
+                            }
+                        }
+                    }
                 }
             }
-            .padding(.horizontal, 34)
-            .padding(.vertical, 28)
         }
-        .navigationTitle("All Movies")
+        .scrollIndicators(.hidden)
+        .contentMargins(.horizontal, LibraryTheme.contentPadding, for: .scrollContent)
+        .contentMargins(.vertical, LibraryTheme.contentPadding, for: .scrollContent)
+        .navigationTitle("Movies")
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                viewControls
-                filterMenu
                 sortMenu
                 addMovieButton
             }
@@ -40,84 +58,14 @@ struct LibraryView: View {
         }
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Your movies")
-                .font(.largeTitle.weight(.semibold))
-            Text("Choose a movie to inspect its source and playback format.")
-                .foregroundStyle(.secondary)
-        }
-    }
-
     private var emptyState: some View {
         ContentUnavailableView {
             Label("No movies yet", systemImage: "film.stack")
         } description: {
-            Text("Add a movie file to start building your library.")
+            Text("Add a movie to see it here.")
         } actions: {
             addMovieButton
         }
-        .frame(maxWidth: .infinity, minHeight: 360)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 30, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 30, style: .continuous)
-                .stroke(.white.opacity(0.32), lineWidth: 1)
-        }
-    }
-
-    private var posterGrid: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 185), spacing: 22)], spacing: 24) {
-            ForEach(model.visibleItems) { item in
-                MediaPosterCard(
-                    item: item,
-                    sourceStatus: model.sourceStatuses[item.id],
-                    showDetails: { model.showDetails(for: item.id) }
-                )
-            }
-        }
-    }
-
-    private var fileList: some View {
-        LazyVStack(spacing: 10) {
-            ForEach(model.visibleItems) { item in
-                Button {
-                    model.showDetails(for: item.id)
-                } label: {
-                    MediaFileRow(item: item, sourceStatus: model.sourceStatuses[item.id])
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var viewControls: some View {
-        Picker("Library view", selection: $model.viewMode) {
-            ForEach(LibraryViewMode.allCases, id: \.self) { mode in
-                Text(mode.title).tag(mode)
-            }
-        }
-        .pickerStyle(.segmented)
-        .frame(width: 170)
-        .accessibilityLabel("Library view")
-    }
-
-    private var filterMenu: some View {
-        Menu {
-            ForEach(MediaFormatFilter.allCases, id: \.self) { filter in
-                Button {
-                    model.formatFilter = filter
-                } label: {
-                    if model.formatFilter == filter {
-                        Label(filter.title, systemImage: "checkmark")
-                    } else {
-                        Text(filter.title)
-                    }
-                }
-            }
-        } label: {
-            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
-        }
-        .accessibilityLabel("Filter movies")
     }
 
     private var sortMenu: some View {
@@ -146,103 +94,48 @@ struct LibraryView: View {
             Label("Add Movie", systemImage: "plus")
         }
         .buttonStyle(.borderedProminent)
-        .tint(Color(red: 0.82, green: 0.48, blue: 0.12))
         .accessibilityHint("Choose one movie file from Files.")
     }
 }
 
-struct MediaPosterCard: View {
+struct MediaMovieTile: View {
     let item: MediaItem
     let sourceStatus: MediaSourceStatus?
-    let showDetails: () -> Void
+    let bookmarkStore: BookmarkStore
 
     var body: some View {
-        Button(action: showDetails) {
-            VStack(alignment: .leading, spacing: 10) {
-                PosterPlaceholderView(fileName: item.fileName, format: item.format)
-                    .aspectRatio(0.72, contentMode: .fit)
+        VStack(alignment: .leading, spacing: LibraryTheme.tileTextSpacing) {
+            MediaThumbnailView(
+                item: item,
+                bookmarkStore: bookmarkStore,
+                sourceStatus: sourceStatus
+            )
+            .aspectRatio(16 / 9, contentMode: .fit)
 
-                Text(item.title)
-                    .font(.headline)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44, alignment: .topLeading)
+            Text(item.title)
+                .font(.headline)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .topLeading)
 
-                Text(item.fileName)
+            if sourceStatus != .available {
+                Label(sourceStatus?.title ?? "Source unavailable", systemImage: "exclamationmark.triangle")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack(spacing: 8) {
-                    Label("On My Vision Pro", systemImage: "visionpro")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 4)
-                    Text("Details ›")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(.thinMaterial, in: Capsule())
-                }
-
-                if sourceStatus != .available {
-                    Label(sourceStatus?.title ?? "Source unavailable", systemImage: "exclamationmark.triangle")
-                        .font(.caption2)
-                        .foregroundStyle(.orange)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-            .padding(14)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(.white.opacity(0.28), lineWidth: 1)
             }
         }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("movie-card-\(item.id)")
-        .accessibilityLabel("Details for \(item.title)")
-        .accessibilityHint("Shows filename, format, source, and playback actions.")
-    }
-}
-
-struct MediaFileRow: View {
-    let item: MediaItem
-    let sourceStatus: MediaSourceStatus?
-
-    var body: some View {
-        HStack(spacing: 16) {
-            PosterPlaceholderView(fileName: item.fileName, format: item.format)
-                .frame(width: 68, height: 82)
-
-            VStack(alignment: .leading, spacing: 5) {
-                Text(item.title)
-                    .font(.headline)
-                Text(item.fileName)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                HStack(spacing: 8) {
-                    FormatPill(format: item.format)
-                    if sourceStatus != .available {
-                        Text(sourceStatus?.title ?? "Source unavailable")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                    }
-                }
-            }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .foregroundStyle(.tertiary)
-        }
-        .padding(12)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.white.opacity(0.25), lineWidth: 1)
-        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(LibraryTheme.tilePadding)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius, style: .continuous))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(item.title), \(item.fileName), \(item.format.displayName)")
+        .accessibilityLabel(tileAccessibilityLabel)
+        .accessibilityHint("Opens movie details.")
+    }
+
+    private var tileAccessibilityLabel: String {
+        if sourceStatus == .available {
+            return "\(item.title), \(item.format.displayName)"
+        }
+        return "\(item.title), \(item.format.displayName), \(sourceStatus?.title ?? "Source unavailable")"
     }
 }

--- a/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
@@ -5,29 +5,17 @@ struct MediaDetailsView: View {
     @ObservedObject var model: PlayerAppModel
     let itemID: String
 
-    @Environment(\.dismiss) private var dismiss
     @State private var isLocatorPresented = false
 
     var body: some View {
-        NavigationStack {
-            Group {
-                if let item = model.item(id: itemID) {
-                    details(for: item)
-                } else {
-                    ContentUnavailableView("Movie unavailable", systemImage: "film")
-                }
-            }
-            .navigationTitle("Details")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") {
-                        model.closeDetails()
-                        dismiss()
-                    }
-                }
+        Group {
+            if let item = model.item(id: itemID) {
+                details(for: item)
+            } else {
+                ContentUnavailableView("Movie unavailable", systemImage: "film")
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
         .fileImporter(
             isPresented: $isLocatorPresented,
             allowedContentTypes: [.movie],
@@ -36,174 +24,93 @@ struct MediaDetailsView: View {
             guard case let .success(urls) = result, let url = urls.first else { return }
             Task { await model.locate(itemID: itemID, at: url) }
         }
+        .onAppear {
+            model.selectedItemID = itemID
+            model.isShowingDetails = true
+        }
+        .onDisappear {
+            guard model.playbackRequest == nil else { return }
+            if model.selectedItemID == itemID {
+                model.closeDetails()
+            }
+        }
     }
 
     @ViewBuilder
     private func details(for item: MediaItem) -> some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 26) {
-                HStack(alignment: .top, spacing: 22) {
-                    PosterPlaceholderView(fileName: item.fileName, format: item.format)
-                        .frame(width: 170, height: 235)
+            VStack(alignment: .leading, spacing: 28) {
+                MediaThumbnailView(
+                    item: item,
+                    bookmarkStore: model.bookmarkStore,
+                    sourceStatus: model.sourceStatuses[item.id]
+                )
+                .aspectRatio(16 / 9, contentMode: .fit)
+                .frame(maxWidth: 900)
 
-                    VStack(alignment: .leading, spacing: 13) {
-                        Text(item.title)
-                            .font(.largeTitle.weight(.semibold))
-                        FormatPill(format: item.format)
-                        Text(item.fileName)
-                            .font(.headline)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                        sourceStatusView(for: item)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(item.title)
+                        .font(.largeTitle.weight(.semibold))
+                        .lineLimit(2)
+                    Text("\(item.format.displayName) · \(item.fileName)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    sourceStatusView(for: item)
                 }
 
                 playbackSection(for: item)
-                metadataSection(for: item)
             }
-            .padding(34)
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, LibraryTheme.contentPadding)
+            .padding(.vertical, 28)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
+        .scrollIndicators(.hidden)
     }
 
     @ViewBuilder
     private func playbackSection(for item: MediaItem) -> some View {
-        let availability = model.playbackAvailability(for: item)
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Playback")
-                .font(.title2.weight(.semibold))
-
-            switch availability {
-            case .playable:
-                Button {
-                    model.requestPlayback(for: item.id)
-                } label: {
-                    Label("Play", systemImage: "play.fill")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color(red: 0.82, green: 0.48, blue: 0.12))
-                .accessibilityIdentifier("play-movie-\(item.id)")
-                .accessibilityHint("Sends this movie to the playback integrator.")
-            case let .planned(message), let .unavailable(message):
-                Button {
-                } label: {
-                    Label(
-                        item.format == .unsupported ? "Play unavailable" : "Play — planned",
-                        systemImage: "play.slash"
-                    )
-                    .frame(maxWidth: .infinity)
-                }
-                .disabled(true)
-                Text(message)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+        switch model.playbackAvailability(for: item) {
+        case .playable:
+            Button {
+                model.requestPlayback(for: item.id)
+            } label: {
+                Label("Play", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity, minHeight: 60)
             }
-        }
-        .padding(22)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(.white.opacity(0.28), lineWidth: 1)
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("play-movie-\(item.id)")
+            .accessibilityHint("Starts playback for this movie.")
+        case let .planned(message), let .unavailable(message):
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
         }
     }
 
     private func sourceStatusView(for item: MediaItem) -> some View {
         let status = model.sourceStatuses[item.id] ?? .missing
-        return VStack(alignment: .leading, spacing: 8) {
+        return VStack(alignment: .leading, spacing: 10) {
             Label(status.title, systemImage: status == .available ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(status == .available ? .green : .orange)
+                .foregroundStyle(.secondary)
 
             if status != .available {
-                HStack(spacing: 10) {
+                HStack(spacing: 12) {
                     Button("Locate") {
                         isLocatorPresented = true
                     }
                     .buttonStyle(.bordered)
+                    .frame(minHeight: 48)
+
                     Button("Remove", role: .destructive) {
                         model.remove(itemID: item.id)
-                        dismiss()
                     }
                     .buttonStyle(.bordered)
+                    .frame(minHeight: 48)
                 }
             }
-        }
-    }
-
-    private func metadataSection(for item: MediaItem) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("File & Technical")
-                .font(.title2.weight(.semibold))
-            LabeledContent("Filename", value: item.fileName)
-            LabeledContent("Format", value: item.format.displayName)
-            LabeledContent("Source", value: "Files")
-        }
-        .padding(22)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-    }
-}
-
-struct PosterPlaceholderView: View {
-    let fileName: String
-    let format: StereoFormat
-
-    var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            LinearGradient(
-                colors: [Color(red: 0.22, green: 0.24, blue: 0.26), Color(red: 0.08, green: 0.09, blue: 0.10)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            VStack(alignment: .leading, spacing: 8) {
-                Image(systemName: "film.stack")
-                    .font(.system(size: 30, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.8))
-                Text(fileName)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.white.opacity(0.88))
-                    .lineLimit(3)
-            }
-            .padding(16)
-            FormatPill(format: format)
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .frame(maxHeight: .infinity, alignment: .topTrailing)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(.white.opacity(0.22), lineWidth: 1)
-        }
-        .accessibilityLabel("Filename placeholder for \(fileName), \(format.displayName)")
-    }
-}
-
-struct FormatPill: View {
-    let format: StereoFormat
-
-    var body: some View {
-        Text(format.displayName)
-            .font(.caption2.weight(.bold))
-            .tracking(0.5)
-            .foregroundStyle(tint)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 5)
-            .background(tint.opacity(0.16), in: Capsule())
-            .overlay {
-                Capsule().stroke(tint.opacity(0.38), lineWidth: 1)
-            }
-            .accessibilityLabel("Format \(format.displayName)")
-    }
-
-    private var tint: Color {
-        switch format {
-        case .mvHEVC:
-            return Color(red: 0.45, green: 0.92, blue: 0.68)
-        case .sideBySide, .overUnder:
-            return Color(red: 0.72, green: 0.66, blue: 1.0)
-        case .unsupported:
-            return Color(red: 1.0, green: 0.72, blue: 0.34)
         }
     }
 }

--- a/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
@@ -88,17 +88,21 @@ struct MediaDetailsView: View {
 
             if status != .available {
                 HStack(spacing: 12) {
-                    Button("Locate") {
+                    Button {
                         isLocatorPresented = true
+                    } label: {
+                        Text("Locate")
+                            .frame(minWidth: 60, minHeight: 60)
                     }
                     .buttonStyle(.bordered)
-                    .frame(minHeight: 60)
 
-                    Button("Remove", role: .destructive) {
+                    Button(role: .destructive) {
                         model.remove(itemID: item.id)
+                    } label: {
+                        Text("Remove")
+                            .frame(minWidth: 60, minHeight: 60)
                     }
                     .buttonStyle(.bordered)
-                    .frame(minHeight: 60)
                 }
             }
         }

--- a/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
@@ -8,14 +8,25 @@ struct MediaDetailsView: View {
     @State private var isLocatorPresented = false
 
     var body: some View {
-        Group {
-            if let item = model.item(id: itemID) {
-                details(for: item)
-            } else {
-                ContentUnavailableView("Movie unavailable", systemImage: "film")
+        NavigationStack {
+            Group {
+                if let item = model.item(id: itemID) {
+                    details(for: item)
+                } else {
+                    ContentUnavailableView("Movie unavailable", systemImage: "film")
+                }
+            }
+            .navigationTitle("Details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        model.closeDetails()
+                    }
+                    .accessibilityIdentifier("details-done")
+                }
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
         .fileImporter(
             isPresented: $isLocatorPresented,
             allowedContentTypes: [.movie],
@@ -29,38 +40,46 @@ struct MediaDetailsView: View {
     @ViewBuilder
     private func details(for item: MediaItem) -> some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
-                MediaThumbnailView(
-                    item: item,
-                    bookmarkStore: model.bookmarkStore,
-                    sourceStatus: model.sourceStatuses[item.id]
-                )
-                .aspectRatio(16 / 9, contentMode: .fit)
-                .frame(maxWidth: 900)
+            VStack(alignment: .leading, spacing: 22) {
+                HStack(alignment: .top, spacing: 24) {
+                    MediaThumbnailView(
+                        item: item,
+                        bookmarkStore: model.bookmarkStore,
+                        sourceStatus: model.sourceStatuses[item.id]
+                    )
+                    .aspectRatio(16 / 9, contentMode: .fit)
+                    .frame(width: 250)
 
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(item.title)
-                        .font(.largeTitle.weight(.semibold))
-                        .lineLimit(2)
-                    Text("\(item.format.displayName) · \(item.fileName)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                    sourceStatusView(for: item)
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(item.title)
+                            .font(.title.weight(.semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.65)
+
+                        HStack(spacing: 10) {
+                            FormatPill(format: item.format)
+                            sourceStatusLabel(for: item)
+                        }
+
+                        Text(item.fileName)
+                            .font(.headline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+
+                        playbackAction(for: item)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                playbackSection(for: item)
+                metadataSection(for: item)
             }
-            .frame(maxWidth: 900, alignment: .leading)
-            .padding(.horizontal, LibraryTheme.contentPadding)
-            .padding(.vertical, 28)
-            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(30)
         }
         .scrollIndicators(.hidden)
     }
 
     @ViewBuilder
-    private func playbackSection(for item: MediaItem) -> some View {
+    private func playbackAction(for item: MediaItem) -> some View {
         switch model.playbackAvailability(for: item) {
         case .playable:
             Button {
@@ -72,21 +91,22 @@ struct MediaDetailsView: View {
             .buttonStyle(.borderedProminent)
             .accessibilityIdentifier("play-movie-\(item.id)")
             .accessibilityHint("Starts playback for this movie.")
-        case let .planned(message), let .unavailable(message):
-            Text(message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        case let .planned(message):
+            unavailablePlayback(message: message, label: "Playback coming later", item: item)
+        case let .unavailable(message):
+            unavailablePlayback(message: message, label: "Play unavailable", item: item)
         }
     }
 
-    private func sourceStatusView(for item: MediaItem) -> some View {
-        let status = model.sourceStatuses[item.id] ?? .missing
-        return VStack(alignment: .leading, spacing: 10) {
-            Label(status.title, systemImage: status == .available ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .font(.subheadline.weight(.semibold))
+    private func unavailablePlayback(message: String, label: String, item: MediaItem) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(label, systemImage: "play.slash")
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
 
-            if status != .available {
+            if (model.sourceStatuses[item.id] ?? .missing) != .available {
                 HStack(spacing: 12) {
                     Button {
                         isLocatorPresented = true
@@ -106,5 +126,46 @@ struct MediaDetailsView: View {
                 }
             }
         }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private func sourceStatusLabel(for item: MediaItem) -> some View {
+        let status = model.sourceStatuses[item.id] ?? .missing
+        return Label(
+            status.title,
+            systemImage: status == .available ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        )
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(status == .available ? Color.green : Color.orange)
+    }
+
+    private func metadataSection(for item: MediaItem) -> some View {
+        let status = model.sourceStatuses[item.id] ?? .missing
+        return VStack(alignment: .leading, spacing: 14) {
+            Text("File & Technical")
+                .font(.title2.weight(.semibold))
+            LabeledContent("Filename", value: item.fileName)
+            LabeledContent("Format", value: item.format.displayName)
+            LabeledContent("Location", value: model.sourceTitle(for: item))
+            LabeledContent("Source status", value: status.title)
+        }
+        .padding(20)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+}
+
+struct FormatPill: View {
+    let format: StereoFormat
+
+    var body: some View {
+        Text(format.displayName)
+            .font(.caption2.weight(.bold))
+            .tracking(0.5)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.thinMaterial, in: Capsule())
+            .accessibilityLabel("Format \(format.displayName)")
     }
 }

--- a/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaDetailsView.swift
@@ -24,16 +24,6 @@ struct MediaDetailsView: View {
             guard case let .success(urls) = result, let url = urls.first else { return }
             Task { await model.locate(itemID: itemID, at: url) }
         }
-        .onAppear {
-            model.selectedItemID = itemID
-            model.isShowingDetails = true
-        }
-        .onDisappear {
-            guard model.playbackRequest == nil else { return }
-            if model.selectedItemID == itemID {
-                model.closeDetails()
-            }
-        }
     }
 
     @ViewBuilder
@@ -102,13 +92,13 @@ struct MediaDetailsView: View {
                         isLocatorPresented = true
                     }
                     .buttonStyle(.bordered)
-                    .frame(minHeight: 48)
+                    .frame(minHeight: 60)
 
                     Button("Remove", role: .destructive) {
                         model.remove(itemID: item.id)
                     }
                     .buttonStyle(.bordered)
-                    .frame(minHeight: 48)
+                    .frame(minHeight: 60)
                 }
             }
         }

--- a/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
@@ -1,6 +1,34 @@
 import AVFoundation
 import SwiftUI
 
+private actor MediaThumbnailGenerationLimiter {
+    private var availablePermits: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(limit: Int) {
+        availablePermits = max(1, limit)
+    }
+
+    func acquire() async {
+        if availablePermits > 0 {
+            availablePermits -= 1
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            availablePermits += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 final class MediaThumbnailCache {
     static let defaultCountLimit = 48
     static let defaultTotalCostLimit = 96 * 1_024 * 1_024
@@ -42,15 +70,27 @@ final class MediaThumbnailLoader {
     static let shared = MediaThumbnailLoader()
 
     let cache: MediaThumbnailCache
+    private let generationLimiter: MediaThumbnailGenerationLimiter
 
-    init(cache: MediaThumbnailCache = MediaThumbnailCache()) {
+    init(
+        cache: MediaThumbnailCache = MediaThumbnailCache(),
+        maximumConcurrentGenerations: Int = 4
+    ) {
         self.cache = cache
+        generationLimiter = MediaThumbnailGenerationLimiter(limit: maximumConcurrentGenerations)
     }
 
     func image(for item: MediaItem, bookmarkStore: BookmarkStore) async -> CGImage? {
         let key = Self.cacheKey(for: item, bookmarkData: bookmarkStore.bookmarkData(for: item.id))
         if let cachedImage = cache.image(for: key) {
             return cachedImage
+        }
+
+        await generationLimiter.acquire()
+        defer {
+            Task {
+                await generationLimiter.release()
+            }
         }
 
         guard !Task.isCancelled,
@@ -63,14 +103,15 @@ final class MediaThumbnailLoader {
         let asset = AVURLAsset(url: lease.url)
         let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
-        generator.maximumSize = CGSize(width: 1600, height: 900)
+        generator.maximumSize = CGSize(width: 1280, height: 720)
 
         let duration = try? await asset.load(.duration)
         let requestedTime = Self.requestedTime(for: duration?.seconds)
         let image = try? await generator.image(at: requestedTime).image
 
-        if let image, !Task.isCancelled {
+        if let image {
             cache.insert(image, for: key)
+            guard !Task.isCancelled else { return nil }
             return image
         }
         return nil

--- a/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
@@ -1,0 +1,134 @@
+import AVFoundation
+import SwiftUI
+
+final class MediaThumbnailCache {
+    static let defaultCountLimit = 48
+
+    private final class Entry: NSObject {
+        let image: CGImage
+
+        init(image: CGImage) {
+            self.image = image
+        }
+    }
+
+    private let cache: NSCache<NSString, Entry>
+
+    init(countLimit: Int = MediaThumbnailCache.defaultCountLimit) {
+        cache = NSCache<NSString, Entry>()
+        cache.countLimit = max(1, countLimit)
+    }
+
+    func image(for key: String) -> CGImage? {
+        cache.object(forKey: key as NSString)?.image
+    }
+
+    func insert(_ image: CGImage, for key: String) {
+        cache.setObject(Entry(image: image), forKey: key as NSString)
+    }
+}
+
+@MainActor
+final class MediaThumbnailLoader {
+    static let shared = MediaThumbnailLoader()
+
+    let cache: MediaThumbnailCache
+
+    init(cache: MediaThumbnailCache = MediaThumbnailCache()) {
+        self.cache = cache
+    }
+
+    func image(for item: MediaItem, bookmarkStore: BookmarkStore) async -> CGImage? {
+        let key = Self.cacheKey(for: item)
+        if let cachedImage = cache.image(for: key) {
+            return cachedImage
+        }
+
+        let image = await Task.detached(priority: .userInitiated) {
+            Self.extractFrame(for: item, bookmarkStore: bookmarkStore)
+        }.value
+
+        if let image {
+            cache.insert(image, for: key)
+        }
+        return image
+    }
+
+    nonisolated static func cacheKey(for item: MediaItem) -> String {
+        "\(item.id)|\(item.fileName)|\(item.format.rawValue)"
+    }
+
+    private nonisolated static func extractFrame(for item: MediaItem, bookmarkStore: BookmarkStore) -> CGImage? {
+        guard let result = try? bookmarkStore.withResolvedURL(for: item.id, { url in
+            let asset = AVAsset(url: url)
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.maximumSize = CGSize(width: 1600, height: 900)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            var generatedImage: CGImage?
+            let requestedTime = CMTime(seconds: 1, preferredTimescale: 600)
+            generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: requestedTime)]) { _, image, _, result, _ in
+                if result == .succeeded {
+                    generatedImage = image
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
+            return generatedImage
+        }) else {
+            return nil
+        }
+        return result
+    }
+}
+
+struct MediaThumbnailView: View {
+    let item: MediaItem
+    let bookmarkStore: BookmarkStore
+    let sourceStatus: MediaSourceStatus?
+
+    @State private var image: CGImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(decorative: image, scale: 1, orientation: .up)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                MediaThumbnailFallback(title: item.title)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius - 6, style: .continuous))
+        .task(id: MediaThumbnailLoader.cacheKey(for: item)) {
+            guard sourceStatus == .available else {
+                image = nil
+                return
+            }
+            image = await MediaThumbnailLoader.shared.image(for: item, bookmarkStore: bookmarkStore)
+        }
+        .accessibilityLabel("Thumbnail for \(item.title)")
+    }
+}
+
+struct MediaThumbnailFallback: View {
+    let title: String
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            LinearGradient(
+                colors: [.secondary.opacity(0.42), .black.opacity(0.82)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Text(title)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(3)
+                .padding(20)
+        }
+    }
+}

--- a/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
+++ b/macos/BDToAVPPlayer/Views/MediaThumbnailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 final class MediaThumbnailCache {
     static let defaultCountLimit = 48
+    static let defaultTotalCostLimit = 96 * 1_024 * 1_024
 
     private final class Entry: NSObject {
         let image: CGImage
@@ -14,9 +15,13 @@ final class MediaThumbnailCache {
 
     private let cache: NSCache<NSString, Entry>
 
-    init(countLimit: Int = MediaThumbnailCache.defaultCountLimit) {
+    init(
+        countLimit: Int = MediaThumbnailCache.defaultCountLimit,
+        totalCostLimit: Int = MediaThumbnailCache.defaultTotalCostLimit
+    ) {
         cache = NSCache<NSString, Entry>()
         cache.countLimit = max(1, countLimit)
+        cache.totalCostLimit = max(1, totalCostLimit)
     }
 
     func image(for key: String) -> CGImage? {
@@ -24,7 +29,11 @@ final class MediaThumbnailCache {
     }
 
     func insert(_ image: CGImage, for key: String) {
-        cache.setObject(Entry(image: image), forKey: key as NSString)
+        cache.setObject(
+            Entry(image: image),
+            forKey: key as NSString,
+            cost: image.bytesPerRow * image.height
+        )
     }
 }
 
@@ -39,48 +48,46 @@ final class MediaThumbnailLoader {
     }
 
     func image(for item: MediaItem, bookmarkStore: BookmarkStore) async -> CGImage? {
-        let key = Self.cacheKey(for: item)
+        let key = Self.cacheKey(for: item, bookmarkData: bookmarkStore.bookmarkData(for: item.id))
         if let cachedImage = cache.image(for: key) {
             return cachedImage
         }
 
-        let image = await Task.detached(priority: .userInitiated) {
-            Self.extractFrame(for: item, bookmarkStore: bookmarkStore)
-        }.value
-
-        if let image {
-            cache.insert(image, for: key)
-        }
-        return image
-    }
-
-    nonisolated static func cacheKey(for item: MediaItem) -> String {
-        "\(item.id)|\(item.fileName)|\(item.format.rawValue)"
-    }
-
-    private nonisolated static func extractFrame(for item: MediaItem, bookmarkStore: BookmarkStore) -> CGImage? {
-        guard let result = try? bookmarkStore.withResolvedURL(for: item.id, { url in
-            let asset = AVAsset(url: url)
-            let generator = AVAssetImageGenerator(asset: asset)
-            generator.appliesPreferredTrackTransform = true
-            generator.maximumSize = CGSize(width: 1600, height: 900)
-
-            let semaphore = DispatchSemaphore(value: 0)
-            var generatedImage: CGImage?
-            let requestedTime = CMTime(seconds: 1, preferredTimescale: 600)
-            generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: requestedTime)]) { _, image, _, result, _ in
-                if result == .succeeded {
-                    generatedImage = image
-                }
-                semaphore.signal()
-            }
-            semaphore.wait()
-            return generatedImage
-        }) else {
+        guard !Task.isCancelled,
+              let lease = try? bookmarkStore.open(id: item.id)
+        else {
             return nil
         }
-        return result
+        defer { lease.close() }
+
+        let asset = AVURLAsset(url: lease.url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 1600, height: 900)
+
+        let duration = try? await asset.load(.duration)
+        let requestedTime = Self.requestedTime(for: duration?.seconds)
+        let image = try? await generator.image(at: requestedTime).image
+
+        if let image, !Task.isCancelled {
+            cache.insert(image, for: key)
+            return image
+        }
+        return nil
     }
+
+    nonisolated static func cacheKey(for item: MediaItem, bookmarkData: Data? = nil) -> String {
+        "\(item.id)|\(item.fileName)|\(item.format.rawValue)|\(bookmarkData?.hashValue ?? 0)"
+    }
+
+    nonisolated static func requestedTime(for duration: TimeInterval?) -> CMTime {
+        guard let duration, duration.isFinite, duration > 0 else {
+            return CMTime(seconds: 1, preferredTimescale: 600)
+        }
+        let seconds = min(max(duration * 0.1, 0), min(30, duration))
+        return CMTime(seconds: seconds, preferredTimescale: 600)
+    }
+
 }
 
 struct MediaThumbnailView: View {
@@ -103,14 +110,24 @@ struct MediaThumbnailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipped()
         .clipShape(RoundedRectangle(cornerRadius: LibraryTheme.tileCornerRadius - 6, style: .continuous))
-        .task(id: MediaThumbnailLoader.cacheKey(for: item)) {
+        .task(id: thumbnailTaskID) {
             guard sourceStatus == .available else {
                 image = nil
                 return
             }
-            image = await MediaThumbnailLoader.shared.image(for: item, bookmarkStore: bookmarkStore)
+            let loadedImage = await MediaThumbnailLoader.shared.image(for: item, bookmarkStore: bookmarkStore)
+            guard !Task.isCancelled else { return }
+            image = loadedImage
         }
-        .accessibilityLabel("Thumbnail for \(item.title)")
+        .accessibilityHidden(true)
+    }
+
+    private var thumbnailTaskID: String {
+        let cacheKey = MediaThumbnailLoader.cacheKey(
+            for: item,
+            bookmarkData: bookmarkStore.bookmarkData(for: item.id)
+        )
+        return "\(cacheKey)|\(sourceStatus == .available)"
     }
 }
 

--- a/macos/BDToAVPPlayer/Views/PlayerView.swift
+++ b/macos/BDToAVPPlayer/Views/PlayerView.swift
@@ -6,6 +6,7 @@ struct PlayerView: View {
     private let onDone: () -> Void
 
     @Environment(\.scenePhase) private var scenePhase
+    @State private var hudVisibility = PlaybackHUDVisibilityState()
 
     init(session: MVHEVCPlayerSession, onDone: @escaping () -> Void) {
         self.session = session
@@ -14,14 +15,58 @@ struct PlayerView: View {
 
     var body: some View {
         GeometryReader3D { geometry in
-            ZStack(alignment: .bottom) {
-                playerSurface(geometry: geometry)
-
-                PlayerHUDView(session: session, onDone: done)
-                    .padding(24)
-            }
+            playerSurface(geometry: geometry)
         }
         .background(.black)
+        .onAppear {
+            hudVisibility.reconcile(isPlaying: session.isPlaying)
+        }
+        .onHover { isHovered in
+            if isHovered {
+                hudVisibility.reveal(isPlaying: session.isPlaying)
+            }
+        }
+        .onChange(of: session.isPlaying) { _, isPlaying in
+            hudVisibility.reconcile(isPlaying: isPlaying)
+        }
+        .onChange(of: session.state) { _, _ in
+            hudVisibility.reconcile(isPlaying: session.isPlaying)
+        }
+        .task(id: hudVisibility.autoHideGeneration) {
+            let generation = hudVisibility.autoHideGeneration
+            guard hudVisibility.isAutoHideScheduled else {
+                return
+            }
+
+            do {
+                try await Task.sleep(nanoseconds: UInt64(PlaybackHUDVisibilityState.autoHideDelay * 1_000_000_000))
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else {
+                return
+            }
+            hudVisibility.autoHideTimerFired(generation: generation)
+        }
+        .ornament(
+            visibility: hudVisibility.isVisible ? .visible : .hidden,
+            attachmentAnchor: .scene(.bottom)
+        ) {
+            PlayerOrnamentView(
+                session: session,
+                onDone: done,
+                onHoverChanged: { isHovered in
+                    hudVisibility.setHovered(isHovered, isPlaying: session.isPlaying)
+                },
+                onScrubbingChanged: { isScrubbing in
+                    hudVisibility.setInteracting(isScrubbing, isPlaying: session.isPlaying)
+                },
+                onInteraction: {
+                    hudVisibility.reveal(isPlaying: session.isPlaying)
+                }
+            )
+        }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase != .active {
                 session.applicationBecameInactive()
@@ -36,24 +81,11 @@ struct PlayerView: View {
     private func playerSurface(geometry: GeometryProxy3D) -> some View {
         switch session.state {
         case .idle:
-            ContentUnavailableView(
-                "No Movie Selected",
-                systemImage: "film.stack",
-                description: Text("Choose an MV-HEVC movie to start spatial playback.")
-            )
-            .foregroundStyle(.white)
+            Color.clear
         case .loading:
-            ProgressView("Preparing MV-HEVC playback…")
-                .padding(24)
-                .glassBackgroundEffect()
-                .foregroundStyle(.white)
+            Color.clear
         case .failed:
-            ContentUnavailableView(
-                "Movie Unavailable",
-                systemImage: "exclamationmark.triangle",
-                description: Text(session.failureMessage ?? "The movie could not be prepared.")
-            )
-            .foregroundStyle(.white)
+            Color.clear
         case .ready:
             RealityView { content in
                 session.installPlayerComponent()
@@ -91,87 +123,195 @@ struct PlayerView: View {
     }
 }
 
-private struct PlayerHUDView: View {
+private struct PlayerOrnamentView: View {
     @ObservedObject var session: MVHEVCPlayerSession
     let onDone: () -> Void
+    let onHoverChanged: (Bool) -> Void
+    let onScrubbingChanged: (Bool) -> Void
+    let onInteraction: () -> Void
 
     @State private var scrubState = PlaybackScrubState()
 
     var body: some View {
-        VStack(spacing: 14) {
-            HStack(spacing: 12) {
-                Text(session.mediaItem?.title ?? "BD to AVP Player")
-                    .font(.headline)
-                    .lineLimit(1)
-                Spacer()
-                Label(session.mediaItem?.format.displayName ?? "MV-HEVC", systemImage: "view.3d")
-                    .font(.caption.weight(.semibold))
-                    .accessibilityLabel("Stereo format \(session.mediaItem?.format.displayName ?? "MV-HEVC")")
-                Button("Done", action: onDone)
-                    .accessibilityIdentifier("player-done")
-                    .accessibilityLabel("Done playing movie")
+        Group {
+            switch session.state {
+            case .ready:
+                readyControls
+            case .loading:
+                statusControls(
+                    title: "Preparing Playback",
+                    systemImage: "film.stack",
+                    message: "Preparing \(session.mediaItem?.title ?? "your movie")…",
+                    showsProgress: true
+                )
+            case .failed:
+                statusControls(
+                    title: "Movie Unavailable",
+                    systemImage: "exclamationmark.triangle",
+                    message: session.failureMessage ?? "The movie could not be prepared.",
+                    showsProgress: false
+                )
+            case .idle:
+                statusControls(
+                    title: "No Movie Selected",
+                    systemImage: "film.stack",
+                    message: "Choose an MV-HEVC movie to start spatial playback.",
+                    showsProgress: false
+                )
             }
+        }
+        .padding(20)
+        .frame(maxWidth: 880)
+        .glassBackgroundEffect()
+        .onHover(perform: onHoverChanged)
+        .accessibilityElement(children: .contain)
+    }
 
-            if session.state == .ready, let warning = session.failureMessage {
+    private var readyControls: some View {
+        VStack(spacing: 16) {
+            ornamentHeader
+
+            if let warning = session.failureMessage {
                 Label(warning, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
+                    .font(.subheadline)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            Slider(
-                value: Binding(
-                    get: { scrubState.value ?? session.currentTime },
-                    set: { scrubState.update(requestedTime: $0, duration: session.duration) }
-                ),
-                in: 0 ... max(1, session.duration),
-                onEditingChanged: { isEditing in
-                    if isEditing {
-                        scrubState.begin(currentTime: session.currentTime)
-                    } else if let scrubbedTime = scrubState.finish() {
-                        session.seek(to: scrubbedTime)
-                    }
-                }
-            )
-            .disabled(!session.canSeek)
-            .accessibilityLabel("Playback position")
-            .accessibilityValue(displayedTimeSummary)
-
-            HStack(spacing: 12) {
-                Button(action: session.seekBackward) {
-                    Label("Back 10 seconds", systemImage: "gobackward.10")
-                }
+            HStack(spacing: 28) {
+                transportButton(
+                    title: "Back 10 seconds",
+                    systemImage: "gobackward.10",
+                    action: session.seekBackward
+                )
                 .disabled(!session.canSeek)
-                .accessibilityLabel("Back 10 seconds")
 
-                Button(action: session.togglePlayback) {
-                    Label(session.isPlaying ? "Pause" : "Play", systemImage: session.isPlaying ? "pause.fill" : "play.fill")
+                Button(action: performPlaybackToggle) {
+                    Label(
+                        session.isPlaying ? "Pause" : "Play",
+                        systemImage: session.isPlaying ? "pause.fill" : "play.fill"
+                    )
+                    .labelStyle(.iconOnly)
+                    .frame(minWidth: 72, minHeight: 72)
                 }
+                .buttonStyle(.borderedProminent)
                 .disabled(!session.canControlPlayback)
                 .accessibilityIdentifier("player-play-pause")
                 .accessibilityLabel(session.isPlaying ? "Pause playback" : "Play movie")
 
-                Button(action: session.seekForward) {
-                    Label("Forward 30 seconds", systemImage: "goforward.30")
-                }
+                transportButton(
+                    title: "Forward 30 seconds",
+                    systemImage: "goforward.30",
+                    action: session.seekForward
+                )
                 .disabled(!session.canSeek)
-                .accessibilityLabel("Forward 30 seconds")
+            }
+            .frame(maxWidth: .infinity)
 
-                Spacer()
+            VStack(spacing: 8) {
+                Slider(
+                    value: Binding(
+                        get: { scrubState.value ?? session.currentTime },
+                        set: {
+                            scrubState.update(requestedTime: $0, duration: session.duration)
+                            onInteraction()
+                        }
+                    ),
+                    in: 0 ... max(1, session.duration),
+                    onEditingChanged: handleScrubbing
+                )
+                .disabled(!session.canSeek)
+                .accessibilityLabel("Playback position")
+                .accessibilityValue(displayedTimeSummary)
 
-                Text(displayedTimeSummary)
-                    .font(.system(.subheadline, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("Playback time \(displayedTimeSummary)")
+                HStack {
+                    Text(PlaybackTimeFormatter.string(for: scrubState.value ?? session.currentTime))
+                    Spacer()
+                    Text(PlaybackTimeFormatter.string(for: session.duration))
+                }
+                .font(.system(.subheadline, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Playback time \(displayedTimeSummary)")
+            }
 
+            HStack(spacing: 16) {
                 audioMenu
                 subtitleMenu
+                Spacer(minLength: 0)
             }
         }
-        .padding(18)
-        .frame(maxWidth: 760)
-        .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .accessibilityElement(children: .contain)
+    }
+
+    private var ornamentHeader: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(session.mediaItem?.title ?? "BD to AVP Player")
+                    .font(.headline)
+                    .lineLimit(1)
+                Label(session.mediaItem?.format.displayName ?? "MV-HEVC", systemImage: "view.3d")
+                    .font(.subheadline)
+                    .accessibilityLabel("Stereo format \(session.mediaItem?.format.displayName ?? "MV-HEVC")")
+            }
+            Spacer(minLength: 20)
+            doneButton
+        }
+    }
+
+    private func statusControls(title: String, systemImage: String, message: String, showsProgress: Bool) -> some View {
+        HStack(spacing: 16) {
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.large)
+            } else {
+                Image(systemName: systemImage)
+                    .font(.title2)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                Text(message)
+                    .font(.subheadline)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 20)
+            doneButton
+        }
+        .frame(maxWidth: 580, alignment: .leading)
+    }
+
+    private var doneButton: some View {
+        Button("Done", action: onDone)
+            .frame(minWidth: 60, minHeight: 60)
+            .accessibilityIdentifier("player-done")
+            .accessibilityLabel("Done playing movie")
+    }
+
+    private func transportButton(title: String, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button {
+            onInteraction()
+            action()
+        } label: {
+            Label(title, systemImage: systemImage)
+                .labelStyle(.iconOnly)
+                .frame(minWidth: 60, minHeight: 60)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityLabel(title)
+    }
+
+    private func performPlaybackToggle() {
+        onInteraction()
+        session.togglePlayback()
+    }
+
+    private func handleScrubbing(_ isEditing: Bool) {
+        onScrubbingChanged(isEditing)
+        if isEditing {
+            scrubState.begin(currentTime: session.currentTime)
+        } else if let scrubbedTime = scrubState.finish() {
+            session.seek(to: scrubbedTime)
+        }
     }
 
     private var displayedTimeSummary: String {
@@ -183,11 +323,13 @@ private struct PlayerHUDView: View {
         Menu {
             ForEach(session.audioOptions) { option in
                 Button(option.displayName) {
+                    onInteraction()
                     session.selectAudio(id: option.id)
                 }
             }
         } label: {
             Label("Audio", systemImage: "speaker.wave.2")
+                .frame(minWidth: 60, minHeight: 60)
         }
         .disabled(session.audioOptions.isEmpty)
         .accessibilityLabel("Audio track")
@@ -197,11 +339,13 @@ private struct PlayerHUDView: View {
         Menu {
             ForEach(session.subtitleOptions) { option in
                 Button(option.displayName) {
+                    onInteraction()
                     session.selectSubtitle(id: option.id)
                 }
             }
         } label: {
             Label("CC", systemImage: "captions.bubble")
+                .frame(minWidth: 60, minHeight: 60)
         }
         .disabled(session.subtitleOptions.isEmpty)
         .accessibilityLabel("Closed captions")

--- a/macos/BDToAVPPlayer/Views/PlayerView.swift
+++ b/macos/BDToAVPPlayer/Views/PlayerView.swift
@@ -2,6 +2,9 @@ import RealityKit
 import SwiftUI
 
 struct PlayerView: View {
+    private static let playerScaleInset: Float = 0.86
+    private static let playerDepthOffset: Float = -0.14
+
     @ObservedObject private var session: MVHEVCPlayerSession
     private let onDone: () -> Void
 
@@ -74,7 +77,7 @@ struct PlayerView: View {
         .ornament(
             visibility: hudVisibility.isVisible ? .visible : .hidden,
             attachmentAnchor: .scene(.bottom),
-            contentAlignment: .top
+            contentAlignment: .topBack
         ) {
             VStack(spacing: 0) {
                 Color.clear
@@ -146,12 +149,12 @@ struct PlayerView: View {
             return
         }
 
-        let scale = min(frameSize.x / screenSize.x, frameSize.y / screenSize.y) * 0.94
+        let scale = min(frameSize.x / screenSize.x, frameSize.y / screenSize.y) * Self.playerScaleInset
         guard scale.isFinite, scale > 0 else {
             return
         }
         session.playerEntity.scale = SIMD3<Float>(repeating: scale)
-        session.playerEntity.position = SIMD3<Float>(0, 0, -0.03)
+        session.playerEntity.position = SIMD3<Float>(0, 0, Self.playerDepthOffset)
     }
 }
 

--- a/macos/BDToAVPPlayer/Views/PlayerView.swift
+++ b/macos/BDToAVPPlayer/Views/PlayerView.swift
@@ -6,6 +6,8 @@ struct PlayerView: View {
     private let onDone: () -> Void
 
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
+    @Environment(\.accessibilitySwitchControlEnabled) private var isSwitchControlEnabled
     @State private var hudVisibility = PlaybackHUDVisibilityState()
 
     init(session: MVHEVCPlayerSession, onDone: @escaping () -> Void) {
@@ -18,19 +20,39 @@ struct PlayerView: View {
             playerSurface(geometry: geometry)
         }
         .background(.black)
+        .overlay {
+            Button {
+                hudVisibility.reveal(isPlaying: session.isPlaying)
+            } label: {
+                Color.clear
+                    .contentShape(Rectangle())
+            }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("player-surface")
+                .accessibilityLabel("Show playback controls")
+                .accessibilityHint("Reveals playback controls for three seconds.")
+        }
         .onAppear {
-            hudVisibility.reconcile(isPlaying: session.isPlaying)
+            hudVisibility.reconcile(isPlaying: isAutomaticHidingAllowed)
         }
         .onHover { isHovered in
             if isHovered {
-                hudVisibility.reveal(isPlaying: session.isPlaying)
+                hudVisibility.reveal(isPlaying: isAutomaticHidingAllowed)
             }
         }
         .onChange(of: session.isPlaying) { _, isPlaying in
-            hudVisibility.reconcile(isPlaying: isPlaying)
+            hudVisibility.reconcile(
+                isPlaying: isPlaying && !isVoiceOverEnabled && !isSwitchControlEnabled
+            )
         }
         .onChange(of: session.state) { _, _ in
-            hudVisibility.reconcile(isPlaying: session.isPlaying)
+            hudVisibility.reconcile(isPlaying: isAutomaticHidingAllowed)
+        }
+        .onChange(of: isVoiceOverEnabled) { _, _ in
+            hudVisibility.reconcile(isPlaying: isAutomaticHidingAllowed)
+        }
+        .onChange(of: isSwitchControlEnabled) { _, _ in
+            hudVisibility.reconcile(isPlaying: isAutomaticHidingAllowed)
         }
         .task(id: hudVisibility.autoHideGeneration) {
             let generation = hudVisibility.autoHideGeneration
@@ -51,19 +73,20 @@ struct PlayerView: View {
         }
         .ornament(
             visibility: hudVisibility.isVisible ? .visible : .hidden,
-            attachmentAnchor: .scene(.bottom)
+            attachmentAnchor: .scene(.bottom),
+            contentAlignment: .top
         ) {
             PlayerOrnamentView(
                 session: session,
                 onDone: done,
                 onHoverChanged: { isHovered in
-                    hudVisibility.setHovered(isHovered, isPlaying: session.isPlaying)
+                    hudVisibility.setHovered(isHovered, isPlaying: isAutomaticHidingAllowed)
                 },
                 onScrubbingChanged: { isScrubbing in
-                    hudVisibility.setInteracting(isScrubbing, isPlaying: session.isPlaying)
+                    hudVisibility.setInteracting(isScrubbing, isPlaying: isAutomaticHidingAllowed)
                 },
                 onInteraction: {
-                    hudVisibility.reveal(isPlaying: session.isPlaying)
+                    hudVisibility.reveal(isPlaying: isAutomaticHidingAllowed)
                 }
             )
         }
@@ -100,6 +123,10 @@ struct PlayerView: View {
     private func done() {
         session.finish()
         onDone()
+    }
+
+    private var isAutomaticHidingAllowed: Bool {
+        session.isPlaying && !isVoiceOverEnabled && !isSwitchControlEnabled
     }
 
     private func fitPlayerEntity(proxy: GeometryProxy3D, content: RealityViewContent) {
@@ -155,57 +182,29 @@ private struct PlayerOrnamentView: View {
                 statusControls(
                     title: "No Movie Selected",
                     systemImage: "film.stack",
-                    message: "Choose an MV-HEVC movie to start spatial playback.",
+                    message: "Choose a movie from your library to begin playback.",
                     showsProgress: false
                 )
             }
         }
-        .padding(20)
-        .frame(maxWidth: 880)
+        .padding(.horizontal, 20)
+        .padding(.top, 30)
+        .padding(.bottom, 20)
+        .frame(maxWidth: 980)
         .glassBackgroundEffect()
         .onHover(perform: onHoverChanged)
         .accessibilityElement(children: .contain)
     }
 
     private var readyControls: some View {
-        VStack(spacing: 16) {
-            ornamentHeader
+        VStack(spacing: 14) {
+            controlBar
 
             if let warning = session.failureMessage {
                 Label(warning, systemImage: "exclamationmark.triangle")
                     .font(.subheadline)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-
-            HStack(spacing: 28) {
-                transportButton(
-                    title: "Back 10 seconds",
-                    systemImage: "gobackward.10",
-                    action: session.seekBackward
-                )
-                .disabled(!session.canSeek)
-
-                Button(action: performPlaybackToggle) {
-                    Label(
-                        session.isPlaying ? "Pause" : "Play",
-                        systemImage: session.isPlaying ? "pause.fill" : "play.fill"
-                    )
-                    .labelStyle(.iconOnly)
-                    .frame(minWidth: 72, minHeight: 72)
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!session.canControlPlayback)
-                .accessibilityIdentifier("player-play-pause")
-                .accessibilityLabel(session.isPlaying ? "Pause playback" : "Play movie")
-
-                transportButton(
-                    title: "Forward 30 seconds",
-                    systemImage: "goforward.30",
-                    action: session.seekForward
-                )
-                .disabled(!session.canSeek)
-            }
-            .frame(maxWidth: .infinity)
 
             VStack(spacing: 8) {
                 Slider(
@@ -230,19 +229,15 @@ private struct PlayerOrnamentView: View {
                 }
                 .font(.system(.subheadline, design: .monospaced))
                 .foregroundStyle(.secondary)
+                .accessibilityElement(children: .ignore)
                 .accessibilityLabel("Playback time \(displayedTimeSummary)")
             }
 
-            HStack(spacing: 16) {
-                audioMenu
-                subtitleMenu
-                Spacer(minLength: 0)
-            }
         }
     }
 
-    private var ornamentHeader: some View {
-        HStack(spacing: 12) {
+    private var controlBar: some View {
+        HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(session.mediaItem?.title ?? "BD to AVP Player")
                     .font(.headline)
@@ -251,7 +246,41 @@ private struct PlayerOrnamentView: View {
                     .font(.subheadline)
                     .accessibilityLabel("Stereo format \(session.mediaItem?.format.displayName ?? "MV-HEVC")")
             }
-            Spacer(minLength: 20)
+            .frame(width: 180, alignment: .leading)
+
+            Spacer(minLength: 8)
+
+            transportButton(
+                title: "Back 10 seconds",
+                systemImage: "gobackward.10",
+                action: session.seekBackward
+            )
+            .disabled(!session.canSeek)
+
+            Button(action: performPlaybackToggle) {
+                Label(
+                    session.isPlaying ? "Pause" : "Play",
+                    systemImage: session.isPlaying ? "pause.fill" : "play.fill"
+                )
+                .labelStyle(.iconOnly)
+                .frame(minWidth: 72, minHeight: 72)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!session.canControlPlayback)
+            .accessibilityIdentifier("player-play-pause")
+            .accessibilityLabel(session.isPlaying ? "Pause playback" : "Play movie")
+
+            transportButton(
+                title: "Forward 30 seconds",
+                systemImage: "goforward.30",
+                action: session.seekForward
+            )
+            .disabled(!session.canSeek)
+
+            Spacer(minLength: 8)
+
+            audioMenu
+            subtitleMenu
             doneButton
         }
     }
@@ -281,8 +310,11 @@ private struct PlayerOrnamentView: View {
     }
 
     private var doneButton: some View {
-        Button("Done", action: onDone)
-            .frame(minWidth: 60, minHeight: 60)
+        Button(action: onDone) {
+            Label("Done", systemImage: "xmark")
+                .labelStyle(.iconOnly)
+                .frame(minWidth: 60, minHeight: 60)
+        }
             .accessibilityIdentifier("player-done")
             .accessibilityLabel("Done playing movie")
     }
@@ -329,6 +361,7 @@ private struct PlayerOrnamentView: View {
             }
         } label: {
             Label("Audio", systemImage: "speaker.wave.2")
+                .labelStyle(.iconOnly)
                 .frame(minWidth: 60, minHeight: 60)
         }
         .disabled(session.audioOptions.isEmpty)
@@ -345,6 +378,7 @@ private struct PlayerOrnamentView: View {
             }
         } label: {
             Label("CC", systemImage: "captions.bubble")
+                .labelStyle(.iconOnly)
                 .frame(minWidth: 60, minHeight: 60)
         }
         .disabled(session.subtitleOptions.isEmpty)

--- a/macos/BDToAVPPlayer/Views/PlayerView.swift
+++ b/macos/BDToAVPPlayer/Views/PlayerView.swift
@@ -22,7 +22,7 @@ struct PlayerView: View {
         .background(.black)
         .overlay {
             Button {
-                hudVisibility.reveal(isPlaying: session.isPlaying)
+                hudVisibility.reveal(isPlaying: isAutomaticHidingAllowed)
             } label: {
                 Color.clear
                     .contentShape(Rectangle())
@@ -76,19 +76,24 @@ struct PlayerView: View {
             attachmentAnchor: .scene(.bottom),
             contentAlignment: .top
         ) {
-            PlayerOrnamentView(
-                session: session,
-                onDone: done,
-                onHoverChanged: { isHovered in
-                    hudVisibility.setHovered(isHovered, isPlaying: isAutomaticHidingAllowed)
-                },
-                onScrubbingChanged: { isScrubbing in
-                    hudVisibility.setInteracting(isScrubbing, isPlaying: isAutomaticHidingAllowed)
-                },
-                onInteraction: {
-                    hudVisibility.reveal(isPlaying: isAutomaticHidingAllowed)
-                }
-            )
+            VStack(spacing: 0) {
+                Color.clear
+                    .frame(height: 16)
+                    .accessibilityHidden(true)
+                PlayerOrnamentView(
+                    session: session,
+                    onDone: done,
+                    onHoverChanged: { isHovered in
+                        hudVisibility.setHovered(isHovered, isPlaying: isAutomaticHidingAllowed)
+                    },
+                    onScrubbingChanged: { isScrubbing in
+                        hudVisibility.setInteracting(isScrubbing, isPlaying: isAutomaticHidingAllowed)
+                    },
+                    onInteraction: {
+                        hudVisibility.reveal(isPlaying: isAutomaticHidingAllowed)
+                    }
+                )
+            }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase != .active {
@@ -180,10 +185,10 @@ private struct PlayerOrnamentView: View {
                 )
             case .idle:
                 statusControls(
-                    title: "No Movie Selected",
+                    title: "Preparing Playback",
                     systemImage: "film.stack",
-                    message: "Choose a movie from your library to begin playback.",
-                    showsProgress: false
+                    message: "Opening \(session.mediaItem?.title ?? "your movie")…",
+                    showsProgress: true
                 )
             }
         }

--- a/macos/BDToAVPPlayerTests/MediaThumbnailTests.swift
+++ b/macos/BDToAVPPlayerTests/MediaThumbnailTests.swift
@@ -5,6 +5,7 @@ import XCTest
 final class MediaThumbnailTests: XCTestCase {
     func testThumbnailCacheUsesABoundedDefaultLimit() {
         XCTAssertEqual(MediaThumbnailCache.defaultCountLimit, 48)
+        XCTAssertEqual(MediaThumbnailCache.defaultTotalCostLimit, 96 * 1_024 * 1_024)
     }
 
     func testThumbnailCacheRoundTripsAFrameByKey() throws {
@@ -33,5 +34,20 @@ final class MediaThumbnailTests: XCTestCase {
         let second = MediaItem(id: "movie", title: "Movie", fileName: "second.mov", format: .mvHEVC)
 
         XCTAssertNotEqual(MediaThumbnailLoader.cacheKey(for: first), MediaThumbnailLoader.cacheKey(for: second))
+    }
+
+    func testThumbnailCacheKeyChangesWhenBookmarkChanges() {
+        let item = MediaItem(id: "movie", title: "Movie", fileName: "movie.mov", format: .mvHEVC)
+
+        XCTAssertNotEqual(
+            MediaThumbnailLoader.cacheKey(for: item, bookmarkData: Data("first".utf8)),
+            MediaThumbnailLoader.cacheKey(for: item, bookmarkData: Data("second".utf8))
+        )
+    }
+
+    func testThumbnailTimeSamplesTenPercentUpToThirtySeconds() {
+        XCTAssertEqual(MediaThumbnailLoader.requestedTime(for: 90).seconds, 9, accuracy: 0.001)
+        XCTAssertEqual(MediaThumbnailLoader.requestedTime(for: 600).seconds, 30, accuracy: 0.001)
+        XCTAssertEqual(MediaThumbnailLoader.requestedTime(for: 6).seconds, 0.6, accuracy: 0.001)
     }
 }

--- a/macos/BDToAVPPlayerTests/MediaThumbnailTests.swift
+++ b/macos/BDToAVPPlayerTests/MediaThumbnailTests.swift
@@ -1,0 +1,37 @@
+import AVFoundation
+import XCTest
+@testable import BDToAVPPlayer
+
+final class MediaThumbnailTests: XCTestCase {
+    func testThumbnailCacheUsesABoundedDefaultLimit() {
+        XCTAssertEqual(MediaThumbnailCache.defaultCountLimit, 48)
+    }
+
+    func testThumbnailCacheRoundTripsAFrameByKey() throws {
+        let cache = MediaThumbnailCache(countLimit: 2)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let image = try XCTUnwrap(
+            CGContext(
+                data: nil,
+                width: 2,
+                height: 2,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )?.makeImage()
+        )
+
+        cache.insert(image, for: "movie")
+
+        XCTAssertNotNil(cache.image(for: "movie"))
+        XCTAssertNil(cache.image(for: "other"))
+    }
+
+    func testThumbnailCacheKeyChangesWhenSourceFilenameChanges() {
+        let first = MediaItem(id: "movie", title: "Movie", fileName: "first.mov", format: .mvHEVC)
+        let second = MediaItem(id: "movie", title: "Movie", fileName: "second.mov", format: .mvHEVC)
+
+        XCTAssertNotEqual(MediaThumbnailLoader.cacheKey(for: first), MediaThumbnailLoader.cacheKey(for: second))
+    }
+}

--- a/macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift
+++ b/macos/BDToAVPPlayerTests/PlaybackPresentationTests.swift
@@ -63,6 +63,56 @@ final class PlaybackPresentationTests: XCTestCase {
         XCTAssertNil(scrubState.finish())
     }
 
+    func testHUDVisibilitySchedulesAutomaticHidingOnlyDuringUnfocusedPlayback() {
+        var visibility = PlaybackHUDVisibilityState()
+
+        visibility.reconcile(isPlaying: true)
+
+        XCTAssertTrue(visibility.isVisible)
+        XCTAssertTrue(visibility.isAutoHideScheduled)
+        XCTAssertEqual(PlaybackHUDVisibilityState.autoHideDelay, 3)
+    }
+
+    func testHUDVisibilityHidesOnlyForTheCurrentScheduledTimer() {
+        var visibility = PlaybackHUDVisibilityState()
+        visibility.reconcile(isPlaying: true)
+        let initialGeneration = visibility.autoHideGeneration
+
+        visibility.reveal(isPlaying: true)
+        let replacementGeneration = visibility.autoHideGeneration
+        visibility.autoHideTimerFired(generation: initialGeneration)
+
+        XCTAssertTrue(visibility.isVisible)
+        XCTAssertTrue(visibility.isAutoHideScheduled)
+
+        visibility.autoHideTimerFired(generation: replacementGeneration)
+
+        XCTAssertFalse(visibility.isVisible)
+        XCTAssertFalse(visibility.isAutoHideScheduled)
+    }
+
+    func testHUDVisibilityRemainsVisibleWhilePausedHoveredOrScrubbing() {
+        var visibility = PlaybackHUDVisibilityState()
+
+        visibility.reconcile(isPlaying: false)
+        XCTAssertTrue(visibility.isVisible)
+        XCTAssertFalse(visibility.isAutoHideScheduled)
+
+        visibility.setHovered(true, isPlaying: true)
+        XCTAssertTrue(visibility.isVisible)
+        XCTAssertFalse(visibility.isAutoHideScheduled)
+
+        visibility.setHovered(false, isPlaying: true)
+        XCTAssertTrue(visibility.isAutoHideScheduled)
+
+        visibility.setInteracting(true, isPlaying: true)
+        XCTAssertTrue(visibility.isVisible)
+        XCTAssertFalse(visibility.isAutoHideScheduled)
+
+        visibility.setInteracting(false, isPlaying: true)
+        XCTAssertTrue(visibility.isAutoHideScheduled)
+    }
+
     func testResumePolicyWritesAnInProgressPosition() {
         XCTAssertEqual(ResumeWritePolicy.decision(currentTime: 42, duration: 120), .write(42))
     }

--- a/macos/BDToAVPPlayerTests/PlayerAppModelTests.swift
+++ b/macos/BDToAVPPlayerTests/PlayerAppModelTests.swift
@@ -26,12 +26,7 @@ final class PlayerAppModelTests: XCTestCase {
             formatInspector: { _ in .mvHEVC }
         )
 
-        XCTAssertEqual(model.viewMode, .posters)
         XCTAssertEqual(model.visibleItems.map(\.id), ["alpha", "zulu"])
-
-        model.formatFilter = .mvHEVC
-
-        XCTAssertEqual(model.visibleItems.map(\.id), ["alpha"])
         XCTAssertEqual(model.library.posters.map(\.id), ["zulu", "alpha"])
         XCTAssertEqual(model.library.files, model.library.posters)
     }
@@ -92,10 +87,13 @@ final class PlayerAppModelTests: XCTestCase {
 
         XCTAssertEqual(model.playbackAvailability(for: item), .playable)
 
+        model.showDetails(for: item.id)
         model.requestPlayback(for: item.id)
 
         XCTAssertEqual(model.playbackRequest?.item, item)
         XCTAssertEqual(callbackItem, item)
+        XCTAssertEqual(model.selectedItemID, item.id)
+        XCTAssertTrue(model.isShowingDetails)
     }
 
     func testBootstrapIndexesSupportedMoviesWithoutOpeningDetails() async throws {

--- a/macos/BDToAVPPlayerTests/PlayerAppModelTests.swift
+++ b/macos/BDToAVPPlayerTests/PlayerAppModelTests.swift
@@ -26,7 +26,13 @@ final class PlayerAppModelTests: XCTestCase {
             formatInspector: { _ in .mvHEVC }
         )
 
+        XCTAssertEqual(model.viewMode, .posters)
         XCTAssertEqual(model.visibleItems.map(\.id), ["alpha", "zulu"])
+
+        model.formatFilter = .mvHEVC
+
+        XCTAssertEqual(model.visibleItems.map(\.id), ["alpha"])
+        XCTAssertEqual(model.sourceTitle(for: items[0]), "Files")
         XCTAssertEqual(model.library.posters.map(\.id), ["zulu", "alpha"])
         XCTAssertEqual(model.library.files, model.library.posters)
     }
@@ -116,6 +122,7 @@ final class PlayerAppModelTests: XCTestCase {
         await model.bootstrap()
 
         XCTAssertEqual(model.library.items.map(\.fileName), ["Example.mov"])
+        XCTAssertEqual(model.sourceTitle(for: model.library.items[0]), "On My Vision Pro")
         XCTAssertEqual(model.sourceStatuses.values.first, .available)
         XCTAssertFalse(model.isShowingDetails)
         XCTAssertTrue(model.hasBootstrapped)

--- a/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
+++ b/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
@@ -29,8 +29,19 @@ final class BDToAVPPlayerUITests: XCTestCase {
         XCTAssertTrue(playPauseButton.waitForExistence(timeout: 30))
         attachScreenshot(named: "player-controls-visible")
 
-        sleep(4)
-        XCTAssertFalse(playPauseButton.exists)
+        let doneButton = app.buttons["player-done"]
+        XCTAssertTrue(doneButton.exists)
+        doneButton.tap()
+        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
+
+        playButton.tap()
+        XCTAssertTrue(playPauseButton.waitForExistence(timeout: 30))
+
+        let hiddenExpectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: playPauseButton
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [hiddenExpectation], timeout: 6), .completed)
         attachScreenshot(named: "player-controls-hidden")
         XCTAssertTrue(app.buttons["player-surface"].exists)
     }

--- a/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
+++ b/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class BDToAVPPlayerUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testSeededMovieDetailsAndPlaybackFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let movieID = "documents:playerlongfixture.mov"
+        let movieTile = app.descendants(matching: .any)
+            .matching(identifier: "movie-tile-\(movieID)")
+            .firstMatch
+        guard movieTile.waitForExistence(timeout: 10) else {
+            throw XCTSkip("Requires PlayerLongFixture.mov in the app Documents directory.")
+        }
+
+        attachScreenshot(named: "library-populated")
+        movieTile.tap()
+
+        let playButton = app.buttons["play-movie-\(movieID)"]
+        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
+        attachScreenshot(named: "movie-details")
+        playButton.tap()
+
+        let playPauseButton = app.buttons["player-play-pause"]
+        XCTAssertTrue(playPauseButton.waitForExistence(timeout: 30))
+        attachScreenshot(named: "player-controls-visible")
+
+        sleep(4)
+        XCTAssertFalse(playPauseButton.exists)
+        attachScreenshot(named: "player-controls-hidden")
+        XCTAssertTrue(app.buttons["player-surface"].exists)
+    }
+
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
+++ b/macos/BDToAVPPlayerUITests/BDToAVPPlayerUITests.swift
@@ -16,16 +16,33 @@ final class BDToAVPPlayerUITests: XCTestCase {
         guard movieTile.waitForExistence(timeout: 10) else {
             throw XCTSkip("Requires PlayerLongFixture.mov in the app Documents directory.")
         }
+        let libraryPlayButton = app.buttons["play-library-\(movieID)"]
+        XCTAssertTrue(libraryPlayButton.isHittable)
 
         attachScreenshot(named: "library-populated")
+        libraryPlayButton.tap()
+
+        let playPauseButton = app.buttons["player-play-pause"]
+        XCTAssertTrue(playPauseButton.waitForExistence(timeout: 30))
+        app.buttons["player-done"].tap()
+        XCTAssertTrue(waitForHittable(movieTile, timeout: 10))
+
         movieTile.tap()
 
         let playButton = app.buttons["play-movie-\(movieID)"]
         XCTAssertTrue(playButton.waitForExistence(timeout: 10))
+        XCTAssertTrue(playButton.isHittable, "Play should be visible without scrolling the Details sheet.")
         attachScreenshot(named: "movie-details")
+
+        let detailsDoneButton = app.buttons["details-done"]
+        XCTAssertTrue(detailsDoneButton.isHittable)
+        detailsDoneButton.tap()
+        XCTAssertTrue(waitForHittable(movieTile, timeout: 10))
+
+        movieTile.tap()
+        XCTAssertTrue(waitForHittable(playButton, timeout: 10))
         playButton.tap()
 
-        let playPauseButton = app.buttons["player-play-pause"]
         XCTAssertTrue(playPauseButton.waitForExistence(timeout: 30))
         attachScreenshot(named: "player-controls-visible")
 
@@ -51,5 +68,13 @@ final class BDToAVPPlayerUITests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    private func waitForHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == true AND hittable == true"),
+            object: element
+        )
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -193,6 +193,25 @@ targets:
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/BDToAVPPlayer.app/BDToAVPPlayer
         XROS_DEPLOYMENT_TARGET: "26.0"
 
+  BDToAVPPlayerUITests:
+    type: bundle.ui-testing
+    platform: auto
+    supportedDestinations: [visionOS]
+    deploymentTarget:
+      visionOS: "26.0"
+    sources:
+      - path: BDToAVPPlayerUITests
+    dependencies:
+      - target: BDToAVPPlayer
+    settings:
+      base:
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.shinycomputers.bd-to-avp.player.ui-tests
+        TARGETED_DEVICE_FAMILY: "7"
+        TEST_TARGET_NAME: BDToAVPPlayer
+        XROS_DEPLOYMENT_TARGET: "26.0"
+
 schemes:
   BluRayToVisionPro:
     build:
@@ -244,3 +263,4 @@ schemes:
     test:
       targets:
         - BDToAVPPlayerTests
+        - BDToAVPPlayerUITests


### PR DESCRIPTION
## Summary

- restore the physically preferred split-view Library with “Your movies,” Posters/Files modes, filtering, sorting, Add Movie, and real 16:9 thumbnails
- restore compact modal Details with full title, truthful source/format, immediate Play, technical metadata, missing-source recovery, and removal
- add a visible direct Play action to playable poster cards and file rows without nested controls
- retain the native bottom playback ornament, auto-hide and assistive-tech safeguards, and context-sensitive Done return behavior
- move the spatial video surface to the playback probe's physically exercised scale/depth geometry so foreground MV-HEVC content remains behind the ornament
- update the visionOS player documentation, test-audit inventory, and seeded UI flow for the accepted hybrid

## Validation

- `uv run python scripts/native_app.py generate`
- visionOS simulator suite: **49 tests passed** (48 unit + 1 seeded UI test)
- seeded UI flow verifies direct Library → Play → Library, Library → Details, Details Done → Library, Details → Play, player Done → Details, replay, and ornament auto-hide
- real visionOS simulator framebuffer reviewed with both fixture thumbnails and visible direct Play actions
- signed **Player Hybrid** installed side-by-side on the paired physical Vision Pro with both fixtures read back from its persistent data container
- physical Vision Pro acceptance passed for Home, Details, direct Play visibility, foreground-video/ornament depth separation, control reachability, auto-hide/reveal, and Done return behavior
- test-audit inventory generator and focused 11-test suite passed
- required GitHub checks: **4/4 passed** on `088fa38`
- unanswered external comments: none

## Status

Ready for review and a merge decision. The implementation, physical UX validation, local regression checks, and required GitHub checks are complete.

Refs #691
Refs #438
